### PR TITLE
[translation] unskip tests now that correct error status is returned

### DIFF
--- a/sdk/translation/azure-ai-translation-document/tests/recordings/test_translation.test_bad_input_target.yaml
+++ b/sdk/translation/azure-ai-translation-document/tests/recordings/test_translation.test_bad_input_target.yaml
@@ -11,13 +11,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.8.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 01 Apr 2021 20:45:50 GMT
+      - Thu, 03 Jun 2021 21:54:32 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     method: PUT
-    uri: https://redacted.blob.core.windows.net/srccd279526-2fbf-4cd2-a6bb-9f7f06749ca7?restype=container
+    uri: https://redacted.blob.core.windows.net/src4bca44dc-69cf-48d4-b19f-152c54698b39?restype=container
   response:
     body:
       string: ''
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 01 Apr 2021 20:45:49 GMT
+      - Thu, 03 Jun 2021 21:54:31 GMT
       etag:
-      - '"0x8D8F54F22BD7477"'
+      - '"0x8D926DA2B6E514E"'
       last-modified:
-      - Thu, 01 Apr 2021 20:45:50 GMT
+      - Thu, 03 Jun 2021 21:54:32 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     status:
       code: 201
       message: Created
@@ -53,17 +53,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.8.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Thu, 01 Apr 2021 20:45:50 GMT
-      x-ms-encryption-algorithm:
-      - AES256
+      - Thu, 03 Jun 2021 21:54:32 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     method: PUT
-    uri: https://redacted.blob.core.windows.net/srccd279526-2fbf-4cd2-a6bb-9f7f06749ca7/003ec918-63b2-4f2d-ada7-4afe4aa52a86.txt
+    uri: https://redacted.blob.core.windows.net/src4bca44dc-69cf-48d4-b19f-152c54698b39/d8e8ca6c-36d9-4130-9755-0bc7d00c342a.txt
   response:
     body:
       string: ''
@@ -73,11 +71,11 @@ interactions:
       content-md5:
       - lyFPYyJLwenMTaN3qtznxw==
       date:
-      - Thu, 01 Apr 2021 20:45:50 GMT
+      - Thu, 03 Jun 2021 21:54:31 GMT
       etag:
-      - '"0x8D8F54F22CE6AB1"'
+      - '"0x8D926DA2B7BD025"'
       last-modified:
-      - Thu, 01 Apr 2021 20:45:50 GMT
+      - Thu, 03 Jun 2021 21:54:32 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -85,12 +83,12 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     status:
       code: 201
       message: Created
 - request:
-    body: '{"inputs": [{"source": {"sourceUrl": "https://redacted.blob.core.windows.net/srccd279526-2fbf-4cd2-a6bb-9f7f06749ca7?se=end&sp=rl&sv=2020-06-12&sr=c&sig=fake_token_value",
+    body: '{"inputs": [{"source": {"sourceUrl": "https://redacted.blob.core.windows.net/src4bca44dc-69cf-48d4-b19f-152c54698b39?se=end&sp=rl&sv=2020-08-04&sr=c&sig=fake_token_value",
       "filter": {}}, "targets": [{"targetUrl": "https://idont.ex.ist", "language":
       "es"}]}]}'
     headers:
@@ -101,28 +99,28 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '313'
+      - '317'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-translation-document/1.0.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches
   response:
     body:
       string: ''
     headers:
       apim-request-id:
-      - 212ba03b-5d9b-49fb-9c5e-e55d5a59f3d3
+      - 6cb8cd71-de28-402d-b6a7-682fcbd15795
       content-length:
       - '0'
       date:
-      - Thu, 01 Apr 2021 20:45:50 GMT
+      - Thu, 03 Jun 2021 21:54:32 GMT
       operation-location:
-      - https://redacted.cognitiveservices.azure.com/translatortext/batch/v1.0-preview.1/batches/b148f681-9951-4892-8786-aef855c66b4d
+      - https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/46c61089-e758-4ef0-9ab0-0b07354b9955
       set-cookie:
-      - ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com
-      - ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
+      - ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
@@ -130,104 +128,10 @@ interactions:
       x-powered-by:
       - ASP.NET
       x-requestid:
-      - 212ba03b-5d9b-49fb-9c5e-e55d5a59f3d3
+      - 6cb8cd71-de28-402d-b6a7-682fcbd15795
     status:
       code: 202
       message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/b148f681-9951-4892-8786-aef855c66b4d
-  response:
-    body:
-      string: '{"id":"b148f681-9951-4892-8786-aef855c66b4d","createdDateTimeUtc":"2021-04-01T20:45:51.110878Z","lastActionDateTimeUtc":"2021-04-01T20:45:51.1108785Z","status":"NotStarted","summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
-    headers:
-      apim-request-id:
-      - 9ab29221-889c-4697-a286-71b676777dde
-      cache-control:
-      - public,max-age=1
-      content-length:
-      - '291'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 01 Apr 2021 20:45:51 GMT
-      etag:
-      - '"4AC725BDB29CCCF0A6C625C4E4F22D5D220ACA895F20F96150A2A0D7E4DA77F4"'
-      set-cookie:
-      - ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com
-      - ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-      x-requestid:
-      - 9ab29221-889c-4697-a286-71b676777dde
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/b148f681-9951-4892-8786-aef855c66b4d
-  response:
-    body:
-      string: '{"id":"b148f681-9951-4892-8786-aef855c66b4d","createdDateTimeUtc":"2021-04-01T20:45:51.110878Z","lastActionDateTimeUtc":"2021-04-01T20:45:51.1108785Z","status":"NotStarted","summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
-    headers:
-      apim-request-id:
-      - 1bebc9ba-9297-4205-871b-687ed394352d
-      cache-control:
-      - public,max-age=1
-      content-length:
-      - '291'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 01 Apr 2021 20:45:51 GMT
-      etag:
-      - '"4AC725BDB29CCCF0A6C625C4E4F22D5D220ACA895F20F96150A2A0D7E4DA77F4"'
-      set-cookie:
-      - ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com
-      - ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-      x-requestid:
-      - 1bebc9ba-9297-4205-871b-687ed394352d
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -238,30 +142,30 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-translation-document/1.0.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/b148f681-9951-4892-8786-aef855c66b4d
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/46c61089-e758-4ef0-9ab0-0b07354b9955
   response:
     body:
-      string: '{"id":"b148f681-9951-4892-8786-aef855c66b4d","createdDateTimeUtc":"2021-04-01T20:45:51.110878Z","lastActionDateTimeUtc":"2021-04-01T20:45:51.2839647Z","status":"ValidationFailed","error":{"code":"InvalidRequest","message":"Cannot
-        access source document location with the current permissions.","target":"Operation","innerError":{"code":"InvalidDocumentAccessLevel","message":"Cannot
-        access source document location with the current permissions."}},"summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+      string: '{"id":"46c61089-e758-4ef0-9ab0-0b07354b9955","createdDateTimeUtc":"2021-06-03T21:54:32.7556399Z","lastActionDateTimeUtc":"2021-06-03T21:54:32.837085Z","status":"ValidationFailed","error":{"code":"InvalidRequest","message":"Cannot
+        access target document location with the current permissions.","target":"Operation","innerError":{"code":"InvalidTargetDocumentAccessLevel","message":"Cannot
+        access target document location with the current permissions."}},"summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
     headers:
       apim-request-id:
-      - 8182def2-a738-487c-82d0-3439c6cc6d25
+      - 79793fac-2da7-4669-83d5-22437314742b
       cache-control:
       - public,max-age=1
       content-length:
-      - '565'
+      - '571'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 01 Apr 2021 20:45:52 GMT
+      - Thu, 03 Jun 2021 21:55:02 GMT
       etag:
-      - '"8AA9056DC0D0204CEF47ADE63345E8727B6A43140C532596A84480A846214229"'
+      - '"20B523E5E12875486979EA15FF6C77384202849DAE3D14352C0A0AA5824CA0B6"'
       set-cookie:
-      - ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com
-      - ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
+      - ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       transfer-encoding:
@@ -273,7 +177,7 @@ interactions:
       x-powered-by:
       - ASP.NET
       x-requestid:
-      - 8182def2-a738-487c-82d0-3439c6cc6d25
+      - 79793fac-2da7-4669-83d5-22437314742b
     status:
       code: 200
       message: OK

--- a/sdk/translation/azure-ai-translation-document/tests/recordings/test_translation_async.test_bad_input_target.yaml
+++ b/sdk/translation/azure-ai-translation-document/tests/recordings/test_translation_async.test_bad_input_target.yaml
@@ -11,13 +11,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.8.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 01 Apr 2021 20:48:09 GMT
+      - Thu, 03 Jun 2021 21:55:23 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     method: PUT
-    uri: https://redacted.blob.core.windows.net/srcdf6b6071-6915-499c-841e-f14cd537ada1?restype=container
+    uri: https://redacted.blob.core.windows.net/srcd06a17a4-09bf-4005-833f-b16ff807d21d?restype=container
   response:
     body:
       string: ''
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 01 Apr 2021 20:48:09 GMT
+      - Thu, 03 Jun 2021 21:55:23 GMT
       etag:
-      - '"0x8D8F54F756EB73A"'
+      - '"0x8D926DA4A15168D"'
       last-modified:
-      - Thu, 01 Apr 2021 20:48:09 GMT
+      - Thu, 03 Jun 2021 21:55:23 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     status:
       code: 201
       message: Created
@@ -53,17 +53,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.8.0 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Thu, 01 Apr 2021 20:48:09 GMT
-      x-ms-encryption-algorithm:
-      - AES256
+      - Thu, 03 Jun 2021 21:55:23 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     method: PUT
-    uri: https://redacted.blob.core.windows.net/srcdf6b6071-6915-499c-841e-f14cd537ada1/daadd2bf-a369-4c42-aca7-91240fbff025.txt
+    uri: https://redacted.blob.core.windows.net/srcd06a17a4-09bf-4005-833f-b16ff807d21d/46cd29a9-a313-495a-9833-9996508ab3a5.txt
   response:
     body:
       string: ''
@@ -73,11 +71,11 @@ interactions:
       content-md5:
       - lyFPYyJLwenMTaN3qtznxw==
       date:
-      - Thu, 01 Apr 2021 20:48:09 GMT
+      - Thu, 03 Jun 2021 21:55:23 GMT
       etag:
-      - '"0x8D8F54F757AE850"'
+      - '"0x8D926DA4A1D6025"'
       last-modified:
-      - Thu, 01 Apr 2021 20:48:09 GMT
+      - Thu, 03 Jun 2021 21:55:23 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -85,12 +83,12 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-06-12'
+      - '2020-08-04'
     status:
       code: 201
       message: Created
 - request:
-    body: '{"inputs": [{"source": {"sourceUrl": "https://redacted.blob.core.windows.net/srcdf6b6071-6915-499c-841e-f14cd537ada1?se=end&sp=rl&sv=2020-06-12&sr=c&sig=fake_token_value",
+    body: '{"inputs": [{"source": {"sourceUrl": "https://redacted.blob.core.windows.net/srcd06a17a4-09bf-4005-833f-b16ff807d21d?se=end&sp=rl&sv=2020-08-04&sr=c&sig=fake_token_value",
       "filter": {}}, "targets": [{"targetUrl": "https://idont.ex.ist", "language":
       "es"}]}]}'
     headers:
@@ -101,116 +99,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-translation-document/1.0.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches
   response:
     body:
       string: ''
     headers:
-      apim-request-id: 7e258e6c-cc30-4b60-8b94-559ba4e5282c
+      apim-request-id: 0ead9f80-132b-49a6-9d4f-b4617a57e875
       content-length: '0'
-      date: Thu, 01 Apr 2021 20:48:09 GMT
-      operation-location: https://redacted.cognitiveservices.azure.com/translatortext/batch/v1.0-preview.1/batches/f9b2d3f7-273e-48ea-ac36-3b5f930a769f
-      set-cookie: ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
+      date: Thu, 03 Jun 2021 21:55:23 GMT
+      operation-location: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/081b3f0c-b2ab-4329-a512-df0ef0b79747
+      set-cookie: ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
       x-powered-by: ASP.NET
-      x-requestid: 7e258e6c-cc30-4b60-8b94-559ba4e5282c
+      x-requestid: 0ead9f80-132b-49a6-9d4f-b4617a57e875
     status:
       code: 202
       message: Accepted
-    url: https://redacted.cognitiveservices.azure.com/translatortext/batch/v1.0-preview.1/batches
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-translation-document/1.0.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f9b2d3f7-273e-48ea-ac36-3b5f930a769f
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/081b3f0c-b2ab-4329-a512-df0ef0b79747
   response:
     body:
-      string: '{"id":"f9b2d3f7-273e-48ea-ac36-3b5f930a769f","createdDateTimeUtc":"2021-04-01T20:48:09.8471582Z","lastActionDateTimeUtc":"2021-04-01T20:48:09.8471588Z","status":"NotStarted","summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+      string: '{"id":"081b3f0c-b2ab-4329-a512-df0ef0b79747","createdDateTimeUtc":"2021-06-03T21:55:24.1837281Z","lastActionDateTimeUtc":"2021-06-03T21:55:24.2544897Z","status":"ValidationFailed","error":{"code":"InvalidRequest","message":"Cannot
+        access target document location with the current permissions.","target":"Operation","innerError":{"code":"InvalidTargetDocumentAccessLevel","message":"Cannot
+        access target document location with the current permissions."}},"summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
     headers:
-      apim-request-id: 45caf0ff-cd94-40de-8807-caed70b4cea2
+      apim-request-id: bbdbb8d3-4ba9-483e-ae46-9ee5c714d0cc
       cache-control: public,max-age=1
-      content-encoding: gzip
       content-type: application/json; charset=utf-8
-      date: Thu, 01 Apr 2021 20:48:09 GMT
-      etag: '"7277699F2D3F0F1EF96FEDCB5FC430B4AB4DA265769F98DA77F78576A62D8A42"'
-      set-cookie: ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
+      date: Thu, 03 Jun 2021 21:55:54 GMT
+      etag: '"32624265D87E44B40CB887D2EEC06A02998F9F8CDEF300930B78F157EC891FBF"'
+      set-cookie: ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       transfer-encoding: chunked
       vary: Accept-Encoding
       x-content-type-options: nosniff
       x-powered-by: ASP.NET
-      x-requestid: 45caf0ff-cd94-40de-8807-caed70b4cea2
+      x-requestid: bbdbb8d3-4ba9-483e-ae46-9ee5c714d0cc
     status:
       code: 200
       message: OK
-    url: https://redacted.cognitiveservices.azure.com/translatortext/batch/v1.0-preview.1/batches/f9b2d3f7-273e-48ea-ac36-3b5f930a769f
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f9b2d3f7-273e-48ea-ac36-3b5f930a769f
-  response:
-    body:
-      string: '{"id":"f9b2d3f7-273e-48ea-ac36-3b5f930a769f","createdDateTimeUtc":"2021-04-01T20:48:09.8471582Z","lastActionDateTimeUtc":"2021-04-01T20:48:09.9748088Z","status":"ValidationFailed","error":{"code":"InvalidRequest","message":"Cannot
-        access source document location with the current permissions.","target":"Operation","innerError":{"code":"InvalidDocumentAccessLevel","message":"Cannot
-        access source document location with the current permissions."}},"summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
-    headers:
-      apim-request-id: 05ce35ff-46ec-40ec-b9bc-6ed0b55ba7b4
-      cache-control: public,max-age=1
-      content-encoding: gzip
-      content-type: application/json; charset=utf-8
-      date: Thu, 01 Apr 2021 20:48:09 GMT
-      etag: '"A8F9A22167C1AAED1B9812BC0F6EF35C5D5069B6637098CF147DA99FF802168B"'
-      set-cookie: ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
-      strict-transport-security: max-age=31536000; includeSubDomains; preload
-      transfer-encoding: chunked
-      vary: Accept-Encoding
-      x-content-type-options: nosniff
-      x-powered-by: ASP.NET
-      x-requestid: 05ce35ff-46ec-40ec-b9bc-6ed0b55ba7b4
-    status:
-      code: 200
-      message: OK
-    url: https://redacted.cognitiveservices.azure.com/translatortext/batch/v1.0-preview.1/batches/f9b2d3f7-273e-48ea-ac36-3b5f930a769f
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-ai-translatortext/1.0.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f9b2d3f7-273e-48ea-ac36-3b5f930a769f
-  response:
-    body:
-      string: '{"id":"f9b2d3f7-273e-48ea-ac36-3b5f930a769f","createdDateTimeUtc":"2021-04-01T20:48:09.8471582Z","lastActionDateTimeUtc":"2021-04-01T20:48:09.9748088Z","status":"ValidationFailed","error":{"code":"InvalidRequest","message":"Cannot
-        access source document location with the current permissions.","target":"Operation","innerError":{"code":"InvalidDocumentAccessLevel","message":"Cannot
-        access source document location with the current permissions."}},"summary":{"total":0,"failed":0,"success":0,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
-    headers:
-      apim-request-id: 1f8efe7b-64e3-4efa-92b8-5b952c7076ef
-      cache-control: public,max-age=1
-      content-encoding: gzip
-      content-type: application/json; charset=utf-8
-      date: Thu, 01 Apr 2021 20:48:10 GMT
-      etag: '"A8F9A22167C1AAED1B9812BC0F6EF35C5D5069B6637098CF147DA99FF802168B"'
-      set-cookie: ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com
-      strict-transport-security: max-age=31536000; includeSubDomains; preload
-      transfer-encoding: chunked
-      vary: Accept-Encoding
-      x-content-type-options: nosniff
-      x-powered-by: ASP.NET
-      x-requestid: 1f8efe7b-64e3-4efa-92b8-5b952c7076ef
-    status:
-      code: 200
-      message: OK
-    url: https://redacted.cognitiveservices.azure.com/translatortext/batch/v1.0-preview.1/batches/f9b2d3f7-273e-48ea-ac36-3b5f930a769f
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/081b3f0c-b2ab-4329-a512-df0ef0b79747
 version: 1

--- a/sdk/translation/azure-ai-translation-document/tests/test_translation.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_translation.py
@@ -207,7 +207,6 @@ class TestTranslation(DocumentTranslationTest):
             result = poller.result()
         assert e.value.error.code == "InvalidDocumentAccessLevel"
 
-    @pytest.mark.skip("https://github.com/Azure/azure-sdk-for-python/issues/17914")
     @DocumentTranslationPreparer()
     @DocumentTranslationClientPreparer()
     def test_bad_input_target(self, client):
@@ -231,7 +230,7 @@ class TestTranslation(DocumentTranslationTest):
         with pytest.raises(HttpResponseError) as e:
             poller = client.begin_translation(translation_inputs)
             result = poller.result()
-        assert e.value.error.code == "InvalidDocumentAccessLevel"
+        assert e.value.error.code == "InvalidTargetDocumentAccessLevel"
 
     @DocumentTranslationPreparer()
     @DocumentTranslationClientPreparer()

--- a/sdk/translation/azure-ai-translation-document/tests/test_translation_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_translation_async.py
@@ -209,7 +209,6 @@ class TestTranslation(AsyncDocumentTranslationTest):
             result = await poller.result()
         assert e.value.error.code == "InvalidDocumentAccessLevel"
 
-    @pytest.mark.skip("https://github.com/Azure/azure-sdk-for-python/issues/17914")
     @DocumentTranslationPreparer()
     @DocumentTranslationClientPreparer()
     async def test_bad_input_target(self, client):
@@ -233,7 +232,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
         with pytest.raises(HttpResponseError) as e:
             poller = await client.begin_translation(translation_inputs)
             result = await poller.result()
-        assert e.value.error.code == "InvalidDocumentAccessLevel"
+        assert e.value.error.code == "InvalidTargetDocumentAccessLevel"
 
     @DocumentTranslationPreparer()
     @DocumentTranslationClientPreparer()


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/17914

This was previously returning "Failed" for a bad target URL, but the service has fixed it to correctly return "ValidationFailed' in v1.0. Also looks like they updated the error code to be more explicit.