### PR TITLE
Correct BuildTargeting in ServiceBus and Eventhub

### DIFF
--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -31,7 +31,6 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: eventhub
-    BuildTargetingString: azure-eventhub*
     # Override the base matrix due to https://github.com/Azure/azure-sdk-for-python/issues/17837
     MatrixConfigs:
       - Name: eventhub_ci_matrix

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -29,7 +29,6 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: servicebus
-    BuildTargetingString: azure-servicebus*
     MatrixFilters:
       - PythonVersion=^(?!pypy3).*
     Artifacts:


### PR DESCRIPTION
@swathipil [This PR](https://github.com/Azure/azure-sdk-for-python/pull/18863) went in a couple days ago. As a result `BuildTargetingString` is now being properly used.

For a couple days mgmt-servicebus and mgmt-eventhub haven't been part of the build as a result. Mgmt folks hit it when attempting to release [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=911148&view=results).

