### PR TITLE
Update Test Timout from 0 to 60

### DIFF
--- a/eng/pipelines/templates/jobs/ci.conda.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.conda.tests.yml
@@ -27,7 +27,7 @@ parameters:
     default: false
   - name: TestTimeoutInMinutes
     type: number
-    default: 120
+    default: 60
   - name: CloudConfig
     type: object
     default: {}

--- a/eng/pipelines/templates/jobs/ci.conda.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.conda.tests.yml
@@ -27,7 +27,7 @@ parameters:
     default: false
   - name: TestTimeoutInMinutes
     type: number
-    default: 0
+    default: 120
   - name: CloudConfig
     type: object
     default: {}

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -19,7 +19,7 @@ parameters:
     default: 'azure-*'
   - name: TestTimeoutInMinutes
     type: number
-    default: 120
+    default: 60
   - name: ToxEnvParallel
     type: string
     default: '--tenvparallel'

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -19,7 +19,7 @@ parameters:
     default: 'azure-*'
   - name: TestTimeoutInMinutes
     type: number
-    default: 0
+    default: 120
   - name: ToxEnvParallel
     type: string
     default: '--tenvparallel'

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -28,7 +28,7 @@ parameters:
     default: 'azure-*'
   - name: TestTimeoutInMinutes
     type: number
-    default: 0
+    default: 120
   - name: ToxEnvParallel
     type: string
     default: '--tenvparallel'

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -28,7 +28,7 @@ parameters:
     default: 'azure-*'
   - name: TestTimeoutInMinutes
     type: number
-    default: 120
+    default: 60
   - name: ToxEnvParallel
     type: string
     default: '--tenvparallel'

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -28,7 +28,7 @@ parameters:
   default: azure-*
 - name: TestTimeoutInMinutes
   type: number
-  default: 0
+  default: 120
 - name: ToxEnvParallel
   type: string
   default: --tenvparallel

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -28,7 +28,7 @@ parameters:
   default: azure-*
 - name: TestTimeoutInMinutes
   type: number
-  default: 120
+  default: 60
 - name: ToxEnvParallel
   type: string
   default: --tenvparallel

--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -27,6 +27,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: cognitiveservices
+    TestTimeoutInMinutes: 120
     Artifacts:
     - name: azure-cognitiveservices-anomalydetector
       safeName: azurecognitiveservicesanomalydetector

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -29,6 +29,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: storage
+    TestTimeoutInMinutes: 120
     # Override the base matrix due to https://github.com/Azure/azure-sdk-for-python/issues/17837
     MatrixConfigs:
       - Name: storage_ci_matrix


### PR DESCRIPTION
This was fine on hosted agents, as the defaults when `0` is passed are much lower.

On self-hosted machines, it's forever. Can't have that!

@weshaggard I adjusted this thing down to 60 (where it was 120), but individually bumped `cognitiveservices` and `storage` to 120, as they DO regularly go above 60 for the nightly run.