### PR TITLE
Clear environment variables before DefaultAzureCredential test

### DIFF
--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -229,7 +229,10 @@ def test_shared_cache_username():
     assert token.token == expected_access_token
 
 
-def test_vscode_arguments():
+def test_vscode_arguments(monkeypatch):
+    monkeypatch.delenv(EnvironmentVariables.AZURE_AUTHORITY_HOST, raising=False)
+    monkeypatch.delenv(EnvironmentVariables.AZURE_TENANT_ID, raising=False)
+
     credential = DefaultAzureCredential.__module__ + ".VisualStudioCodeCredential"
 
     # DefaultAzureCredential shouldn't specify a default authority or tenant to VisualStudioCodeCredential
@@ -244,13 +247,13 @@ def test_vscode_arguments():
     mock_credential.assert_called_once_with(**tenant)
 
     # tenant id can also be specified in $AZURE_TENANT_ID
-    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: tenant["tenant_id"]}, clear=True):
+    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: tenant["tenant_id"]}):
         with patch(credential) as mock_credential:
             DefaultAzureCredential()
     mock_credential.assert_called_once_with(**tenant)
 
     # keyword argument should override environment variable
-    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: "not-" + tenant["tenant_id"]}, clear=True):
+    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: "not-" + tenant["tenant_id"]}):
         with patch(credential) as mock_credential:
             DefaultAzureCredential(visual_studio_code_tenant_id=tenant["tenant_id"])
     mock_credential.assert_called_once_with(**tenant)

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -214,7 +214,10 @@ async def test_shared_cache_username():
     assert token.token == expected_access_token
 
 
-def test_vscode_arguments():
+def test_vscode_arguments(monkeypatch):
+    monkeypatch.delenv(EnvironmentVariables.AZURE_AUTHORITY_HOST, raising=False)
+    monkeypatch.delenv(EnvironmentVariables.AZURE_TENANT_ID, raising=False)
+
     credential = DefaultAzureCredential.__module__ + ".VisualStudioCodeCredential"
 
     # DefaultAzureCredential shouldn't specify a default authority or tenant to VisualStudioCodeCredential
@@ -229,13 +232,13 @@ def test_vscode_arguments():
     mock_credential.assert_called_once_with(**tenant)
 
     # tenant id can also be specified in $AZURE_TENANT_ID
-    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: tenant["tenant_id"]}, clear=True):
+    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: tenant["tenant_id"]}):
         with patch(credential) as mock_credential:
             DefaultAzureCredential()
     mock_credential.assert_called_once_with(**tenant)
 
     # keyword argument should override environment variable
-    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: "not-" + tenant["tenant_id"]}, clear=True):
+    with patch.dict(os.environ, {EnvironmentVariables.AZURE_TENANT_ID: "not-" + tenant["tenant_id"]}):
         with patch(credential) as mock_credential:
             DefaultAzureCredential(visual_studio_code_tenant_id=tenant["tenant_id"])
     mock_credential.assert_called_once_with(**tenant)


### PR DESCRIPTION
DefaultAzureCredential uses $AZURE_TENANT_ID as a default tenant for VisualStudioCodeCredential. #18846 was able to merge with a test that fails when that variable has a value because it doesn't have a value in CI. It has a value in the nightly live test run, however, so this PR unsets the variable at the start of the test. It also unsets AZURE_AUTHORITY_HOST to prevent a similar future problem when we start running live tests in sovereign clouds.