### PR TITLE
[Key Vault] Extend pipeline test timeout

### DIFF
--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -17,6 +17,7 @@ stages:
         JobName: ${{ replace(service, '-', '_') }}
         DeployArmTemplate: true
         AllocateResourceGroup: true
+        TestTimeoutInMinutes: 240
         ${{ if eq(service, 'azure-keyvault-keys') }}:
           AdditionalMatrixConfigs:
             - Name: keyvault_test_matrix_addons


### PR DESCRIPTION
A hopefully temporary change to prevent our live test pipelines from getting cancelled at the two-hour mark (the last successful run took 3 hours and 46 minutes).