### PR TITLE
Update test results titles to include service directory and cloud names

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -126,6 +126,7 @@ jobs:
         parameters:
           BuildTargetingString: $(BuildTargetingStringValue)
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          CloudName: ${{ parameters.CloudConfig.Cloud }}
           CoverageArg: $(CoverageArg)
           EnvVars:
             AZURE_RUN_MODE: 'Live' #Record, Playback

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -3,6 +3,7 @@ parameters:
   TestMarkArgument: ''
   EnvVars: {}
   ServiceDirectory: ''
+  CloudName: ''
   PythonVersion: ''
   OSVmImage: ''
   BeforeTestSteps: []
@@ -84,7 +85,7 @@ steps:
     condition: always()
     inputs:
       testResultsFiles: '**/*test*.xml'
-      testRunTitle: '$(OSName) Python ${{ parameters.PythonVersion }}'
+      testRunTitle: '${{ parameters.ServiceDirectory }} ${{ parameters.CloudName }} $(Agent.JobName)'
       failTaskOnFailedTests: true
 
   - task: PythonScript@0


### PR DESCRIPTION
When testing with multiple clouds, it can be hard to tell from the coverage view which failures come from which cloud and/or job.