### PR TITLE
Enabled flexible local testing and ensure consistency among services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,10 +92,17 @@ venv/
 code_reports
 
 # Azure Storage test credentials
+sdk/storage/azure-storage-blob/tests/_shared/settings_real.py
+sdk/storage/azure-storage-queue/tests/_shared/settings_real.py
+sdk/storage/azure-storage-file-share/tests/_shared/settings_real.py
+sdk/storage/azure-storage-file-datalake/tests/settings_real.py
+
+# The locations below are deprecated - keep to prevent any accidental secrets leakage ==========
 sdk/storage/azure-storage-blob/tests/settings_real.py
 sdk/storage/azure-storage-queue/tests/settings_real.py
 sdk/storage/azure-storage-file-share/tests/settings_real.py
-sdk/storage/azure-storage-file-datalake/tests/settings_real.py
+# ==============================================================================================
+
 *.code-workspace
 sdk/cosmos/azure-cosmos/test/test_config.py
 

--- a/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
@@ -5,10 +5,6 @@
 # license information.
 # --------------------------------------------------------------------------
 from __future__ import division
-from contextlib import contextmanager
-import copy
-import inspect
-import os
 import os.path
 import time
 from datetime import datetime, timedelta
@@ -43,8 +39,10 @@ from azure.core.credentials import AccessToken
 from azure.storage.blob import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
 try:
+    # Running locally - use configuration in settings_real.py
     from .settings_real import *
 except ImportError:
+    # Running on the pipeline - use fake values in order to create rg, etc.
     from .settings_fake import *
 
 try:

--- a/sdk/storage/azure-storage-blob/tests/blob_performance.py
+++ b/sdk/storage/azure-storage-blob/tests/blob_performance.py
@@ -12,7 +12,7 @@ from azure.storage.blob import (
     ContainerClient,
     BlobClient,
 )
-import tests.settings_real as settings
+import _shared.settings_real as settings
 
 # Warning:
 # This script will take a while to run with everything enabled.

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_blob_access_conditions.test_set_blob_properties_with_if_none_match_fail.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_blob_access_conditions.test_set_blob_properties_with_if_none_match_fail.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:40 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
     method: PUT
     uri: https://storagename.blob.core.windows.net/utcontainerb1921f2b?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 17:22:41 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       etag:
-      - '"0x8D7596FF19BD234"'
+      - '"0x8D91F3B4D9376CA"'
       last-modified:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: hello world
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -53,13 +53,13 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:40 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
     method: PUT
     uri: https://storagename.blob.core.windows.net/utcontainerb1921f2b/blob1
   response:
@@ -71,11 +71,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Fri, 25 Oct 2019 17:22:41 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       etag:
-      - '"0x8D7596FF1A4D6EC"'
+      - '"0x8D91F3B4DB76284"'
       last-modified:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -83,7 +83,9 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
+      x-ms-version-id:
+      - '2021-05-25T05:09:41.7031300Z'
     status:
       code: 201
       message: Created
@@ -91,17 +93,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/utcontainerb1921f2b/blob1
   response:
@@ -117,11 +119,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 17:22:41 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       etag:
-      - '"0x8D7596FF1A4D6EC"'
+      - '"0x8D91F3B4DB76284"'
       last-modified:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
@@ -131,7 +133,9 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
+      x-ms-is-current-version:
+      - 'true'
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -139,7 +143,9 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
+      x-ms-version-id:
+      - '2021-05-25T05:09:41.7031300Z'
     status:
       code: 200
       message: OK
@@ -147,7 +153,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -155,36 +161,36 @@ interactions:
       Content-Length:
       - '0'
       If-None-Match:
-      - '"0x8D7596FF1A4D6EC"'
+      - '"0x8D91F3B4DB76284"'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-content-disposition:
       - inline
       x-ms-blob-content-language:
       - spanish
       x-ms-date:
-      - Fri, 25 Oct 2019 17:22:42 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
     method: PUT
     uri: https://storagename.blob.core.windows.net/utcontainerb1921f2b/blob1?comp=properties
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ConditionNotMet</Code><Message>The
-        condition specified using HTTP conditional header(s) is not met.\nRequestId:363a2d2e-901e-00d9-6c58-8b2793000000\nTime:2019-10-25T17:22:42.7538498Z</Message></Error>"
+        condition specified using HTTP conditional header(s) is not met.\nRequestId:553c318a-a01e-0052-0f24-513148000000\nTime:2021-05-25T05:09:42.0713805Z</Message></Error>"
     headers:
       content-length:
       - '252'
       content-type:
       - application/xml
       date:
-      - Fri, 25 Oct 2019 17:22:41 GMT
+      - Tue, 25 May 2021 05:09:41 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
       - ConditionNotMet
       x-ms-version:
-      - '2019-02-02'
+      - '2020-08-04'
     status:
       code: 412
       message: The condition specified using HTTP conditional header(s) is not met.

--- a/sdk/storage/azure-storage-file-share/tests/_shared/settings_fake.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/settings_fake.py
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+STORAGE_ACCOUNT_NAME = ""
+STORAGE_ACCOUNT_KEY = ""
+
+ACCOUNT_URL_SUFFIX = 'core.windows.net'
+RUN_IN_LIVE = "False"
+SKIP_LIVE_RECORDING = "True"
+
+PROTOCOL = "https"
+
+ENABLE_LOGGING = True
+

--- a/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
@@ -5,10 +5,6 @@
 # license information.
 # --------------------------------------------------------------------------
 from __future__ import division
-from contextlib import contextmanager
-import copy
-import inspect
-import os
 import os.path
 import time
 from datetime import datetime, timedelta
@@ -40,8 +36,14 @@ except ImportError:
 
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.credentials import AccessToken
-from azure.storage.fileshare import generate_account_sas, AccountSasPermissions, ResourceTypes
+from azure.storage.blob import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
+try:
+    # Running locally - use configuration in settings_real.py
+    from .settings_real import *
+except ImportError:
+    # Running on the pipeline - use fake values in order to create rg, etc.
+    from .settings_fake import *
 
 try:
     from devtools_testutils import mgmt_settings_real as settings
@@ -52,6 +54,10 @@ import pytest
 
 
 LOGGING_FORMAT = '%(asctime)s %(name)-20s %(levelname)-5s %(message)s'
+os.environ['AZURE_STORAGE_ACCOUNT_NAME'] = STORAGE_ACCOUNT_NAME
+os.environ['AZURE_STORAGE_ACCOUNT_KEY'] = STORAGE_ACCOUNT_KEY
+os.environ['AZURE_TEST_RUN_LIVE'] = os.environ.get('AZURE_TEST_RUN_LIVE', None) or RUN_IN_LIVE
+os.environ['AZURE_SKIP_LIVE_RECORDING'] = os.environ.get('AZURE_SKIP_LIVE_RECORDING', None) or SKIP_LIVE_RECORDING
 
 
 class FakeTokenCredential(object):
@@ -60,8 +66,10 @@ class FakeTokenCredential(object):
     """
     def __init__(self):
         self.token = AccessToken("YOU SHALL NOT PASS", 0)
+        self.get_token_count = 0
 
     def get_token(self, *args):
+        self.get_token_count += 1
         return self.token
 
 
@@ -94,6 +102,10 @@ class GlobalStorageAccountPreparer(AzureMgmtPreparer):
             self.test_class_instance.scrubber.register_name_pair(
                 storage_account.name,
                 "storagename"
+            )
+            self.test_class_instance.scrubber.register_name_pair(
+                ":.{43}=\r",
+                ":fake_shared_key=\r"
             )
         else:
             name = "storagename"
@@ -143,6 +155,8 @@ class StorageTestCase(AzureMgmtTestCase):
     def __init__(self, *args, **kwargs):
         super(StorageTestCase, self).__init__(*args, **kwargs)
         self.replay_processors.append(XMSRequestIDBody())
+        self.logger = logging.getLogger('azure.storage')
+        self.configure_logging()
 
     def connection_string(self, account, key):
         return "DefaultEndpointsProtocol=https;AcCounTName=" + account.name + ";AccOuntKey=" + str(key) + ";EndpoIntSuffix=core.windows.net"
@@ -155,21 +169,18 @@ class StorageTestCase(AzureMgmtTestCase):
         """
         try:
             if storage_type == "blob":
-                return storage_account.primary_endpoints.blob
+                return storage_account.primary_endpoints.blob.rstrip("/")
             if storage_type == "queue":
-                return storage_account.primary_endpoints.queue
+                return storage_account.primary_endpoints.queue.rstrip("/")
             if storage_type == "file":
-                return storage_account.primary_endpoints.file
+                return storage_account.primary_endpoints.file.rstrip("/")
             else:
                 raise ValueError("Unknown storage type {}".format(storage_type))
         except AttributeError: # Didn't find "primary_endpoints"
             return 'https://{}.{}.core.windows.net'.format(storage_account, storage_type)
 
     def configure_logging(self):
-        try:
-            enable_logging = self.get_settings_value("ENABLE_LOGGING")
-        except AzureTestError:
-            enable_logging = True  # That's the default value in fake settings
+        enable_logging = ENABLE_LOGGING
 
         self.enable_logging() if enable_logging else self.disable_logging()
 
@@ -177,7 +188,7 @@ class StorageTestCase(AzureMgmtTestCase):
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter(LOGGING_FORMAT))
         self.logger.handlers = [handler]
-        self.logger.setLevel(logging.INFO)
+        self.logger.setLevel(logging.DEBUG)
         self.logger.propagate = True
         self.logger.disabled = False
 
@@ -414,11 +425,11 @@ def storage_account():
                     )
                     storage_account.name = storage_name
                     storage_account.id = storage_name
-                    storage_account.primary_endpoints=Endpoints()
-                    storage_account.primary_endpoints.blob = 'https://{}.{}.core.windows.net'.format(storage_name, 'blob')
-                    storage_account.primary_endpoints.queue = 'https://{}.{}.core.windows.net'.format(storage_name, 'queue')
-                    storage_account.primary_endpoints.table = 'https://{}.{}.core.windows.net'.format(storage_name, 'table')
-                    storage_account.primary_endpoints.file = 'https://{}.{}.core.windows.net'.format(storage_name, 'file')
+                    storage_account.primary_endpoints = Endpoints()
+                    storage_account.primary_endpoints.blob = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'blob', ACCOUNT_URL_SUFFIX)
+                    storage_account.primary_endpoints.queue = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'queue', ACCOUNT_URL_SUFFIX)
+                    storage_account.primary_endpoints.table = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'table', ACCOUNT_URL_SUFFIX)
+                    storage_account.primary_endpoints.file = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'file', ACCOUNT_URL_SUFFIX)
                     storage_key = existing_storage_key
 
                 if not storage_connection_string:

--- a/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
@@ -17,7 +17,6 @@ except ImportError:
 import zlib
 import math
 import sys
-import string
 import random
 import re
 import logging
@@ -36,7 +35,7 @@ except ImportError:
 
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.credentials import AccessToken
-from azure.storage.blob import generate_account_sas, AccountSasPermissions, ResourceTypes
+from azure.storage.fileshare import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
 try:
     # Running locally - use configuration in settings_real.py

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_create_file.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_create_file.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.5.0b1 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Fri, 07 Feb 2020 00:20:00 GMT
+      - Tue, 25 May 2021 05:10:01 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2020-04-08'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare8e670a80?restype=share
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 07 Feb 2020 00:19:59 GMT
+      - Tue, 25 May 2021 05:10:02 GMT
       etag:
-      - '"0x8D7AB63786D9005"'
+      - '"0x8D91F3B5A50323A"'
       last-modified:
-      - Fri, 07 Feb 2020 00:20:00 GMT
+      - Tue, 25 May 2021 05:10:02 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-07-07'
+      - '2020-04-08'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.5.0b1 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Fri, 07 Feb 2020 00:20:00 GMT
+      - Tue, 25 May 2021 05:10:02 GMT
       x-ms-file-attributes:
       - hidden
       x-ms-file-creation-time:
@@ -65,7 +65,7 @@ interactions:
       x-ms-type:
       - file
       x-ms-version:
-      - '2019-07-07'
+      - '2020-04-08'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare8e670a80/file8e670a80
   response:
@@ -75,31 +75,31 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 07 Feb 2020 00:20:03 GMT
+      - Tue, 25 May 2021 05:10:03 GMT
       etag:
-      - '"0x8D7AB637AA16810"'
+      - '"0x8D91F3B5AED006C"'
       last-modified:
-      - Fri, 07 Feb 2020 00:20:04 GMT
+      - Tue, 25 May 2021 05:10:03 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Hidden | Archive
       x-ms-file-change-time:
-      - '2020-02-07T00:20:04.3724816Z'
+      - '2021-05-25T05:10:03.8648940Z'
       x-ms-file-creation-time:
-      - '2020-02-07T00:20:04.3724816Z'
+      - '2021-05-25T05:10:03.8648940Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2020-02-07T00:20:04.3724816Z'
+      - '2021-05-25T05:10:03.8648940Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 13386448057641523291*1253935651986682069
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2020-04-08'
     status:
       code: 201
       message: Created
@@ -107,17 +107,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.5.0b1 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Fri, 07 Feb 2020 00:20:04 GMT
+      - Tue, 25 May 2021 05:10:03 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2020-04-08'
     method: HEAD
     uri: https://storagename.file.core.windows.net/utshare8e670a80/file8e670a80
   response:
@@ -129,27 +129,27 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 07 Feb 2020 00:20:05 GMT
+      - Tue, 25 May 2021 05:10:03 GMT
       etag:
-      - '"0x8D7AB637AA16810"'
+      - '"0x8D91F3B5AED006C"'
       last-modified:
-      - Fri, 07 Feb 2020 00:20:04 GMT
+      - Tue, 25 May 2021 05:10:03 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Hidden | Archive
       x-ms-file-change-time:
-      - '2020-02-07T00:20:04.3724816Z'
+      - '2021-05-25T05:10:03.8648940Z'
       x-ms-file-creation-time:
-      - '2020-02-07T00:20:04.3724816Z'
+      - '2021-05-25T05:10:03.8648940Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2020-02-07T00:20:04.3724816Z'
+      - '2021-05-25T05:10:03.8648940Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 13386448057641523291*1253935651986682069
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -159,7 +159,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-07-07'
+      - '2020-04-08'
     status:
       code: 200
       message: OK

--- a/sdk/storage/azure-storage-queue/tests/_shared/settings_fake.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/settings_fake.py
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+STORAGE_ACCOUNT_NAME = ""
+STORAGE_ACCOUNT_KEY = ""
+
+ACCOUNT_URL_SUFFIX = 'core.windows.net'
+RUN_IN_LIVE = "False"
+SKIP_LIVE_RECORDING = "True"
+
+PROTOCOL = "https"
+
+ENABLE_LOGGING = True
+

--- a/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
@@ -36,7 +36,7 @@ except ImportError:
 
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.credentials import AccessToken
-from azure.storage.blob import generate_account_sas, AccountSasPermissions, ResourceTypes
+from azure.storage.queue import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
 try:
     # Running locally - use configuration in settings_real.py

--- a/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
@@ -5,7 +5,6 @@
 # license information.
 # --------------------------------------------------------------------------
 from __future__ import division
-import os
 import os.path
 import time
 from datetime import datetime, timedelta
@@ -37,8 +36,14 @@ except ImportError:
 
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.credentials import AccessToken
-from azure.storage.queue import generate_account_sas, AccountSasPermissions, ResourceTypes
+from azure.storage.blob import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
+try:
+    # Running locally - use configuration in settings_real.py
+    from .settings_real import *
+except ImportError:
+    # Running on the pipeline - use fake values in order to create rg, etc.
+    from .settings_fake import *
 
 try:
     from devtools_testutils import mgmt_settings_real as settings
@@ -49,6 +54,10 @@ import pytest
 
 
 LOGGING_FORMAT = '%(asctime)s %(name)-20s %(levelname)-5s %(message)s'
+os.environ['AZURE_STORAGE_ACCOUNT_NAME'] = STORAGE_ACCOUNT_NAME
+os.environ['AZURE_STORAGE_ACCOUNT_KEY'] = STORAGE_ACCOUNT_KEY
+os.environ['AZURE_TEST_RUN_LIVE'] = os.environ.get('AZURE_TEST_RUN_LIVE', None) or RUN_IN_LIVE
+os.environ['AZURE_SKIP_LIVE_RECORDING'] = os.environ.get('AZURE_SKIP_LIVE_RECORDING', None) or SKIP_LIVE_RECORDING
 
 
 class FakeTokenCredential(object):
@@ -57,8 +66,10 @@ class FakeTokenCredential(object):
     """
     def __init__(self):
         self.token = AccessToken("YOU SHALL NOT PASS", 0)
+        self.get_token_count = 0
 
     def get_token(self, *args):
+        self.get_token_count += 1
         return self.token
 
 
@@ -91,6 +102,10 @@ class GlobalStorageAccountPreparer(AzureMgmtPreparer):
             self.test_class_instance.scrubber.register_name_pair(
                 storage_account.name,
                 "storagename"
+            )
+            self.test_class_instance.scrubber.register_name_pair(
+                ":.{43}=\r",
+                ":fake_shared_key=\r"
             )
         else:
             name = "storagename"
@@ -140,6 +155,8 @@ class StorageTestCase(AzureMgmtTestCase):
     def __init__(self, *args, **kwargs):
         super(StorageTestCase, self).__init__(*args, **kwargs)
         self.replay_processors.append(XMSRequestIDBody())
+        self.logger = logging.getLogger('azure.storage')
+        self.configure_logging()
 
     def connection_string(self, account, key):
         return "DefaultEndpointsProtocol=https;AcCounTName=" + account.name + ";AccOuntKey=" + str(key) + ";EndpoIntSuffix=core.windows.net"
@@ -163,10 +180,7 @@ class StorageTestCase(AzureMgmtTestCase):
             return 'https://{}.{}.core.windows.net'.format(storage_account, storage_type)
 
     def configure_logging(self):
-        try:
-            enable_logging = self.get_settings_value("ENABLE_LOGGING")
-        except AzureTestError:
-            enable_logging = True  # That's the default value in fake settings
+        enable_logging = ENABLE_LOGGING
 
         self.enable_logging() if enable_logging else self.disable_logging()
 
@@ -174,7 +188,7 @@ class StorageTestCase(AzureMgmtTestCase):
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter(LOGGING_FORMAT))
         self.logger.handlers = [handler]
-        self.logger.setLevel(logging.INFO)
+        self.logger.setLevel(logging.DEBUG)
         self.logger.propagate = True
         self.logger.disabled = False
 
@@ -411,11 +425,11 @@ def storage_account():
                     )
                     storage_account.name = storage_name
                     storage_account.id = storage_name
-                    storage_account.primary_endpoints=Endpoints()
-                    storage_account.primary_endpoints.blob = 'https://{}.{}.core.windows.net'.format(storage_name, 'blob')
-                    storage_account.primary_endpoints.queue = 'https://{}.{}.core.windows.net'.format(storage_name, 'queue')
-                    storage_account.primary_endpoints.table = 'https://{}.{}.core.windows.net'.format(storage_name, 'table')
-                    storage_account.primary_endpoints.file = 'https://{}.{}.core.windows.net'.format(storage_name, 'file')
+                    storage_account.primary_endpoints = Endpoints()
+                    storage_account.primary_endpoints.blob = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'blob', ACCOUNT_URL_SUFFIX)
+                    storage_account.primary_endpoints.queue = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'queue', ACCOUNT_URL_SUFFIX)
+                    storage_account.primary_endpoints.table = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'table', ACCOUNT_URL_SUFFIX)
+                    storage_account.primary_endpoints.file = '{}://{}.{}.{}'.format(PROTOCOL, storage_name, 'file', ACCOUNT_URL_SUFFIX)
                     storage_key = existing_storage_key
 
                 if not storage_connection_string:

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_list_queues_with_metadata.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_list_queues_with_metadata.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-queue/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-queue/12.1.6 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 30 Oct 2019 19:51:20 GMT
+      - Tue, 25 May 2021 05:09:24 GMT
       x-ms-version:
       - '2018-03-28'
     method: PUT
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 30 Oct 2019 19:51:19 GMT
+      - Tue, 25 May 2021 05:09:24 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -37,7 +37,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -45,9 +45,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-queue/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-queue/12.1.6 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 30 Oct 2019 19:51:20 GMT
+      - Tue, 25 May 2021 05:09:24 GMT
       x-ms-meta-val1:
       - test
       x-ms-meta-val2:
@@ -63,7 +63,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 30 Oct 2019 19:51:19 GMT
+      - Tue, 25 May 2021 05:09:24 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -81,13 +81,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-queue/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-queue/12.1.6 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 30 Oct 2019 19:51:20 GMT
+      - Tue, 25 May 2021 05:09:25 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
-    uri: https://storagename.queue.core.windows.net/?prefix=pyqueuesync665a1100&maxresults=1&include=metadata&comp=list
+    uri: https://storagename.queue.core.windows.net/?comp=list&prefix=pyqueuesync665a1100&maxresults=1&include=metadata
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
@@ -99,7 +99,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 30 Oct 2019 19:51:19 GMT
+      - Tue, 25 May 2021 05:09:25 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:


### PR DESCRIPTION
Currently running our local tests is very confusing when onboarding. This PR simplifies it just a little bit so its more digestible.
Previously we consumed `settings_real` that we expected to be under the tests directory (in the `.gitignore`) rather than `tests._shared.settings_real` which goes against our import in testcase. This made us never actually use the `settings_real.py` file and instead having to set env vars or change `settings_fake.py` and having to **undo** before we push to GitHub (which is bad)

I corrected the gitignore so that we can add `settings_real.py` under the `_shared` directory instead.
This enables us to set our parameters in `settings_real` when running locally, when the live tests pipeline is ran it will check against the `settings_fake` and it will behave correctly.

Furthermore, other services (fileshares, queues) only supported getting the storage account config from env vars, this PR made it consistent with blobs so we can also use `settings_real` for all of them.

Adjusted workflow/TLDR:
- We can either pass our storage account config through env vars OR `settings_real.py` under `tests/_shared` for ALL services