### PR TITLE
Update Validate-Formatting to use `black` output vs `git diff`

### DIFF
--- a/scripts/devops_tasks/validate_formatting.py
+++ b/scripts/devops_tasks/validate_formatting.py
@@ -9,44 +9,35 @@ import argparse
 import os
 import logging
 import sys
-
-from common_tasks import run_check_call
+import subprocess
+import pdb
 
 logging.getLogger().setLevel(logging.INFO)
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 sdk_dir = os.path.join(root_dir, "sdk")
 
-SWAGGER_FOLDER = "swagger"
-
-
 def run_black(service_dir):
     logging.info("Running black for {}".format(service_dir))
 
-    command = [sys.executable, "-m", "black", "-l", "120", "sdk/{}".format(service_dir)]
+    out = subprocess.Popen([sys.executable, "-m", "black", "-l", "120", "sdk/{}".format(service_dir)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd = root_dir
+    )
 
-    run_check_call(command, root_dir)
+    stdout,stderr = out.communicate()
 
+    if stderr:
+        raise RuntimeError("black ran into some trouble during its invocation: " + stderr)
 
-def check_diff(folder):
-    # We don't care about changes to txt files (dev_requirements change)
-    run_check_call(["git", "status"], sdk_dir, always_exit=False)
+    if stdout:
+        if "reformatted" in stdout.decode('utf-8'):
+            return False
 
-    dir_changed = folder.split("/")[:-2]
-    command = [
-        "git",
-        "diff",
-        "--exit-code",
-        "{}".format("/".join(dir_changed)),
-    ]
-    result = run_check_call(command, sdk_dir, always_exit=False)
-    if result:
-        command = ["git", "status"]
-        run_check_call(command, root_dir)
-        raise ValueError(
-            "Found difference between formatted code and current commit. Please re-generate with the latest autorest."
-        )
+    return True
 
+    
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Run black to verify formatted code."
@@ -61,7 +52,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     if args.validate != "False":
-        run_black(args.service_directory)
-        check_diff("sdk/{}".format(args.service_directory))
+        if not run_black(args.service_directory):
+            raise ValueError("Found difference between formatted code and current commit. Please re-generate with the latest autorest.")
+        
     else:
         print("Skipping formatting validation")

--- a/scripts/devops_tasks/validate_formatting.py
+++ b/scripts/devops_tasks/validate_formatting.py
@@ -10,7 +10,6 @@ import os
 import logging
 import sys
 import subprocess
-import pdb
 
 logging.getLogger().setLevel(logging.INFO)
 


### PR DESCRIPTION
[Here is a failing build.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=977321&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=23d29da4-00cb-5783-b17c-96bda25d9c52) the reason this is happening is because the script currently will break on anything being different at all. Unfortunately the `template` pipeline actually modifies the `version` and the `changelog`, so this means that the `validate formatting` finds a git diff and explodes.

Do you have any issues with this @seankane-msft ?