### PR TITLE
[translation] update default polling interval

### DIFF
--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_client.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_client.py
@@ -16,7 +16,13 @@ from ._models import (
 )
 from ._user_agent import USER_AGENT
 from ._polling import TranslationPolling, DocumentTranslationLROPollingMethod
-from ._helpers import get_http_logging_policy, convert_datetime, get_authentication_policy, get_translation_input
+from ._helpers import (
+    get_http_logging_policy,
+    convert_datetime,
+    get_authentication_policy,
+    get_translation_input,
+    POLLING_INTERVAL
+)
 if TYPE_CHECKING:
     from azure.core.paging import ItemPaged
     from azure.core.credentials import TokenCredential, AzureKeyCredential
@@ -64,7 +70,7 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
         self._api_version = kwargs.pop('api_version', None)
 
         authentication_policy = get_authentication_policy(credential)
-
+        polling_interval = kwargs.pop("polling_interval", POLLING_INTERVAL)
         self._client = _BatchDocumentTranslationClient(
             endpoint=endpoint,
             credential=credential,  # type: ignore
@@ -72,6 +78,7 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
             sdk_moniker=USER_AGENT,
             authentication_policy=authentication_policy,
             http_logging_policy=get_http_logging_policy(),
+            polling_interval=polling_interval,
             **kwargs
         )
 

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py
@@ -17,6 +17,7 @@ from ._generated.models import (
 )
 from ._models import DocumentTranslationInput
 COGNITIVE_KEY_HEADER = "Ocp-Apim-Subscription-Key"
+POLLING_INTERVAL = 1
 
 
 def get_translation_input(args, kwargs, continuation_token):

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_client_async.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_client_async.py
@@ -17,7 +17,13 @@ from .._models import (
     FileFormat,
     DocumentStatusResult
 )
-from .._helpers import get_http_logging_policy, convert_datetime, get_authentication_policy, get_translation_input
+from .._helpers import (
+    get_http_logging_policy,
+    convert_datetime,
+    get_authentication_policy,
+    get_translation_input,
+    POLLING_INTERVAL
+)
 from ._async_polling import AsyncDocumentTranslationLROPollingMethod, AsyncDocumentTranslationLROPoller
 from .._polling import TranslationPolling
 if TYPE_CHECKING:
@@ -67,6 +73,7 @@ class DocumentTranslationClient(object):
         self._api_version = kwargs.pop('api_version', None)
 
         authentication_policy = get_authentication_policy(credential)
+        polling_interval = kwargs.pop("polling_interval", POLLING_INTERVAL)
         self._client = _BatchDocumentTranslationClient(
             endpoint=endpoint,
             credential=credential,  # type: ignore
@@ -74,6 +81,7 @@ class DocumentTranslationClient(object):
             sdk_moniker=USER_AGENT,
             authentication_policy=authentication_policy,
             http_logging_policy=get_http_logging_policy(),
+            polling_interval=polling_interval,
             **kwargs
         )
 

--- a/sdk/translation/azure-ai-translation-document/tests/preparer.py
+++ b/sdk/translation/azure-ai-translation-document/tests/preparer.py
@@ -39,9 +39,6 @@ class DocumentTranslationClientPreparer(AzureMgmtPreparer):
         # set polling interval to 0 for recorded tests
         if not self.is_live:
             self.client_kwargs["polling_interval"] = 0
-        else:
-            # default is 30s, but our tests translate very small docs so this helps speed up live testing
-            self.client_kwargs["polling_interval"] = 5
 
         client = self.client_cls(
             doctranslation_test_endpoint,


### PR DESCRIPTION
This polling interval is used between the POST and the first GET in the LRO. After which, the Retry-After seconds are extracted from the GET headers and used to control polling interval henceforth.