### PR TITLE
[Mgmt] record eh mgmt tests and update requirements

### DIFF
--- a/sdk/eventhub/azure-mgmt-eventhub/dev_requirements.txt
+++ b/sdk/eventhub/azure-mgmt-eventhub/dev_requirements.txt
@@ -1,3 +1,5 @@
 -e ../../../tools/azure-sdk-tools
 aiohttp>=3.0; python_version >= '3.5'
 -e ../../../tools/azure-devtools
+azure-identity
+azure-mgmt-network

--- a/sdk/eventhub/azure-mgmt-eventhub/tests.yml
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests.yml
@@ -11,6 +11,4 @@ stages:
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        TEST_MODE: 'RunLiveNoRecord'
         AZURE_TEST_RUN_LIVE: 'true'
-        AZURE_SKIP_LIVE_RECORDING: 'True'

--- a/sdk/eventhub/azure-mgmt-eventhub/tests.yml
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests.yml
@@ -7,10 +7,10 @@ stages:
       ServiceDirectory: eventhub
       BuildTargetingString: azure-mgmt-eventhub
       EnvVars:
-        AZURE_CLIENT_ID: $(python-eh-livetest-event-hub-aad-client-id)
-        AZURE_TENANT_ID: $(python-eh-livetest-event-hub-aad-tenant-id)
-        AZURE_CLIENT_SECRET: $(python-eh-livetest-event-hub-aad-secret)
-        AZURE_SUBSCRIPTION_ID: $(python-eh-livetest-event-hub-subscription-id)
+        AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
         TEST_MODE: 'RunLiveNoRecord'
         AZURE_TEST_RUN_LIVE: 'true'
         AZURE_SKIP_LIVE_RECORDING: 'True'

--- a/sdk/eventhub/azure-mgmt-eventhub/tests/recordings/test_cli_mgmt_eventhub.test_disaster_recovery_configs.yaml
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests/recordings/test_cli_mgmt_eventhub.test_disaster_recovery_configs.yaml
@@ -14,31 +14,31 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee","name":"namesp2test4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namesp2test4eb615ee","createdAt":"2020-09-16T07:11:21.83Z","updatedAt":"2020-09-16T07:11:21.83Z","serviceBusEndpoint":"https://namesp2test4eb615ee.servicebus.windows.net:443/","status":"Activating"}}'
+      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee","name":"namesp2test4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"South
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Updating","metricId":"00000000-0000-0000-0000-000000000000:namesp2test4eb615ee","createdAt":"2021-03-31T22:28:12.337Z","updatedAt":"2021-05-24T18:07:41.933Z","serviceBusEndpoint":"https://namesp2test4eb615ee.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '761'
+      - '715'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:11:23 GMT
+      - Mon, 24 May 2021 18:07:42 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -62,77 +62,31 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee","name":"namesp2test4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namesp2test4eb615ee","createdAt":"2020-09-16T07:11:21.83Z","updatedAt":"2020-09-16T07:11:21.83Z","serviceBusEndpoint":"https://namesp2test4eb615ee.servicebus.windows.net:443/","status":"Activating"}}'
+      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee","name":"namesp2test4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"South
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namesp2test4eb615ee","createdAt":"2021-03-31T22:28:12.337Z","updatedAt":"2021-05-24T18:07:42.807Z","serviceBusEndpoint":"https://namesp2test4eb615ee.servicebus.windows.net:443/","status":"Active"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '761'
+      - '712'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:11:53 GMT
+      - Mon, 24 May 2021 18:08:12 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/SN1
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee?api-version=2017-04-01
-  response:
-    body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee","name":"namesp2test4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namesp2test4eb615ee","createdAt":"2020-09-16T07:11:21.83Z","updatedAt":"2020-09-16T07:12:03.62Z","serviceBusEndpoint":"https://namesp2test4eb615ee.servicebus.windows.net:443/","status":"Active"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '759'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 07:12:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/SN1
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -159,31 +113,31 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","name":"namesptest4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"North
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namesptest4eb615ee","createdAt":"2020-09-16T07:12:43.457Z","updatedAt":"2020-09-16T07:12:43.457Z","serviceBusEndpoint":"https://namesptest4eb615ee.servicebus.windows.net:443/","status":"Activating"}}'
+      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","name":"namesptest4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"North
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Updating","metricId":"00000000-0000-0000-0000-000000000000:namesptest4eb615ee","createdAt":"2021-05-24T17:51:02.39Z","updatedAt":"2021-05-24T18:08:19.087Z","serviceBusEndpoint":"https://namesptest4eb615ee.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '759'
+      - '710'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:12:44 GMT
+      - Mon, 24 May 2021 18:08:19 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -207,77 +161,31 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","name":"namesptest4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"North
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namesptest4eb615ee","createdAt":"2020-09-16T07:12:43.457Z","updatedAt":"2020-09-16T07:12:43.457Z","serviceBusEndpoint":"https://namesptest4eb615ee.servicebus.windows.net:443/","status":"Activating"}}'
+      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","name":"namesptest4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"North
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namesptest4eb615ee","createdAt":"2021-05-24T17:51:02.39Z","updatedAt":"2021-05-24T18:08:20.427Z","serviceBusEndpoint":"https://namesptest4eb615ee.servicebus.windows.net:443/","status":"Active"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '759'
+      - '707'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:13:14 GMT
+      - Mon, 24 May 2021 18:08:49 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/SN1
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee?api-version=2017-04-01
-  response:
-    body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","name":"namesptest4eb615ee","type":"Microsoft.EventHub/Namespaces","location":"North
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namesptest4eb615ee","createdAt":"2020-09-16T07:12:43.457Z","updatedAt":"2020-09-16T07:13:31.007Z","serviceBusEndpoint":"https://namesptest4eb615ee.servicebus.windows.net:443/","status":"Active"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 07:13:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/SN1
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -303,31 +211,31 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/authorizationRules/authorizationrule4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/authorizationRules/authorizationrule4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/authorizationRules/authorizationrule4eb615ee","name":"authorizationrule4eb615ee","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/authorizationRules/authorizationrule4eb615ee","name":"authorizationrule4eb615ee","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
         Central US","properties":{"rights":["Send"]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '398'
+      - '349'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:14:07 GMT
+      - Mon, 24 May 2021 18:08:55 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -355,9 +263,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/checkNameAvailability?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/checkNameAvailability?api-version=2017-04-01
   response:
     body:
       string: '{"nameAvailable":true,"reason":"None"}'
@@ -369,16 +277,16 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:14:07 GMT
+      - Mon, 24 May 2021 18:08:55 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -393,7 +301,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: 'b''b\''{"properties": {"partnerNamespace": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee"}}\'''''
+    body: '{"properties": {"partnerNamespace": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee"}}'
     headers:
       Accept:
       - application/json
@@ -402,34 +310,34 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '227'
+      - '178'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '656'
+      - '558'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:14:15 GMT
+      - Mon, 24 May 2021 18:09:03 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/SN1
+      - Service-Bus-Resource-Provider/CH3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -453,111 +361,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '656'
+      - '558'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:14:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/SN1
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/SN1
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '656'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 07:14:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/SN1
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/SN1
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '656'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 07:14:47 GMT
+      - Mon, 24 May 2021 18:09:03 GMT
       expires:
       - '-1'
       pragma:
@@ -588,21 +406,156 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '656'
+      - '558'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:15:17 GMT
+      - Mon, 24 May 2021 18:09:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/CH3
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '558'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 May 2021 18:09:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/CH3
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Accepted","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '558'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 May 2021 18:10:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/CH3
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Succeeded","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication","pendingReplicationOperationsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '597'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 May 2021 18:10:35 GMT
       expires:
       - '-1'
       pragma:
@@ -633,30 +586,30 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/messagingplan?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee","name":"disasterdecoveryconfig4eb615ee","type":"Microsoft.EventHub/Namespaces/disasterrecoveryconfigs","properties":{"provisioningState":"Succeeded","partnerNamespace":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee","role":"Primary","type":"MetadataReplication","pendingReplicationOperationsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/messagingplan","name":"2","type":"Microsoft.EventHub/MessagingSKUPlan","location":null,"tags":null,"properties":{"sku":2,"selectedEventHubUnit":1,"updatedAt":"2021-05-24T18:07:36.2120033Z","revision":4,"eventHubProcessingUnits":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '695'
+      - '378'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:15:52 GMT
+      - Mon, 24 May 2021 18:11:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -678,76 +631,31 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/messagingplan?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/authorizationRules/authorizationrule4eb615ee?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/messagingplan","name":"2","type":"Microsoft.EventHub/MessagingSKUPlan","location":null,"tags":null,"properties":{"sku":2,"selectedEventHubUnit":1,"updatedAt":"2020-09-16T07:11:22.6816823Z","revision":3}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '399'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 07:16:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/CH3
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/CH3
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/authorizationRules/authorizationrule4eb615ee?api-version=2017-04-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/authorizationRules/authorizationrule4eb615ee","name":"authorizationrule4eb615ee","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/authorizationRules/authorizationrule4eb615ee","name":"authorizationrule4eb615ee","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
         Central US","properties":{"rights":["Send"]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '453'
+      - '404'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:16:23 GMT
+      - Mon, 24 May 2021 18:11:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -771,12 +679,12 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/authorizationRules/authorizationrule4eb615ee/listKeys?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/authorizationRules/authorizationrule4eb615ee/listKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"aliasPrimaryConnectionString":"Endpoint=sb://disasterdecoveryconfig4eb615ee.servicebus.windows.net/;SharedAccessKeyName=authorizationrule4eb615ee;SharedAccessKey=l7V9r5Gjbmqlb0Koehg1U4YD4+m8+78aXR//8LFUykI=","aliasSecondaryConnectionString":"Endpoint=sb://disasterdecoveryconfig4eb615ee.servicebus.windows.net/;SharedAccessKeyName=authorizationrule4eb615ee;SharedAccessKey=KL0F9Nriwd6+Uq+HBlUllsVOMj6qXWzOxBNdBfmAjCg=","primaryKey":"l7V9r5Gjbmqlb0Koehg1U4YD4+m8+78aXR//8LFUykI=","secondaryKey":"KL0F9Nriwd6+Uq+HBlUllsVOMj6qXWzOxBNdBfmAjCg=","keyName":"authorizationrule4eb615ee"}'
+      string: '{"aliasPrimaryConnectionString":"Endpoint=sb://disasterdecoveryconfig4eb615ee.servicebus.windows.net/;SharedAccessKeyName=authorizationrule4eb615ee;SharedAccessKey=kKBsq8W3JVJvo6mhWjeX0745mRTsxq04KxNt67TW2h8=","aliasSecondaryConnectionString":"Endpoint=sb://disasterdecoveryconfig4eb615ee.servicebus.windows.net/;SharedAccessKeyName=authorizationrule4eb615ee;SharedAccessKey=mVIbfk5VI1EyhAhaAjzvDQY0Qa+NihD2Sr6QbSlwsaM=","primaryKey":"kKBsq8W3JVJvo6mhWjeX0745mRTsxq04KxNt67TW2h8=","secondaryKey":"mVIbfk5VI1EyhAhaAjzvDQY0Qa+NihD2Sr6QbSlwsaM=","keyName":"authorizationrule4eb615ee"}'
     headers:
       cache-control:
       - no-cache
@@ -785,16 +693,16 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:16:24 GMT
+      - Mon, 24 May 2021 18:11:07 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -820,9 +728,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/breakPairing?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesp2test4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/breakPairing?api-version=2017-04-01
   response:
     body:
       string: ''
@@ -832,16 +740,16 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 07:16:25 GMT
+      - Mon, 24 May 2021 18:11:07 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
@@ -863,9 +771,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/failover?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee/failover?api-version=2017-04-01
   response:
     body:
       string: ''
@@ -875,16 +783,16 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 07:16:25 GMT
+      - Mon, 24 May 2021 18:11:07 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
@@ -906,13 +814,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
   response:
     body:
       string: '{"error":{"message":"Delete operation is only allowed when primary
-        namespace does not have secondary namespace. CorrelationId: 78c57f58-748c-498c-b96f-b3699c19573d","code":"BadRequest"}}'
+        namespace does not have secondary namespace. CorrelationId: 8f2c0b97-1c6f-48da-8bd9-3e0ceb649c1d","code":"BadRequest"}}'
     headers:
       cache-control:
       - no-cache
@@ -921,16 +829,16 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:16:26 GMT
+      - Mon, 24 May 2021 18:11:08 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
@@ -952,13 +860,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
   response:
     body:
       string: '{"error":{"message":"Delete operation is only allowed when primary
-        namespace does not have secondary namespace. CorrelationId: 2ebda4fc-0c2d-4958-b974-43a0f03c1116","code":"BadRequest"}}'
+        namespace does not have secondary namespace. CorrelationId: 9e018762-bb6c-4fba-bf03-772c0a350cc2","code":"BadRequest"}}'
     headers:
       cache-control:
       - no-cache
@@ -967,16 +875,16 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:16:56 GMT
+      - Mon, 24 May 2021 18:11:38 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
@@ -998,13 +906,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
   response:
     body:
       string: '{"error":{"message":"Delete operation is only allowed when primary
-        namespace does not have secondary namespace. CorrelationId: a5fc17d3-d2c8-46e4-a6af-be620d1adfeb","code":"BadRequest"}}'
+        namespace does not have secondary namespace. CorrelationId: 7997ea35-86d0-45bc-a835-cb81bfa7ac6a","code":"BadRequest"}}'
     headers:
       cache-control:
       - no-cache
@@ -1013,16 +921,16 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 07:17:26 GMT
+      - Mon, 24 May 2021 18:12:08 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
@@ -1044,9 +952,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_eventhub_test_disaster_recovery_configs4eb615ee/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namesptest4eb615ee/disasterRecoveryConfigs/disasterdecoveryconfig4eb615ee?api-version=2017-04-01
   response:
     body:
       string: ''
@@ -1056,16 +964,16 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 07:17:58 GMT
+      - Mon, 24 May 2021 18:12:39 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       server-sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:

--- a/sdk/eventhub/azure-mgmt-eventhub/tests/recordings/test_cli_mgmt_eventhub.test_eventhub.yaml
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests/recordings/test_cli_mgmt_eventhub.test_eventhub.yaml
@@ -11,69 +11,23 @@ interactions:
       Content-Length:
       - '74'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-storage/5.0.0 Azure-SDK-For-Python
-      accept-language:
-      - en-US
+      - azsdk-python-azure-mgmt-storage/18.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda?api-version=2019-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda?api-version=2021-04-01
   response:
     body:
-      string: ''
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda","name":"storageaccount13130eda","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2021-05-24T18:05:39.2128438Z","key2":"2021-05-24T18:05:39.2128438Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-24T18:05:39.2284526Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-24T18:05:39.2284526Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-05-24T18:05:39.0878161Z","primaryEndpoints":{"blob":"https://storageaccount13130eda.blob.core.windows.net/","queue":"https://storageaccount13130eda.queue.core.windows.net/","table":"https://storageaccount13130eda.table.core.windows.net/","file":"https://storageaccount13130eda.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '0'
-      content-type:
-      - text/plain; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 03:28:35 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/3d6793c0-2f29-4476-bdd1-2c0aa0ccac9b?monitor=true&api-version=2019-04-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-storage/5.0.0 Azure-SDK-For-Python
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/3d6793c0-2f29-4476-bdd1-2c0aa0ccac9b?monitor=true&api-version=2019-04-01
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda","name":"storageaccount13130eda","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2020-09-16T03:28:35.4204338Z"},"blob":{"enabled":true,"lastEnabledTime":"2020-09-16T03:28:35.4204338Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-09-16T03:28:35.3110634Z","primaryEndpoints":{"blob":"https://storageaccount13130eda.blob.core.windows.net/","queue":"https://storageaccount13130eda.queue.core.windows.net/","table":"https://storageaccount13130eda.table.core.windows.net/","file":"https://storageaccount13130eda.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1156'
+      - '1261'
       content-type:
       - application/json
       date:
-      - Wed, 16 Sep 2020 03:28:53 GMT
+      - Mon, 24 May 2021 18:12:41 GMT
       expires:
       - '-1'
       pragma:
@@ -88,14 +42,16 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
     status:
       code: 200
       message: OK
 - request:
     body: '{"location": "eastus", "properties": {"addressSpace": {"addressPrefixes":
-      ["10.0.0.0/16"]}, "subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
-      "name": "subnet13130eda"}], "enableDdosProtection": false, "enableVmProtection":
-      false}}'
+      ["10.0.0.0/16"]}, "subnets": [{"name": "subnet13130eda", "properties": {"addressPrefix":
+      "10.0.0.0/24", "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
+      "Enabled"}}], "enableDdosProtection": false, "enableVmProtection": false}}'
     headers:
       Accept:
       - application/json
@@ -104,47 +60,42 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '241'
+      - '334'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
-      accept-language:
-      - en-US
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda?api-version=2019-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda?api-version=2021-02-01
   response:
     body:
-      string: "{\r\n  \"name\": \"virtualnetwork13130eda\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda\"\
-        ,\r\n  \"etag\": \"W/\\\"f92c40bd-34d5-4ee2-9a2c-5730b4e29c3b\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
-        ,\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n \
-        \   \"resourceGuid\": \"75bfcdb2-3ab2-407e-9bf8-8834a85a888e\",\r\n    \"\
-        addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\
-        \r\n      ]\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\"\
-        : \"subnet13130eda\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda\"\
-        ,\r\n        \"etag\": \"W/\\\"f92c40bd-34d5-4ee2-9a2c-5730b4e29c3b\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\"\
-        : [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n  \
-        \        \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n        },\r\
-        \n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n    \
-        \  }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
-        : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
+      string: "{\r\n  \"name\": \"virtualnetwork13130eda\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda\",\r\n
+        \ \"etag\": \"W/\\\"5bb4152b-7b42-4b75-b96d-e9243de4da13\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\":
+        \"8c2a18f5-6297-4114-98aa-592f25a871ce\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"subnet13130eda\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda\",\r\n
+        \       \"etag\": \"W/\\\"5bb4152b-7b42-4b75-b96d-e9243de4da13\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
+        [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cc9564ec-fa8d-415a-8a70-0162dfa164a9?api-version=2019-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a6fda868-18aa-48e9-8a6e-c329e437380d?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '1433'
+      - '1273'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:29:01 GMT
+      - Mon, 24 May 2021 18:12:44 GMT
       expires:
       - '-1'
       pragma:
@@ -157,9 +108,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - dafdd5fb-3e73-480c-b49f-98866e4319b8
+      - e03c6232-920a-49a7-b800-cb2aa02be529
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -167,16 +118,15 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cc9564ec-fa8d-415a-8a70-0162dfa164a9?api-version=2019-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a6fda868-18aa-48e9-8a6e-c329e437380d?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -188,7 +138,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:29:05 GMT
+      - Mon, 24 May 2021 18:12:48 GMT
       expires:
       - '-1'
       pragma:
@@ -205,7 +155,67 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 49759dde-699f-41fb-933e-529037c24093
+      - 5d45ff3a-a5bc-4c2a-8879-caf0b3bf78d6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"virtualnetwork13130eda\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda\",\r\n
+        \ \"etag\": \"W/\\\"e7f9979c-a124-4eb5-9c7c-d568bf51b5d0\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"8c2a18f5-6297-4114-98aa-592f25a871ce\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"subnet13130eda\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda\",\r\n
+        \       \"etag\": \"W/\\\"e7f9979c-a124-4eb5-9c7c-d568bf51b5d0\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
+        [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1275'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 May 2021 18:12:48 GMT
+      etag:
+      - W/"e7f9979c-a124-4eb5-9c7c-d568bf51b5d0"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 7df815d9-1bcc-4f66-91e3-6ea7a8ca1201
     status:
       code: 200
       message: OK
@@ -219,39 +229,28 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda?api-version=2019-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda?api-version=2021-02-01
   response:
     body:
-      string: "{\r\n  \"name\": \"virtualnetwork13130eda\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda\"\
-        ,\r\n  \"etag\": \"W/\\\"cca1a9d1-c36a-41e5-b123-6b5e0e11bc4f\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
-        ,\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n\
-        \    \"resourceGuid\": \"75bfcdb2-3ab2-407e-9bf8-8834a85a888e\",\r\n    \"\
-        addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\
-        \r\n      ]\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\"\
-        : \"subnet13130eda\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda\"\
-        ,\r\n        \"etag\": \"W/\\\"cca1a9d1-c36a-41e5-b123-6b5e0e11bc4f\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\"\
-        : [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n  \
-        \        \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n        },\r\
-        \n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n    \
-        \  }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
-        : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
+      string: "{\r\n  \"name\": \"subnet13130eda\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda\",\r\n
+        \ \"etag\": \"W/\\\"e7f9979c-a124-4eb5-9c7c-d568bf51b5d0\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
+        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1435'
+      - '554'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:29:05 GMT
+      - Mon, 24 May 2021 18:12:48 GMT
       etag:
-      - W/"cca1a9d1-c36a-41e5-b123-6b5e0e11bc4f"
+      - W/"e7f9979c-a124-4eb5-9c7c-d568bf51b5d0"
       expires:
       - '-1'
       pragma:
@@ -268,62 +267,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 26e7bc57-73e8-47a7-8811-c6326e2c9c64
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda?api-version=2019-09-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"subnet13130eda\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda\"\
-        ,\r\n  \"etag\": \"W/\\\"cca1a9d1-c36a-41e5-b123-6b5e0e11bc4f\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.0.0.0/24\",\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
-        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\
-        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '617'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 03:29:06 GMT
-      etag:
-      - W/"cca1a9d1-c36a-41e5-b123-6b5e0e11bc4f"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 8236c6c7-9162-43fe-b9a7-cbf87fa68cc5
+      - 3973fbbe-212d-4e13-b2ca-42e7262038c7
     status:
       code: 200
       message: OK
@@ -342,22 +286,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda","name":"namespace13130eda","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2020-09-16T03:29:13.98Z","updatedAt":"2020-09-16T03:29:13.98Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Activating"}}'
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2021-05-24T18:12:52.43Z","updatedAt":"2021-05-24T18:12:52.43Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '767'
+      - '704'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:29:15 GMT
+      - Mon, 24 May 2021 18:12:52 GMT
       expires:
       - '-1'
       pragma:
@@ -390,22 +334,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda","name":"namespace13130eda","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2020-09-16T03:29:13.98Z","updatedAt":"2020-09-16T03:29:13.98Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Activating"}}'
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2021-05-24T18:12:52.43Z","updatedAt":"2021-05-24T18:12:52.43Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '767'
+      - '704'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:29:46 GMT
+      - Mon, 24 May 2021 18:13:22 GMT
       expires:
       - '-1'
       pragma:
@@ -436,22 +380,68 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda","name":"namespace13130eda","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2020-09-16T03:29:13.98Z","updatedAt":"2020-09-16T03:30:01.053Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Active"}}'
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2021-05-24T18:12:52.43Z","updatedAt":"2021-05-24T18:12:52.43Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '766'
+      - '704'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:16 GMT
+      - Mon, 24 May 2021 18:13:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/CH3
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda?api-version=2017-04-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda","name":"namespace13130eda","type":"Microsoft.EventHub/Namespaces","location":"South
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2021-05-24T18:12:52.43Z","updatedAt":"2021-05-24T18:13:55.483Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Active"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '703'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 May 2021 18:14:22 GMT
       expires:
       - '-1'
       pragma:
@@ -482,21 +472,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/messagingplan?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/messagingplan","name":"2","type":"Microsoft.EventHub/MessagingSKUPlan","location":null,"tags":null,"properties":{"sku":2,"selectedEventHubUnit":1,"updatedAt":"2020-09-16T03:29:15.6954303Z","revision":1}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/messagingplan","name":"2","type":"Microsoft.EventHub/MessagingSKUPlan","location":null,"tags":null,"properties":{"sku":2,"selectedEventHubUnit":1,"updatedAt":"2021-05-24T18:12:53.643985Z","revision":1,"eventHubProcessingUnits":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '411'
+      - '375'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:17 GMT
+      - Mon, 24 May 2021 18:14:24 GMT
       expires:
       - '-1'
       pragma:
@@ -518,12 +508,11 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: 'b''b\''{"properties": {"messageRetentionInDays": 4, "partitionCount": 4,
-      "status": "Active", "captureDescription": {"enabled": true, "encoding": "Avro",
-      "intervalInSeconds": 120, "sizeLimitInBytes": 10485763, "destination": {"name":
-      "EventHubArchive.AzureBlockBlob", "properties": {"storageAccountResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda",
-      "blobContainer": "container", "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}}}}}\'''''
+    body: '{"properties": {"messageRetentionInDays": 4, "partitionCount": 4, "status":
+      "Active", "captureDescription": {"enabled": true, "encoding": "Avro", "intervalInSeconds":
+      120, "sizeLimitInBytes": 10485763, "destination": {"name": "EventHubArchive.AzureBlockBlob",
+      "properties": {"storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda",
+      "blobContainer": "container", "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}}}}}'
     headers:
       Accept:
       - application/json
@@ -532,26 +521,81 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '656'
+      - '593'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda","name":"eventhub13130eda","type":"Microsoft.EventHub/Namespaces/EventHubs","location":"South
-        Central US","properties":{"messageRetentionInDays":4,"partitionCount":4,"status":"Active","createdAt":"2020-09-16T03:30:21.01Z","updatedAt":"2020-09-16T03:30:21.527Z","partitionIds":["0","1","2","3"],"captureDescription":{"enabled":true,"encoding":"Avro","destination":{"name":"EventHubArchive.AzureBlockBlob","properties":{"storageAccountResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda","blobContainer":"container","archiveNameFormat":"{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}},"intervalInSeconds":120,"sizeLimitInBytes":10485763}}}'
+        Central US","properties":{"messageRetentionInDays":4,"partitionCount":4,"status":"Active","createdAt":"2021-05-24T18:14:41.4Z","updatedAt":"2021-05-24T18:14:41.693Z","partitionIds":["0","1","2","3"],"captureDescription":{"enabled":true,"encoding":"Avro","destination":{"name":"EventHubArchive.AzureBlockBlob","properties":{"storageAccountResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda","blobContainer":"container","archiveNameFormat":"{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}},"intervalInSeconds":120,"sizeLimitInBytes":10485763}}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1081'
+      - '954'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:21 GMT
+      - Mon, 24 May 2021 18:14:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/CH3
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"defaultAction": "Deny", "virtualNetworkRules": [{"subnet":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda"},
+      "ignoreMissingVnetServiceEndpoint": true}], "ipRules": [{"ipMask": "1.1.1.1",
+      "action": "Allow"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '356'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/networkRuleSets/default?api-version=2017-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/networkRuleSets/default","name":"default","type":"Microsoft.EventHub/Namespaces/NetworkRuleSets","location":"South
+        Central US","properties":{"defaultAction":"Deny","virtualNetworkRules":[{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda"},"ignoreMissingVnetServiceEndpoint":true}],"ipRules":[{"ipMask":"1.1.1.1","action":"Allow"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '614'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 May 2021 18:14:54 GMT
       expires:
       - '-1'
       pragma:
@@ -575,10 +619,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: 'b''b\''{"properties": {"defaultAction": "Deny", "virtualNetworkRules":
-      [{"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda"},
-      "ignoreMissingVnetServiceEndpoint": true}], "ipRules": [{"ipMask": "1.1.1.1",
-      "action": "Allow"}]}}\'''''
+    body: '{"properties": {"rights": ["Listen", "Send"]}}'
     headers:
       Accept:
       - application/json
@@ -587,26 +628,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '419'
+      - '46'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/networkRuleSets/default?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/networkRuleSets/default","name":"default","type":"Microsoft.EventHub/Namespaces/NetworkRuleSets","location":"South
-        Central US","properties":{"defaultAction":"Deny","virtualNetworkRules":[{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork13130eda/subnets/subnet13130eda"},"ignoreMissingVnetServiceEndpoint":true}],"ipRules":[{"ipMask":"1.1.1.1","action":"Allow"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda","name":"authorizationrule13130eda","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
+        Central US","properties":{"rights":["Listen","Send"]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '740'
+      - '356'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:38 GMT
+      - Mon, 24 May 2021 18:15:00 GMT
       expires:
       - '-1'
       pragma:
@@ -630,7 +671,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"rights": ["Listen", "Send"]}}'
+    body: '{"properties": {"userMetadata": "New consumergroup"}}'
     headers:
       Accept:
       - application/json
@@ -639,26 +680,27 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '46'
+      - '53'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/consumergroups/consumergroup13130eda?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda","name":"authorizationrule13130eda","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/consumergroups/consumergroup13130eda","name":"consumergroup13130eda","type":"Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups","location":"South
+        Central US","properties":{"createdAt":"2021-05-24T18:15:02.6345201Z","updatedAt":"2021-05-24T18:15:02.6345201Z","userMetadata":"New
+        consumergroup"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '419'
+      - '471'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:45 GMT
+      - Mon, 24 May 2021 18:15:02 GMT
       expires:
       - '-1'
       pragma:
@@ -682,7 +724,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"userMetadata": "New consumergroup"}}'
+    body: '{"properties": {"rights": ["Listen", "Send"]}}'
     headers:
       Accept:
       - application/json
@@ -691,27 +733,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '53'
+      - '46'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/consumergroups/consumergroup13130eda?api-version=2017-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/consumergroups/consumergroup13130eda","name":"consumergroup13130eda","type":"Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups","location":"South
-        Central US","properties":{"createdAt":"2020-09-16T03:30:47.6021966Z","updatedAt":"2020-09-16T03:30:47.6021966Z","userMetadata":"New
-        consumergroup"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda","name":"authorizationrule13130eda","type":"Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules","location":"South
+        Central US","properties":{"rights":["Listen","Send"]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '534'
+      - '393'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:46 GMT
+      - Mon, 24 May 2021 18:15:02 GMT
       expires:
       - '-1'
       pragma:
@@ -735,58 +776,6 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"rights": ["Listen", "Send"]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '46'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda","name":"authorizationrule13130eda","type":"Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '456'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 03:30:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/CH3
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/CH3
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -796,7 +785,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
   response:
@@ -807,11 +796,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '419'
+      - '356'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:49 GMT
+      - Mon, 24 May 2021 18:15:03 GMT
       expires:
       - '-1'
       pragma:
@@ -842,7 +831,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
   response:
@@ -853,11 +842,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '456'
+      - '393'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:49 GMT
+      - Mon, 24 May 2021 18:15:03 GMT
       expires:
       - '-1'
       pragma:
@@ -888,23 +877,23 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/consumergroups/consumergroup13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/consumergroups/consumergroup13130eda","name":"consumergroup13130eda","type":"Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups","location":"South
-        Central US","properties":{"createdAt":"2020-09-16T03:30:47.622Z","updatedAt":"2020-09-16T03:30:47.622Z","userMetadata":"New
+        Central US","properties":{"createdAt":"2021-05-24T18:15:02.642Z","updatedAt":"2021-05-24T18:15:02.642Z","userMetadata":"New
         consumergroup"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '526'
+      - '463'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:50 GMT
+      - Mon, 24 May 2021 18:15:03 GMT
       expires:
       - '-1'
       pragma:
@@ -935,7 +924,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/networkRuleSets/default?api-version=2017-04-01
   response:
@@ -946,11 +935,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '740'
+      - '614'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:51 GMT
+      - Mon, 24 May 2021 18:15:04 GMT
       expires:
       - '-1'
       pragma:
@@ -981,22 +970,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda","name":"eventhub13130eda","type":"Microsoft.EventHub/Namespaces/EventHubs","location":"South
-        Central US","properties":{"messageRetentionInDays":4,"partitionCount":4,"status":"Active","createdAt":"2020-09-16T03:30:21.01","updatedAt":"2020-09-16T03:30:48.827","partitionIds":["0","1","2","3"],"captureDescription":{"enabled":true,"encoding":"Avro","destination":{"name":"EventHubArchive.AzureBlockBlob","properties":{"storageAccountResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda","blobContainer":"container","archiveNameFormat":"{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}},"intervalInSeconds":120,"sizeLimitInBytes":10485763}}}'
+        Central US","properties":{"messageRetentionInDays":4,"partitionCount":4,"status":"Active","createdAt":"2021-05-24T18:14:41.4","updatedAt":"2021-05-24T18:15:03.59","partitionIds":["0","1","2","3"],"captureDescription":{"enabled":true,"encoding":"Avro","destination":{"name":"EventHubArchive.AzureBlockBlob","properties":{"storageAccountResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount13130eda","blobContainer":"container","archiveNameFormat":"{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}},"intervalInSeconds":120,"sizeLimitInBytes":10485763}}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1079'
+      - '951'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:51 GMT
+      - Mon, 24 May 2021 18:15:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1027,22 +1016,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda","name":"namespace13130eda","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2020-09-16T03:29:13.98Z","updatedAt":"2020-09-16T03:30:01.053Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Active"}}'
+        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2021-05-24T18:12:52.43Z","updatedAt":"2021-05-24T18:13:55.483Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Active"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '766'
+      - '703'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:51 GMT
+      - Mon, 24 May 2021 18:15:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1077,12 +1066,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda/regenerateKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=KmUiElEE9ZN2NDkMXVAiOn8QTMLwXLjhFHKYjmPQKGg=;EntityPath=eventhub13130eda","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=J6drTin5nVTlOMPiyC0EWqcQR5XIXc6VQvl/UPmSvZ4=;EntityPath=eventhub13130eda","primaryKey":"KmUiElEE9ZN2NDkMXVAiOn8QTMLwXLjhFHKYjmPQKGg=","secondaryKey":"J6drTin5nVTlOMPiyC0EWqcQR5XIXc6VQvl/UPmSvZ4=","keyName":"authorizationrule13130eda"}'
+      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=tc4aigG9lrJWOJMTZfMC9qYKCvkvLPkArFra3ttbxPA=;EntityPath=eventhub13130eda","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=FeIJ5LNGBWlnlBwSdnKKTs+JX68cIHVttA7RLRsb2Fw=;EntityPath=eventhub13130eda","primaryKey":"tc4aigG9lrJWOJMTZfMC9qYKCvkvLPkArFra3ttbxPA=","secondaryKey":"FeIJ5LNGBWlnlBwSdnKKTs+JX68cIHVttA7RLRsb2Fw=","keyName":"authorizationrule13130eda"}'
     headers:
       cache-control:
       - no-cache
@@ -1091,7 +1080,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:53 GMT
+      - Mon, 24 May 2021 18:15:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1126,12 +1115,12 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda/listKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=KmUiElEE9ZN2NDkMXVAiOn8QTMLwXLjhFHKYjmPQKGg=;EntityPath=eventhub13130eda","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=J6drTin5nVTlOMPiyC0EWqcQR5XIXc6VQvl/UPmSvZ4=;EntityPath=eventhub13130eda","primaryKey":"KmUiElEE9ZN2NDkMXVAiOn8QTMLwXLjhFHKYjmPQKGg=","secondaryKey":"J6drTin5nVTlOMPiyC0EWqcQR5XIXc6VQvl/UPmSvZ4=","keyName":"authorizationrule13130eda"}'
+      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=tc4aigG9lrJWOJMTZfMC9qYKCvkvLPkArFra3ttbxPA=;EntityPath=eventhub13130eda","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=FeIJ5LNGBWlnlBwSdnKKTs+JX68cIHVttA7RLRsb2Fw=;EntityPath=eventhub13130eda","primaryKey":"tc4aigG9lrJWOJMTZfMC9qYKCvkvLPkArFra3ttbxPA=","secondaryKey":"FeIJ5LNGBWlnlBwSdnKKTs+JX68cIHVttA7RLRsb2Fw=","keyName":"authorizationrule13130eda"}'
     headers:
       cache-control:
       - no-cache
@@ -1140,7 +1129,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:30:54 GMT
+      - Mon, 24 May 2021 18:15:05 GMT
       expires:
       - '-1'
       pragma:
@@ -1177,12 +1166,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda/regenerateKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=Ttj7CbtNRfJvDUkRTgrwx63wTH9UmFYhz6pARFz3zRM=","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=8Y/d/jMih48rhVIj9WrayqEM0Sx+4iRxvLzHNW1coxM=","primaryKey":"Ttj7CbtNRfJvDUkRTgrwx63wTH9UmFYhz6pARFz3zRM=","secondaryKey":"8Y/d/jMih48rhVIj9WrayqEM0Sx+4iRxvLzHNW1coxM=","keyName":"authorizationrule13130eda"}'
+      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=KKUQ4pUNectaumr3/S8ZQem0ALaE/n4X1jRK/Qpy6QM=","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=EORDLjtnPz0L+ivwNGKNAlUaFooW+Fy6ZzuoH2iWv10=","primaryKey":"KKUQ4pUNectaumr3/S8ZQem0ALaE/n4X1jRK/Qpy6QM=","secondaryKey":"EORDLjtnPz0L+ivwNGKNAlUaFooW+Fy6ZzuoH2iWv10=","keyName":"authorizationrule13130eda"}'
     headers:
       cache-control:
       - no-cache
@@ -1191,7 +1180,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:31:00 GMT
+      - Mon, 24 May 2021 18:15:12 GMT
       expires:
       - '-1'
       pragma:
@@ -1226,12 +1215,12 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda/listKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=Ttj7CbtNRfJvDUkRTgrwx63wTH9UmFYhz6pARFz3zRM=","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=8Y/d/jMih48rhVIj9WrayqEM0Sx+4iRxvLzHNW1coxM=","primaryKey":"Ttj7CbtNRfJvDUkRTgrwx63wTH9UmFYhz6pARFz3zRM=","secondaryKey":"8Y/d/jMih48rhVIj9WrayqEM0Sx+4iRxvLzHNW1coxM=","keyName":"authorizationrule13130eda"}'
+      string: '{"primaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=KKUQ4pUNectaumr3/S8ZQem0ALaE/n4X1jRK/Qpy6QM=","secondaryConnectionString":"Endpoint=sb://namespace13130eda.servicebus.windows.net/;SharedAccessKeyName=authorizationrule13130eda;SharedAccessKey=EORDLjtnPz0L+ivwNGKNAlUaFooW+Fy6ZzuoH2iWv10=","primaryKey":"KKUQ4pUNectaumr3/S8ZQem0ALaE/n4X1jRK/Qpy6QM=","secondaryKey":"EORDLjtnPz0L+ivwNGKNAlUaFooW+Fy6ZzuoH2iWv10=","keyName":"authorizationrule13130eda"}'
     headers:
       cache-control:
       - no-cache
@@ -1240,7 +1229,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:31:01 GMT
+      - Mon, 24 May 2021 18:15:13 GMT
       expires:
       - '-1'
       pragma:
@@ -1277,22 +1266,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda?api-version=2017-04-01
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda","name":"namespace13130eda","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag3":"value3","tag4":"value4"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Updating","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2020-09-16T03:29:13.98Z","updatedAt":"2020-09-16T03:31:02.723Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Activating"}}'
+        Central US","tags":{"tag3":"value3","tag4":"value4"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Updating","metricId":"00000000-0000-0000-0000-000000000000:namespace13130eda","createdAt":"2021-05-24T18:12:52.43Z","updatedAt":"2021-05-24T18:15:14.58Z","serviceBusEndpoint":"https://namespace13130eda.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '769'
+      - '705'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:31:06 GMT
+      - Mon, 24 May 2021 18:15:15 GMT
       expires:
       - '-1'
       pragma:
@@ -1329,7 +1318,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/checkNameAvailability?api-version=2017-04-01
   response:
@@ -1343,7 +1332,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:31:07 GMT
+      - Mon, 24 May 2021 18:15:15 GMT
       expires:
       - '-1'
       pragma:
@@ -1378,7 +1367,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
   response:
@@ -1390,7 +1379,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 03:31:08 GMT
+      - Mon, 24 May 2021 18:15:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1421,7 +1410,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda/consumergroups/consumergroup13130eda?api-version=2017-04-01
   response:
@@ -1433,7 +1422,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 03:31:08 GMT
+      - Mon, 24 May 2021 18:15:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1464,7 +1453,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/authorizationRules/authorizationrule13130eda?api-version=2017-04-01
   response:
@@ -1476,7 +1465,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 03:31:15 GMT
+      - Mon, 24 May 2021 18:15:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1507,7 +1496,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/eventhubs/eventhub13130eda?api-version=2017-04-01
   response:
@@ -1519,7 +1508,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 03:31:16 GMT
+      - Mon, 24 May 2021 18:15:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1550,7 +1539,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda?api-version=2017-04-01
   response:
@@ -1562,7 +1551,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 03:31:18 GMT
+      - Mon, 24 May 2021 18:15:42 GMT
       expires:
       - '-1'
       location:
@@ -1593,7 +1582,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace13130eda/operationresults/namespace13130eda?api-version=2017-04-01
   response:
@@ -1605,7 +1594,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Sep 2020 03:31:48 GMT
+      - Mon, 24 May 2021 18:16:12 GMT
       expires:
       - '-1'
       pragma:

--- a/sdk/eventhub/azure-mgmt-eventhub/tests/recordings/test_cli_mgmt_eventhub_async.test_eventhub.yaml
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests/recordings/test_cli_mgmt_eventhub_async.test_eventhub.yaml
@@ -11,69 +11,23 @@ interactions:
       Content-Length:
       - '74'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-storage/5.0.0 Azure-SDK-For-Python
-      accept-language:
-      - en-US
+      - azsdk-python-azure-mgmt-storage/18.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157?api-version=2019-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157?api-version=2021-04-01
   response:
     body:
-      string: ''
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157","name":"storageaccount75861157","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2021-05-24T18:06:01.0574808Z","key2":"2021-05-24T18:06:01.0574808Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-24T18:06:01.0574808Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-24T18:06:01.0574808Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-05-24T18:06:00.9324882Z","primaryEndpoints":{"blob":"https://storageaccount75861157.blob.core.windows.net/","queue":"https://storageaccount75861157.queue.core.windows.net/","table":"https://storageaccount75861157.table.core.windows.net/","file":"https://storageaccount75861157.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '0'
-      content-type:
-      - text/plain; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 03:32:05 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/5bafcb9e-1204-439c-976d-2ff61b898607?monitor=true&api-version=2019-04-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-storage/5.0.0 Azure-SDK-For-Python
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/5bafcb9e-1204-439c-976d-2ff61b898607?monitor=true&api-version=2019-04-01
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157","name":"storageaccount75861157","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2020-09-16T03:32:06.2490774Z"},"blob":{"enabled":true,"lastEnabledTime":"2020-09-16T03:32:06.2490774Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-09-16T03:32:06.1396628Z","primaryEndpoints":{"blob":"https://storageaccount75861157.blob.core.windows.net/","queue":"https://storageaccount75861157.queue.core.windows.net/","table":"https://storageaccount75861157.table.core.windows.net/","file":"https://storageaccount75861157.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1156'
+      - '1261'
       content-type:
       - application/json
       date:
-      - Wed, 16 Sep 2020 03:32:24 GMT
+      - Mon, 24 May 2021 18:16:14 GMT
       expires:
       - '-1'
       pragma:
@@ -88,14 +42,16 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
     status:
       code: 200
       message: OK
 - request:
     body: '{"location": "eastus", "properties": {"addressSpace": {"addressPrefixes":
-      ["10.0.0.0/16"]}, "subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
-      "name": "subnet75861157"}], "enableDdosProtection": false, "enableVmProtection":
-      false}}'
+      ["10.0.0.0/16"]}, "subnets": [{"name": "subnet75861157", "properties": {"addressPrefix":
+      "10.0.0.0/24", "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
+      "Enabled"}}], "enableDdosProtection": false, "enableVmProtection": false}}'
     headers:
       Accept:
       - application/json
@@ -104,47 +60,42 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '241'
+      - '334'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
-      accept-language:
-      - en-US
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157?api-version=2019-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157?api-version=2021-02-01
   response:
     body:
-      string: "{\r\n  \"name\": \"virtualnetwork75861157\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157\"\
-        ,\r\n  \"etag\": \"W/\\\"05a7436d-44fb-4b25-ba53-6faf46fecc3d\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
-        ,\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n \
-        \   \"resourceGuid\": \"31efd706-4599-41ae-83ab-12ddbf4b8383\",\r\n    \"\
-        addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\
-        \r\n      ]\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\"\
-        : \"subnet75861157\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157\"\
-        ,\r\n        \"etag\": \"W/\\\"05a7436d-44fb-4b25-ba53-6faf46fecc3d\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\"\
-        : [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n  \
-        \        \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n        },\r\
-        \n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n    \
-        \  }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
-        : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
+      string: "{\r\n  \"name\": \"virtualnetwork75861157\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157\",\r\n
+        \ \"etag\": \"W/\\\"e7446f5f-edf5-463c-8bf2-ab5b9839db0f\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\":
+        \"e7af8093-4615-49e3-b2ac-31fca5870ade\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"subnet75861157\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157\",\r\n
+        \       \"etag\": \"W/\\\"e7446f5f-edf5-463c-8bf2-ab5b9839db0f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
+        [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/4384d76a-9a2a-46af-939d-1f341ea6a4b8?api-version=2019-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/50ff8cea-0efa-47e5-a831-dbcc3b902e87?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '1433'
+      - '1273'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:32:29 GMT
+      - Mon, 24 May 2021 18:16:17 GMT
       expires:
       - '-1'
       pragma:
@@ -157,9 +108,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ed3d3337-ea14-469d-93c1-a7a6444754a1
+      - 8ec6cc5f-4d8b-4258-bdd2-8add554d5ae5
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -167,16 +118,15 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/4384d76a-9a2a-46af-939d-1f341ea6a4b8?api-version=2019-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/50ff8cea-0efa-47e5-a831-dbcc3b902e87?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -188,7 +138,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:32:35 GMT
+      - Mon, 24 May 2021 18:16:21 GMT
       expires:
       - '-1'
       pragma:
@@ -205,7 +155,67 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f72d395d-5f51-4095-bdb6-5129d60f4d86
+      - 6e17e642-b163-44c6-a36a-f5a245f93ff3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"virtualnetwork75861157\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157\",\r\n
+        \ \"etag\": \"W/\\\"0431f421-97a2-4e96-b809-ec64fc8d9207\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"e7af8093-4615-49e3-b2ac-31fca5870ade\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"subnet75861157\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157\",\r\n
+        \       \"etag\": \"W/\\\"0431f421-97a2-4e96-b809-ec64fc8d9207\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
+        [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1275'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 May 2021 18:16:21 GMT
+      etag:
+      - W/"0431f421-97a2-4e96-b809-ec64fc8d9207"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 14312e32-fa50-4a53-9094-a50fb77a8056
     status:
       code: 200
       message: OK
@@ -219,39 +229,28 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
+      - azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157?api-version=2019-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157?api-version=2021-02-01
   response:
     body:
-      string: "{\r\n  \"name\": \"virtualnetwork75861157\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157\"\
-        ,\r\n  \"etag\": \"W/\\\"6a7919c1-0bd6-49f2-8dc4-dfd1a3c722fe\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
-        ,\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n\
-        \    \"resourceGuid\": \"31efd706-4599-41ae-83ab-12ddbf4b8383\",\r\n    \"\
-        addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\
-        \r\n      ]\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\"\
-        : \"subnet75861157\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157\"\
-        ,\r\n        \"etag\": \"W/\\\"6a7919c1-0bd6-49f2-8dc4-dfd1a3c722fe\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\"\
-        : [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n  \
-        \        \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n        },\r\
-        \n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n    \
-        \  }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
-        : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
+      string: "{\r\n  \"name\": \"subnet75861157\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157\",\r\n
+        \ \"etag\": \"W/\\\"0431f421-97a2-4e96-b809-ec64fc8d9207\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
+        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1435'
+      - '554'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 16 Sep 2020 03:32:35 GMT
+      - Mon, 24 May 2021 18:16:21 GMT
       etag:
-      - W/"6a7919c1-0bd6-49f2-8dc4-dfd1a3c722fe"
+      - W/"0431f421-97a2-4e96-b809-ec64fc8d9207"
       expires:
       - '-1'
       pragma:
@@ -268,62 +267,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e8029cd9-73d8-43a4-b286-79ae17c37989
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.10
-        msrest_azure/0.6.2 azure-mgmt-network/7.0.0 Azure-SDK-For-Python
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157?api-version=2019-09-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"subnet75861157\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157\"\
-        ,\r\n  \"etag\": \"W/\\\"6a7919c1-0bd6-49f2-8dc4-dfd1a3c722fe\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.0.0.0/24\",\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
-        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\
-        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '617'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 16 Sep 2020 03:32:36 GMT
-      etag:
-      - W/"6a7919c1-0bd6-49f2-8dc4-dfd1a3c722fe"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 7d923e15-fb3c-49e6-a836-3c6afe0828dd
+      - 12323b12-2820-45ed-b74e-9b40b028201d
     status:
       code: 200
       message: OK
@@ -338,18 +282,65 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157","name":"namespace75861157","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namespace75861157","createdAt":"2020-09-16T03:32:46.16Z","updatedAt":"2020-09-16T03:32:46.16Z","serviceBusEndpoint":"https://namespace75861157.servicebus.windows.net:443/","status":"Activating"}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9eyj0UdtkdfhJ9NslU2L9vqjR7u/ZPRRMaNv7zbrSTOti1VbVMvm
+        7nmW7RzsZOfb093Zwfb+Tjbbfjid5tv5brZ/f2ea3Z/cf3C3zptqXU/zz+tqvWruNldZOy9W223e
+        tHdXdXVZzPK6uftFMa2rpjpvx6eX+bL99npyFzg2hELeuF8f3D/4dHf3/gNCD58RSvjR/aq9XuGr
+        CMwXpnVDzcpqmmEg1PR1tW7n6Qm1qrMy/eo1fdtmFw1IRT93qcVlVq7zXfl8z/y99xFRhgaxymui
+        HzcvmuN1W50tz8uszU+X2aTMiXLnWdnko48W2btisV68mRMtLuardfvVsmjptZ3RR2+z87eZbd/W
+        a2pOkC+LhjAslhc0MS0GdVLn9AvmZ5G3dTE9o9Yf3WYiHsUoNRVoxy0B2dvZ293eub+9t/9m9+DR
+        7qeP9vbHD/Yf/BQ1W69mt2nW5PVlMc2frJvT5WxVFUu0n7ftqnl0tz+HY20+WTfjq2I5q66a8TJv
+        H+3v37sLYDTgNdHmo+NpW1zSRC0vPvolv+T/ASZKU1/CAgAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:32:47 GMT
+      date: Mon, 24 May 2021 18:16:25 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-HTTPAPI/2.0
+      server-sb: Service-Bus-Resource-Provider/CH3
+      strict-transport-security: max-age=31536000; includeSubDomains
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests: '49'
+    status:
+      code: 200
+      message: OK
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9eyj0UdtkdfhJ9NslU2L9vqjR7u/ZPRRMaNv7zbrSTOti1VbVMvm
+        7nmW7RzsZOfb093Zwfb+Tjbbfjid5tv5brZ/f2ea3Z/cf3C3zptqXU/zz+tqvWruNldZOy9W223e
+        tHdXdXVZzPK6uftFMa2rpjpvx6eX+bL99npyFzg2hELeuF8f3D/4dHf3/gNCD58RSvjR/aq9XuGr
+        CMwXpnVDzcpqmmEg1PR1tW7n6Qm1qrMy/eo1fdtmFw1IRT93qcVlVq7zXfl8z/y99xFRhgaxymui
+        HzcvmuN1W50tz8uszU+X2aTMiXLnWdnko48W2btisV68mRMtLuardfvVsmjptZ3RR2+z87eZbd/W
+        a2pOkC+LhjAslhc0MS0GdVLn9AvmZ5G3dTE9o9Yf3WYiHsUoNRVoxy0B2dvZ293eub+9t/9m9+DR
+        7qeP9vbHD/Yf/BQ1W69mt2nW5PVlMc2frJvT5WxVFUu0n7ftqnl0tz+HY20+WTfjq2I5q66a8TJv
+        H+3v37sLYDTgNdHmo+NpW1zSRC0vPvolv+T/ASZKU1/CAgAA
+    headers:
+      cache-control: no-cache
+      content-encoding: gzip
+      content-type: application/json; charset=utf-8
+      date: Mon, 24 May 2021 18:16:55 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
@@ -358,27 +349,35 @@ interactions:
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests: '47'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157","name":"namespace75861157","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:namespace75861157","createdAt":"2020-09-16T03:32:46.16Z","updatedAt":"2020-09-16T03:32:46.16Z","serviceBusEndpoint":"https://namespace75861157.servicebus.windows.net:443/","status":"Activating"}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9eyj0UdtkdfhJ9NslU2L9vqjR7u/ZPRRMaNv7zbrSTOti1VbVMvm
+        7nmW7RzsZOfb093Zwfb+Tjbbfjid5tv5brZ/f2ea3Z/cf3C3zptqXU/zz+tqvWruNldZOy9W223e
+        tHdXdXVZzPK6uftFMa2rpjpvx6eX+bL99npyFzg2hELeuF8f3D/4dHf3/gNCD58RSvjR/aq9XuGr
+        CMwXpnVDzcpqmmEg1PR1tW7n6Qm1qrMy/eo1fdtmFw1IRT93qcVlVq7zXfl8z/y99xFRhgaxymui
+        HzcvmuN1W50tz8uszU+X2aTMiXLnWdnko48W2btisV68mRMtLuardfvVsmjptZ3RR2+z87eZbd/W
+        a2pOkC+LhjAslhc0MS0G9XpNFM5n1IjA5W1dTM+o/Ue3mYpHMVpN65wAz45bArK3s7e7vXN/e2//
+        ze7Bo91PH+3tjx/sP/gparZezYaaPXi0uz9+eO8emjV5fVlM8yfr5nQ5W1XFEu3nbbtqHt3tz+JY
+        m0/WzfiqWM6qq2a8zNtH+/v37gIYDXlN1PnoeNoWl/lHv+SX/D+dIAaIwAIAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:33:18 GMT
+      date: Mon, 24 May 2021 18:17:25 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
@@ -390,56 +389,35 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
-  response:
-    body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157","name":"namespace75861157","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace75861157","createdAt":"2020-09-16T03:32:46.16Z","updatedAt":"2020-09-16T03:33:32.26Z","serviceBusEndpoint":"https://namespace75861157.servicebus.windows.net:443/","status":"Active"}}'
-    headers:
-      cache-control: no-cache
-      content-encoding: gzip
-      content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:33:49 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
-      strict-transport-security: max-age=31536000; includeSubDomains
-      transfer-encoding: chunked
-      vary: Accept-Encoding
-      x-content-type-options: nosniff
-    status:
-      code: 200
-      message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/messagingplan?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/messagingplan","name":"2","type":"Microsoft.EventHub/MessagingSKUPlan","location":null,"tags":null,"properties":{"sku":2,"selectedEventHubUnit":1,"updatedAt":"2020-09-16T03:32:46.5659797Z","revision":1}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJKv3dZBfF8mJVZsuPRh+hBSG4R7+21yv8GoH4hXnp9e/11Ut5r6ymGQbz0aPluizp5eyiMb8T
+        dqu8boucPvnFHzVv1x892ht91ORlPm3zmYH61bJoP3q0O/povZpl9Pkx/fXR3s7e7vbO/e29/Te7
+        B492P32092C89+DTgwd7n/4U9Vrnl0XDvdJ7uQJ6WVc01obQA0jqc+eX/JL/B9QEIml4AQAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:33:49 GMT
+      date: Mon, 24 May 2021 18:17:26 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -447,85 +425,102 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/messagingplan?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/messagingplan?api-version=2017-04-01
 - request:
-    body: 'b''b\''{"properties": {"messageRetentionInDays": 4, "partitionCount": 4,
-      "status": "Active", "captureDescription": {"enabled": true, "encoding": "Avro",
-      "intervalInSeconds": 120, "sizeLimitInBytes": 10485763, "destination": {"name":
-      "EventHubArchive.AzureBlockBlob", "properties": {"storageAccountResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157",
-      "blobContainer": "container", "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}}}}}\'''''
+    body: '{"properties": {"messageRetentionInDays": 4, "partitionCount": 4, "status":
+      "Active", "captureDescription": {"enabled": true, "encoding": "Avro", "intervalInSeconds":
+      120, "sizeLimitInBytes": 10485763, "destination": {"name": "EventHubArchive.AzureBlockBlob",
+      "properties": {"storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157",
+      "blobContainer": "container", "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}}}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '656'
+      - '593'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157","name":"eventhub75861157","type":"Microsoft.EventHub/Namespaces/EventHubs","location":"South
-        Central US","properties":{"messageRetentionInDays":4,"partitionCount":4,"status":"Active","createdAt":"2020-09-16T03:33:53.07Z","updatedAt":"2020-09-16T03:33:53.37Z","partitionIds":["0","1","2","3"],"captureDescription":{"enabled":true,"encoding":"Avro","destination":{"name":"EventHubArchive.AzureBlockBlob","properties":{"storageAccountResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157","blobContainer":"container","archiveNameFormat":"{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}},"intervalInSeconds":120,"sizeLimitInBytes":10485763}}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJao5Wc8LG/ma++mj0EZoTtpFv2usVvon09oLe4S6au+azhl4oq2mGwdJLr6t1O09P6Ls6K9Ov
+        XtO3hP8qr9sibz569Is/IgBNdpG/yltqQ++cLZ9m1/TNPjXMqBU+O6nWy5Y/atqsXdO3Hx1P2+Iy
+        J2jTOs/afHZM33+0t7O3u71zf3tv/83uwaPdB4/u7Yx39u79FDVbr2Ybmx3so5Xt8WxGnXzvox36
+        bJf+v0f/v/fR96m3bNWu6/xpbicUY8iX2aTMaa7bep2P6M9pNSuWF9TV8WVd0bszmrdiqTT5xYbU
+        hmTH9XROgxkf/4BAPyHivaV/JvRaSKmmrWqi1PF0CnK8Ug45o25/KCz2Wrq/G6JBL8rfmfztsc2E
+        BnFSLdusWOY1ITm1v48+ymTI4J9nVb3IMC2/GH8xN/2Su7/Y0IZ+fekmhf76ffKsph9fELA5/SRm
+        oX+/TSOhH18Uy3WLt1/n1Nnsl3z0S37J6KNi2eb1ZVaeLeVTouXu3g6xUvGD/HmxKNqz5ZNrGjV9
+        vLN/cP/Bp/d+yS/5Jf8Pk38jObsDAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:33:53 GMT
+      date: Mon, 24 May 2021 18:17:31 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-writes: '1197'
+      x-ms-ratelimit-remaining-subscription-writes: '1199'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
 - request:
-    body: 'b''b\''{"properties": {"defaultAction": "Deny", "virtualNetworkRules":
-      [{"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157"},
+    body: '{"properties": {"defaultAction": "Deny", "virtualNetworkRules": [{"subnet":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157"},
       "ignoreMissingVnetServiceEndpoint": true}], "ipRules": [{"ipMask": "1.1.1.1",
-      "action": "Allow"}]}}\'''''
+      "action": "Allow"}]}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '419'
+      - '356'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default","name":"default","type":"Microsoft.EventHub/Namespaces/NetworkRuleSets","location":"South
-        Central US","properties":{"defaultAction":"Deny","virtualNetworkRules":[{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157"},"ignoreMissingVnetServiceEndpoint":true}],"ipRules":[{"ipMask":"1.1.1.1","action":"Allow"}]}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJ6jJvr6r67at1mb/O2+buLD/P1mX70egjtCVU3Qft9QofRHp4QU0ZbHP3RQiPXiuraYZh0quv
+        q3U7T0/orTor069e07eE+Sqv2yJvPnr0i01nx1N94Wm+vKZGl0XdrrPSg02tv/eLPyIqEv548YdG
+        VcXhbohSY/4mdPC3JS9hRB8RXP5pPv7ol4w+Ki6WVZ1/UTRNsbz4SfrydV5fFtP8dDlbVcWSRtXW
+        6/yXfJ9artyIi9UXWfOWxro75v+IOJkh1nFZVlcf/ZLv/5Jf8v8AtpgovGYCAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:10 GMT
+      date: Mon, 24 May 2021 18:17:43 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-writes: '1196'
+      x-ms-ratelimit-remaining-subscription-writes: '1198'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default?api-version=2017-04-01
 - request:
     body: '{"properties": {"rights": ["Listen", "Send"]}}'
     headers:
@@ -536,31 +531,37 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157","name":"authorizationrule75861157","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJarZu51Vd/CADJq/WJTUKPqrpI9P4o9FHAED4b2rSXq/QJILIC3qZe2/uHvsAuFt6s6ym/De9
+        /bqiBukJvVhnZfrVa/qWxrjK67agpo9+8Ud1cTFv6bfvffS8aNp8SQ1e58vZR9//Jb/k/wFwLp8T
+        ZAEAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:17 GMT
+      date: Mon, 24 May 2021 18:17:50 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-writes: '1195'
+      x-ms-ratelimit-remaining-subscription-writes: '1197'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
 - request:
     body: '{"properties": {"userMetadata": "New consumergroup"}}'
     headers:
@@ -571,32 +572,37 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157","name":"consumergroup75861157","type":"Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups","location":"South
-        Central US","properties":{"createdAt":"2020-09-16T03:34:19.4735733Z","updatedAt":"2020-09-16T03:34:19.4735733Z","userMetadata":"New
-        consumergroup"}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJao5Wc8LG/ma/mhJq60VeX0iHwZ+m0UejjwCThjT0dXu9wtcRvF7Qi4xMc9d81tw9UTAySnq/
+        rKYZqEQwXlfrdp6eUNM6K9OvXtO3NPBVXrdF3nz06Bd/NK3zrM1nxy013tvZ293eub+9t/9m9+DR
+        7oNH93fHB7u7n+4cHPwUvbhezW7dtMnrL/I2oxcyav0iv0qDwX70S37J/wN4G4C/1wEAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:18 GMT
+      date: Mon, 24 May 2021 18:17:51 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-writes: '1194'
+      x-ms-ratelimit-remaining-subscription-writes: '1196'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
 - request:
     body: '{"properties": {"rights": ["Listen", "Send"]}}'
     headers:
@@ -607,53 +613,65 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157","name":"authorizationrule75861157","type":"Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJao5Wc8LG/ma/ytbtvKqLH2RA8tW6pPeDj2r6yDT+aPQRYNPQNjVpr1doEsHxBb3MiDV3zWfN
+        3WMfFCNAMMpqyn8TnNcVNUhPqHmdlelXr+lbIsQqr9uCmj76xR/VxcW8pd++99HzomnzJTV4nS9n
+        H33/l/yS/wet1i7RiQEAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:19 GMT
+      date: Mon, 24 May 2021 18:17:52 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-writes: '1193'
+      x-ms-ratelimit-remaining-subscription-writes: '1195'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157","name":"authorizationrule75861157","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJarZu51Vd/CADJq/WJTUKPqrpI9P4o9FHAED4b2rSXq/QJILIC3qZe2/uHvsAuFt6s6ym/De9
+        /bqiBukJvVhnZfrVa/qWxrjK67agpo9+8Ud1cTFv6bfvffS8aNp8SQ1e58vZR9//Jb/k/wFwLp8T
+        ZAEAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:20 GMT
+      date: Mon, 24 May 2021 18:17:53 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -661,29 +679,35 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157","name":"authorizationrule75861157","type":"Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJao5Wc8LG/ma/ytbtvKqLH2RA8tW6pPeDj2r6yDT+aPQRYNPQNjVpr1doEsHxBb3MiDV3zWfN
+        3WMfFCNAMMpqyn8TnNcVNUhPqHmdlelXr+lbIsQqr9uCmj76xR/VxcW8pd++99HzomnzJTV4nS9n
+        H33/l/yS/wet1i7RiQEAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:20 GMT
+      date: Mon, 24 May 2021 18:17:54 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -691,30 +715,35 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157","name":"consumergroup75861157","type":"Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups","location":"South
-        Central US","properties":{"createdAt":"2020-09-16T03:34:19.482Z","updatedAt":"2020-09-16T03:34:19.482Z","userMetadata":"New
-        consumergroup"}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJao5Wc8LG/ma/mhJq60VeX0iHwZ+m0UejjwCThjT0dXu9wtcRvF7Qi4xMc9d81tw9UTAySnq/
+        rKYZqEQwXlfrdp6eUNM6K9OvXtO3NPBVXrdF3nz06Bd/NK3zrM1nxy013tvZ293eub+9t/9m9+DR
+        7oNH93fHB7uf/hS9tF7NbtWsyesv8jajxhm1fJFfpcEgP/olv+T/Af5MWMfPAQAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:21 GMT
+      date: Mon, 24 May 2021 18:17:54 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -722,29 +751,35 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157","name":"authorizationrule75861157","type":"Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}]}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMt2Dnay8+3p7uxge38nm20/nE7z7Xw327+/M83u
+        T+4/uFvnTbWup/nndbVeNXebq6ydF6vtNm/au6u6uixmed3c/aKY1lVTnbfj08t82X57Pbm7zBZ5
+        s8qmeeN+fXD/4NPdXYKao9WcsLG/2a+ydTuv6uIHGZB8tS7p/eCjmj4yjT8afQTYNLRNTdrrFZpE
+        cHxBLzNizV3zWXP32AfFCBCMspry3wTndUUN0hNqXmdl+tVr+pYIscrrtqCmj37xR3VxMW/pt+99
+        9Lxo2nxJDV7ny9lH3/8lv+T7v+T/AaETFHCVAQAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:21 GMT
+      date: Mon, 24 May 2021 18:17:54 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -752,31 +787,36 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/$Default","name":"$Default","type":"Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups","location":"South
-        Central US","properties":{"createdAt":"2020-09-16T03:33:53.122Z","updatedAt":"2020-09-16T03:33:53.122Z"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157","name":"consumergroup75861157","type":"Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups","location":"South
-        Central US","properties":{"createdAt":"2020-09-16T03:34:19.478Z","updatedAt":"2020-09-16T03:34:19.478Z","userMetadata":"New
-        consumergroup"}}]}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMt2Dnay8+3p7uxge38nm20/nE7z7Xw327+/M83u
+        T+4/uFvnTbWup/nndbVeNXebq6ydF6vtNm/au6u6uixmed3c/aKY1lVTnbfj08t82X57Pbm7zBZ5
+        s8qmeeN+fXD/4NPdXYKao9WcsLG/2a+mhNp6kdcX0uHv9jQ/z9Zl+9HoI4ChUXiftNcrfBLp/QW1
+        5S6bu+az5u6Jgpax0PtlNc1AC4Lxulq38/SEmtZZmX71mr6l4a3yui3y5qNHv/ijaZ1nbT47bqnx
+        3s7e7vbO/e29/Te7B492Hzy6tzO+t7f7U/TSejW7udkv+SWj/w9PSfCnaURDB0wa0tDX/6+ZrPu7
+        44O9G+fKtWry+ou8zahtRg1f5FdpMESaze//kv8HM/p5tWwDAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:21 GMT
+      date: Mon, 24 May 2021 18:17:55 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -785,29 +825,36 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default","name":"default","type":"Microsoft.EventHub/Namespaces/NetworkRuleSets","location":"South
-        Central US","properties":{"defaultAction":"Deny","virtualNetworkRules":[{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157"},"ignoreMissingVnetServiceEndpoint":true}],"ipRules":[{"ipMask":"1.1.1.1","action":"Allow"}]}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJ6jJvr6r67at1mb/O2+buLD/P1mX70egjtCVU3Qft9QofRHp4QU0ZbHP3RQiPXiuraYZh0quv
+        q3U7T0/orTor069e07eE+Sqv2yJvPnr0i01nx1N94Wm+vKZGl0XdrrPSg02tv/eLPyIqEv548YOp
+        enFLqioOd0OUGvM3oYO/LXkJI/qI4PJP8/FHv2T0UXGxrOr8i6JpiuXFT9KXr/P6spjmp8vZqiqW
+        NKq2Xue/5PvUcuVGXKy+yJq3NNbdMf9HxMkMsY7Lsrr66Jd8/5f8kv8HjrLXW2YCAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:23 GMT
+      date: Mon, 24 May 2021 18:18:16 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -815,29 +862,40 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157","name":"eventhub75861157","type":"Microsoft.EventHub/Namespaces/EventHubs","location":"South
-        Central US","properties":{"messageRetentionInDays":4,"partitionCount":4,"status":"Active","createdAt":"2020-09-16T03:33:53.07","updatedAt":"2020-09-16T03:34:20.507","partitionIds":["0","1","2","3"],"captureDescription":{"enabled":true,"encoding":"Avro","destination":{"name":"EventHubArchive.AzureBlockBlob","properties":{"storageAccountResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157","blobContainer":"container","archiveNameFormat":"{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}},"intervalInSeconds":120,"sizeLimitInBytes":10485763}}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMs2znYyc63p7uzg+39nWy2/XA6zbfz3Wz//s40uz+5/+BunTfVup7m
+        n9fVetXcba6ydl6sttu8ae+u6uqymOV1c/eLYlpXTXXejk8v82X77fXk7jJb5M0qm+aN+/XB/YNP
+        d3cJao5Wc8LG/ma++mj0EZoTtpFv2usVvon09oLe4S6au+azhl4oq2mGwdJLr6t1O09P6Ls6K9Ov
+        XtO3hP8qr9sibz569Is/IgBNdpG/yltqQ++cLZ9m1/TNPjXMqBU+O6nWy5Y/atqsXdO3Hx1P2+Iy
+        J2jTOs/afHZM33+0t7O3u71zf3tv/83uwaPdB4/u7Yx39u5Rq/VqNtzq/r3xDhrZ/s5m1MX3Ptqh
+        z3bp/3v0/3sffZ/6ylbtus6f5nY6MYJ8mU3KnGa6rdf5iP6cVrNieUE9HV/WFb07o1krlkqRX2wI
+        bQh2XE/nNJTx8Q8I9BMi3Vv6Z0KvhXRq2qomOh1PpyDGK+WPM+r2h8Jgr6X7uyEa9KL8ncnfHtNM
+        aBAn1bLNimVeE5JT+/voo0yGDO55VtWLDLPyi/EX89IvufuLDW3o15duUuiv3yfPavrxBQGb009i
+        Ffr32zQS+vFFsVy3ePt1Tp3NfslHv+SXjD4qlm1eX2bl2VI+JVru7u0QIxU/yJ8Xi6I9Wz65plHT
+        xzv7B/cffHrvl/ySX/L/AF3ieR+5AwAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:23 GMT
+      date: Mon, 24 May 2021 18:18:24 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -845,30 +903,36 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/RootManageSharedAccessKey","name":"RootManageSharedAccessKey","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Manage","Send"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157","name":"authorizationrule75861157","type":"Microsoft.EventHub/Namespaces/AuthorizationRules","location":"South
-        Central US","properties":{"rights":["Listen","Send"]}}]}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMt2Dnay8+3p7uxge38nm20/nE7z7Xw327+/M83u
+        T+4/uFvnTbWup/nndbVeNXebq6ydF6vtNm/au6u6uixmed3c/aKY1lVTnbfj08t82X57Pbm7zBZ5
+        s8qmeeN+fXD/4NPdXYKardt5VRc/yIDJq3VJjV5VVftFtswu8tfzrM5nx4RK0/xe+fVHo48AgPDf
+        1KS9XqFJBJEX9DL33tw97nVLb5bVlP+mt19X1CA9oRfrrEy/ek3f0hhXed0W1PTRL/6oLi7mLf32
+        vY+eF02bL6mBIES/vM6Xs4++/0t+yej/C9QOPqrpI9OYBgIAhP+mJj9n1DZE/v4v+X8Al2Dw4N4C
+        AAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:24 GMT
+      date: Mon, 24 May 2021 18:18:27 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -876,29 +940,37 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets/default","name":"default","type":"Microsoft.EventHub/Namespaces/NetworkRuleSets","location":"South
-        Central US","properties":{"defaultAction":"Deny","virtualNetworkRules":[{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rgname/providers/Microsoft.Network/virtualNetworks/virtualnetwork75861157/subnets/subnet75861157"},"ignoreMissingVnetServiceEndpoint":true}],"ipRules":[{"ipMask":"1.1.1.1","action":"Allow"}]}}]}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMt2Dnay8+3p7uxge38nm20/nE7z7Xw327+/M83u
+        T+4/uFvnTbWup/nndbVeNXebq6ydF6vtNm/au6u6uixmed3c/aKY1lVTnbfj08t82X57Pbm7zBZ5
+        s8qmeeN+fXD/4NPdXYK6zNurqn77al3mr/O2uTvLz7N12X40+ghtCVX3QXu9wgeRHl5QUwbb3H0R
+        wqPXymqaYZj06utq3c7TE3qrzsr0q9f0LWG+yuu2yJuPHv1i09nxVF94mi+vqdFlUbfrrPRgU2ui
+        JVGR8MeLH0zVi1tSVXG4G6LUmL8JHfxtyUsY0UcEl3+ajz/6JaOPiotlVedfFE1TLC9+kr58ndeX
+        xTQ/Xc5WVbGkUbX1Ov8l36eWKzfiYvVF1rylse6O+T8iTmaIdVyW1dVHv+T7v+SXfP+X/D/8cnRl
+        cgIAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:25 GMT
+      date: Mon, 24 May 2021 18:18:29 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -906,29 +978,40 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/networkRuleSets?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157","name":"eventhub75861157","type":"Microsoft.EventHub/Namespaces/EventHubs","location":"South
-        Central US","properties":{"messageRetentionInDays":4,"partitionCount":4,"status":"Active","createdAt":"2020-09-16T03:33:53.07","updatedAt":"2020-09-16T03:34:20.507","partitionIds":["0","1","2","3"],"captureDescription":{"enabled":true,"encoding":"Avro","destination":{"name":"EventHubArchive.AzureBlockBlob","properties":{"storageAccountResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storageaccount75861157","blobContainer":"container","archiveNameFormat":"{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"}},"intervalInSeconds":120,"sizeLimitInBytes":10485763}}}]}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMt2Dnay8+3p7uxge38nm20/nE7z7Xw327+/M83u
+        T+4/uFvnTbWup/nndbVeNXebq6ydF6vtNm/au6u6uixmed3c/aKY1lVTnbfj08t82X57Pbm7zBZ5
+        s8qmeeN+fXD/4NPdXYKao9WcsLG/ma8+Gn2E5oRt5Jv2eoVvIr29oHe4i+au+ayhF8pqmmGw9NLr
+        at3O0xP6rs7K9KvX9C3hv8rrtsibjx794o8IQJNd5K/yltrQO2fLp9k1fbNPDTNqhc9OqvWy5Y+a
+        NmvX9O1Hx9O2uMwJ2rTOszafHdP3H+3t7O1u79zf3tt/s3vwaPfBo3s74529e9RqvZoNt7p/b7yD
+        Rra/sxl18b2PduizXfr/Hv3/3kffp76yVbuu86e5nU6MIF9mkzKnmW7rdT6iP6fVrFheUE/Hl3VF
+        785o1oqlUuQXG0Ibgh3X0zkNZXz8AwL9hEj3lv6Z0GshnZq2qolOx9MpiPFK+eOMuv2hMNhr6f5u
+        iAa9KH9n8rfHNBMaxEm1bLNimdeE5NT+PvookyGDe55V9SLDrPxi/MW89Evu/mJDG/r1pZsU+uv3
+        ybOafnxBwOb0k1iF/v02jYR+fFEs1y3efp1TZ7Nf8tEv+SWjj4plm9ckkGdL+ZRoubu3Q4xU/CB/
+        XiyK9mz55JpGTR/v7B/cf/DpvV/yS37J93/J/wOAF6AzxQMAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:26 GMT
+      date: Mon, 24 May 2021 18:18:30 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -937,29 +1020,38 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157","name":"namespace75861157","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace75861157","createdAt":"2020-09-16T03:32:46.16Z","updatedAt":"2020-09-16T03:33:32.26Z","serviceBusEndpoint":"https://namespace75861157.servicebus.windows.net:443/","status":"Active"}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9eyj0UdtkdfhJ9NslU2L9vqjR7u/ZPRRMaNv7zbrSTOti1VbVMvm
+        7nmW7RzsZOfb093Zwfb+Tjbbfjid5tv5brZ/f2ea3Z/cf3C3zptqXU/zz+tqvWruNldZOy9W223e
+        tHdXdXVZzPK6uftFMa2rpjpvx6eX+bL99npyFzg2hELeuF8f3D/4dHf3/gNCD58RSvjR/aq9XuGr
+        CMwXpnVDzcpqmmEg1PR1tW7n6Qm1qrMy/eo1fdtmFw1IRT93qcVlVq7zXfl8z/y99xFRhgaxymui
+        HzcvmuN1W50tz8uszU+X2aTMiXLnWdnko48W2btisV68mRMtLuardfvVsmjptZ3RR2+z87eZbd/W
+        a2pOkC+LhjAslhc0MS0G9XpNFM5n1IjA5W1dTM+o/Ue3mYpHMVpN65wAz45bArK3s7e7vXN/e2//
+        ze7Bo91PH+3tjx/sP/gparZezYaaPXi0uz9+eO8emjV5fVlM8yfr5nQ5W1XFEu3nbbtqHt3tz+JY
+        m0/WzfiqWM6qq2a8zNtH+/v37gIYDXlN1PnoeNoWl/lHv+SX/D+dIAaIwAIAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:26 GMT
+      date: Mon, 24 May 2021 18:18:31 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -967,29 +1059,46 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157","name":"namespace75861157","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace75861157","createdAt":"2020-09-16T03:32:46.16Z","updatedAt":"2020-09-16T03:33:32.26Z","serviceBusEndpoint":"https://namespace75861157.servicebus.windows.net:443/","status":"Active"}}]}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2cfjT5qi7wOP5lmq2xatNcfPdr9JaOPihl9e7dZ
+        T5ppXazaolo2d8+zbOdgJzvfnu7ODrb3d7LZ9sPpNN/Od7P9+zvT7P7k/oO7dd5U63qaf15X61Vz
+        t7nK2nmx2m7zpr27qqvLYpbXzd0vimldNdV5Oz69zJftt9eTu8CxIRTy8KXtHA3mhAjhiDaE1+D3
+        7fUK30egv6A3BTo1K6tphiFR09OsadOvXtOHbXbREK1o7ITmKq/bgtoS7YrmeN1WZ8vzMmvz02U2
+        KXOizXlWNvnoo0X2rlisF2/mNNqL+WrdfrUsWnptZ/TR2+z8bWbbt/WamhPky6KhnovlBZG+BbKv
+        10TDfEaNCFze1sX0jNp/dBtiPxokxLTOCfrsuCVIezt7O9u7e9u7n77Z2320s/tob2+8u3/vp6jZ
+        ejUbarb3aHd3vPcQrZq8viym+ZN1c7qcrapiiebztl01j+4OzNVY35msm/FVsZxVV814mbeP9vfv
+        3QVEGvuayPTR8bQtLvOPfskvGf1/lVfl1z28s59PPt29n+eEID4lpPCj/+X7c+nrat3O0xNqVWdl
+        wK74uUstWOR35fM98/feR0QdGsj/R7g5Tq0OK+9u79zbvrf7Zm/v0d7Bo9298b17D8CkHVamZve3
+        9/bf7KLNo70H43ufcjPlyzgvRxD4cEZ+kjXFlJrSDICLzZ//L2Jh89IsX1ROhAlHtCG8Br9/f0b+
+        YalbbU+gv1EOHaREn0nvb+88eEPK9t5D4pXxzn0wX4xHpdX+zqN7u+P7u2ilHBdn0TgGH86lRB2j
+        XFthVO+T/xfxqvyKV4yEEn74kHDCj6b73fvz6Iuq/nmjbDvEirExlOiDR/fhEozvsT8QY2O0IlV7
+        79H+p+ODh7dVtX73P394eHFtWe/du+vrH/yA/llkbwlJNCLEhhu8Pzf3NC5+/v+FiRfXoBgPu0Oo
+        IU7+9NH9/Uf37o8f7jOPDrHyA/jJuw/GD8W5UNaMs/LAbL0nP48+yso2r5eEDsDRF6uqaRfFRc0z
+        +e7du7fXb/+/zPX21wf3Dz7d3b3/gNDDZ4QSfnS/en9O//nkJNPoPVoNMTsp5E8f7e2PH2xmdmr2
+        4NHuPjE7B4XKt3Fm73X/nmz+S37J93/J/wNPHcvzoRAAAA==
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:26 GMT
+      date: Mon, 24 May 2021 18:18:32 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -997,118 +1106,55 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/CentralUS","name":"Central
-        US","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Central
-        US","fullName":"Central US"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/EastUS","name":"East
-        US","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"East
-        US","fullName":"East US"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/EastUS2","name":"East
-        US 2","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"East
-        US 2","fullName":"East US 2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/NorthCentralUS","name":"North
-        Central US","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"North
-        Central US","fullName":"North Central US"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/SouthCentralUS","name":"South
-        Central US","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"South
-        Central US","fullName":"South Central US"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/WestUS","name":"West
-        US","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"West
-        US","fullName":"West US"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/WestUS2","name":"West
-        US 2","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"West
-        US 2","fullName":"West US 2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/WestCentralUS","name":"West
-        Central US","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"West
-        Central US","fullName":"West Central US"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/NorthEurope","name":"North
-        Europe","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"North
-        Europe","fullName":"North Europe"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/WestEurope","name":"West
-        Europe","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"West
-        Europe","fullName":"West Europe"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/EastAsia","name":"East
-        Asia","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"East
-        Asia","fullName":"East Asia"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/SoutheastAsia","name":"Southeast
-        Asia","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Southeast
-        Asia","fullName":"Southeast Asia"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/BrazilSouth","name":"Brazil
-        South","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Brazil
-        South","fullName":"Brazil South"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/JapanEast","name":"Japan
-        East","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Japan
-        East","fullName":"Japan East"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/JapanWest","name":"Japan
-        West","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Japan
-        West","fullName":"Japan West"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/CentralIndia","name":"Central
-        India","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Central
-        India","fullName":"Central India"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/SouthIndia","name":"South
-        India","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"South
-        India","fullName":"South India"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/WestIndia","name":"West
-        India","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"West
-        India","fullName":"West India"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/UKSouth2","name":"UK
-        South 2","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"UK
-        South 2","fullName":"UK South 2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/UKNorth","name":"UK
-        North","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"UK
-        North","fullName":"UK North"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/CanadaCentral","name":"Canada
-        Central","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Canada
-        Central","fullName":"Canada Central"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/CanadaEast","name":"Canada
-        East","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Canada
-        East","fullName":"Canada East"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/AustraliaEast","name":"Australia
-        East","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Australia
-        East","fullName":"Australia East"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/AustraliaSoutheast","name":"Australia
-        Southeast","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Australia
-        Southeast","fullName":"Australia Southeast"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/UKSouth","name":"UK
-        South","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"UK
-        South","fullName":"UK South"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/UKWest","name":"UK
-        West","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"UK
-        West","fullName":"UK West"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/EASTUS2EUAP","name":"EAST
-        US 2 EUAP","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"EAST
-        US 2 EUAP","fullName":"EAST US 2 EUAP"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/CentralUSEUAP","name":"Central
-        US EUAP","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Central
-        US EUAP","fullName":"Central US EUAP"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/KoreaCentral","name":"Korea
-        Central","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Korea
-        Central","fullName":"Korea Central"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/KoreaSouth","name":"Korea
-        South","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Korea
-        South","fullName":"Korea South"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/FranceCentral","name":"France
-        Central","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"France
-        Central","fullName":"France Central"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/FranceSouth","name":"France
-        South","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"France
-        South","fullName":"France South"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/AustraliaCentral","name":"Australia
-        Central","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Australia
-        Central","fullName":"Australia Central"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/AustraliaCentral2","name":"Australia
-        Central 2","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Australia
-        Central 2","fullName":"Australia Central 2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/UAECentral","name":"UAE
-        Central","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"UAE
-        Central","fullName":"UAE Central"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/UAENorth","name":"UAE
-        North","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"UAE
-        North","fullName":"UAE North"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/SouthAfricaWest","name":"South
-        Africa West","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"South
-        Africa West","fullName":"South Africa West"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/SouthAfricaNorth","name":"South
-        Africa North","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"South
-        Africa North","fullName":"South Africa North"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/SwitzerlandNorth","name":"Switzerland
-        North","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Switzerland
-        North","fullName":"Switzerland North"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/SwitzerlandWest","name":"Switzerland
-        West","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Switzerland
-        West","fullName":"Switzerland West"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/GermanyWestCentral","name":"Germany
-        West Central","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Germany
-        West Central","fullName":"Germany West Central"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/GermanyNorth","name":"Germany
-        North","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Germany
-        North","fullName":"Germany North"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/NorwayEast","name":"Norway
-        East","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Norway
-        East","fullName":"Norway East"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/NorwayWest","name":"Norway
-        West","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Norway
-        West","fullName":"Norway West"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/sku/Basic/regions/BrazilSoutheast","name":"Brazil
-        Southeast","type":"Microsoft.EventHub/sku/Regions","location":null,"tags":null,"properties":{"code":"Brazil
-        Southeast","fullName":"Brazil Southeast"}}],"nextLink":null}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMt2Dnay8+3p7uxge38nm20/nE7z7Xw327+/M83u
+        T+4/uLuqq8tiltfN3S+KaV011Xk7Pr3Ml+2315O7zdv13SdZU0zv1vkFwzyhb+qs/Or1R6OPltmC
+        Ov9IP0r5s/Z6hc8GYL0SKNSurKYZsPzo0XJdlvRedtGY3wmlVV63RU6f/OKPptUMEINezqndi17v
+        v+SXjH54hDjNmpb6tFTA30CChvKzRQLXhTd+8+HPweD3CJNw9Ck++tkeP3fSpwB9/EOlwYuqbufK
+        fUR/Swr+PNUvCC/65meNIpG+PML0vv2h0ud1tY7Shz/3saJx/mzRJ9KXR5/etz9U+nw3hwwRRkoX
+        /A0kaFg/W+RwXXhUMB/+HAweghyOnoSYxvGzPH7upE8B+viHTgNlPiJ/SAn9nLCiL3526RF01aWK
+        9+UPlTasuk7XQJqwUsrwh6n99GeNLJ1+PJoE3/xQCYLZ0H4tPfCZQYaG9bNFjrAbjxr+Fz9UYsDi
+        HzdFRugoKfBJqh/9rBHC78Qjg/v4h0oEtl459c1dW0rYjwUlGtbPFjl6PXk06Xz3QyXMkzr7QVEy
+        BoSUkkU+TM2nP2tE6fTjkST45odKkO9kq2wJLiWElBz8Uaqf/awRI+jFI4X3+Q+fENBahE5ACP3s
+        Z5kQ2kuPEPz5D5UQatbPljMSTksL/TQ1H/+skaPbkUeR8KsfKlFYMqVfSxL+TJGhgf1sESTsxiOH
+        /8UPlRjgSenW0gIfKSo0pJ8tUgS9eJTwPv+hEuKr34vnACGD0uGr30uUOMULNJ6fLToEvXh08D7/
+        IdOBnV9CxpHBfPKzSQTTR0gC+fSHSoCTbJnNMtVPhJCSQT42gRJ9/rNGjF5PHkk63/0cEIateZcq
+        +uHPNkm0mz49+IsfKjGO1w1moOjQw34sKNHQfrZI0uvJo0rnu58bwrD2QmhAuPWo43/5QyCR312U
+        Tq7BD5VYanQIK6UQqTzzyc8aWbw+PFrYT3/IBIC9J0zc+PWDn83haxfh6PnDH+rgT49fv6Hk6OlX
+        xy8JG6UAPqQ0XLqX6uc/a4To9eTRo/PdD5Usaty+es1dW8Lox8BKv/hZo0y/K4803S9/qLT5vao6
+        7/sm/Kl1CmiAP1uE6XbkkSX86odPFFFeHZKYD3+WCWK66ZFDvvhQYrwXMZ7V2XKam3mw9JCP7fzQ
+        0H62SNLryaNK57ufA8LIjHTJYj792SaK6adPEvnmh0oQ6/2Y6bBUsd/YmaIh/myRJtaZR5/+1z+n
+        REKUPkQlCtVpvD80OnF3myhFDX6otPrq+FR7JsSUSPSZQYc+/FkjTtiNRxT/ix82MSR5EZDCfPSz
+        SgjTSYcM8vEPlQis1Y7P62KasXttacFfpPKNeN40tp8tmsQ682jT//rnikYyQ3Eime9+OFQyvQ2R
+        Sb7/4dLpqmh/kNdltpxJ745O7htFjIb7s0amSGc+lXpf/1wRiTk5SiP95odCIu1rgEL87Q+VQJ/n
+        9SJbXqNjYxYsjfQ7xsoaDRrvzxadBvrzaBVt8XNBL2HlHqXMxz/rJDIdRWgjX/1QiUJdXmXXnFu1
+        JJHPJOFKA/vZIkjYjUcO/4ufA2KAQwmhkBj64c82MbSbPjH4ix8qMZ7U2Q+Kkk0lZ5MtReQLCfP0
+        m581skT68mjT+/aHSiBMyVev7xFKShh8gFwaPvpZo4jfiUcK9/EPlQbfKSpe4DYK3dKCvpClb6vr
+        aWw/WzSJdebRpv/1zwmNMEWEWI9A+vkPgTraU5Q0/N0PlS6vr/JZvjRTYgkjH9upogH+bBGm15NH
+        mM53PweEYa1GSIVkMZ/+bBPF9NMniXzzS37J9wm1/F37vFi+FYC/5P8BL2zQlN01AAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:27 GMT
+      date: Mon, 24 May 2021 18:18:33 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -1116,354 +1162,294 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/providers/Microsoft.EventHub/sku/Basic/regions?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.EventHub/sku/Basic/regions?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/namespaces?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/7vx5onejribdkm3bpke5mddlz57worfeu7edc4sdd5xec2dng2m4hhit6yy7d5u6asotq6vmh6a/providers/Microsoft.EventHub/namespaces/myNamespacexxyyzzykk","name":"myNamespacexxyyzzykk","type":"Microsoft.EventHub/Namespaces","location":"East
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:mynamespacexxyyzzykk","createdAt":"2020-08-18T05:04:57.527Z","updatedAt":"2020-08-18T05:11:09.503Z","serviceBusEndpoint":"https://myNamespacexxyyzzykk.servicebus.windows.net:443/","status":"Active","alternateName":"postmigrationxxxy"}},{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pddr3wg3pl4rkkpm72j4ktc36kvz76yhaqpylpakpnoe4zmekffxzdvaq2cpddpf67uj6yfqaqh/providers/Microsoft.EventHub/namespaces/namespacexf7e318f9","name":"namespacexf7e318f9","type":"Microsoft.EventHub/Namespaces","location":"East
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespacexf7e318f9","createdAt":"2020-09-16T03:32:46.977Z","updatedAt":"2020-09-16T03:33:36.487Z","serviceBusEndpoint":"https://namespacexf7e318f9.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_mgmt_servicebus_namespace_test_migration_configsa9a51771/providers/Microsoft.EventHub/namespaces/myNamespacexxyyzzy","name":"myNamespacexxyyzzy","type":"Microsoft.EventHub/Namespaces","location":"East
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:mynamespacexxyyzzy","createdAt":"2020-08-17T08:07:13.307Z","updatedAt":"2020-08-17T08:27:01.143Z","serviceBusEndpoint":"https://myNamespacexxyyzzy.servicebus.windows.net:443/","status":"Active","alternateName":"postmigrationxxy"}},{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157","name":"namespace75861157","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:namespace75861157","createdAt":"2020-09-16T03:32:46.16Z","updatedAt":"2020-09-16T03:33:32.26Z","serviceBusEndpoint":"https://namespace75861157.servicebus.windows.net:443/","status":"Active"}}]}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2cfjT5qi7wOP5lmq2xatNcfPdr9JaOPihl9e7dZ
+        T5ppXazaolo2d8+zbOdgJzvfnu7ODrb3d7LZ9sPpNN/Od7P9+zvT7P7k/oO7dd5U63qaf15X61Vz
+        dzqvs1n+9u6qri6LWV43d78opnXVVOft+PQyX7bfXk/uAr2Ges+buzk+m1O328tme1Vm1xcEZznb
+        bhyiaE3I3aJle71Cy0iPLwiG9EjNymqaYYTU9Lt506ZfvaYP2+yiIdIRKQj1VV63BbUlUhbN8bqt
+        zpbnZdbmp8tsUuZEqvOsbPLRR4vsXbFYL97MCZWL+WrdfrUsWnptZ/TR2+z8bWbbt/WamhPky6Kh
+        novlBc1EC2Rfr4mk+YwaEbi8rYvpGbX/6Da0f3QLkkzrnPqZHbcEc29n9+H2zr3t3XtvdnYf7dL/
+        dsY7n977KWq2Xs28Znu72zu723sP3+ztPdp78Ghvb3zwKVo1eX1ZTPMn6+Z0OVtVxRLN5227ah7d
+        vXEmx/r2ZN2Mr4rlrLpqxsu8fbS/f+8uYBM91kS6j46nbXGZf/RLfsno/wXsfL0uaa62V9ftvFpu
+        uxHcmr/1lW16Z7vML7Lp9XY+J3TRhFAc+vrnGycP0aHPvvvbe/fe7O08urf/aH9n/CDGvTtotUOt
+        7j3a331072B87+EDNNNO4uyrX4YYfDjPPsmaYkpNaRLAsObPnx1undRtXpdNtd0SM0zy2a25dCLv
+        LflFQg9fEUrdj//fy5XankB/o2zZJUCfHe9v7+2/2X346P7uo72D8cHeID9SM9Km+w8e3dsd7+yi
+        lfJWnB2Dnj+cDYkYRlES4cGJ3ic/O8z4vp6AtiepW08IKXxDiHQ+/X8vB/7s6MXO8GP8d2+X+e/h
+        o9174/0HrOh6/Le7u717AP67t/to5974wQE3U66KM6Df84fzn9F7RHMwn/nzZ4fzmnqZXWT1dvaD
+        NX0zewtHZHVrPmzqwroyhCK+IbQ6n/6/lw+1PYH+RhmxM/4+Iz4gJgOHwegSh7GG6/Eh9OC9N7sH
+        j+7T//bG97iVMlecDf1+/z/GhqvsbX292Daf0geYk1twoLzI/g8+JWy8T37ecZ439j7X0f/uw8+j
+        YGb/YLwHdgqZLmhE+u/BeOdm3We6/HCGIwIYK0vEBs95n/zssN3bYlJny1Y8h1vzXPDWthE5QhJt
+        CLHB7//fy48/OxZ5kBA95twlfUe2+dNHO2R0D8a7Md+w0+z+/fG9ezfzZxyH/09yK72c1bd3EqX5
+        LL8khPAxIeF/9PONGf2xR/mPnD7Se58+2v90vLMf4T+xybs7iKjv33+0TzZ5h5spL8X5z3b7Q2O5
+        ezQt3xTLEdS8zsptwv/WfAdBm64IJXxGaNi/f3gcJxw0xHB7PySOswOPsRv4aA++3b374/sPwUYh
+        twWtHpKrOH5472Zuky5/aKz2TWq3n67K6vZMxq2NNgfX4DtCpPf512a6dI8+fj+2+3+HouuRoM9+
+        e9u7nLC+dwBr+zCW1+40u/9gvH8LbRf2/f9JPnybXcyL6+zWnKjtxb+gURNi+JaQiXzz848bI0QI
+        +RFmlRZQ9nmd5VPKVZNZZbcu5MegGa2z7I4f3udmymNxfuz2/uEcaeJgoj3Y0fz5s8OLP52fnxfN
+        nNG/NUP6LxFm+Iaw6Xz6/2ZG1PYE+hvlxA4Folx4/80OOXeUn35A7MXqLsqF0mwPacT7B9xM+SrO
+        hX7PH86BRAujAYnuYELvE8eH36gbWC2XRX69XV/cmgutEdj+6ewyI8zwHWHT+/yHyonCWbfmxJ8d
+        ldgjQZ8VaeGZ41zK1ezuj8Xw9jnRa3X/YPypBC3KX3FODLv+cF406q8VRjR/Oi789BvkQgrji2Y6
+        vzULrrPFL1pB5ggjfExY+B/9v5nxtD2B/kY5zx9+n+loIfjhm939R+Tx7dJysSi2Ptd5zcgrvLd7
+        sxW23X44wxEVjKojioPnvE8c2+0+oIn5pvjup5tftC7qfHuRXW83LX1JaWdMzC1YkF6RNwg7fEwI
+        +R+9PwueZsyC9OH7MaBosiH++2FFxP7YY/y39+AN+Xb3KQdDyyID7PcpxSVYFtmjVbx9w6XKV3H2
+        s73+8NiPZuWb4r7r4qffFTmWRrbfb3HO6XrijnPCD98RTr3P358Lv74iFL76uebDHgn6zHifHL03
+        O7xGt7c3Hl4rRtpw79HOPnShuozKZXFmDLv+oXHkfZqfb4ojdbn71oyo7benZZ4taZF8ewl2QgPC
+        J/7lD5Ml1dYO8eQPiSXjdIjy5adIVN978Ojew2jmcI+YklTpzhtiyh1yDj8dH+wx+yqvxfky0v+H
+        M6fxB2kCwJnmT8eW36SirLPFdVZvr8rsGopyObs1g+qbNGg4KYQgviOkep+/P1u+rtbtPD2hVpRG
+        J/6kb392uVPbE+hvlD17pIhx5t7eGzAcraI8GO/dZ57rsKbfDNx5q6Ri2PeHcyXRwyhIoj0Y0/vk
+        Z4c3r9clTcT26rqdVyRd4BrYgFtzKL1YZ9O3e7y0j88JreCz9+fM/68rzGD4fW78FPab9OQes9mn
+        slLc50av2f2d8cEtvEnX7/8nObHJlllZruv3yeXMs7qZs1UgtPA5oRJ89v7cd0JozLIU4Qx98f9F
+        /gsIEOW/gze7Dx/tkKl+OL434EC6Zoinxwf7aKVsFWc/1+3/R9nvMiOg78N95hWrNQk5fE0Ixb56
+        f15UTUgf/n+RD2M06LPjg+1diq0fPtqn/1HULEvJfXY0ze7vPLpH6vAW8Uyv+/9PsuUiJ7kqZrJQ
+        dGvONJ+9oZdAdnxF+HQ/fn+O/CH6iz87TGm4AeTE2GIMSRHKHiWu7z/aIf04zJC22f1PxzuyUq0c
+        FmdIQ1ym/oczo4lZWuFE8+fPEhvS6MuSlCOp9+1ZvqhuzYr6pr5GCOI7Qqr3+fszo6rHH4KjqO0J
+        9DfKjD0a9LnxYHt3H27g/j1SfeN9cQP73Gib7T/a3xnvSYpSWSzOjWHf/19jR1KKxHtOt9+eHfVN
+        yD+hh28Ipc6nPx9ZMaRAnxEfsgF+QAvQj/YobBlwGynvuHcP+R1KPdJSzc4ON1PmGmBEr+cPZ0Oi
+        hTHIRHdwovfJzw4zNvUyu6A0QPaDNX0ze4scz+2T4Rg2pLCYlTmhiG8Irc6n/29myJ8dO90hQJQf
+        D5AGp1VmcgjV/vb40TV7QC3Hu7fgR7/nb44fqVci+yA/7tHk/L+DH2kdO19ktKpzUTRtfb1NxMmJ
+        awh/NCIMhxv8/OPSYVrEGBbpxYNHu7uUIqflQebEGMNqM1rhuT9+uMt8vZFhB5D4ofHuN6lLl8V0
+        XpWUj3z/XLm+2tTuXUITDQi1+Jc//xg2Toces+7S/z7ltex7SFLu7TEX9pjVNSN+vT9+8JCbKd/F
+        mTWCwP8nGZWg5hQIk/N8eWsONe/AwhBi+IaQ6Xz6tXmSPvz/Ikd2hh9lxYdvdu9jWWafVrKHHE/6
+        nzS7D/W6s8fNlLPirOj3/OE8aAIeojkY0PxJnfwscN8qe1tfL7bL6a15j1Z58ilJG5kGcm4IMXxH
+        yPQ+/9r890PQidqeQH+jLNijQYwJKdsDV5MykAfjnYElRNtsfwe8+uAWTBj2/eFsSPQwio9oD070
+        PnHMuLdDU/RNceNlcUGCtA1tfns/U1+yETyhh28Jo8g3/29myp8dtRghQp8rd7d39t/s7EDn3d83
+        WZ8+V9pmxJi743u34Mpu7x/Ol0YftsKU5k/Hkfdoer4phvzpIrsmj7gsyuvmPdZzzHDbCs4JYYfv
+        CKPe51+bHenDn11m1PYE+hvlxh4FYry4S/nwe4926X/7g/G4a0ar3zu38hjDvj+cE4keRh+2woze
+        J44fv0lzTVBJnL6+s8hGCd8ROr3P/9/LjD87mrFHgD4v7nFYQtpun/hsvDOwhOOa0UoPLXHfIjcU
+        9v3/SV5srrJ2Xqx4CLdmRv8lZxUIR7QhvAa/f3/mPM3+v8ycg4QYYNK93Uc7u5QsH+/ub2JSNKMc
+        5u547yFaKd/FeTSOwv8nefUD7fg2jcogiK8JqdhXP994NEaDKHs+eLNHTuPOo52D8R7YLsqcptH9
+        vfE+GimfxXmz1/WHs6XxJFvhSfPnzw5DXq8pXqPs5HU7r5ZOuG7PmfO2zqZvd5uWAIOp8B2h1vv8
+        /XlSjfoPIeDR9gT6m2XLLg1iPLn3EIEMReFksO+xLowxpW11f3e8v8uKVflsgC2Drj+cJ4kczN3U
+        mkgPtvQ++dnhzCa7zAjo9nuoSfNKfklY4XPCJPjsazLh6RpMR1/87LLhz45yDAjQ4UCKoyl82X2z
+        c4+SQMgyPjwAa3U40G/1kJbLx/fuo5UyVZwBXa8/NOb7f08GaL5NvHFOyOE7wqf3+dfkwx+KMvzZ
+        4cIeCQY4kVa171FS8sF4d4+DlwFWRLMH8DIf3EIZhn3/0Pjxm1WGk/l1nV3Smqh8/n6MCc+ZI0t8
+        RhjZv38WGfH/pYxohx5jwD3irIeP7pGl/ZQ4a5ABtRmFOZR8lGVvZao4A0qfPzTG+0YV4XXx0++K
+        HHz3nspQX7QuJaGIbwmryDc/TD4Uvhpiw70fEh9GiNDnSHL89t7skGXmlcLdmHtoWz1EovLe3vhT
+        4VtltjhDdjv/cNY0UUorfGn+dEz5TWrDzwuwxouqLc4LYYjbByzy7nfzyber6i2oju8Ird7nP0yW
+        fF/VqO0J9DfKkxdFS9xwlU/mSoMBjtyj5A2tB94b39tnXhtgSTTbJTVpbLkyWZwlQ/p/OEMSPYxm
+        bIUnvU9+dtjyG4iliYNowXVvl3DEF4RX+OH/m5nyZ0dPhuOPMuQ9JGz2SP89GO/ssTsYZUhuRrZ9
+        h/j2PjdTJoszpNfx/ye5sb7Y/umqrC4NH74HG4YvEob4lrCKfPPzkSF7RIhy5X3ov3sImcf3Y8lG
+        anWPteQeNYGWvHcLw93t/P+TnEmDoE/EndzZuT/99P5Btv3w4Wx3e//T3XvbD/cezran5zsPd2bZ
+        lNb2H74P5y6bvfzew9n5hFDYyz/d3p9OHmw/PPj00+3s3s697MH+9OD+HuJPvEbDeZ9Xvjav04f/
+        H+X0W9OmLwL3tnfuI07f//TR3sFYeDsmAtrqAdT3vvgTytSDInA7rP4/Lxt7e3v39s4f5Nu7Ow9p
+        kA8e7NP7lAzOdw4mu9PZvYMsz99PNvann+7szx4cbO+SeG3v39s9357s7U+3H05mn07u7+0/fLh7
+        QEPDazSc93nl56Vs3JI2G2SDQjtKp0oOa4NwUNb13vjgATdTrt4gHLdB6//zwrG7v//pg0k+pcXk
+        /P72/v3zne1sOru/fY8EY38329v/dG/2fsKRzQ4mk3vZ7vaMlMf2/uRhtj25P5tu3yMOyab3H2TZ
+        PjQdXqPhvM8rPy+F45a0GRaO+7uPiE/3d5jrh4Xj/t6jnYfjT2+Rhrs1Wv+fF44Z+U7TT3c/3d7Z
+        /5Q0wPlD8qoeZPTnvb3Jg3t7D/cPDqbvJxzn0/2988nk/nY2+zQjsk3ptwcP6J/sIJtMDvY+zc8x
+        NLxGw3mfV35eCsctabNROO49HO/dY66nCR9qtkcR7/jhHjdTrt4gHLdB6//zwnH/PPt0P/80354+
+        eDDd3t/bzbcP9kkN7Ow/yGhKd8mBfM+Qg2KYyfTe/vn27r0DskUP7326/XB2f2d7SrB39sgQ7X2K
+        MBGv0XDe55Wfl8JxS9psEA4KqXfGDyTJs0E47j3a3yXLgVbK1Btk4zZY/X9SNihRtMre1teLe+/D
+        9foKYYXPCZPgs6/Nt/9fTgu54cdYc3cPPEf5x92d8af3WSHHWNM2u0++z6dopTw1yJra7f8nec/k
+        sZBqXd2fLM6X583+ZD+/oNYPyktyyt5eF9MfrIrrq/N7D+6t769+cF2v3n26vLyYZNPVfLX309c/
+        /emDxf6nt1+Y9PtsH8zrt1Max/Knf5oGiVY0sA0tvjZj04f/32JrmgGwNYYXJ8U0xuQPkPWkfObu
+        3vhTiVejTE7NyG2nXPzemDJ8aKbcO8DlA1j8f5LnSd9yDvfqp/P57ZlWE794iTDDN4RN59OvzZz/
+        X9a6PgGmEZZEiv0eLfrQ8vh4f2MinltRul7zMcpbAxzpdfxD48L7NDffIBc200k+mzXTeb7I6vyi
+        aNr6+tYMGXuZkEULQnDg259/DDpAiA2Muo90+f1PmQWjnCrrmPucOUQj5b44n8b6/6Hx6zepNUng
+        6JNtjuCmO9n96f29g+37iFX3KaNJ6Y19Wj56+PDhg3x/d/Jw9/zWjEyAlw15G/fOD87vbx/k+4TR
+        wf0H27SE8HB7cr5D2dS9T8/PpxkNDa/RcN7nla/N8vTh/xcZ/n1oE5OCe7tvdmgtiBaNHowfDHsQ
+        2oz+d3987+EtPIjbovX/eeHY2z/49N7+AaX7793Pt/czym1O9nYmFLZOJp/uAfLk0/cTjiy7P7s3
+        PaAlqN1dwmj6YHd78vDeOWWFdiafUm/Z5GFOQ8NrNJz3eeXnpXDckjYDwkEsT+mNHRKOe5uEQ5rd
+        vz++fx+tlKk3yMZtsPr/pGw0V1k7L1bbiB1uzffy6x7e2c8nn+7ezzEl+JSQwo/+l+/Py6+rdTtP
+        T6hVnZUBU+PnLrW4zMp1viuf75m/9z4i6tBA/j/C83FqDXA3RYV7Bwge7w1ltu9v7+2/2UUbWIh7
+        n3Iz5cs4e0cQ+KEx8h5N1TfGyNlkfl1nl1D1/Dmr+1uzdJ29beZFO9/mSAlfEFrhh+/PwqqO/z/r
+        nofj7zPl/vYOORr3H+3R/3bHBwPho2316aOdT8d7u2ilHBZnSa/bHxorfpM6dZEts4t8tk1B5OX6
+        ulkssluz4XFbZg08rsmM1u+3H97PaaFpf4eS6XuUUZ/tfLp3fn+STfYOpoQ93iOM3+ud92fi04yZ
+        mD78/yILZ+9DnAEOJ326//DRPiVIhtZMTLP7FHpSs1tkSG4/af+fFIFsuZ7Os+X22/z6MluXLcnC
+        rWWgLJbX2fLCvEo44kvCq//F+3Pz/9dVcp8GUaY9eLND3Pjg0R6tpgg3RplWmh082qG03s0LfZ2+
+        /z/JmNNskRVZVb8PQ9p3FgjL8QXhEn74/owYc2xpnITT/0c4cRoQIMaFlIsjnXjvISWOx7tD8ZjX
+        7P4uLXdwM+WsOBt6Hf9/kgUpoKRPJB1xcH6wt5cf7G5P83NKRzzcOdie3Nt5uH1//8G9T893HuTT
+        e5Nb8ykBXja7D3b3Pp1mn25/ej47pywOjMsO2ZXdfG/v4fnepw939jFfeI2G8z6vvD+Pq7KlD/+/
+        yODvQ5s++9+nmA18fZ8y1g/HDx4yX/fZ3za7T+k6khK0UqaOc/+tsfr/vGxMdh7en+Y7O9vZvfze
+        9v5sb7Y9me1SRnuyOzu/P53RWGfvJxuzvfufPsh2H2zfe0gZQIKzt509+HS2fXDw6V42y3cefvoA
+        6QS8RsN5n1d+XsrGLWmzQTYoItwfP7jPWYoNsvEpSZERIeXqDcJxG7Q+XDieZE2BmIFmC5Jh/pze
+        Uiw207crFl8rS2demuWLajtHg/l6Ai5EG0J58Pv3Z+YfVoyo7Qn0N8rNg5SIsu6DNzu7cFf298c7
+        nD6Oci632qd4cHd8/+aURxyDD+dSoo5R2K0wqveJ49W9HZqwb0qHNx+WiVtdT6slpX6YFoQlviLE
+        uh+/P5Oqxv3/bOjXpcAQc957tEv8SQqT9eUQc1KrvUe7B+MDVr7KaHHmDDr+cJ40qpJoDoY0fzpu
+        /CYdCsb99cv3iPb4jWbFKU98THj4H70/3/1/XDn6g4+x3C5lvh4iBbz/cLy3z9wU4zlqtkcKkRbe
+        7o13dpg1lZM2MB26/f8Yw71+yZi/B8M1K36DCYyPCQ//o593DOcPfpjh7tEi18H4IfhogN2o0f59
+        2N9Pd5krlY/i7GY7/f8YuzHWWfke7KZvMHnxMeHhf/T+7PbDs6vankB/owznD3+A4fbuUaTy6N6D
+        8d6nrLoGWA7NOKa5f4tgxXb74SxHVDBOHVEcXOd98rPDeLS4tcre1tcL463emgHJkQjfJBzxNeEV
+        ++r/zQz5s+PoxagQ5cs9MNz+HvGcMalRvjTN7u+NH9xCFfa6//8kf/5084vWRZ1vN7O327OqJXxv
+        zaDV4gKBNqGGDwkd98H7M+Prat3O0//PZ/sdCWKcuEfW9lOyx4/2KOz4FBwWY0RtRbZ7d7x3n/lV
+        OSvOiNrn/yfZ73L7B7T+SQufX1QkQ+X1q7zMsyZ/Q+N5mTVkhTE/t+DFcn2eLy/qdWGEEeyF7wnN
+        6Hfvz6H/X1eXUTJEuXQfy5339ik+Hu9yTibKpdLqPlatPuX8jvJfnEn7vf9/kl8X2TK7yGe0LLq9
+        nE1n69nt7flxW2bN9r1pNtk/zzNaydrZ3d6f3t/bnpCQb08+Pbg/meYPJuf78ILxHmH8Xu+8P0tr
+        BPT/WZbO3oc8Q6z+EBke+KL32OYP8Tqtu1KzvfHB/s0a+fbT9v9JITBZWFidW7P/4tpy4bt319c/
+        +AH9s8jeEpJoRIgNN/jajE0fKlvj5y59cZmV6xyrLfT3nvl77yMiDo3j/yNcv7gGxXjYHUINsDh5
+        E7S8eu/++OFw3gnNHjyiXDwtrz4USVDWjLP4wGz9/OFn+RWv7OeTT3fv5znhhw8JJ/xout+9Pxe/
+        qOoBnxg////CzlFiDXEy5UV3oYXvDWa00IpyXhTJfTo+eHgzI/e7//nGw/Trg/sHn+7u3n9A6OEz
+        Qgk/ul+9PwcPR3X4+f8vDqbRe7QaYmBizU85/NusiqnZg0e7+6SKb/Y2et2/NwN//5f8P8Xc2dFo
+        vwAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:27 GMT
+      date: Mon, 24 May 2021 18:18:34 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
+      x-ms-inline-count: ''
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/providers/Microsoft.EventHub/namespaces?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.EventHub/namespaces?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/providers/Microsoft.EventHub/operations?api-version=2017-04-01
   response:
     body:
-      string: '{"value":[{"name":"Microsoft.EventHub/checkNamespaceAvailability/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"Get namespace
-        availability.","description":"Checks availability of namespace under given
-        subscription. This API is deprecated please use CheckNameAvailabiltiy instead."},"isDataAction":false},{"name":"Microsoft.EventHub/checkNameAvailability/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"Get namespace
-        availability.","description":"Checks availability of namespace under given
-        subscription."},"isDataAction":false},{"name":"Microsoft.EventHub/register/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub Resource Provider","operation":"Registers
-        the EventHub Resource Provider","description":"Registers the subscription
-        for the EventHub resource provider and enables the creation of EventHub resources"},"isDataAction":false},{"name":"Microsoft.EventHub/unregister/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub Resource Provider","operation":"Registers
-        the EventHub Resource Provider","description":"Registers the EventHub Resource
-        Provider"},"isDataAction":false},{"name":"Microsoft.EventHub/locations/deleteVirtualNetworkOrSubnets/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub Resource Provider","operation":"Deletes
-        the VNet rules in EventHub Resource Provider for the specified VNet","description":"Deletes
-        the VNet rules in EventHub Resource Provider for the specified VNet"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace","operation":"Create Or Update Namespace
-        ","description":"Create a Namespace Resource and Update its properties. Tags
-        and Capacity of the Namespace are the properties which can be updated."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace","operation":"Get Namespace Resource","description":"Get
-        the list of Namespace Resource Description"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/operationresults/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace","operation":"Get Namespace Resource","description":"Get
-        the status of Namespace operation"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/Delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace","operation":"Delete Namespace","description":"Delete
-        Namespace Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/authorizationRules/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Get Namespace
-        Authorization Rules","description":"Get the list of Namespaces Authorization
-        Rules description."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/authorizationRules/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Create or Update
-        Namespace Authorization Rules","description":"Create a Namespace level Authorization
-        Rules and update its properties. The Authorization Rules Access Rights, the
-        Primary and Secondary Keys can be updated."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/authorizationRules/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Delete Namespace
-        Authorization Rule","description":"Delete Namespace Authorization Rule. The
-        Default Namespace Authorization Rule cannot be deleted. "},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/authorizationRules/listkeys/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Get Namespace
-        Listkeys","description":"Get the Connection String to the Namespace"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/authorizationRules/regenerateKeys/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Resource Regeneratekeys","description":"Regenerate
-        the Primary or Secondary key to the Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/messagingPlan/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace","operation":"Get Messaging Plan (Deprecated)","description":"Gets
-        the Messaging Plan for a namespace. This API is deprecated. Properties exposed
-        via the MessagingPlan resource are moved to the (parent) Namespace resource
-        in later API versions.. This operation is not supported on API version 2017-04-01."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/messagingPlan/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace","operation":"Create or Update Messaging
-        Plan (Deprecated)","description":"Updates the Messaging Plan for a namespace.
-        This API is deprecated. Properties exposed via the MessagingPlan resource
-        are moved to the (parent) Namespace resource in later API versions.. This
-        operation is not supported on API version 2017-04-01."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/authorizationRules/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Updates Namespace
-        Authorization Rule (Deprecated)","description":"Updates Namespace Authorization
-        Rule. This API is depricated. Please use a PUT call to update the Namespace
-        Authorization Rule instead.. This operation is not supported on API version
-        2017-04-01."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/schemagroups/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"SchemaGroup","operation":"Create or Update SchemaGroup","description":"Create
-        or Update SchemaGroup properties."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/schemagroups/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"SchemaGroup","operation":"Get SchemaGroup","description":"Get
-        list of SchemaGroup Resource Descriptions"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/schemagroups/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"SchemaGroup","operation":"Delete SchemaGroup","description":"Operation
-        to delete SchemaGroup Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub","operation":"Create or Update EventHub","description":"Create
-        or Update EventHub properties."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub","operation":"Get EventHub","description":"Get
-        list of EventHub Resource Descriptions"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/Delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub","operation":"Delete EventHub","description":"Operation
-        to delete EventHub Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/authorizationRules/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub AuthorizationRules","operation":" Get
-        EventHub Authorization Rules","description":" Get the list of EventHub Authorization
-        Rules"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/authorizationRules/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub AuthorizationRules","operation":"Create
-        or Update EventHub Authorization Rule","description":"Create EventHub Authorization
-        Rules and Update its properties. The Authorization Rules Access Rights can
-        be updated."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/authorizationRules/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub AuthorizationRules","operation":"Delete
-        EventHub Authorization Rules","description":"Operation to delete EventHub
-        Authorization Rules"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/authorizationRules/listkeys/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub AuthorizationRules","operation":"List
-        EventHub keys","description":"Get the Connection String to EventHub"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/authorizationRules/regenerateKeys/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub AuthorizationRules","operation":"Resource
-        Regeneratekeys","description":"Regenerate the Primary or Secondary key to
-        the Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventhubs/authorizationRules/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"EventHub AuthorizationRules","operation":"Update
-        EventHub Authorization Rules (Deprecated)","description":"Operation to update
-        EventHub. This operation is not supported on API version 2017-04-01. Authorization
-        Rules. Please use a PUT call to update Authorization Rule."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventHubs/consumergroups/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"ConsumerGroup","operation":"Create or Update ConsumerGroup","description":"Create
-        or Update ConsumerGroup properties."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventHubs/consumergroups/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"ConsumerGroup","operation":"Get ConsumerGroup","description":"Get
-        list of ConsumerGroup Resource Descriptions"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/eventHubs/consumergroups/Delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"ConsumerGroup","operation":"Delete ConsumerGroup","description":"Operation
-        to delete ConsumerGroup Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/sku/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Sku","operation":"Get Sku","description":"Get
-        list of Sku Resource Descriptions"},"isDataAction":false},{"name":"Microsoft.EventHub/sku/regions/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"SkuRegions","operation":"Get SkuRegions","description":"Get
-        list of SkuRegions Resource Descriptions"},"isDataAction":false},{"name":"Microsoft.EventHub/operations/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Operations","operation":"Get Operations","description":"Get
-        Operations"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/providers/Microsoft.Insights/metricDefinitions/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace metrics","operation":"Get Namespace
-        metrics","description":"Get list of Namespace metrics Resource Descriptions"},"properties":{"serviceSpecification":{"metricSpecifications":[{"name":"SuccessfulRequests","displayName":"Successful
-        Requests","displayDescription":"Successful Requests for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true},{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"Success"}]}],"fillGapWithZero":true},{"name":"ServerErrors","displayName":"Server
-        Errors.","displayDescription":"Server Errors for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true},{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"InternalServerError"}]}],"fillGapWithZero":true},{"name":"UserErrors","displayName":"User
-        Errors.","displayDescription":"User Errors for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true},{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"ClientError"}]}],"fillGapWithZero":true},{"name":"QuotaExceededErrors","displayName":"Quota
-        Exceeded Errors.","displayDescription":"Quota Exceeded Errors for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true},{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"QuotaExceeded"}]}],"fillGapWithZero":true},{"name":"ThrottledRequests","displayName":"Throttled
-        Requests.","displayDescription":"Throttled Requests for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true},{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"ServerBusy"}]}],"fillGapWithZero":true},{"name":"IncomingRequests","displayName":"Incoming
-        Requests","displayDescription":"Incoming Requests for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"IncomingMessages","displayName":"Incoming
-        Messages","displayDescription":"Incoming Messages for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingMessages","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"OutgoingMessages","displayName":"Outgoing
-        Messages","displayDescription":"Outgoing Messages for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"OutgoingMessages","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"IncomingBytes","displayName":"Incoming
-        Bytes.","displayDescription":"Incoming Bytes for Microsoft.EventHub.","unit":"Bytes","aggregationType":"Total","internalMetricName":"IncomingBytes","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"OutgoingBytes","displayName":"Outgoing
-        Bytes.","displayDescription":"Outgoing Bytes for Microsoft.EventHub.","unit":"Bytes","aggregationType":"Total","internalMetricName":"OutgoingBytes","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"ActiveConnections","displayName":"ActiveConnections","displayDescription":"Total
-        Active Connections for Microsoft.EventHub.","unit":"Count","aggregationType":"Average","internalMetricName":"NamespaceActiveConnections","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"ConnectionsOpened","displayName":"Connections
-        Opened.","displayDescription":"Connections Opened for Microsoft.EventHub.","unit":"Count","aggregationType":"Average","internalMetricName":"ConnectionOpen","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"ConnectionsClosed","displayName":"Connections
-        Closed.","displayDescription":"Connections Closed for Microsoft.EventHub.","unit":"Count","aggregationType":"Average","internalMetricName":"ConnectionClose","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"CaptureBacklog","displayName":"Capture
-        Backlog.","displayDescription":"Capture Backlog for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"ArchiveBacklog","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"CapturedMessages","displayName":"Captured
-        Messages.","displayDescription":"Captured Messages for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"ArchivedMessages","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"CapturedBytes","displayName":"Captured
-        Bytes.","displayDescription":"Captured Bytes for Microsoft.EventHub.","unit":"Bytes","aggregationType":"Total","internalMetricName":"ArchivedBytes","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"Size","displayName":"Size","displayDescription":"Size
-        of an EventHub in Bytes.","unit":"Bytes","aggregationType":"Average","internalMetricName":"EntitySize","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","lockAggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"EntityName","toBeExportedForShoebox":true}],"supportedAggregationTypes":["Average","Min","Max"],"fillGapWithZero":true},{"name":"INREQS","displayName":"Incoming
-        Requests (Deprecated)","displayDescription":"Total incoming send requests
-        for a namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"SUCCREQ","displayName":"Successful
-        Requests (Deprecated)","displayDescription":"Total successful requests for
-        a namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"FAILREQ","displayName":"Failed
-        Requests (Deprecated)","displayDescription":"Total failed requests for a namespace
-        (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"SVRBSY","displayName":"Server
-        Busy Errors (Deprecated)","displayDescription":"Total server busy errors for
-        a namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"INTERR","displayName":"Internal
-        Server Errors (Deprecated)","displayDescription":"Total internal server errors
-        for a namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"MISCERR","displayName":"Other
-        Errors (Deprecated)","displayDescription":"Total failed requests for a namespace
-        (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"INMSGS","displayName":"Incoming
-        Messages (obsolete) (Deprecated)","displayDescription":"Total incoming messages
-        for a namespace. This metric is deprecated. Please use Incoming Messages metric
-        instead (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHINMSGS","displayName":"Incoming
-        Messages (Deprecated)","displayDescription":"Total incoming messages for a
-        namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"OUTMSGS","displayName":"Outgoing
-        Messages (obsolete) (Deprecated)","displayDescription":"Total outgoing messages
-        for a namespace. This metric is deprecated. Please use Outgoing Messages metric
-        instead (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHOUTMSGS","displayName":"Outgoing
-        Messages (Deprecated)","displayDescription":"Total outgoing messages for a
-        namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHINMBS","displayName":"Incoming
-        bytes (obsolete) (Deprecated)","displayDescription":"Event Hub incoming message
-        throughput for a namespace. This metric is deprecated. Please use Incoming
-        bytes metric instead (Deprecated)","unit":"Bytes","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHINBYTES","displayName":"Incoming
-        bytes (Deprecated)","displayDescription":"Event Hub incoming message throughput
-        for a namespace (Deprecated)","unit":"Bytes","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHOUTMBS","displayName":"Outgoing
-        bytes (obsolete) (Deprecated)","displayDescription":"Event Hub outgoing message
-        throughput for a namespace. This metric is deprecated. Please use Outgoing
-        bytes metric instead (Deprecated)","unit":"Bytes","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHOUTBYTES","displayName":"Outgoing
-        bytes (Deprecated)","displayDescription":"Event Hub outgoing message throughput
-        for a namespace (Deprecated)","unit":"Bytes","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHABL","displayName":"Archive
-        backlog messages (Deprecated)","displayDescription":"Event Hub archive messages
-        in backlog for a namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHAMSGS","displayName":"Archive
-        messages (Deprecated)","displayDescription":"Event Hub archived messages in
-        a namespace (Deprecated)","unit":"Count","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"EHAMBS","displayName":"Archive
-        message throughput (Deprecated)","displayDescription":"Event Hub archived
-        message throughput in a namespace (Deprecated)","unit":"Bytes","aggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true}]}},"isDataAction":false},{"name":"Microsoft.EventHub/clusters/providers/Microsoft.Insights/metricDefinitions/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Cluster metrics","operation":"Get Cluster metrics","description":"Get
-        list of Cluster metrics Resource Descriptions"},"properties":{"serviceSpecification":{"metricSpecifications":[{"name":"SuccessfulRequests","displayName":"Successful
-        Requests","displayDescription":"Successful Requests for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"Success"}]}],"fillGapWithZero":true},{"name":"ServerErrors","displayName":"Server
-        Errors.","displayDescription":"Server Errors for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"InternalServerError"}]}],"fillGapWithZero":true},{"name":"UserErrors","displayName":"User
-        Errors.","displayDescription":"User Errors for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"ClientError"}]}],"fillGapWithZero":true},{"name":"QuotaExceededErrors","displayName":"Quota
-        Exceeded Errors.","displayDescription":"Quota Exceeded Errors for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"QuotaExceeded"}]}],"fillGapWithZero":true},{"name":"ThrottledRequests","displayName":"Throttled
-        Requests.","displayDescription":"Throttled Requests for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"OperationResult","isHidden":true,"defaultDimensionValues":[{"value":"ServerBusy"}]}],"fillGapWithZero":true},{"name":"IncomingRequests","displayName":"Incoming
-        Requests","displayDescription":"Incoming Requests for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingRequests","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"IncomingMessages","displayName":"Incoming
-        Messages","displayDescription":"Incoming Messages for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"IncomingMessages","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"OutgoingMessages","displayName":"Outgoing
-        Messages","displayDescription":"Outgoing Messages for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"OutgoingMessages","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"IncomingBytes","displayName":"Incoming
-        Bytes.","displayDescription":"Incoming Bytes for Microsoft.EventHub.","unit":"Bytes","aggregationType":"Total","internalMetricName":"IncomingBytes","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"OutgoingBytes","displayName":"Outgoing
-        Bytes.","displayDescription":"Outgoing Bytes for Microsoft.EventHub.","unit":"Bytes","aggregationType":"Total","internalMetricName":"OutgoingBytes","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"ActiveConnections","displayName":"ActiveConnections","displayDescription":"Total
-        Active Connections for Microsoft.EventHub.","unit":"Count","aggregationType":"Average","internalMetricName":"NamespaceActiveConnections","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"ConnectionsOpened","displayName":"Connections
-        Opened.","displayDescription":"Connections Opened for Microsoft.EventHub.","unit":"Count","aggregationType":"Average","internalMetricName":"ConnectionOpen","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"ConnectionsClosed","displayName":"Connections
-        Closed.","displayDescription":"Connections Closed for Microsoft.EventHub.","unit":"Count","aggregationType":"Average","internalMetricName":"ConnectionClose","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"CaptureBacklog","displayName":"Capture
-        Backlog.","displayDescription":"Capture Backlog for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"ArchiveBacklog","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"CapturedMessages","displayName":"Captured
-        Messages.","displayDescription":"Captured Messages for Microsoft.EventHub.","unit":"Count","aggregationType":"Total","internalMetricName":"ArchivedMessages","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"CapturedBytes","displayName":"Captured
-        Bytes.","displayDescription":"Captured Bytes for Microsoft.EventHub.","unit":"Bytes","aggregationType":"Total","internalMetricName":"ArchivedBytes","isDimensionRequired":false,"resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"fillGapWithZero":true},{"name":"CPU","displayName":"CPU","displayDescription":"CPU
-        utilization for the Event Hub Cluster as a percentage","unit":"Percent","aggregationType":"Maximum","internalMetricName":"Processor\\%
-        Processor Time","resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"PerformanceCountersV2","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"Role","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"AvailableMemory","displayName":"Available
-        Memory","displayDescription":"Available memory for the Event Hub Cluster as
-        a percentage of total memory.","unit":"Percent","aggregationType":"Maximum","internalMetricName":"NodeMemoryUtilization","resourceIdDimensionNameOverride":"ScaleUnit","sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"Role","toBeExportedForShoebox":true}],"fillGapWithZero":true},{"name":"Size","displayName":"Size","displayDescription":"Size
-        of an EventHub in Bytes.","unit":"Bytes","aggregationType":"Average","internalMetricName":"EntitySize","isDimensionRequired":false,"sourceMdmAccount":"servicebus","sourceMdmNamespace":"OperationQoSMetrics","lockAggregationType":"Total","availabilities":[{"timeGrain":"PT1M","blobDuration":"P30D"}],"dimensions":[{"name":"Role","toBeExportedForShoebox":true}],"supportedAggregationTypes":["Average","Min","Max"],"fillGapWithZero":true}]}},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/providers/Microsoft.Insights/diagnosticSettings/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace diagnostic settings","operation":"Get
-        Namespace diagnostic settings","description":"Get list of Namespace diagnostic
-        settings Resource Descriptions"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/providers/Microsoft.Insights/diagnosticSettings/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace diagnostic settings","operation":"Create
-        or Update Namespace diagnostic settings","description":"Get list of Namespace
-        diagnostic settings Resource Descriptions"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/providers/Microsoft.Insights/logDefinitions/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Namespace logs","operation":"Get Namespace logs","description":"Get
-        list of Namespace logs Resource Descriptions"},"properties":{"serviceSpecification":{"logSpecifications":[{"name":"ArchiveLogs","displayName":"Archive
-        Logs","blobDuration":"PT5M"},{"name":"OperationalLogs","displayName":"Operational
-        Logs","blobDuration":"PT5M"},{"name":"AutoScaleLogs","displayName":"Auto Scale
-        Logs","blobDuration":"PT10M"},{"name":"KafkaCoordinatorLogs","displayName":"Kafka
-        Coordinator Logs","blobDuration":"PT5M"},{"name":"KafkaUserErrorLogs","displayName":"Kafka
-        User Error Logs","blobDuration":"PT5M"},{"name":"EventHubVNetConnectionEvent","displayName":"VNet/IP
-        Filtering Connection Logs","blobDuration":"PT5M"},{"name":"CustomerManagedKeyUserLogs","displayName":"Customer
-        Managed Key Logs","blobDuration":"PT5M"}]}},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterrecoveryconfigs/checkNameAvailability/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"Get alias
-        availability.","description":"Checks availability of namespace alias under
-        given subscription."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterRecoveryConfigs/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"DisasterRecoveryConfigurations","operation":"Create
-        or Update Disaster Recovery configuration.","description":"Creates or Updates
-        the Disaster Recovery configuration associated with the namespace."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterRecoveryConfigs/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"DisasterRecoveryConfigurations","operation":"Get
-        Disaster Recovery configuration","description":"Gets the Disaster Recovery
-        configuration associated with the namespace."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterRecoveryConfigs/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"DisasterRecoveryConfigurations","operation":"Delete
-        Disaster Recovery configuration","description":"Deletes the Disaster Recovery
-        configuration associated with the namespace. This operation can only be invoked
-        via the primary namespace."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterRecoveryConfigs/breakPairing/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"DisasterRecoveryConfigurations","operation":"Break
-        Pairing","description":"Disables Disaster Recovery and stops replicating changes
-        from primary to secondary namespaces."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterRecoveryConfigs/failover/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"DisasterRecoveryConfigurations","operation":"Failover","description":"Invokes
-        a GEO DR failover and reconfigures the namespace alias to point to the secondary
-        namespace."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterRecoveryConfigs/authorizationRules/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Get Disaster
-        Recovery Primary Namespace''s Authorization Rules","description":"Get Disaster
-        Recovery Primary Namespace''s Authorization Rules"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/disasterRecoveryConfigs/authorizationRules/listkeys/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"AuthorizationRules","operation":"Gets the authorization
-        rules keys for the Disaster Recovery primary namespace","description":"Gets
-        the authorization rules keys for the Disaster Recovery primary namespace"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/messages/send/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Messages","operation":"Send messages","description":"Send
-        messages"},"isDataAction":true},{"name":"Microsoft.EventHub/namespaces/messages/receive/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Messages","operation":"Receive messages","description":"Receive
-        messages"},"isDataAction":true},{"name":"Microsoft.EventHub/namespaces/schemas/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Schemas","operation":"Retrieve schemas","description":"Retrieve
-        schemas"},"isDataAction":true},{"name":"Microsoft.EventHub/namespaces/schemas/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Schemas","operation":"Write schemas","description":"Write
-        schemas"},"isDataAction":true},{"name":"Microsoft.EventHub/namespaces/schemas/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Schemas","operation":"Delete schemas","description":"Delete
-        schemas"},"isDataAction":true},{"name":"Microsoft.EventHub/namespaces/removeAcsNamepsace/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Remove ACS namespace","operation":"Remove ACS
-        namespace","description":"Remove ACS namespace"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/ipFilterRules/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"IPFilter","operation":"Get IP Filter Resource","description":"Get
-        IP Filter Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/ipFilterRules/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"IPFilter","operation":"Create IP Filter Resource","description":"Create
-        IP Filter Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/ipFilterRules/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"IPFilter","operation":"Delete IP Filter Resource","description":"Delete
-        IP Filter Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/virtualNetworkRules/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Virtual Network Rule","operation":"Gets VNET Rule
-        Resource","description":"Gets VNET Rule Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/virtualNetworkRules/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Virtual Network Rule","operation":"Create VNET
-        Rule Resource","description":"Create VNET Rule Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/virtualNetworkRules/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Virtual Network Rule","operation":"Delete VNET
-        Rule Resource","description":"Delete VNET Rule Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/networkrulesets/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Network Rule Set","operation":"Gets NetworkRuleSet
-        Resource","description":"Gets NetworkRuleSet Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/networkrulesets/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Network Rule Set","operation":"Create VNET Rule
-        Resource","description":"Create VNET Rule Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/networkrulesets/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Network Rule Set","operation":"Delete VNET Rule
-        Resource","description":"Delete VNET Rule Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/networkruleset/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Network Rule Set","operation":"Gets NetworkRuleSet
-        Resource","description":"Gets NetworkRuleSet Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/networkruleset/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Network Rule Set","operation":"Create VNET Rule
-        Resource","description":"Create VNET Rule Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/networkruleset/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Network Rule Set","operation":"Delete VNET Rule
-        Resource","description":"Delete VNET Rule Resource"},"isDataAction":false},{"name":"Microsoft.EventHub/clusters/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Cluster","operation":"Get Cluster Resource","description":"Gets
-        the Cluster Resource Description"},"isDataAction":false},{"name":"Microsoft.EventHub/clusters/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Cluster","operation":"Write on Cluster Resource","description":"Creates
-        or modifies an existing Cluster resource."},"isDataAction":false},{"name":"Microsoft.EventHub/clusters/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Cluster","operation":"Delete Cluster Resource","description":"Deletes
-        an existing Cluster resource."},"isDataAction":false},{"name":"Microsoft.EventHub/availableClusterRegions/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"List available
-        clusters read operation","description":"Read operation to list available pre-provisioned
-        clusters by Azure region."},"isDataAction":false},{"name":"Microsoft.EventHub/clusters/namespaces/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"List namespaces
-        within a cluster read operation","description":"List namespace ARM IDs for
-        namespaces within a cluster."},"isDataAction":false},{"name":"Microsoft.EventHub/clusters/operationresults/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"Get Cluster
-        Resource","description":"Get the status of an asynchronous cluster operation."},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnectionProxies/validate/action","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Private Endpoint Connection Proxy","operation":"Validate
-        Private Endpoint Connection Proxy","description":"Validate Private Endpoint
-        Connection Proxy"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnectionProxies/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Private Endpoint Connection Proxy","operation":"Get
-        Private Endpoint Connection Proxy","description":"Get Private Endpoint Connection
-        Proxy"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnectionProxies/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Private Endpoint Connection Proxy","operation":"Create
-        Private Endpoint Connection Proxy","description":"Create Private Endpoint
-        Connection Proxy"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnectionProxies/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Private Endpoint Connection Proxy","operation":"Delete
-        Private Endpoint Connection Proxy","description":"Delete Private Endpoint
-        Connection Proxy"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnectionProxies/operationstatus/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"Private endpoint
-        operation status","description":"Get the status of an asynchronous private
-        endpoint operation"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnections/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Private Endpoint Connection","operation":"Get
-        Private Endpoint Connection","description":"Get Private Endpoint Connection"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnections/write","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Private Endpoint Connection","operation":"Create
-        or Update Private Endpoint Connection","description":"Create or Update Private
-        Endpoint Connection"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnections/delete","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Private Endpoint Connection","operation":"Removes
-        Private Endpoint Connection","description":"Removes Private Endpoint Connection"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateLinkResources/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"PrivateLinks","operation":"Gets the resource types
-        that support private endpoint connections","description":"Gets the resource
-        types that support private endpoint connections"},"isDataAction":false},{"name":"Microsoft.EventHub/namespaces/privateEndpointConnections/operationstatus/read","display":{"provider":"Microsoft
-        Azure EventHub","resource":"Non Resource Operation","operation":"Private endpoint
-        operation status","description":"Get the status of an asynchronous private
-        endpoint operation"},"isDataAction":false}],"nextLink":""}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zRMlvQLx99UUzrqqnO2/HpZb5sv72e3J3O8+nbF/R1s8qm+fFlVpTZpCiL9vpuNm2L
+        avnR6KNZ0azK7PqjR7/4o1VdXRazvPaBpcc/WNd5akDSC3XeVOt6ii5fVMv0lf6ZfrnK60yBVvb3
+        Rx99nrcpUGQc0sxDYkwtZ3kzrYuVtj0Bwk3QKK3OvdfXS8IvvSgInbRZT+y74/TNvGjS45dnKf2Y
+        5as6n2ZtPktXZZ419B79n4GDGpYQbXGdFsumzbPZ+KNfMvqoaJ5mbXYspHl0npVN/ktGtyKwBUkY
+        //+Otl+LNHV+URBl62+GGuZTR5KXBkRIkVfabZO2cwcs+lpInvBFf/zpeVXzhxaaQSw140iz5SzN
+        l9mkzOX9aZ0zRqBw77XmaxF0vfz/Nkk3vPh1yFFWJODUuLk7y8u8zX+yqNt1Vr7I26uqfvtl/Xo9
+        WeZt80Om1VPGRQb8k4RLWq/BEsXSAu6DsPzVrPJpcV6Q1sKrBDkk5zcJ++tQHN+wpmjuXtVFmwPB
+        D6Ap1CaDo499Ep5AdEjl1elXqxl+sw1TahmSRNtmXhtLAoikQijaBqJKnbRF3pCtyC5IEdL3Jxm9
+        o4oQVHJgMsIbn7jX0qt5MZ2n02yZTkhZMuSvaTbwDXfTkJrMZhjWzwIhYRzsd5Yu1CikIZphpCXJ
+        KujQfyV96r3wgeO1CNIA1iXJ5/97CNC0WbtuQhI4cB84bhFe9P2zMFAB7tCmr8Mhdhs4YnzgsLJ1
+        O6/q4geMySvoo29iQo97UOl7f8CYMjeYoHlq2ocUwBuY5B6Xk9PYf508SPvyB4t4hEbfhP4M0Gaw
+        9L1PJFWOZABUDdoxx4ZML3uDdq/7urXML/My9jIrU1GJfWVLVI+9cjwl4jTpq+Ji3jYjnpyXdbHI
+        6muG9jqfVssZ/vq98uvmm1a7kTkRNwJk+NmclJ4kBm+keIXeCGfiFu8ImZ/m5xkp1Y0tQcll1YKY
+        MuLZOP1ZoCbk7C1N3DfjfwXD4A7oe5+sEG836ufaOTUKKYlmYLSTarnMGbH0dVsXy4u0rfgLC+Nn
+        gSTkvudLoJyDo39IhDGKnjS+6T1KGfc108FIIikPJ4j0oqGTAfuhZKJfmuyCJuBlmS2JQh9sOtwE
+        hnTAzH9hOkvRW7r11KYJ7lDrkB7UXjztzkvwpzMXNEPuKOHQyzuMiYLoHiowzd+tqoY878siC0Ey
+        RIM8u5yL6pIaKpG3VvTRsr3juNI1Jq+/pI5q7voyrxtCuxkrOuiZBw6kIOzNerWqasIrpc+8N9K9
+        nd0H2zv72zu7H6xS6Rc3qm/Ewtlh08d2SPS5WiaaCTVslqAyRxsnVl750dy+19xGtNkPR32Z2XJU
+        Cl5J8c7t5nsTBCUtiEc/MNMFQ6OZdunDLH351RuynmWJORRHhKdyE2SaS8qAUHpRu7BjQ0c/rNlr
+        KE25yC7qar36ZlzP1wzwcwCkL+yY6JueaIZNw6nZ1Nh3Ib/R8VOfH2pjPDTpC6Bphk9Wwx8EfRuO
+        GN/DM0IE4rWz5pQ8ONv862UJ8U1s2OLrAaGflYGrixo2CMduc9gQH0HHb29p8KHDphhl2c4pf/uN
+        sLr3qT/eHut67cJhD7b8JjncjZl6+1D29j4FgmbI4F3vq3CU+NIwtmlkZ/Qb5Wo3VOE5oPLND1Zg
+        +++E440xs2lsx/3NDTVif7/BiQ7tFoOnhj45UsxvvDmbObQPCcRvwDr2uCL29s8mob5JLRAiz/Cp
+        oU+pYXEPXuVx06sh0fTlDa9IpkVBf61MC3kw32gmZSPtRTIwzh8K8TtSG74gxKA3QppvlOQYgJ9N
+        ekFYKMqm7wQ2IRsnnOniGyIcEiYWCOJ8NAjpZOQ5mjoxr/6sEudnI39iPr2ZREapk3Y3aETp5L5m
+        cv2wEikbKfdDJpWqp/gLKb+xOWYLZFIUlYUGNUexk+3vfQKpGCY3x3j9l74ZpUmfNXeJJZr1Iq/V
+        Tf8mjBVJKINkt5q+sqTCd2JhiBt1krqNw4nY3Nw3Pj9rFCEMPtTPCZCmr4C0IQjUWvf7kAZoAb0M
+        JyZoaWX3m/dv6bMeIcS4Ab2fJVJIB+EYqUlIjUA01VwGb1iqfC1CNG/X38SMv367pg/8wWEW5dNw
+        PPjczC59b7H/8DmVoVxQ82+EiQk5Mi2ARp9HRua+3DhAbfYNjtPi8o0M0/IXRmJB0xcYR/Blf5je
+        119nIPhGhdCg3dx17c6WDTvQlOgmv2dKa23FsgDwb2TcLoko4DHC7vBjbfpUMJPdaz0854QtdQU9
+        DtybvL4spvnrVT4tzpEIpWb4XMAEH1P771mSvl5znHG+Ll/lv2idNy3jJzQBMkETQqbbxsMq3pQT
+        9JacduLGBGJNU0EvnVTrZUt/ZhcXJHqM4pvrFXp+U7VZSd8US0qsL7PyCx6MonW2nFYLcmVNR2jX
+        PC0WOU05uTj0aVHnM2Wi0UdCxS9mCwqsuMNHhmaTNd613wM8TwG1sMz5E9Vr6RxNs8usKLNJURIn
+        gfpEzZb6/bzOChDh5ZvdL6jVpKwmT9fyOj69t/P0o1/yfRBOUZQ3dR5Ol23RCsVHH7XVk/yU1ijg
+        GT2r6tfzKp9U7z561NZrXxwsdsQjtIJMLxbNt4vZLKf+0JT6krVlS5WfzEqiFfd7iV8JiE4ZoQbk
+        zouy/Dxbfbdo5z+V15XA8bp8TSTL69O6rmpQQpmA0TZfpvItJli/7vCI3+pH3EGv49P/l3LHmdJW
+        Jo3njNAEojdxyldEP24Pmigj8ADkK51/TLR+GXKJ1+ZHPEKv49P/l/LISVnQjPBcEXpA8Cbe+Ik1
+        Tcvpu2mez/IZvwiiKB/wCLRNahopK2DOtVnILtHWP2Iceh2f/r+UcXjSzJwRgkDxJtZ5M6+rti3z
+        GaistFeO4BF4LawLggnXNiHX9Jv+iGXodXz6/1KWETv0ZN1cE3bA7yZ+idBdWYGxdw0sC7gWIbP0
+        Gv6IV+h1fPpN8QqBuO10fkEua3ZBKKJXnizuwDVI+y0GptM0/FmfTtMR2v1oOul9QnvdXlQhaXSy
+        uAPXwM6SaxFOZ6/hz9p0mp5MR2j3o+mk9x2nP7luCT90yTPF0N23KX+NidDvw5kMm908jdyM/nzP
+        aTTdmNeLH80hvU9oK3sbuugcMXT3rUwOZkG/D+cwbPazNoemG/N68aM5pPcffYT86WVOGX5d9AXS
+        Ok/cw8YW4Uwy/VNpjjUD0/7mOR1Wr8fkwpHmpO+is4ofPAHSq9cp3vh/8RTbKR6YHzs/3pCIw5bE
+        pZb6GHzYAhlyagLKaptwhvpNfxbnxnWGrtDq/wvz8UMQOUeY5qSsGqICuuXp4h6CFqk0wYRom+Ep
+        laY/lCnlrtDsR3NK7xNlslVLiz9PsunbsroggDpZDN5+ner3mAtt0JnNsN2HTCVrY/omOpHH9XRO
+        +lK7QasfzSO9T/SUCZh5HrtOFHfgGtjgAZOhTaJz6Vr+bM+mj3Txo/mk94miOgnG7dOZYujuW/E9
+        MRH6/cBMcrObp5Gb0Z9fcxrN68WP5pDep0Re8QOA0alhoN0Pw/nCd1ghz5Z2MT4tljJ7t5qmG8yg
+        jA69oMUPZ5bKavr2uIeo4aef8zls1iv5soMjIHrk/KJYFov1Ar9l7/g3evem+T978er0J17TOzrZ
+        jBJ9rFG5S7JuPc1XdT7NCI07rnnIG0wx4gZ9t8mXs7Q2ACDZWYpueTK6AJVvbtbSHzYdN9Hj9Vcn
+        J0QRgqAjVILo8vz5uvw6JGnc2/8fo8ez47PnMXo8o05JaX8NWpzLm/8fo8Prn3z15PXvQwB0ZEoG
+        WQdJsRBiFjs7+Gv7GCWgruhlUlfXaS4v/3+DGGcv3py+ekUAdHBKjDPV56lS5b0JYgyCocz/p4jy
+        xdnrkxhVvmznNJT3psX/N8Xk7MUXrz/fYE6MF51uVZOmKvM2v9Mdib4Zo4m1LEQEAdOhyjh9My8a
+        +hqWPaXfZhb0OH1Z5lmTp2v6fx8f88qyafNs1sXp/yXUPf327ekbDkCbfy2idmH9v4QYX371JkoL
+        k4z2aPF1eK0yYIgKAqZDltvyWh8f88r/y3ntPQgcjkCbfy2qdmH9v4YaJHlP+rSwgjdBvPO+nMYB
+        VCoRlMIhMoAuaTuvq/XFfLVuuxS6Ld91UDPtNzLdcNT2wyPzk9/nzenNhA7R17bfAHW7kP9fQxhI
+        Y4QBrTAqXb4uA3YFcwOJbsuAHdRM+/+XMyDROc6BneF08Ne23wB5u5D/X0OZ4yfP6X0dqBJF02rp
+        RJLdZnjvS55MwdjXKaNkQN6OPD/3BuI4aiwNgQh7GVkHfW19A2Fm7n2izP83qBFRVh1i+ELQGYe+
+        d1uy+JBuRaCfa2kCQRi/k9X6K4yAYOmY8RW1OHn5lfsspAN9RQqWXqLhs06FiLys80WxXqSvf6+v
+        3Oj9jOzLnNKhA1xhEoaUcdUQXJKjigt+MDwP2+L/u6lZM0nx1OyrfFUW04yH+O1iNqPldZ49ap+f
+        Z+uytSnpn8xKis353Uv8Si+/rItFVl8TeHSwMXHraO4StyaZS+/K1D4rSpqPl1lL/xIeH239HsWd
+        34/4GVP9u9ELPT7j5HiM0b7IF1V9bWZP+QrfUiP5Lu18GTKdtvm54bvvVvVbsp6v8/bTfTT+Ee/9
+        v5f3vv9LfgnQf5q12fEUvZovHFP2F/juTss1+YV1c3dVV5fFDL+5Vmc05It529wVxJ7m54Q1QDd3
+        a/IlCRdl2Y8e/eKPDAC/n/T4B7TGaBes6IU6F0agVifStTI1Jr4y7EDffp63ab/FLPdlA23Kommx
+        LtZpSxly6Sj1xKn5iEhEeFI3wju/2PDo61U+Lc6JBdAMnwuY4GNqT7OupHTrEpAEZAqBnVADHB40
+        IWS6bTys4k1ZyC0h7YR5An6zsxEVbhPRmY7QboNcmwk7m9k2APQlcW1N000AX0+zMv8KOBH3c1uS
+        8g/XAj8bcm57Iu4gqab3v4a862RRN+ioJ42A48mc5OQlDU396fRj+PZLTVJjavXrDnf4rX7EF/9v
+        5QuzDCPTxbNFXaLTm3jkK6IFt8f4lAVACP1KZx5TrF+G/OG1+RF3/L+VO07KguaCZ4m6Qmc3ccVP
+        rGlCTt9N83yWz/hFDFA5AJQwbVLTSJkAs63NQkaJtv4Ry/y/lWV4usxsUWfo7iameUMBedvSCibo
+        q1RXXgAl/BbW1cBUa5uQX/pNf8Qs/29lFrE6T9aNCURu4pQIxZUJQAWvgZ181yJkk17DH3HJB3HJ
+        bWfOrAMSKJ0XYOY1sCuFrsXAzJmGP+szZzpCu59/M2fWMjwq6LwAM6+BnRDXIpy5XsOftZkzPZmO
+        0G7DzFla/799LgxHmpS0khloed+m/DWoqN+H0xA2u3kOuBn9+Z5zYLoxrxcbJuD/56JjSKDTAbS8
+        b2UeQHD9PpyusNnP2nSZbszrxc+/6UIK8jI/qZbLnH6Dw2OnBKhtbhFOGpM6leap1/7m6RvWeCbp
+        SnMTm0D8YOpJr16neOPn32x6BKDulzRgO1dALWyRShPMg7YJ57Pf9GdxJl1n6Aqtfl7P3klZNTRg
+        OzNALWxBiXQ0Ae21zfDsSdMfyuxxV2j283D6slVLqyhPsunbsrogQDovwMt9ner3ILs26Exc2O5D
+        Zo01Mn0TnbPjejonnandoNXP2ymbeT6zzgkw8xpY9x101ybRaXMtf7Ynzke6CKbuQ6eOp+b/K1Nn
+        fDedFKDlfSsOJGiu3w9MGje7eca4Gf35NWfMvF78PJyul1/R2zoJQKb7WWdiXn6VrlvC5QfcE89M
+        O9cV6pQmhWyarCNnTZqlNKApfUHSQAB1rl7KZ/RBf7bc+n50vl7WFVYOq/r3/X1/99T+kb4hctAr
+        P4QZItxpxItsOSWfll7K6+Yn96jxh81RPKv5qioxqrZ6kp++W1V1m8+eVfXreZVPqnc6j/TyTRN8
+        LKiV+Rf5oqqvCaJOLMblf08KMmwQzrxrt+B2t5/6tDpPW4ihvunJLdETjeiD9+aFF9VMh/SV40dq
+        /EPggp8NOf1Z5YHXxQ8ARucVQ+l9GE42vsO0ZUuZXsxusRRt7E0f/01/9ifvBr/0dNkW7TV6QYsN
+        WtfS/8Pnp6ymb497iBr78HM4e816JV92sAMsj5BfFEuVByMZ9G585r//S34JkzVrMwTgwJXp6bFE
+        35zexTdMwubuqq4uSVjq5q5rd0YDvJi3zd1ZkV0sq6Ytpq/ztqU0TXO3zjMvKPro0S/+yEDwu0qP
+        f0BG3XIUvWCElVrZCUwd/LTRDqhpZSaV2n6et+lN7We5z9B4oyyaFky98U1agxGUUk8imo9+yPS8
+        qosWc/7DIugJTWBLEl+nX61m+O2ml/+/Q12KoZ7m5yQ7gPwNcyrBBjF8SoIUvQa3oRaaDpOHkKRO
+        RDX9YqMCX6/yaXFeTLXvX0wq7iL4jBo7baTO7nPqBygJAdC/+y7VL7tq7s39LwgJC8nq16zUF0Jo
+        3ve3hHi8bis2y9o8hIdvU/56ENzuTgDv98rO32YnVVXPimXWVrW+FoLlRpQQta0GoYfI8ntf0Ryc
+        1vVG0GiTcqNbQjb89pMv8talbvhTejnsAm3unr1MnxUlGVgSLhqJeeOW3Z2Qu1Yt8vqLbEkmZvZ7
+        5dfAWN8NezNNU22bUuONvXywCaL+M3iTdT6tyAZeT6vleUGqcTrPp2+BlTqksNjXdzPpw6INaSCZ
+        eU/BJspZCbRMTG0ge/K7SG9WFvBxPQTgFIVSfgI8w0YQeDtCBbJeEobpBQnfMm3WEwthTBP1jdDv
+        ldKPuIPp902YlqdR2MoCYAmfYD3bYt4mWsvrqcytvh8hJUNoHIiGA48b4FAY0lTTgprP0ivyj/gd
+        S6CfNfoSrh9qYMzAQtA6rC55wY/mhQFK0BshQemd/zeTcJaX+Q+XR59yjzeRg14K6SivfROkTN/M
+        C2Jwg1I6pcirWpbX6SSnwOuyekuvXRYZv7Wqi0VG8N3bP1sTMSFmfvsyK2BevhkVa6gU9qQ06s7K
+        E3Sfav/0XYf4BIrSEU2E8tlylpK9WjVpna9KdobIPk7n2ZLSsul5XS0sEcmzaOi15Qx/OJL8rJH0
+        nMwBPvg5IOcz7Zo+Dil5xgxGtir9/PTL9Omr1CDJhIQBFqjUBPxnR6kmjEi4otX6Fr/g+wg9f9bI
+        ma3beVVr9ufVmtjhm1DA5HB2oNL3PilJgUbY7qXyFLwTxvvjJg1ApQZWSP8Pg/bDoyyClrf5NX0n
+        PdE4fpaJTMxFDBWgktZomgIPm4LsE8+Itx0owe4R/RuE/oGTQL/wktHdJl/OvhnyeqtQPlFfUweU
+        h7XfhUQJv+0NipNL7z0mUiA5+bc/q8OiqUEfDnfqJRhZr8GHDa6hMGSRYWwfrGxeCyj6MBwQ5S1z
+        Qlh7oq+7A+o0+GYG9E2EB/ERfReQLbbUQzCc8NtvZizfiB8ZH4x4fhZf6iIYTefrDxtOTascl/nx
+        tIElWDX02TcjSq8Ybnp88tpTZOEwB5qEg4026g35/RRisZK8BtsFosAHS9nZSwFIn/oDJCuQ2iQK
+        KXhtT30FQxxo9o0O8mbJY0hfZ5QSQMdG0B3ocMtvdKzfiGQODFZlLzIE6i4Y7HDLDxzsZVG366yk
+        DN1VVb+VIRNhP5SHf1LApgqX/T9q4Q+eGLVJf/LF6Rv+0g2IOg6GPtTuZ2Hg3wRf32LkyrmRMVHX
+        wdiHW/4sjP4b4fRbDF95OTIo6joY/nDLDxz+UrBjD5rY65vgeH/AKa2O0bf+oJmLtQ2aUAs3Guo5
+        GPfGxt/w0L8JnldUU+CaErL0rT/2YS6mboOBD7f8hkf9jfD6DcMe5l7qNhj2cMtvdNg/f9n85yWX
+        //+ayaclLfPltI5OtPxQnj4RWPShPzLizlS/cahSR7k/KGokqZluS39Z/MMG+E2wrmJHH/ojlECW
+        Mkn6tUWe2oXDFI6lrH+dLqoZLdrT75T2z99Rmg35agPAdPn1kqh2yN8I4ypO9KE/ZuVC/XJ4xNLu
+        Z2OUusxa5gruVX5Br34jjHyrVeHnNBqz1ktSaIhOo8pmblmHXgoJ8ir4Ggl05Fg9QKs632aMG/qe
+        1oAs4Mm1Il3zSL8e1Qw0X90BY+D5Q6GY65cXxQpaJjNDpIH5tKG3Q9KF76fHr75Iz55K0tZ+2of6
+        gXSy6NBo12X7w6MWqUQrKaYxNQlJgkZQm02btWvSK+cQtKy5Xk7ndbWs6CMdiCPr16MHvhEC36VU
+        +CVpsdPljNeAaPVgmTOgl3X1jjTa3UtaJMKa/TeTs6JFEXSXmv5S1yEtmFTvrqm5HRy1/0ntnb68
+        +cWQmu/x6s82Db8BLrt5ECHhwEu3eSek2e3e+tkm1zdh3G8eRUgvMeb01c2vhSS79Ys/21T7RvyD
+        m4cRkk08Avrq5tdCst36xZ9tstnRiNb9JmT1VhbBjJxW7Bgzp9NV/1P7kGQQzs3mQQcbgfmzRsZv
+        hGCGFga8xwXU0A1CaLC5dZ9mm9r/7JHlZ1mJUUOfLqqFyHn6anWT0aNXQyK918s/exT72VZg1NAn
+        mSx7NRsHS7gElLrNO98MgZ4Xy7dGh3yTMga4UC0+JUhIJF43zdP2ekWjbOdZmzbr1aqq275umdoh
+        A15Ipw+H+M1Q0cyPm54fKfwPJeDxCvTJyp/1gIAauuE8+kj63aycCJeAgrd5Z4BQ3x99tMzftZAX
+        AvTRL/l/AI7ABZ69vQAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:27 GMT
+      date: Mon, 24 May 2021 18:18:35 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -1482,17 +1468,24 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157/regenerateKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=CZCxHdd79rH8kMfw8TT95OMWzrO0ejsUePsuYIlhbZM=;EntityPath=eventhub75861157","secondaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=r9jrnqiCV0vq7XSyxD7CbCco94X+Vxno26J5Bo75uvw=;EntityPath=eventhub75861157","primaryKey":"CZCxHdd79rH8kMfw8TT95OMWzrO0ejsUePsuYIlhbZM=","secondaryKey":"r9jrnqiCV0vq7XSyxD7CbCco94X+Vxno26J5Bo75uvw=","keyName":"authorizationrule75861157"}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
+        WGT19Um1XObTtqiWr9u6WF589Oij0+VsVRXL9rNm8uju3WW2yJtVNs0f3D/4dHf3/oNxk9eXxTSf
+        rJvxVbGcVVfNeJm3dw9fz7M6nx1Pp3nT/F759Qt68bNs3c6ruvhBhh7qdWmhdFt/tp99flnvPLjf
+        LL/zZP3q9znde/L8J3/qtDr4fb7z5PO95bdfTtovLu4+vDu7enD22eHpsi3a65dZO/8sv8yX7Xw9
+        MYA/Gn3U5NNqOft/0+B+n99r/t3vviov8oufnjz8vZ5Ov7y7/PL3evrl+Xfn5z/57Sef5Kv8i8sv
+        fjK7f3X5+9w0OJ03gkqjeR+i0buWMPL2+2BFb7+VYdOLgwP/6Jf8P90rEBZZAgAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:28 GMT
+      date: Mon, 24 May 2021 18:18:51 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
@@ -1505,28 +1498,35 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157/regenerateKeys?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157/regenerateKeys?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157/listKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=CZCxHdd79rH8kMfw8TT95OMWzrO0ejsUePsuYIlhbZM=;EntityPath=eventhub75861157","secondaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=r9jrnqiCV0vq7XSyxD7CbCco94X+Vxno26J5Bo75uvw=;EntityPath=eventhub75861157","primaryKey":"CZCxHdd79rH8kMfw8TT95OMWzrO0ejsUePsuYIlhbZM=","secondaryKey":"r9jrnqiCV0vq7XSyxD7CbCco94X+Vxno26J5Bo75uvw=","keyName":"authorizationrule75861157"}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
+        WGT19Um1XObTtqiWr9u6WF589Oij0+VsVRXL9rNm8uju3WW2yJtVNs0f3D/4dHf3/oNxk9eXxTSf
+        rJvxVbGcVVfNeJm3dw9fz7M6nx1Pp3nT/F759Qt68bNs3c6ruvhBhh7qdWmhdFt/tp99flnvPLjf
+        LL/zZP3q9znde/L8J3/qtDr4fb7z5PO95bdfTtovLu4+vDu7enD22eHpsi3a65dZO/8sv8yX7Xw9
+        MYA/Gn3U5NNqOft/0+B+n99r/t3vviov8oufnjz8vZ5Ov7y7/PL3evrl+Xfn5z/57Sef5Kv8i8sv
+        fjK7f3X5+9w0OJ03gkqjeR+i0buWMPL2+2BFb7+VYdOLgwP/6Jf8P90rEBZZAgAA
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:28 GMT
+      date: Mon, 24 May 2021 18:18:52 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -1535,7 +1535,7 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157/listKeys?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157/listKeys?api-version=2017-04-01
 - request:
     body: '{"keyType": "PrimaryKey"}'
     headers:
@@ -1546,21 +1546,28 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157/regenerateKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=KB7Q+5PcOdkx5KlyH98Y7/kFasn8FTWFKK9H6okufGw=","secondaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=ILU4lF4Neqek49ux6cK5B+iVWWmCWMM/rMw8R0dTtFI=","primaryKey":"KB7Q+5PcOdkx5KlyH98Y7/kFasn8FTWFKK9H6okufGw=","secondaryKey":"ILU4lF4Neqek49ux6cK5B+iVWWmCWMM/rMw8R0dTtFI=","keyName":"authorizationrule75861157"}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
+        WGT19Um1XObTtqiWr9u6WF589Oij0+VsVRXL9rNm8uju3WW2yJtVNs0f3D/4dHf3/oNxk9eXxTSf
+        rJvxVbGcVVfNeJm3dw9fz7M6nx1Pp3nT/F759Qt68bNs3c6ruvhBhh7qdWmhdFt/9uTV529+cnb1
+        xU/Of68X50/KRbP/Uy8OFqtXX/0+T15n+cvs3uXu/OmT5Wn95O1nH40+avJptZz9v2kAJ+f7+9f5
+        64e7v+j86YPf6/TN7k+9qZffffog+70f/kSzfHH+e331nSfN9e/13e9e8ACU/vQmYfx1By9vv2fP
+        b2Vo9OLg4D76Jf8PBjQZqCECAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:34 GMT
+      date: Mon, 24 May 2021 18:18:59 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -1569,28 +1576,35 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157/regenerateKeys?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157/regenerateKeys?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157/listKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=KB7Q+5PcOdkx5KlyH98Y7/kFasn8FTWFKK9H6okufGw=","secondaryConnectionString":"Endpoint=sb://namespace75861157.servicebus.windows.net/;SharedAccessKeyName=authorizationrule75861157;SharedAccessKey=ILU4lF4Neqek49ux6cK5B+iVWWmCWMM/rMw8R0dTtFI=","primaryKey":"KB7Q+5PcOdkx5KlyH98Y7/kFasn8FTWFKK9H6okufGw=","secondaryKey":"ILU4lF4Neqek49ux6cK5B+iVWWmCWMM/rMw8R0dTtFI=","keyName":"authorizationrule75861157"}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
+        WGT19Um1XObTtqiWr9u6WF589Oij0+VsVRXL9rNm8uju3WW2yJtVNs0f3D/4dHf3/oNxk9eXxTSf
+        rJvxVbGcVVfNeJm3dw9fz7M6nx1Pp3nT/F759Qt68bNs3c6ruvhBhh7qdWmhdFt/9uTV529+cnb1
+        xU/Of68X50/KRbP/Uy8OFqtXX/0+T15n+cvs3uXu/OmT5Wn95O1nH40+avJptZz9v2kAJ+f7+9f5
+        64e7v+j86YPf6/TN7k+9qZffffog+70f/kSzfHH+e331nSfN9e/13e9e8ACU/vQmYfx1By9vv2fP
+        b2Vo9OLg4D76Jf8PBjQZqCECAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:35 GMT
+      date: Mon, 24 May 2021 18:18:59 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -1599,7 +1613,7 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157/listKeys?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157/listKeys?api-version=2017-04-01
 - request:
     body: '{"location": "South Central US", "tags": {"tag3": "value3", "tag4": "value4"}}'
     headers:
@@ -1610,31 +1624,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157","name":"namespace75861157","type":"Microsoft.EventHub/Namespaces","location":"South
-        Central US","tags":{"tag3":"value3","tag4":"value4"},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Updating","metricId":"00000000-0000-0000-0000-000000000000:namespace75861157","createdAt":"2020-09-16T03:32:46.16Z","updatedAt":"2020-09-16T03:34:36.993Z","serviceBusEndpoint":"https://namespace75861157.servicebus.windows.net:443/","status":"Activating"}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9eyj0UdtkdfhJ9NslU2L9vqjR7u/ZPRRMaNv7zbrSTOti1VbVMvm
+        7nmW7RzsZOfb093Zwfb+Tjbbfjid5tv5brZ/f2ea3Z/cf3C3zptqXU/zz+tqvWruNldZOy9W223e
+        tHdXdXVZzPK6uftFMa2rpjpvx6eX+bL99npyFzg2hELeuF8f3D/4dHf3/gNCD58RSvjR/aq9XuGr
+        CMwXpnVDzcpqmmEg1PR1tW7n6Qm1qrMy/eo1fdtmFw1IRT/vUYvLrFzn9+TzffP3/kdEGRrEKq+J
+        fty8aI7XbXW2PC+zNj9dZpMyJ8qdZ2WTjz5aZO+KxXrxZk60uJiv1u1Xy6Kl13ZGH73Nzt9mtn1b
+        r6k5Qb4sGsKwWF7QxLQY1FerGSG9vCBMFnlbF9Mzav7RbWbiUYxU0zonuLPjloDs7eztbu/c397b
+        f7N78Gj300d7++MH+w9+ipqt0Wu82cNHO7vjh5/eQ7Mmry+Laf5k3ZwuZ6uqWKL9vG1XzaO7/Ukc
+        a/PJuhlfFctZddWMl3n7aH//3l0AoxGviTgfHU/b4lIG/Ut+yf8DqTkrHMMCAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:39 GMT
+      date: Mon, 24 May 2021 18:19:02 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests: '46'
+      x-ms-ratelimit-remaining-subscription-resource-requests: '49'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
 - request:
     body: '{"name": "sdk-DisasterRecovery-9474"}'
     headers:
@@ -1645,21 +1668,24 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventHub/checkNameAvailability?api-version=2017-04-01
   response:
     body:
-      string: '{"nameAvailable":true,"reason":"None","message":null}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8ts
+        kR9fZkWZTcr8o0dtvc5HH9V51lTLjx599KJa5h+NPlrkTZNd0NfLdVn+kv8HVH71/DUAAAA=
     headers:
       cache-control: no-cache
       content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Wed, 16 Sep 2020 03:34:40 GMT
+      date: Mon, 24 May 2021 18:19:03 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       transfer-encoding: chunked
       vary: Accept-Encoding
@@ -1668,14 +1694,14 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/providers/Microsoft.EventHub/checkNameAvailability?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.EventHub/checkNameAvailability?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
   response:
@@ -1684,25 +1710,25 @@ interactions:
     headers:
       cache-control: no-cache
       content-length: '0'
-      date: Wed, 16 Sep 2020 03:34:40 GMT
+      date: Mon, 24 May 2021 18:19:05 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-deletes: '14997'
+      x-ms-ratelimit-remaining-subscription-deletes: '14999'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
   response:
@@ -1711,25 +1737,25 @@ interactions:
     headers:
       cache-control: no-cache
       content-length: '0'
-      date: Wed, 16 Sep 2020 03:34:41 GMT
+      date: Mon, 24 May 2021 18:19:06 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-deletes: '14996'
+      x-ms-ratelimit-remaining-subscription-deletes: '14998'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157/consumergroups/consumergroup75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
   response:
@@ -1738,25 +1764,25 @@ interactions:
     headers:
       cache-control: no-cache
       content-length: '0'
-      date: Wed, 16 Sep 2020 03:34:47 GMT
+      date: Mon, 24 May 2021 18:19:14 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-deletes: '14995'
+      x-ms-ratelimit-remaining-subscription-deletes: '14997'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/authorizationRules/authorizationrule75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
   response:
@@ -1765,25 +1791,25 @@ interactions:
     headers:
       cache-control: no-cache
       content-length: '0'
-      date: Wed, 16 Sep 2020 03:34:49 GMT
+      date: Mon, 24 May 2021 18:19:16 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-deletes: '14994'
+      x-ms-ratelimit-remaining-subscription-deletes: '14996'
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/eventhubs/eventhub75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
   response:
@@ -1792,24 +1818,24 @@ interactions:
     headers:
       cache-control: no-cache
       content-length: '0'
-      date: Wed, 16 Sep 2020 03:34:50 GMT
+      date: Mon, 24 May 2021 18:19:18 GMT
       expires: '-1'
       location: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/operationresults/namespace75861157?api-version=2017-04-01
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/SN1
+      server-sb: Service-Bus-Resource-Provider/CH3
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
-      x-ms-ratelimit-remaining-subscription-deletes: '14993'
+      x-ms-ratelimit-remaining-subscription-deletes: '14995'
     status:
       code: 202
       message: Accepted
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157?api-version=2017-04-01
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.6.9 (Linux-4.9.184-linuxkit-x86_64-with-Ubuntu-18.04-bionic)
+      - azsdk-python-azure-mgmt-eventhub/8.0.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.EventHub/namespaces/namespace75861157/operationresults/namespace75861157?api-version=2017-04-01
   response:
@@ -1818,15 +1844,15 @@ interactions:
     headers:
       cache-control: no-cache
       content-length: '0'
-      date: Wed, 16 Sep 2020 03:35:21 GMT
+      date: Mon, 24 May 2021 18:19:49 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-HTTPAPI/2.0
-      server-sb: Service-Bus-Resource-Provider/CH3
+      server-sb: Service-Bus-Resource-Provider/SN1
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
     status:
       code: 200
       message: OK
-    url: https://management.azure.com/subscriptions/92f95d8f-3c67-4124-91c7-8cf07cdbf241/resourceGroups/7wtij4p6f6esljsgpllyyqddjvezv3htie5d5lei4pkcw3o57fo5l5khn2nxdqkwyjbbw5e6y6z/providers/Microsoft.EventHub/namespaces/namespace75861157/operationresults/namespace75861157?api-version=2017-04-01
+    url: https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/swathip-test/providers/Microsoft.EventHub/namespaces/namespace75861157/operationresults/namespace75861157?api-version=2017-04-01
 version: 1

--- a/sdk/eventhub/azure-mgmt-eventhub/tests/test_cli_mgmt_eventhub.py
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests/test_cli_mgmt_eventhub.py
@@ -64,7 +64,7 @@ class MgmtEventHubTest(AzureMgmtTestCase):
             kind=azure.mgmt.storage.models.Kind.storage,
             location=location
         )
-        result_create = self.storage_client.storage_accounts.create(
+        result_create = self.storage_client.storage_accounts.begin_create(
             group_name,
             storage_name,
             params_create,
@@ -89,7 +89,7 @@ class MgmtEventHubTest(AzureMgmtTestCase):
                 ),
             ],
         )
-        azure_operation_poller = self.network_client.virtual_networks.create_or_update(
+        azure_operation_poller = self.network_client.virtual_networks.begin_create_or_update(
             group_name,
             network_name,
             params_create,

--- a/sdk/eventhub/azure-mgmt-eventhub/tests/test_cli_mgmt_eventhub_async.py
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests/test_cli_mgmt_eventhub_async.py
@@ -63,7 +63,7 @@ class MgmtEventHubTest(AzureMgmtAsyncTestCase):
             kind=azure.mgmt.storage.models.Kind.storage,
             location=location
         )
-        result_create = self.storage_client.storage_accounts.create(
+        result_create = self.storage_client.storage_accounts.begin_create(
             group_name,
             storage_name,
             params_create,
@@ -88,7 +88,7 @@ class MgmtEventHubTest(AzureMgmtAsyncTestCase):
                 ),
             ],
         )
-        azure_operation_poller = self.network_client.virtual_networks.create_or_update(
+        azure_operation_poller = self.network_client.virtual_networks.begin_create_or_update(
             group_name,
             network_name,
             params_create,


### PR DESCRIPTION
Currently, the Event Hubs mgmt tests are failing in the build pipeline. We need to re-record the mgmt tests to get these to pass. Fixed 2 things:
1) Added necessary dependencies to `azure-mgmt-eventhub/dev_requirements.txt`
2) Updated the method names in different tests from `create/create_or_update` to `begin_create/begin_create_or_update`.