### PR TITLE
[textanalytics] move async file to aio

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_response_handlers_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_response_handlers_async.py
@@ -9,7 +9,7 @@ import functools
 from urllib.parse import urlparse, parse_qsl
 
 from azure.core.async_paging import AsyncList, AsyncItemPaged
-from ._response_handlers import healthcare_result, get_iter_items
+from .._response_handlers import healthcare_result, get_iter_items
 
 
 async def healthcare_extract_page_data_async(

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -28,7 +28,7 @@ from .._response_handlers import (
     language_result,
     pii_entities_result,
 )
-from .._response_handlers_async import healthcare_paged_result, analyze_paged_result
+from ._response_handlers_async import healthcare_paged_result, analyze_paged_result
 from .._models import (
     DetectLanguageInput,
     TextDocumentInput,


### PR DESCRIPTION
Moves _response_handlers_async.py into the `aio` directory