### PR TITLE
[EventHubs] Get Iot Hub Name from Redirect Address

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -42,6 +42,7 @@ TIMEOUT_SAMPLES = {
         "recv_with_checkpoint_store.py": (10),
         "recv_with_custom_starting_position.py": (10),
         "sample_code_eventhub.py": (10),
+        "iot_hub_connection_string_receive_async.py": (10),
         "receive_batch_with_checkpoint_async.py": (10),
         "recv_async.py": (10),
         "recv_track_last_enqueued_event_prop_async.py": (10),
@@ -84,7 +85,6 @@ IGNORED_SAMPLES = {
         "connection_to_custom_endpoint_address.py",
         "proxy.py",
         "connection_to_custom_endpoint_address_async.py",
-        "iot_hub_connection_string_receive_async.py",
         "proxy_async.py"
     ],
     "azure-servicebus": [

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -97,7 +97,7 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         # Once a redirect error is received, close the original client and recreate a new one to the re-directed address
         receive_client.close()
         fully_qualified_name = redirect.hostname.decode("utf-8")
-        # Get IoT Hub name from redirect address, in case name has been modified by service during creation
+        # Use regular expression to parse the Event Hub name from the IoT Hub redirection address
         iot_hub_name = re.search(":\d+\/.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
         conn_str = "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
             fully_qualified_name,

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -24,9 +24,7 @@ from urllib.parse import urlencode, quote_plus
 from uamqp import ReceiveClient, Source
 from uamqp.errors import LinkRedirect
 
-from provisioningserviceclient import ProvisioningServiceClient
-from provisioningserviceclient.models import IndividualEnrollment, AttestationMechanism
-from azure.iot.device.aio import ProvisioningDeviceClient, IoTHubDeviceClient
+from azure.iot.device.aio import IoTHubDeviceClient
 from azure.iot.device import Message
 from azure.eventhub import EventData
 from azure.eventhub.aio import EventHubProducerClient, EventHubConsumerClient
@@ -51,45 +49,8 @@ def generate_sas_token(uri, policy, key, expiry=None):
         result['skn'] = policy
     return 'SharedAccessSignature ' + urlencode(result)
 
-async def send_messages_with_provisioned_iot_device(iothub_conn_str):
-    #dps_conn_str = 'HostName=swathip-test-iot-provisioning.azure-devices-provisioning.net;SharedAccessKeyName=provisioningserviceowner;SharedAccessKey=eR3Vnxivm9R40MbtgAJ9slsh7TQdYzYj7Dgdohg28kE='
-    ##os.environ["DPS_SERVICE_CONNECTION_STR"]
-    #endorsement_key = 'AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAtW6MOyCu/Nih47atIIoZtlYkhLeCTiSrtRN3q6hqgOllA979No4BOcDWF90OyzJvjQknMfXS/Dx/IJIBnORgCg1YX/j4EEtO7Ase29Xd63HjvG8M94+u2XINu79rkTxeueqW7gPeRZQPnl1xYmqawYcyzJS6GKWKdoIdS+UWu6bJr58V3xwvOQI4NibXKD7htvz07jLItWTFhsWnTdZbJ7PnmfCa2vbRH/9pZIow+CcAL9mNTNNN4FdzYwapNVO+6SY/W4XU0Q+dLMCKYarqVNH5GzAWDfKT8nKzg69yQejJM8oeUWag/8odWOfbszA+iFjw3wVNrA5n8grUieRkPQ=='
-    ##os.environ["DPS_ENDORSEMENT_KEY"]
-    #registration_id = 'test_registration_id'
-    ##os.environ["DPS_REGISTRATION_ID"]
-    #provisioning_host = os.getenv("PROVISIONING_HOST")
-    #id_scope = os.getenv("PROVISIONING_IDSCOPE")
-    #provisioning_service_client = ProvisioningServiceClient.create_from_connection_string(dps_conn_str)
-    ##registration_id = os.getenv("PROVISIONING_REGISTRATION_ID")
-    ##symmetric_key = os.getenv("PROVISIONING_SYMMETRIC_KEY")
-    #att_mech = AttestationMechanism.create_with_tpm(endorsement_key)
-    #individual_enrollment = IndividualEnrollment.create(registration_id, att_mech, device_id='test-device-id')
-    ##provisioning_service_client.delete(individual_enrollment)
-    #individual_enrollment = provisioning_service_client.create_or_update(individual_enrollment)
-
-    ##provisioning_device_client = ProvisioningDeviceClient.create_from_symmetric_key(
-    ##    provisioning_host=provisioning_host,
-    ##    registration_id=registration_id,
-    ##    id_scope=id_scope,
-    ##    symmetric_key=symmetric_key,
-    ##)
-
-    #print(dir(individual_enrollment))
-    #registration_state = individual_enrollment.registration_state
-    #print(dir(registration_state))
-    #registration_result = await provisioning_service_client.register()
-
-    #print("The complete registration result is")
-    #print(registration_result.registration_state.device_id)
-
-    #if registration_result.status == "assigned":
-    #device_client = IoTHubDeviceClient.create_from_symmetric_key(
-    #    symmetric_key=symmetric_key,
-    #    hostname=registration_result.registration_state.assigned_hub,
-    #    device_id=registration_result.registration_state.device_id,
-    #)
-    device_client = IoTHubDeviceClient.create_from_connection_string('HostName=swathip-test-iot-hub-aaaaaaaaaa.azure-devices.net;DeviceId=swathip-test-device-id;SharedAccessKey=5ho6Stu6VHIjmzz+bZl8w0EfvwhlXprup2HePcy0f20=')
+async def send_messages_with_provisioned_iot_device(device_conn_str):
+    device_client = IoTHubDeviceClient.create_from_connection_string(device_conn_str)
     # Connect the client.
     await device_client.connect()
 
@@ -102,8 +63,6 @@ async def send_messages_with_provisioned_iot_device(iothub_conn_str):
 
     # finally, disconnect
     await device_client.disconnect()
-    #else:
-    #    print("Can not send messages from the provisioned device")
 
 def parse_iot_conn_str(iothub_conn_str):
     hostname = None
@@ -137,16 +96,12 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         # Once a redirect error is received, close the original client and recreate a new one to the re-directed address
         receive_client.close()
         fully_qualified_name = redirect.hostname.decode("utf-8")
-        print("NAME:")
-        print(iot_hub_name)
-        print(iot_hub_name[:25])
-        conn_str = "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={}".format(
+        conn_str = "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
             fully_qualified_name,
             shared_access_key_name,
-            shared_access_key
-            #iot_hub_name[:25]
+            shared_access_key,
+            iot_hub_name[:25]
         )
-        print(conn_str)
         return conn_str
     except Exception as exp:
         raise ValueError(
@@ -174,11 +129,9 @@ async def receive_events_from_iothub(iothub_conn_str):
         )
 
 async def main():
-    iothub_conn_str = 'HostName=swathip-test-iot-hub-aaaaaaaaaa.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=u1Lxmqh/gViXrP0cbImpIrxb5eT1R9HOZg97Xuei/do='#HostName=swathip-test-iot.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=VNq0G9TZV+ndgqS8lOZ1OmWuinoO7TKZ+r4cVeSmek4='
-    #iothub_conn_str = os.environ["IOTHUB_CONNECTION_STR"]
-    #device_id = 'swathip-test-iot-device-sample'
-    #device_id = os.environ["IOTHUB_DEVICE"]
-    await send_messages_with_provisioned_iot_device(iothub_conn_str)
+    iothub_conn_str = os.environ["IOTHUB_CONNECTION_STR"]
+    device_conn_str = os.environ["IOT_DEVICE_CONNECTION_STR"]
+    await send_messages_with_provisioned_iot_device(device_conn_str)
     await receive_events_from_iothub(iothub_conn_str)
 
 loop = asyncio.get_event_loop()

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -98,7 +98,7 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         receive_client.close()
         fully_qualified_name = redirect.hostname.decode("utf-8")
         # Get IoT Hub name from redirect address, in case name has been modified by service during creation
-        iot_hub_name = re.search("\.net.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
+        iot_hub_name = re.search(":\d+\/.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
         conn_str = "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
             fully_qualified_name,
             shared_access_key_name,

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -15,6 +15,7 @@ https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-bu
 """
 
 import os
+import re
 import time
 from base64 import b64encode, b64decode
 from hashlib import sha256
@@ -96,11 +97,13 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         # Once a redirect error is received, close the original client and recreate a new one to the re-directed address
         receive_client.close()
         fully_qualified_name = redirect.hostname.decode("utf-8")
+        # Get IoT Hub name from redirect address, in case name has been modified by service during creation
+        iot_hub_name = re.search("\.net.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
         conn_str = "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
             fully_qualified_name,
             shared_access_key_name,
             shared_access_key,
-            iot_hub_name[:25]
+            iot_hub_name
         )
         return conn_str
     except Exception as exp:

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -24,7 +24,12 @@ from urllib.parse import urlencode, quote_plus
 from uamqp import ReceiveClient, Source
 from uamqp.errors import LinkRedirect
 
-from azure.eventhub.aio import EventHubConsumerClient
+from provisioningserviceclient import ProvisioningServiceClient
+from provisioningserviceclient.models import IndividualEnrollment, AttestationMechanism
+from azure.iot.device.aio import ProvisioningDeviceClient, IoTHubDeviceClient
+from azure.iot.device import Message
+from azure.eventhub import EventData
+from azure.eventhub.aio import EventHubProducerClient, EventHubConsumerClient
 
 
 def generate_sas_token(uri, policy, key, expiry=None):
@@ -46,6 +51,59 @@ def generate_sas_token(uri, policy, key, expiry=None):
         result['skn'] = policy
     return 'SharedAccessSignature ' + urlencode(result)
 
+async def send_messages_with_provisioned_iot_device(iothub_conn_str):
+    #dps_conn_str = 'HostName=swathip-test-iot-provisioning.azure-devices-provisioning.net;SharedAccessKeyName=provisioningserviceowner;SharedAccessKey=eR3Vnxivm9R40MbtgAJ9slsh7TQdYzYj7Dgdohg28kE='
+    ##os.environ["DPS_SERVICE_CONNECTION_STR"]
+    #endorsement_key = 'AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAtW6MOyCu/Nih47atIIoZtlYkhLeCTiSrtRN3q6hqgOllA979No4BOcDWF90OyzJvjQknMfXS/Dx/IJIBnORgCg1YX/j4EEtO7Ase29Xd63HjvG8M94+u2XINu79rkTxeueqW7gPeRZQPnl1xYmqawYcyzJS6GKWKdoIdS+UWu6bJr58V3xwvOQI4NibXKD7htvz07jLItWTFhsWnTdZbJ7PnmfCa2vbRH/9pZIow+CcAL9mNTNNN4FdzYwapNVO+6SY/W4XU0Q+dLMCKYarqVNH5GzAWDfKT8nKzg69yQejJM8oeUWag/8odWOfbszA+iFjw3wVNrA5n8grUieRkPQ=='
+    ##os.environ["DPS_ENDORSEMENT_KEY"]
+    #registration_id = 'test_registration_id'
+    ##os.environ["DPS_REGISTRATION_ID"]
+    #provisioning_host = os.getenv("PROVISIONING_HOST")
+    #id_scope = os.getenv("PROVISIONING_IDSCOPE")
+    #provisioning_service_client = ProvisioningServiceClient.create_from_connection_string(dps_conn_str)
+    ##registration_id = os.getenv("PROVISIONING_REGISTRATION_ID")
+    ##symmetric_key = os.getenv("PROVISIONING_SYMMETRIC_KEY")
+    #att_mech = AttestationMechanism.create_with_tpm(endorsement_key)
+    #individual_enrollment = IndividualEnrollment.create(registration_id, att_mech, device_id='test-device-id')
+    ##provisioning_service_client.delete(individual_enrollment)
+    #individual_enrollment = provisioning_service_client.create_or_update(individual_enrollment)
+
+    ##provisioning_device_client = ProvisioningDeviceClient.create_from_symmetric_key(
+    ##    provisioning_host=provisioning_host,
+    ##    registration_id=registration_id,
+    ##    id_scope=id_scope,
+    ##    symmetric_key=symmetric_key,
+    ##)
+
+    #print(dir(individual_enrollment))
+    #registration_state = individual_enrollment.registration_state
+    #print(dir(registration_state))
+    #registration_result = await provisioning_service_client.register()
+
+    #print("The complete registration result is")
+    #print(registration_result.registration_state.device_id)
+
+    #if registration_result.status == "assigned":
+    #device_client = IoTHubDeviceClient.create_from_symmetric_key(
+    #    symmetric_key=symmetric_key,
+    #    hostname=registration_result.registration_state.assigned_hub,
+    #    device_id=registration_result.registration_state.device_id,
+    #)
+    device_client = IoTHubDeviceClient.create_from_connection_string('HostName=swathip-test-iot-hub-aaaaaaaaaa.azure-devices.net;DeviceId=swathip-test-device-id;SharedAccessKey=5ho6Stu6VHIjmzz+bZl8w0EfvwhlXprup2HePcy0f20=')
+    # Connect the client.
+    await device_client.connect()
+
+    for i in range(3):
+        message = Message("Sending to IotHub, message {}".format(i))
+        print("Sending message: {}".format(message))
+        await device_client.send_message(message)
+        print("Message sent succesfully.")
+        time.sleep(1)
+
+    # finally, disconnect
+    await device_client.disconnect()
+    #else:
+    #    print("Can not send messages from the provisioned device")
 
 def parse_iot_conn_str(iothub_conn_str):
     hostname = None
@@ -63,7 +121,6 @@ def parse_iot_conn_str(iothub_conn_str):
         raise ValueError("Invalid connection string")
     return hostname, shared_access_key_name, shared_access_key
 
-
 def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
     hostname, shared_access_key_name, shared_access_key = parse_iot_conn_str(iothub_conn_str)
     iot_hub_name = hostname.split(".")[0]
@@ -80,12 +137,17 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         # Once a redirect error is received, close the original client and recreate a new one to the re-directed address
         receive_client.close()
         fully_qualified_name = redirect.hostname.decode("utf-8")
-        return "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
+        print("NAME:")
+        print(iot_hub_name)
+        print(iot_hub_name[:25])
+        conn_str = "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={}".format(
             fully_qualified_name,
             shared_access_key_name,
-            shared_access_key,
-            iot_hub_name
+            shared_access_key
+            #iot_hub_name[:25]
         )
+        print(conn_str)
+        return conn_str
     except Exception as exp:
         raise ValueError(
             "{} is not an invalid IoT Hub connection string. The underlying exception is {}".format(
@@ -93,7 +155,6 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
                 exp,
             )
         )
-
 
 async def receive_events_from_iothub(iothub_conn_str):
     """Convert the iot hub connection string to the built-in eventhub connection string
@@ -112,8 +173,13 @@ async def receive_events_from_iothub(iothub_conn_str):
             starting_position=-1  # "-1" is from the beginning of the partition.
         )
 
+async def main():
+    iothub_conn_str = 'HostName=swathip-test-iot-hub-aaaaaaaaaa.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=u1Lxmqh/gViXrP0cbImpIrxb5eT1R9HOZg97Xuei/do='#HostName=swathip-test-iot.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=VNq0G9TZV+ndgqS8lOZ1OmWuinoO7TKZ+r4cVeSmek4='
+    #iothub_conn_str = os.environ["IOTHUB_CONNECTION_STR"]
+    #device_id = 'swathip-test-iot-device-sample'
+    #device_id = os.environ["IOTHUB_DEVICE"]
+    await send_messages_with_provisioned_iot_device(iothub_conn_str)
+    await receive_events_from_iothub(iothub_conn_str)
 
-if __name__ == '__main__':
-    iothub_conn_str = os.environ["IOTHUB_CONN_STR"]
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(receive_events_from_iothub(iothub_conn_str))
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/sdk/eventhub/azure-eventhub/samples/sample_dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/samples/sample_dev_requirements.txt
@@ -1,2 +1,4 @@
 azure-eventhub-checkpointstoreblob
 azure-eventhub-checkpointstoreblob-aio; python_version >= '3.6'
+azure-iot-device
+azure-iothub-provisioningserviceclient

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -61,6 +61,27 @@
       "metadata": {
         "description": "The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung."
       }
+    },
+    "iotSkuName": {
+      "type": "string",
+      "defaultValue": "S1",
+      "metadata": {
+        "description": "The SKU to use for the IoT Hub."
+      }
+    },
+    "iotSkuUnits": {
+      "type": "string",
+      "defaultValue": "1",
+      "metadata": {
+        "description": "The number of IoT Hub units."
+      }
+    },
+    "iotEHd2cPartitions": {
+      "type": "string",
+      "defaultValue": "4",
+      "metadata": {
+        "description": "Partitions used for the event stream."
+      }
     }
   },
   "variables": {
@@ -75,6 +96,8 @@
     "defaultSASKeyName": "RootManageSharedAccessKey",
     "eventHubsAuthRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('eventHubsNamespace'), variables('defaultSASKeyName'))]",
     "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount'))]",
+    "iotHubName": "[concat('eh-', parameters('baseName'), '-iot-hub')]",
+    "iotHubDeviceName": "[concat('eh-', parameters('baseName'), '-device-iot-hub')]"
   },
   "resources": [
     {
@@ -159,6 +182,149 @@
         "principalId": "[parameters('testApplicationOid')]",
         "scope": "[resourceGroup().id]"
       }
+    },
+    {
+      "name": "[variables('iotHubName')]",
+      "type": "Microsoft.Devices/IotHubs",
+      "apiVersion": "2020-08-01",
+      "location": "[parameters('location')]",
+      "tags": {},
+      "properties": {
+        "authorizationPolicies": [
+          {
+            "keyName": "string",
+            "primaryKey": "string",
+            "secondaryKey": "string",
+            "rights": "string"
+          }
+        ],
+        "publicNetworkAccess": "string",
+        "ipFilterRules": [
+          {
+            "filterName": "string",
+            "action": "string",
+            "ipMask": "string"
+          }
+        ],
+        "minTlsVersion": "string",
+        "privateEndpointConnections": [
+          {
+            "properties": {
+              "privateEndpoint": {},
+              "privateLinkServiceConnectionState": {
+                "status": "string",
+                "description": "string",
+                "actionsRequired": "string"
+              }
+            }
+          }
+        ],
+        "eventHubEndpoints": {},
+        "routing": {
+          "endpoints": {
+            "serviceBusQueues": [
+              {
+                "id": "string",
+                "connectionString": "string",
+                "endpointUri": "string",
+                "entityPath": "string",
+                "authenticationType": "string",
+                "name": "string",
+                "subscriptionId": "string",
+                "resourceGroup": "string"
+              }
+            ],
+            "serviceBusTopics": [
+              {
+                "id": "string",
+                "connectionString": "string",
+                "endpointUri": "string",
+                "entityPath": "string",
+                "authenticationType": "string",
+                "name": "string",
+                "subscriptionId": "string",
+                "resourceGroup": "string"
+              }
+            ],
+            "eventHubs": [
+              {
+                "id": "string",
+                "connectionString": "string",
+                "endpointUri": "string",
+                "entityPath": "string",
+                "authenticationType": "string",
+                "name": "string",
+                "subscriptionId": "string",
+                "resourceGroup": "string"
+              }
+            ],
+            "storageContainers": [
+              {
+                "id": "string",
+                "connectionString": "string",
+                "endpointUri": "string",
+                "authenticationType": "string",
+                "name": "string",
+                "subscriptionId": "string",
+                "resourceGroup": "string",
+                "containerName": "string",
+                "fileNameFormat": "string",
+                "batchFrequencyInSeconds": "integer",
+                "maxChunkSizeInBytes": "integer",
+                "encoding": "string"
+              }
+            ]
+          },
+          "routes": [
+            {
+              "name": "string",
+              "source": "string",
+              "condition": "string",
+              "endpointNames": [
+                "string"
+              ],
+              "isEnabled": "boolean"
+            }
+          ],
+          "fallbackRoute": {
+            "name": "string",
+            "source": "DeviceMessages",
+            "condition": "string",
+            "endpointNames": [
+              "string"
+            ],
+            "isEnabled": "boolean"
+          },
+          "enrichments": [
+            {
+              "key": "string",
+              "value": "string",
+              "endpointNames": [
+                "string"
+              ]
+            }
+          ]
+        },
+        "storageEndpoints": {},
+        "messagingEndpoints": {},
+        "enableFileUploadNotifications": "boolean",
+        "cloudToDevice": {
+          "maxDeliveryCount": "integer",
+          "defaultTtlAsIso8601": "string",
+          "feedback": {
+            "lockDurationAsIso8601": "string",
+            "ttlAsIso8601": "string",
+            "maxDeliveryCount": "integer"
+          }
+        },
+        "comments": "string",
+        "features": "string"
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "resources": []
     }
   ],
   "outputs": {


### PR DESCRIPTION
Fixes: #19087 
Follows[ C# sample,](https://github.com/Azure/azure-sdk-for-net/blob/350c23ea19ed76d74f7d97dfe3aec82671fdcc9d/samples/iothub-connect-to-eventhubs/IotHubConnection.cs#L97) which also gets IoT Hub name from redirect address.