### PR TITLE
[Service Bus]Match the partition key with session id only when both are set

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**
 
-* Fixed a bug when setting the `partition_key` on `ServiceBusMessage` that should ensure that the session ID has been set before checking that the value passed in is equivalent to the session ID (PR #19233, thanks @bishnu-shb).
+* Fixed a bug that when setting `ServiceBusMessage.partition_key`, input value should be not validated against `session_id` of None (PR #19233, thanks @bishnu-shb).
 
 ## 7.3.0 (2021-06-08)
 

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 7.3.1 (Unreleased)
+
+**Bug Fixes**
+
+* Fixed a bug when setting the `partition_key` on `ServiceBusMessage` that should ensure that the session ID has been set before checking that the value passed in is equivalent to the session ID (PR #19233, thanks @bishnu-shb).
+
 ## 7.3.0 (2021-06-08)
 
 **New Features**

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -310,7 +310,7 @@ class ServiceBusMessage(
                 )
             )
 
-        if value and value != self.session_id:
+        if value and self.session_id and value != self.session_id:
             raise ValueError(
                 "partition_key:{} cannot be set to a different value than session_id:{}".format(
                     value, self.session_id

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_version.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "7.3.0"
+VERSION = "7.3.1"

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -129,8 +129,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 message.content_type = 'application/text'
                 message.correlation_id = 'cid'
                 message.message_id = str(i)
-                with pytest.raises(ValueError):
-                    message.partition_key = 'pk'
+                message.partition_key = 'pk'
                 message.to = 'to'
                 message.reply_to = 'reply_to'
                 sender.send_messages(message)
@@ -216,8 +215,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 messages = []
                 for i in range(10):
                     message = ServiceBusMessage("Handler message no. {}".format(i))
-                    with pytest.raises(ValueError):
-                        message.partition_key = 'pkey'
+                    message.partition_key = 'pkey'
                     message.time_to_live = timedelta(seconds=60)
                     message.scheduled_enqueue_time_utc = utc_now() + timedelta(seconds=60)
                     message.partition_key = None

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -64,8 +64,7 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
                 for i in range(3):
                     message = ServiceBusMessage("Handler message no. {}".format(i))
 
-                    with pytest.raises(ValueError):
-                        message.partition_key = 'pkey'
+                    message.partition_key = 'pkey'
 
                     message.session_id = session_id
                     message.partition_key = session_id


### PR DESCRIPTION
The azure documentation says "if a message has the partition key property but not the session ID property set, then Service Bus uses the partition key property value as the partition key. If the message has both the session ID and the partition key properties set, both properties must be identical" [https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning#using-a-partition-key]. 
[Re-raised #18955]