### PR TITLE
Make IMDS unavailability easier to debug

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -20,8 +19,6 @@ if TYPE_CHECKING:
     # pylint:disable=ungrouped-imports
     from typing import Any, Optional
     from azure.core.credentials import AccessToken
-
-_LOGGER = logging.getLogger(__name__)
 
 IMDS_URL = "http://169.254.169.254/metadata/identity/oauth2/token"
 
@@ -51,6 +48,7 @@ class ImdsCredential(GetTokenMixin):
             self._endpoint_available = True  # type: Optional[bool]
         else:
             self._endpoint_available = None
+        self._error_message = None  # type: Optional[str]
         self._user_assigned_identity = "client_id" in kwargs or "identity_config" in kwargs
 
     def _acquire_token_silently(self, *scopes):
@@ -67,16 +65,18 @@ class ImdsCredential(GetTokenMixin):
                 self._client.request_token(*scopes, connection_timeout=0.3, retry_total=0)
                 self._endpoint_available = True
             except HttpResponseError:
-                # received a response, choked on it
+                # IMDS responded
                 self._endpoint_available = True
-            except Exception:  # pylint:disable=broad-except
+            except Exception as ex:  # pylint:disable=broad-except
                 # if anything else was raised, assume the endpoint is unavailable
                 self._endpoint_available = False
-                _LOGGER.info("No response from the IMDS endpoint.")
+                self._error_message = (
+                    "ManagedIdentityCredential authentication unavailable, no response from the IMDS endpoint."
+                )
+                six.raise_from(CredentialUnavailableError(self._error_message), ex)
 
         if not self._endpoint_available:
-            message = "ManagedIdentityCredential authentication unavailable, no managed identity endpoint found."
-            raise CredentialUnavailableError(message=message)
+            raise CredentialUnavailableError(self._error_message)
 
         try:
             token = self._client.request_token(*scopes, headers={"Metadata": "true"})
@@ -85,13 +85,13 @@ class ImdsCredential(GetTokenMixin):
             # or the identity with the specified client_id is not available
             if ex.status_code == 400:
                 self._endpoint_available = False
-                message = "ManagedIdentityCredential authentication unavailable. "
+                self._error_message = "ManagedIdentityCredential authentication unavailable. "
                 if self._user_assigned_identity:
-                    message += "The requested identity has not been assigned to this resource."
+                    self._error_message += "The requested identity has not been assigned to this resource."
                 else:
-                    message += "No identity has been assigned to this resource."
-                six.raise_from(CredentialUnavailableError(message=message), ex)
+                    self._error_message += "No identity has been assigned to this resource."
+                six.raise_from(CredentialUnavailableError(message=self._error_message), ex)
 
             # any other error is unexpected
-            six.raise_from(ClientAuthenticationError(message=ex.message, response=ex.response), None)
+            six.raise_from(ClientAuthenticationError(message=ex.message, response=ex.response), ex)
         return token

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -19,8 +18,6 @@ if TYPE_CHECKING:
     from typing import Any, Optional
     from azure.core.credentials import AccessToken
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class ImdsCredential(AsyncContextManager, GetTokenMixin):
     def __init__(self, **kwargs: "Any") -> None:
@@ -31,6 +28,7 @@ class ImdsCredential(AsyncContextManager, GetTokenMixin):
             self._endpoint_available = True  # type: Optional[bool]
         else:
             self._endpoint_available = None
+        self._error_message = None  # type: Optional[str]
         self._user_assigned_identity = "client_id" in kwargs or "identity_config" in kwargs
 
     async def close(self) -> None:
@@ -48,16 +46,18 @@ class ImdsCredential(AsyncContextManager, GetTokenMixin):
                 await self._client.request_token(*scopes, connection_timeout=0.3, retry_total=0)
                 self._endpoint_available = True
             except HttpResponseError:
-                # received a response, choked on it
+                # IMDS responded
                 self._endpoint_available = True
-            except Exception:  # pylint:disable=broad-except
+            except Exception as ex:  # pylint:disable=broad-except
                 # if anything else was raised, assume the endpoint is unavailable
                 self._endpoint_available = False
-                _LOGGER.info("No response from the IMDS endpoint.")
+                self._error_message = (
+                    "ManagedIdentityCredential authentication unavailable, no response from the IMDS endpoint."
+                )
+                raise CredentialUnavailableError(message=self._error_message) from ex
 
         if not self._endpoint_available:
-            message = "ManagedIdentityCredential authentication unavailable, no managed identity endpoint found."
-            raise CredentialUnavailableError(message=message)
+            raise CredentialUnavailableError(message=self._error_message)
 
         try:
             token = await self._client.request_token(*scopes, headers={"Metadata": "true"})
@@ -66,13 +66,13 @@ class ImdsCredential(AsyncContextManager, GetTokenMixin):
             # or the identity with the specified client_id is not available
             if ex.status_code == 400:
                 self._endpoint_available = False
-                message = "ManagedIdentityCredential authentication unavailable. "
+                self._error_message = "ManagedIdentityCredential authentication unavailable. "
                 if self._user_assigned_identity:
-                    message += "The requested identity has not been assigned to this resource."
+                    self._error_message += "The requested identity has not been assigned to this resource."
                 else:
-                    message += "No identity has been assigned to this resource."
-                raise CredentialUnavailableError(message=message) from ex
+                    self._error_message += "No identity has been assigned to this resource."
+                raise CredentialUnavailableError(message=self._error_message) from ex
 
             # any other error is unexpected
-            raise ClientAuthenticationError(message=ex.message, response=ex.response) from None
+            raise ClientAuthenticationError(message=ex.message, response=ex.response) from ex
         return token


### PR DESCRIPTION
A few small changes to make it easier to understand why ImdsCredential decided IMDS is unavailable (#19091):
1. use `raise from` to expose the exceptions motivating authentication errors
2. remove redundant logging of IMDS unavailability (the resulting authentication exception is logged at a higher level elsewhere)
3. raise a consistent error message on subsequent `get_token` calls after deciding IMDS is unavailable