### PR TITLE
📄 core: Add license file; include in manifest

### DIFF
--- a/sdk/core/azure-common/LICENSE.md
+++ b/sdk/core/azure-common/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Microsoft Azure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/core/azure-common/MANIFEST.in
+++ b/sdk/core/azure-common/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.md
+include LICENSE.md

--- a/sdk/core/azure-core-tracing-opencensus/LICENSE.md
+++ b/sdk/core/azure-core-tracing-opencensus/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Microsoft Azure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/core/azure-core-tracing-opencensus/MANIFEST.in
+++ b/sdk/core/azure-core-tracing-opencensus/MANIFEST.in
@@ -5,4 +5,4 @@ include azure/core/__init__.py
 include azure/core/tracing/__init__.py
 include azure/core/tracing/ext/__init__.py
 recursive-include examples *.py
-
+include LICENSE.md

--- a/sdk/core/azure-core-tracing-opentelemetry/LICENSE.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Microsoft Azure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/core/azure-core-tracing-opentelemetry/MANIFEST.in
+++ b/sdk/core/azure-core-tracing-opentelemetry/MANIFEST.in
@@ -5,4 +5,4 @@ include azure/core/__init__.py
 include azure/core/tracing/__init__.py
 include azure/core/tracing/ext/__init__.py
 recursive-include samples *.py
-
+include LICENSE.md

--- a/sdk/core/azure-core/LICENSE.md
+++ b/sdk/core/azure-core/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Microsoft Azure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/core/azure-core/MANIFEST.in
+++ b/sdk/core/azure-core/MANIFEST.in
@@ -4,4 +4,4 @@ include azure/__init__.py
 recursive-include samples *.py *.md
 recursive-include doc *.rst
 include azure/core/py.typed
-
+include LICENSE.md

--- a/sdk/core/azure-mgmt-core/MANIFEST.in
+++ b/sdk/core/azure-mgmt-core/MANIFEST.in
@@ -5,4 +5,4 @@ include azure/mgmt/__init__.py
 recursive-include samples *.py *.md
 recursive-include doc *.rst
 include azure/mgmt/core/py.typed
-
+include LICENSE.md

--- a/sdk/core/azure-mgmt/LICENSE.md
+++ b/sdk/core/azure-mgmt/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Microsoft Azure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/core/azure-mgmt/MANIFEST.in
+++ b/sdk/core/azure-mgmt/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.md
+include LICENSE.md

--- a/sdk/core/azure-servicemanagement-legacy/LICENSE.md
+++ b/sdk/core/azure-servicemanagement-legacy/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Microsoft Azure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/core/azure-servicemanagement-legacy/MANIFEST.in
+++ b/sdk/core/azure-servicemanagement-legacy/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.md
 include azure_bdist_wheel.py
+include LICENSE.md


### PR DESCRIPTION
Ensure a license file is included when the core packages are published
to pypi.

Signed-off-by: Major Hayden <major@mhtx.net>