### PR TITLE
Fix async ManagedIdentityCredential.__aenter__

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -6,6 +6,10 @@
   pre-filling the username/email address field on the login page
   ([#19225](https://github.com/Azure/azure-sdk-for-python/issues/19225))
 
+### Fixed
+- `azure.identity.aio.ManagedIdentityCredential` is an async context manager
+  that closes its underlying transport session at the end of a `with` block
+
 ## 1.7.0b1 (2021-06-08)
 Beginning with this release, this library requires Python 2.7 or 3.6+.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/app_service.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/app_service.py
@@ -26,6 +26,14 @@ class AppServiceCredential(AsyncContextManager, GetTokenMixin):
         else:
             self._available = False
 
+    async def __aenter__(self):
+        if self._available:
+            await self._client.__aenter__()
+        return self
+
+    async def close(self) -> None:
+        await self._client.close()
+
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         if not self._available:
             raise CredentialUnavailableError(
@@ -33,9 +41,6 @@ class AppServiceCredential(AsyncContextManager, GetTokenMixin):
             )
 
         return await super().get_token(*scopes, **kwargs)
-
-    async def close(self) -> None:
-        await self._client.close()
 
     async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
         return self._client.get_cached_token(*scopes)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
@@ -48,6 +48,14 @@ class AzureArcCredential(AsyncContextManager, GetTokenMixin):
                 policies=_get_policies(config), request_factory=functools.partial(_get_request, url), **kwargs
             )
 
+    async def __aenter__(self):
+        if self._available:
+            await self._client.__aenter__()
+        return self
+
+    async def close(self) -> None:
+        await self._client.close()
+
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         if not self._available:
             raise CredentialUnavailableError(
@@ -55,9 +63,6 @@ class AzureArcCredential(AsyncContextManager, GetTokenMixin):
             )
 
         return await super().get_token(*scopes, **kwargs)
-
-    async def close(self) -> None:
-        await self._client.close()
 
     async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
         return self._client.get_cached_token(*scopes)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/cloud_shell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/cloud_shell.py
@@ -32,15 +32,20 @@ class CloudShellCredential(AsyncContextManager, GetTokenMixin):
         else:
             self._available = False
 
+    async def __aenter__(self):
+        if self._available:
+            await self._client.__aenter__()
+        return self
+
+    async def close(self) -> None:
+        await self._client.close()
+
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         if not self._available:
             raise CredentialUnavailableError(
                 message="Cloud Shell managed identity configuration not found in environment"
             )
         return await super(CloudShellCredential, self).get_token(*scopes, **kwargs)
-
-    async def close(self) -> None:
-        await self._client.close()
 
     async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
         return self._client.get_cached_token(*scopes)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
@@ -33,6 +33,10 @@ class ImdsCredential(AsyncContextManager, GetTokenMixin):
             self._endpoint_available = None
         self._user_assigned_identity = "client_id" in kwargs or "identity_config" in kwargs
 
+    async def __aenter__(self):
+        await self._client.__aenter__()
+        return self
+
     async def close(self) -> None:
         await self._client.close()
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
@@ -26,6 +26,14 @@ class ServiceFabricCredential(AsyncContextManager, GetTokenMixin):
         else:
             self._available = False
 
+    async def __aenter__(self):
+        if self._available:
+            await self._client.__aenter__()
+        return self
+
+    async def close(self) -> None:
+        await self._client.close()
+
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         if not self._available:
             raise CredentialUnavailableError(
@@ -33,9 +41,6 @@ class ServiceFabricCredential(AsyncContextManager, GetTokenMixin):
             )
 
         return await super().get_token(*scopes, **kwargs)
-
-    async def close(self) -> None:
-        await self._client.close()
 
     async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
         return self._client.get_cached_token(*scopes)

--- a/sdk/identity/azure-identity/tests/test_managed_identity_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_client_async.py
@@ -12,9 +12,30 @@ from azure.identity.aio._internal.managed_identity_client import AsyncManagedIde
 import pytest
 
 from helpers import mock_response, Request
-from helpers_async import async_validating_transport
+from helpers_async import async_validating_transport, AsyncMockTransport
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_close():
+    transport = AsyncMockTransport()
+    client = AsyncManagedIdentityClient(lambda *_: None, transport=transport)
+
+    await client.close()
+
+    assert transport.__aexit__.call_count == 1
+
+
+async def test_context_manager():
+    transport = AsyncMockTransport()
+    client = AsyncManagedIdentityClient(lambda *_: None, transport=transport)
+
+    async with client:
+        assert transport.__aenter__.call_count == 1
+        assert transport.__aexit__.call_count == 0
+
+    assert transport.__aenter__.call_count == 1
+    assert transport.__aexit__.call_count == 1
 
 
 async def test_caching():


### PR DESCRIPTION
The internal async managed identity credentials are all context managers but they inherit a default `__aenter__` that doesn't actually work for them. This PR corrects that, makes the internal AsyncManagedIdentityClient a context manager, and tests all of it through ManagedIdentityCredential.