### PR TITLE
[azure-mgmt-monitor] skip test to unblock ci

### DIFF
--- a/sdk/monitor/azure-mgmt-monitor/tests/test_cli_mgmt_monitor_async.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/test_cli_mgmt_monitor_async.py
@@ -6,6 +6,7 @@
 # license information.
 #--------------------------------------------------------------------------
 import time
+import pytest
 import unittest
 
 import azure.mgmt.monitor.aio

--- a/sdk/monitor/azure-mgmt-monitor/tests/test_cli_mgmt_monitor_async.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/test_cli_mgmt_monitor_async.py
@@ -281,6 +281,7 @@ class MgmtMonitorClientTest(AzureMgmtAsyncTestCase):
         result = self.vm_client.virtual_machines.create_or_update(group_name, vm_name, BODY)
         return result.result()
 
+    @pytest.mark.skip("https://github.com/Azure/azure-sdk-for-python/issues/19389")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     def test_monitor_diagnostic_settings(self, resource_group):
         SUBSCRIPTION_ID = self.settings.SUBSCRIPTION_ID


### PR DESCRIPTION
This is blocking ci for a while https://github.com/Azure/azure-sdk-for-python/issues/19389

skipping this test for now