### PR TITLE
[EventHubs] Get IoT Hub Name from Redirect Address in sample

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -83,6 +83,10 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         fully_qualified_name = redirect.hostname.decode("utf-8")
         # Use regular expression to parse the Event Hub name from the IoT Hub redirection address
         if redirect.address:
+            # The regex searches for the Event Hub compatible name in the redirection address. The name is nested in
+            # between the port and 'ConsumerGroups'.
+            # (ex. "...servicebus.windows.net:12345/<Event Hub name>/ConsumerGroups/...").
+            # The regex matches string ':<digits>/', then any characters, then the string '/ConsumerGroups'.
             iot_hub_name = re.search(":\d+\/.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
         return "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
             fully_qualified_name,

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -82,7 +82,8 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         receive_client.close()
         fully_qualified_name = redirect.hostname.decode("utf-8")
         # Use regular expression to parse the Event Hub name from the IoT Hub redirection address
-        iot_hub_name = re.search(":\d+\/.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
+        if redirect.address:
+            iot_hub_name = re.search(":\d+\/.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
         return "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
             fully_qualified_name,
             shared_access_key_name,

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -15,6 +15,7 @@ https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-bu
 """
 
 import os
+import re
 import time
 from base64 import b64encode, b64decode
 from hashlib import sha256
@@ -80,6 +81,8 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
         # Once a redirect error is received, close the original client and recreate a new one to the re-directed address
         receive_client.close()
         fully_qualified_name = redirect.hostname.decode("utf-8")
+        # Use regular expression to parse the Event Hub name from the IoT Hub redirection address
+        iot_hub_name = re.search(":\d+\/.*/ConsumerGroups", str(redirect.address)).group(0).split("/")[1]
         return "Endpoint=sb://{}/;SharedAccessKeyName={};SharedAccessKey={};EntityPath={}".format(
             fully_qualified_name,
             shared_access_key_name,


### PR DESCRIPTION
Fixes: #19087 
Follows[ C# sample,](https://github.com/Azure/azure-sdk-for-net/blob/350c23ea19ed76d74f7d97dfe3aec82671fdcc9d/samples/iothub-connect-to-eventhubs/IotHubConnection.cs#L97) which also gets IoT Hub name from redirect address.