### PR TITLE
[Key Vault] Clarify when content_type is required for cert policies

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -338,10 +338,10 @@ class CertificateClient(KeyVaultClientBase):
         # type: (str, bytes, **Any) -> KeyVaultCertificate
         """Import a certificate created externally. Requires certificates/import permission.
 
-        Imports an existing valid certificate, containing a private key, into
-        Azure Key Vault. The certificate to be imported can be in either PFX or
-        PEM format. If the certificate is in PEM format the PEM file must
-        contain the key as well as x509 certificates.
+        Imports an existing valid certificate, containing a private key, into Azure Key Vault. The certificate to be
+        imported can be in either PFX or PEM format. If the certificate is in PEM format the PEM file must contain the
+        key as well as x509 certificates, and you must provide a ``policy`` with :attr:`CertificatePolicy.content_type`
+        of :attr:`CertificateContentType.pem`.
 
         :param str certificate_name: The name of the certificate.
         :param bytes certificate_bytes: Bytes of the certificate object to import. This certificate
@@ -351,7 +351,8 @@ class CertificateClient(KeyVaultClientBase):
         :paramtype tags: dict[str, str]
         :keyword str password: If the private key in the passed in certificate is encrypted, it
          is the password used for encryption.
-        :keyword policy: The management policy for the certificate
+        :keyword policy: The management policy for the certificate. Required if importing a PEM-format certificate,
+         with :attr:`CertificatePolicy.content_type` set to :attr:`CertificateContentType.pem`.
         :paramtype policy: ~azure.keyvault.certificates.CertificatePolicy
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -618,8 +618,6 @@ class CertificateOperation(object):
 class CertificatePolicy(object):
     """Management policy for a certificate.
 
-    If setting the policy, ``content_type`` is required and must be a valid :class:`CertificateContentType` value.
-
     :param str issuer_name: Name of the referenced issuer object or reserved names; for example,
         'Self' or 'Unknown"
     :keyword str subject: The subject name of the certificate. Should be a valid X509
@@ -645,8 +643,8 @@ class CertificatePolicy(object):
     :paramtype enhanced_key_usage: list[str]
     :keyword key_usage: List of key usages.
     :paramtype key_usage: list[str or ~azure.keyvault.certificates.KeyUsageType]
-    :keyword content_type: The media type (MIME type) of the secret backing the certificate. Required whenever setting
-        the policy of a certificate. If not specified, :attr:`CertificateContentType.pkcs12` is assumed.
+    :keyword content_type: The media type (MIME type) of the secret backing the certificate.  If not specified,
+        :attr:`CertificateContentType.pkcs12` is assumed.
     :paramtype content_type: str or ~azure.keyvault.certificates.CertificateContentType
     :keyword int validity_in_months: The duration that the certificate is valid in months.
     :keyword lifetime_actions: Actions that will be performed by Key Vault over the lifetime

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -618,6 +618,8 @@ class CertificateOperation(object):
 class CertificatePolicy(object):
     """Management policy for a certificate.
 
+    If setting the policy, ``content_type`` is required and must be a valid :class:`CertificateContentType` value.
+
     :param str issuer_name: Name of the referenced issuer object or reserved names; for example,
         'Self' or 'Unknown"
     :keyword str subject: The subject name of the certificate. Should be a valid X509
@@ -643,7 +645,8 @@ class CertificatePolicy(object):
     :paramtype enhanced_key_usage: list[str]
     :keyword key_usage: List of key usages.
     :paramtype key_usage: list[str or ~azure.keyvault.certificates.KeyUsageType]
-    :keyword content_type: The media type (MIME type) of the secret backing the certificate.
+    :keyword content_type: The media type (MIME type) of the secret backing the certificate. Required whenever setting
+        the policy of a certificate. If not specified, :attr:`CertificateContentType.pkcs12` is assumed.
     :paramtype content_type: str or ~azure.keyvault.certificates.CertificateContentType
     :keyword int validity_in_months: The duration that the certificate is valid in months.
     :keyword lifetime_actions: Actions that will be performed by Key Vault over the lifetime

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -314,10 +314,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
     ) -> KeyVaultCertificate:
         """Import a certificate created externally. Requires certificates/import permission.
 
-        Imports an existing valid certificate, containing a private key, into
-        Azure Key Vault. The certificate to be imported can be in either PFX or
-        PEM format. If the certificate is in PEM format the PEM file must
-        contain the key as well as x509 certificates.
+        Imports an existing valid certificate, containing a private key, into Azure Key Vault. The certificate to be
+        imported can be in either PFX or PEM format. If the certificate is in PEM format the PEM file must contain the
+        key as well as x509 certificates, and you must provide a ``policy`` with :attr:`CertificatePolicy.content_type`
+        of :attr:`CertificateContentType.pem`.
 
         :param str certificate_name: The name of the certificate.
         :param bytes certificate_bytes: Bytes of the certificate object to import.
@@ -327,7 +327,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :paramtype tags: dict[str, str]
         :keyword str password: If the private key in the passed in certificate is encrypted, it
          is the password used for encryption.
-        :keyword policy: The management policy for the certificate
+        :keyword policy: The management policy for the certificate. Required if importing a PEM-format certificate,
+         with :attr:`CertificatePolicy.content_type` set to :attr:`CertificateContentType.pem`.
         :paramtype policy: ~azure.keyvault.certificates.CertificatePolicy
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate


### PR DESCRIPTION
Resolves #15043. Work to add a certificate import sample is tracked by #19029.