### PR TITLE
Bump Sphinx Version to Resolve Wonky ToC Caption

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -138,7 +138,7 @@ changedir = {toxinidir}
 passenv = *
 deps =
   {[base]deps}
-  sphinx==3.0.4
+  sphinx==3.5.4
   sphinx_rtd_theme==0.5.0
   recommonmark==0.6.0
   m2r==0.2.1


### PR DESCRIPTION
???
![image](https://user-images.githubusercontent.com/45376673/121416986-46dca800-c91e-11eb-9c94-4b8169b307de.png)

Reason? Bug in sphinx builder which doesn't assign the correct class to the containing `<p>` element.

Bad
```
<p><span class="caption-text">Developer Documentation</span></p>
```

Good
```
<p class="caption"><span class="caption-text">Developer Documentation</span></p>
```
![image](https://user-images.githubusercontent.com/45376673/121417184-768bb000-c91e-11eb-8d75-ad564fb56664.png)
