### PR TITLE
Exclude Latest Version of azure-communication-phonenumbers from regression

### DIFF
--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -27,7 +27,8 @@ EXCLUDED_PACKAGE_VERSIONS = {
     'azure-storage-blob-changefeed' : '12.0.0b2',
     'azure-storage-file-datalake': '12.2.0b1',
     'azure-communication-identity': '1.0.0',
-    'azure-communication-phonenumbers': '1.0.1'
+    'azure-communication-phonenumbers': '1.0.0',
+    'azure-communication-sms': '1.0.0'
 }
 
 # This method identifies release tag for latest or oldest released version of a given package

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -26,7 +26,8 @@ EXCLUDED_PACKAGE_VERSIONS = {
     'azure-schemaregistry-avroserializer': '1.0.0b1',
     'azure-storage-blob-changefeed' : '12.0.0b2',
     'azure-storage-file-datalake': '12.2.0b1',
-    'azure-communication-identity': '1.0.0'
+    'azure-communication-identity': '1.0.0',
+    'azure-communication-phonenumbers': '1.0.1'
 }
 
 # This method identifies release tag for latest or oldest released version of a given package


### PR DESCRIPTION
Due to imcompatible tests. @xiangyan99 

Checking for others that have the same issue.

- [Run with just phonenumbers out](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=990350&view=results)