### PR TITLE
Fix for #19724, upload_blob uploads 0 bytes for socket stream.

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
@@ -11,6 +11,7 @@ from typing import (  # pylint: disable=unused-import
 
 import logging
 from os import fstat
+import stat
 from io import (SEEK_END, SEEK_SET, UnsupportedOperation)
 
 import isodate
@@ -70,7 +71,11 @@ def get_length(data):
             pass
         else:
             try:
-                return fstat(fileno).st_size
+                mode = fstat(fileno).st_mode
+                if stat.S_ISREG(mode) or stat.S_ISLNK(mode):
+                    #st_size only meaningful if regular file or symlink, other types
+                    # e.g. sockets may return misleading sizes like 0
+                    return fstat(fileno).st_size
             except OSError:
                 # Not a valid fileno, may be possible requests returned
                 # a socket number?


### PR DESCRIPTION
See issue: #19724 

Check fd is reg file or symlink in get_length before using st_size.

st_size is not meaningful for non-regular files (or symlinks).
See man (2) stat.