### PR TITLE
[textanalytics] fix healthcare result types for statistics/warnings

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -496,7 +496,7 @@ class AnalyzeHealthcareEntitiesResult(DictMixin):
             entities=entities,
             entity_relations=relations,
             warnings=healthcare_result.warnings,
-            statistics=healthcare_result.statistics,
+            statistics=TextDocumentStatistics._from_generated(healthcare_result.statistics),  # pylint: disable=protected-access
         )
 
     def __repr__(self):

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -495,7 +495,7 @@ class AnalyzeHealthcareEntitiesResult(DictMixin):
             id=healthcare_result.id,
             entities=entities,
             entity_relations=relations,
-            warnings=healthcare_result.warnings,
+            warnings=[TextAnalyticsWarning._from_generated(w) for w in healthcare_result.warnings],  # pylint: disable=protected-access
             statistics=TextDocumentStatistics._from_generated(healthcare_result.statistics),  # pylint: disable=protected-access
         )
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -152,8 +152,8 @@ class TestHealth(TextAnalyticsTest):
             if doc.is_error:
                 num_error += 1
                 continue
-            assert doc.statistics.characters_count
-            assert doc.statistics.transactions_count
+            assert doc.statistics.character_count
+            assert doc.statistics.transaction_count
         assert num_error == 1
 
     @TextAnalyticsPreparer()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -171,8 +171,8 @@ class TestHealth(AsyncTextAnalyticsTest):
             if doc.is_error:
                 num_error += 1
                 continue
-            assert doc.statistics.characters_count
-            assert doc.statistics.transactions_count
+            assert doc.statistics.character_count
+            assert doc.statistics.transaction_count
         assert num_error == 1
 
     @TextAnalyticsPreparer()


### PR DESCRIPTION
These were using the generated types, fixed to use the exposed types.