### PR TITLE
Async/BearerTokenCredentialPolicy consistently calls on_exception

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -128,8 +128,13 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
                 if "WWW-Authenticate" in response.http_response.headers:
                     request_authorized = self.on_challenge(request, response)
                     if request_authorized:
-                        response = self.next.send(request)
-                        self.on_response(request, response)
+                        try:
+                            response = self.next.send(request)
+                            self.on_response(request, response)
+                        except Exception:  # pylint:disable=broad-except
+                            handled = self.on_exception(request)
+                            if not handled:
+                                raise
 
         return response
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -84,8 +84,13 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy):
                 if "WWW-Authenticate" in response.http_response.headers:
                     request_authorized = await self.on_challenge(request, response)
                     if request_authorized:
-                        response = await self.next.send(request)
-                        await await_result(self.on_response, request, response)
+                        try:
+                            response = await self.next.send(request)
+                            await await_result(self.on_response, request, response)
+                        except Exception:  # pylint:disable=broad-except
+                            handled = await await_result(self.on_exception, request)
+                            if not handled:
+                                raise
 
         return response
 


### PR DESCRIPTION
Closes #19080