### PR TITLE
[EventHubs] Fix bug in sending stress test code and update default stress test settings

### DIFF
--- a/sdk/eventhub/azure-eventhub/stress/azure_eventhub_producer_stress.py
+++ b/sdk/eventhub/azure-eventhub/stress/azure_eventhub_producer_stress.py
@@ -31,8 +31,8 @@ def handle_exception(error, ignore_send_failure, stress_logger, azure_monitor_me
 
 
 def stress_send_sync(producer: EventHubProducerClient, args, stress_logger, azure_monitor_metric):
-    batch = producer.create_batch(partition_id=args.send_partition_id, partition_key=args.send_partition_key)
     try:
+        batch = producer.create_batch(partition_id=args.send_partition_id, partition_key=args.send_partition_key)
         while True:
             event_data = EventData(body=b"D" * args.payload)
             batch.add(event_data)
@@ -41,6 +41,8 @@ def stress_send_sync(producer: EventHubProducerClient, args, stress_logger, azur
             producer.send_batch(batch)
         except EventHubError as e:
             return handle_exception(e, args.ignore_send_failure, stress_logger, azure_monitor_metric)
+    except EventHubError as e:
+        return handle_exception(e, args.ignore_send_failure, stress_logger, azure_monitor_metric)
     return len(batch)
 
 
@@ -57,8 +59,8 @@ def stress_send_list_sync(producer: EventHubProducerClient, args, stress_logger,
 
 
 async def stress_send_async(producer: EventHubProducerClientAsync, args, stress_logger, azure_monitor_metric):
-    batch = await producer.create_batch()
     try:
+        batch = await producer.create_batch(partition_id=args.send_partition_id, partition_key=args.send_partition_key)
         while True:
             event_data = EventData(body=b"D" * args.payload)
             batch.add(event_data)
@@ -67,6 +69,8 @@ async def stress_send_async(producer: EventHubProducerClientAsync, args, stress_
             await producer.send_batch(batch)
         except EventHubError as e:
             return handle_exception(e, args.ignore_send_failure, stress_logger, azure_monitor_metric)
+    except EventHubError as e:
+        return handle_exception(e, args.ignore_send_failure, stress_logger, azure_monitor_metric)
     return len(batch)
 
 
@@ -275,7 +279,7 @@ class StressTestRunner(object):
                     logger.info("keyboard interrupted")
                     self.stop()
                 except Exception as e:
-                    logger.exception("%r failed:", type(worker), e)
+                    logger.exception("%r failed: %r", type(worker), e)
                     self.stop()
             logger.info("%r has finished testing", test_method)
 
@@ -373,7 +377,7 @@ class StressTestRunner(object):
                     logger.info("keyboard interrupted")
                     self.stop()
                 except Exception as e:
-                    logger.exception("%r failed: ", type(worker), e)
+                    logger.exception("%r failed: %r", type(worker), e)
                     self.stop()
             logger.info("%r has finished testing", test_method)
 

--- a/sdk/eventhub/azure-eventhub/stress/stress_runner.cfg
+++ b/sdk/eventhub/azure-eventhub/stress/stress_runner.cfg
@@ -14,7 +14,7 @@ auth_timeout=60
 # log output per output_interval messages
 output_interval=1000
 # By default every stress test will create a new eventhub, if set to no, the specific eventhub name should be provided
-create_new_eventhub=yes
+create_new_eventhub=no
 partition_cnt_to_create=32
 message_retention_in_days=7
 run_generated_commands=yes
@@ -57,7 +57,7 @@ transport_type=0
 retry_total=5
 retry_backoff_factor=0.8
 retry_backoff_max=180
-ignore_send_failure=False
+ignore_send_failure=True
 
 
 [RUN_METHODS]
@@ -71,7 +71,7 @@ receive_async=no
 receive_with_checkpointstore_sync=no
 # receive alone require manual eventhub connection string input -- the eventhub and blob resource must exist
 receive_with_checkpointstore_async=no
-send_and_receive_sync=no
+send_and_receive_sync=yes
 send_and_receive_async=yes
 send_and_receive_with_checkpointstore_sync=no
 send_and_receive_with_checkpointstore_async=no


### PR DESCRIPTION
The issues were found when running stress test with chaos-mesh: https://github.com/Azure/azure-sdk-for-python/issues/19241.

After fixing the test code, send could ignore error and recover properly.
also updated the default settings for stress test config.