### PR TITLE
Reduce redundant logging during ChainedTokenCredential.get_token()

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### Bugs Fixed
 
 ### Other Changes
+- Reduced redundant `ChainedTokenCredential` and `DefaultAzureCredential`
+  logging. On Python 3.7+, credentials invoked by these classes now log debug
+  rather than info messages.
+  ([#18972](https://github.com/Azure/azure-sdk-for-python/issues/18972))
 
 ## 1.7.0b2 (2021-07-08)
 ### Features Added

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -71,16 +71,15 @@ class ChainedTokenCredential(object):
             except CredentialUnavailableError as ex:
                 # credential didn't attempt authentication because it lacks required data or state -> continue
                 history.append((credential, ex.message))
-                _LOGGER.info("%s - %s is unavailable", self.__class__.__name__, credential.__class__.__name__)
             except Exception as ex:  # pylint: disable=broad-except
                 # credential failed to authenticate, or something unexpectedly raised -> break
                 history.append((credential, str(ex)))
-                _LOGGER.warning(
+                _LOGGER.debug(
                     '%s.get_token failed: %s raised unexpected error "%s"',
                     self.__class__.__name__,
                     credential.__class__.__name__,
                     ex,
-                    exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                    exc_info=True,
                 )
                 break
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -7,6 +7,7 @@ import logging
 from azure.core.exceptions import ClientAuthenticationError
 
 from .. import CredentialUnavailableError
+from .._internal import within_credential_chain
 
 try:
     from typing import TYPE_CHECKING
@@ -61,6 +62,7 @@ class ChainedTokenCredential(object):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :raises ~azure.core.exceptions.ClientAuthenticationError: no credential in the chain provided a token
         """
+        within_credential_chain.set(True)
         history = []
         for credential in self.credentials:
             try:
@@ -83,6 +85,7 @@ class ChainedTokenCredential(object):
                 )
                 break
 
+        within_credential_chain.set(False)
         attempts = _get_error_message(history)
         message = self.__class__.__name__ + " failed to retrieve a token from the included credentials." + attempts
         _LOGGER.warning(message)

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -14,6 +14,23 @@ from .._constants import EnvironmentVariables, KnownAuthorities
 if TYPE_CHECKING:
     from typing import Any, Optional
 
+try:
+    from contextvars import ContextVar
+
+    within_credential_chain = ContextVar("within_credential_chain", default=False)
+except ImportError:
+    # No ContextVar on Python < 3.7. Credentials will behave as if they're never in a chain i.e. they will log fully.
+
+    class AlwaysFalse:
+        # pylint:disable=no-self-use
+        def get(self):
+            return False
+
+        def set(self, _):
+            pass
+
+    within_credential_chain = AlwaysFalse()  # type: ignore
+
 
 def normalize_authority(authority):
     # type: (str) -> str

--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -8,6 +8,9 @@ import logging
 from six import raise_from
 from azure.core.exceptions import ClientAuthenticationError
 
+from . import within_credential_chain
+
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -25,10 +28,18 @@ def log_get_token(class_name):
         def wrapper(*args, **kwargs):
             try:
                 token = fn(*args, **kwargs)
-                _LOGGER.info("%s succeeded", qualified_name)
+                _LOGGER.log(
+                    logging.DEBUG if within_credential_chain.get() else logging.INFO, "%s succeeded", qualified_name
+                )
                 return token
             except Exception as ex:
-                _LOGGER.warning("%s failed: %s", qualified_name, ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
+                _LOGGER.log(
+                    logging.DEBUG if within_credential_chain.get() else logging.WARNING,
+                    "%s failed: %s",
+                    qualified_name,
+                    ex,
+                    exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                )
                 raise
 
         return wrapper

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+from . import within_credential_chain
 from .._constants import DEFAULT_REFRESH_OFFSET, DEFAULT_TOKEN_REFRESH_RETRY_DELAY
 
 try:
@@ -80,11 +81,19 @@ class GetTokenMixin(ABC):
                     token = self._request_token(*scopes, **kwargs)
                 except Exception:  # pylint:disable=broad-except
                     pass
-            _LOGGER.info("%s.get_token succeeded", self.__class__.__name__)
+            _LOGGER.log(
+                logging.DEBUG if within_credential_chain.get() else logging.INFO,
+                "%s.get_token succeeded",
+                self.__class__.__name__,
+            )
             return token
 
         except Exception as ex:
-            _LOGGER.warning(
-                "%s.get_token failed: %s", self.__class__.__name__, ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG)
+            _LOGGER.log(
+                logging.DEBUG if within_credential_chain.get() else logging.WARNING,
+                "%s.get_token failed: %s",
+                self.__class__.__name__,
+                ex,
+                exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
             )
             raise

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -62,16 +62,15 @@ class ChainedTokenCredential(AsyncContextManager):
             except CredentialUnavailableError as ex:
                 # credential didn't attempt authentication because it lacks required data or state -> continue
                 history.append((credential, ex.message))
-                _LOGGER.info("%s - %s is unavailable", self.__class__.__name__, credential.__class__.__name__)
             except Exception as ex:  # pylint: disable=broad-except
                 # credential failed to authenticate, or something unexpectedly raised -> break
                 history.append((credential, str(ex)))
-                _LOGGER.warning(
+                _LOGGER.debug(
                     '%s.get_token failed: %s raised unexpected error "%s"',
                     self.__class__.__name__,
                     credential.__class__.__name__,
                     ex,
-                    exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                    exc_info=True,
                 )
                 break
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -10,6 +10,7 @@ from azure.core.exceptions import ClientAuthenticationError
 from .._internal import AsyncContextManager
 from ... import CredentialUnavailableError
 from ..._credentials.chained import _get_error_message
+from ..._internal import within_credential_chain
 
 if TYPE_CHECKING:
     from typing import Any, Optional
@@ -52,6 +53,7 @@ class ChainedTokenCredential(AsyncContextManager):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :raises ~azure.core.exceptions.ClientAuthenticationError: no credential in the chain provided a token
         """
+        within_credential_chain.set(True)
         history = []
         for credential in self.credentials:
             try:
@@ -74,6 +76,7 @@ class ChainedTokenCredential(AsyncContextManager):
                 )
                 break
 
+        within_credential_chain.set(False)
         attempts = _get_error_message(history)
         message = self.__class__.__name__ + " failed to retrieve a token from the included credentials." + attempts
         raise ClientAuthenticationError(message=message)

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -8,6 +8,7 @@ import time
 from typing import TYPE_CHECKING
 
 from ..._constants import DEFAULT_REFRESH_OFFSET, DEFAULT_TOKEN_REFRESH_RETRY_DELAY
+from ..._internal import within_credential_chain
 
 if TYPE_CHECKING:
     # pylint:disable=ungrouped-imports,unused-import
@@ -70,11 +71,19 @@ class GetTokenMixin(abc.ABC):
                     token = await self._request_token(*scopes, **kwargs)
                 except Exception:  # pylint:disable=broad-except
                     pass
-            _LOGGER.info("%s.get_token succeeded", self.__class__.__name__)
+            _LOGGER.log(
+                logging.DEBUG if within_credential_chain.get() else logging.INFO,
+                "%s.get_token succeeded",
+                self.__class__.__name__,
+            )
             return token
 
         except Exception as ex:
-            _LOGGER.warning(
-                "%s.get_token failed: %s", self.__class__.__name__, ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG)
+            _LOGGER.log(
+                logging.DEBUG if within_credential_chain.get() else logging.WARNING,
+                "%s.get_token failed: %s",
+                self.__class__.__name__,
+                ex,
+                exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
             )
             raise


### PR DESCRIPTION
This PR closes #18972 by reducing redundant logging during `ChainedTokenCredential.get_token()` and, by inheritance, `DefaultAzureCredential.get_token()`. The rationale is that when `get_token()` fails for a credential chain, it logs an aggregate of the inner credentials' error messages, making those credentials' logging of same redundant. Similarly, when `get_token()` succeeds, users will seldom find error messages from unavailable inner credentials interesting. On the contrary, those messages can be confusing: "Why do I see half a dozen error messages when authentication succeeds?"

Here's the diff for DefaultAzureCredential failure given typical logging configuration (filtering `DEBUG` messages):
```diff
[INFO] No environment configuration found.
[INFO] ManagedIdentityCredential will use IMDS
-[WARNING] EnvironmentCredential.get_token failed: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
-[INFO] DefaultAzureCredential - EnvironmentCredential is unavailable
[INFO] No response from the IMDS endpoint.
-[WARNING] ImdsCredential.get_token failed: ManagedIdentityCredential authentication unavailable, no managed identity endpoint found.
-[WARNING] ManagedIdentityCredential.get_token failed: ManagedIdentityCredential authentication unavailable, no managed identity endpoint found.
-[INFO] DefaultAzureCredential - ManagedIdentityCredential is unavailable
-[WARNING] SharedTokenCacheCredential.get_token failed: SharedTokenCacheCredential authentication unavailable. No accounts were found in the cache.
-[INFO] DefaultAzureCredential - SharedTokenCacheCredential is unavailable
-[WARNING] VisualStudioCodeCredential.get_token failed: Failed to get Azure user details from Visual Studio Code.
-[INFO] DefaultAzureCredential - VisualStudioCodeCredential is unavailable
-[WARNING] AzureCliCredential.get_token failed: Please run 'az login' to set up an account
-[INFO] DefaultAzureCredential - AzureCliCredential is unavailable
-[WARNING] AzurePowerShellCredential.get_token failed: Please run "Connect-AzAccount" to set up account
-[INFO] DefaultAzureCredential - AzurePowerShellCredential is unavailable
[WARNING] DefaultAzureCredential failed to retrieve a token from the included credentials.
Attempted credentials:
        EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
        ManagedIdentityCredential: ManagedIdentityCredential authentication unavailable, no managed identity endpoint found.
        SharedTokenCacheCredential: SharedTokenCacheCredential authentication unavailable. No accounts were found in the cache.
        VisualStudioCodeCredential: Failed to get Azure user details from Visual Studio Code.
        AzureCliCredential: Please run 'az login' to set up an account
        AzurePowerShellCredential: Please run "Connect-AzAccount" to set up account
```

Similarly, DefaultAzureCredential success:
```diff
[INFO] No environment configuration found.
[INFO] ManagedIdentityCredential will use IMDS
-[WARNING] EnvironmentCredential.get_token failed: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
-[INFO] DefaultAzureCredential - EnvironmentCredential is unavailable
[INFO] No response from the IMDS endpoint.
-[WARNING] ImdsCredential.get_token failed: ManagedIdentityCredential authentication unavailable, no managed identity endpoint found.
-[WARNING] ManagedIdentityCredential.get_token failed: ManagedIdentityCredential authentication unavailable, no managed identity endpoint found.
-[INFO] DefaultAzureCredential - ManagedIdentityCredential is unavailable
-[WARNING] SharedTokenCacheCredential.get_token failed: SharedTokenCacheCredential authentication unavailable. No accounts were found in the cache.
-[INFO] DefaultAzureCredential - SharedTokenCacheCredential is unavailable
-[INFO] DefaultAzureCredential - VisualStudioCodeCredential is unavailable
-[WARNING] AzureCliCredential.get_token failed: Please run 'az login' to set up an account
-[INFO] DefaultAzureCredential - AzureCliCredential is unavailable
-[INFO] AzurePowerShellCredential.get_token succeeded
[INFO] DefaultAzureCredential acquired a token from AzurePowerShellCredential
```

Inner credentials still log these messages, however they do so at `DEBUG` level when they're invoked by ChainedTokenCredential, using a ContextVar to determine whether that's the case. Unfortunately, ContextVar was added in Python 3.7. For Python 3.6, we have a [backport](https://pypi.org/project/contextvars/). The nearest equivalent available to 2.7 is `threading.local`, which isn't concurrency-safe. Another alternative that works everywhere is to pass around an internal keyword argument, but 🤮

In the end, because this isn't a functional or API change, I don't mind excluding 2.7. Similarly, if the backport is unacceptable, I observe that 3.6 will be EOL in 6 months. But that's just my opinion, please feel free to change my mind or propose alternative solutions 😄 