### PR TITLE
Run mypy in azure-keyvault-administration CI

### DIFF
--- a/eng/tox/mypy_hard_failure_packages.py
+++ b/eng/tox/mypy_hard_failure_packages.py
@@ -9,6 +9,7 @@ MYPY_HARD_FAILURE_OPTED = [
   "azure-core",
   "azure-eventhub",
   "azure-identity",
+  "azure-keyvault-administration",
   "azure-servicebus",
   "azure-ai-textanalytics",
   "azure-ai-formrecognizer",

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -31,9 +31,9 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional
+    from typing import Any, Optional
     from azure.core.credentials import AccessToken, TokenCredential
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.pipeline import PipelineResponse
 
 
 def _enforce_tls(request):
@@ -61,7 +61,7 @@ def _get_challenge_request(request):
 
 
 def _update_challenge(request, challenger):
-    # type: (HttpRequest, HttpResponse) -> HttpChallenge
+    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
     """parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
@@ -95,7 +95,7 @@ class ChallengeAuthPolicy(ChallengeAuthPolicyBase, HTTPPolicy):
         super(ChallengeAuthPolicy, self).__init__(**kwargs)
 
     def send(self, request):
-        # type: (PipelineRequest) -> HttpResponse
+        # type: (PipelineRequest) -> PipelineResponse
         _enforce_tls(request)
 
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)

--- a/sdk/keyvault/azure-keyvault-administration/mypy.ini
+++ b/sdk/keyvault/azure-keyvault-administration/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+python_version = 3.6
+warn_unused_configs = True
+ignore_missing_imports = True
+
+[mypy-azure.keyvault.*._generated.*]
+ignore_errors = True

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -31,9 +31,9 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional
+    from typing import Any, Optional
     from azure.core.credentials import AccessToken, TokenCredential
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.pipeline import PipelineResponse
 
 
 def _enforce_tls(request):
@@ -61,7 +61,7 @@ def _get_challenge_request(request):
 
 
 def _update_challenge(request, challenger):
-    # type: (HttpRequest, HttpResponse) -> HttpChallenge
+    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
     """parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
@@ -95,7 +95,7 @@ class ChallengeAuthPolicy(ChallengeAuthPolicyBase, HTTPPolicy):
         super(ChallengeAuthPolicy, self).__init__(**kwargs)
 
     def send(self, request):
-        # type: (PipelineRequest) -> HttpResponse
+        # type: (PipelineRequest) -> PipelineResponse
         _enforce_tls(request)
 
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -31,9 +31,9 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional
+    from typing import Any, Optional
     from azure.core.credentials import AccessToken, TokenCredential
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.pipeline import PipelineResponse
 
 
 def _enforce_tls(request):
@@ -61,7 +61,7 @@ def _get_challenge_request(request):
 
 
 def _update_challenge(request, challenger):
-    # type: (HttpRequest, HttpResponse) -> HttpChallenge
+    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
     """parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
@@ -95,7 +95,7 @@ class ChallengeAuthPolicy(ChallengeAuthPolicyBase, HTTPPolicy):
         super(ChallengeAuthPolicy, self).__init__(**kwargs)
 
     def send(self, request):
-        # type: (PipelineRequest) -> HttpResponse
+        # type: (PipelineRequest) -> PipelineResponse
         _enforce_tls(request)
 
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -31,9 +31,9 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional
+    from typing import Any, Optional
     from azure.core.credentials import AccessToken, TokenCredential
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.pipeline import PipelineResponse
 
 
 def _enforce_tls(request):
@@ -61,7 +61,7 @@ def _get_challenge_request(request):
 
 
 def _update_challenge(request, challenger):
-    # type: (HttpRequest, HttpResponse) -> HttpChallenge
+    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
     """parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
@@ -95,7 +95,7 @@ class ChallengeAuthPolicy(ChallengeAuthPolicyBase, HTTPPolicy):
         super(ChallengeAuthPolicy, self).__init__(**kwargs)
 
     def send(self, request):
-        # type: (PipelineRequest) -> HttpResponse
+        # type: (PipelineRequest) -> PipelineResponse
         _enforce_tls(request)
 
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)


### PR DESCRIPTION
Part of #19158. The only remaining errors were in `challenge_auth_policy.py` which is also used by other Key Vault libraries, so I copied fixes to them as well. I didn't enable mypy in CI for those other packages because they require more work before they will pass.