### PR TITLE
Add check for tracing_enabled setting

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
@@ -85,7 +85,7 @@ class DistributedTracingPolicy(SansIOHTTPPolicy):
         ctxt = request.context.options
         try:
             span_impl_type = settings.tracing_implementation()
-            if span_impl_type is None:
+            if (not settings.tracing_enabled()) or (span_impl_type is None):
                 return
 
             namer = ctxt.pop('network_span_namer', self._network_span_namer)


### PR DESCRIPTION
Updating `DistributedTracingPolicy` to check that tracing is enabled along with having an implementation type present before tracing a request