### PR TITLE
Prevent DeprecationWarning in Identity tests

### DIFF
--- a/sdk/identity/azure-identity/tests/test_powershell_credential.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential.py
@@ -260,7 +260,7 @@ def test_allow_multitenant_authentication():
         assert command[-1].startswith("pwsh -NonInteractive -EncodedCommand ")
         encoded_script = command[-1].split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
-        match = re.search("Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
+        match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
         tenant = match.groups()[1]
 
         assert tenant is None or tenant == second_tenant, 'unexpected tenant "{}"'.format(tenant)
@@ -292,7 +292,7 @@ def test_multitenant_authentication_not_allowed():
         assert command[-1].startswith("pwsh -NonInteractive -EncodedCommand ")
         encoded_script = command[-1].split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
-        match = re.search("Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
+        match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
         tenant = match.groups()[1]
 
         assert tenant is None, "credential shouldn't accept an explicit tenant ID"

--- a/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
@@ -263,7 +263,7 @@ async def test_allow_multitenant_authentication():
         assert command.startswith("pwsh -NonInteractive -EncodedCommand ")
         encoded_script = command.split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
-        match = re.search("Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
+        match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
         tenant = match[2]
 
         assert tenant is None or tenant == second_tenant, 'unexpected tenant "{}"'.format(tenant)
@@ -296,7 +296,7 @@ async def test_multitenant_authentication_not_allowed():
         assert command.startswith("pwsh -NonInteractive -EncodedCommand ")
         encoded_script = command.split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
-        match = re.search("Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
+        match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
         tenant = match[2]
 
         assert tenant is None, "credential shouldn't accept an explicit tenant ID"


### PR DESCRIPTION
Python 3.9 logs a deprecation warning for "\S" in regex strings, which I suppose will stop working entirely in a future version. That's reasonable because it's escape sequence syntax that happens to be a match pattern also. Easy fix: make the regex a raw string.