### PR TITLE
[pipeline] upgrade autorest.python from `5.8.3` to `5.8.4`

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.4.5",
-      "use": ["@autorest/python@5.8.3", "@autorest/modelerfour@4.19.2"],
+      "use": ["@autorest/python@5.8.4", "@autorest/modelerfour@4.19.2"],
       "python": "",
       "python-mode": "update",
       "sdkrel:python-sdks-folder": "./sdk/.",


### PR DESCRIPTION
test link:

https://github.com/openapi-env-test/azure-rest-api-specs/pull/2942 (network)
https://github.com/openapi-env-test/azure-rest-api-specs/pull/2941 (policyinsights)