### PR TITLE
Updating CODEOWNERS for ACS Identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,7 @@
 
 # PRLabel: %Communication
 /sdk/communication/                                                  @turalf @ankitarorabit @memontic-ms @Azure/azure-sdk-communication-code-reviewers
+/sdk/communication/azure-communication-identity/                     @petrsvihlik @martinbarnas-ms
 
 # PRLabel: %KeyVault
 /sdk/keyvault/                                                       @schaabs @chlowell @mccoyp


### PR DESCRIPTION
Reason: The ACS SDKs (including Identity) are being handed over to the service teams.