### PR TITLE
[translation] filters renames/alignment

### DIFF
--- a/sdk/translation/azure-ai-translation-document/CHANGELOG.md
+++ b/sdk/translation/azure-ai-translation-document/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Breaking Changes
 
+- Changed: renamed kwargs `translated_before` and `translated_after` to `created_before` and `created_after`, respectively,
+for `list_all_document_statuses`.
+- Changed: renamed `order_by` sorting query option `createdDateTimeUtc` to `created_on` for `list_all_translation_statuses` and
+`list_all_document_statuses`.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_client.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_client.py
@@ -21,6 +21,7 @@ from ._polling import TranslationPolling, DocumentTranslationLROPollingMethod
 from ._helpers import (
     get_http_logging_policy,
     convert_datetime,
+    convert_order_by,
     get_authentication_policy,
     get_translation_input,
     POLLING_INTERVAL,
@@ -231,14 +232,17 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
             By default, we sort by all submitted operations descendingly by start time.
         :keyword int results_per_page: is the number of operations returned per page.
         :keyword list[str] translation_ids: translation operations ids to filter by.
-        :keyword list[str] statuses: translation operation statuses to filter by.
+        :keyword list[str] statuses: translation operation statuses to filter by. Options include
+            'NotStarted', 'Running', 'Succeeded', 'Failed', 'Cancelled', 'Cancelling',
+            and 'ValidationFailed'.
         :keyword created_after: get operations created after certain datetime.
         :paramtype created_after: Union[str, datetime.datetime]
         :keyword created_before: get operations created before certain datetime.
         :paramtype created_before: Union[str, datetime.datetime]
-        :keyword list[str] order_by: the sorting query for the operations returned.
-            format: ["parm1 asc/desc", "parm2 asc/desc", ...]
-            (ex: 'createdDateTimeUtc asc', 'createdDateTimeUtc desc').
+        :keyword list[str] order_by: the sorting query for the operations returned. Currently only
+            'created_on' supported.
+            format: ["param1 asc/desc", "param2 asc/desc", ...]
+            (ex: 'created_on asc', 'created_on desc').
         :return: A pageable of TranslationStatus.
         :rtype: ~azure.core.paging.ItemPaged[TranslationStatus]
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -252,6 +256,8 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
                 :dedent: 4
                 :caption: List all submitted translations under the resource.
         """
+
+        order_by = convert_order_by(kwargs.pop("order_by", None))
         created_after = kwargs.pop("created_after", None)
         created_before = kwargs.pop("created_before", None)
         created_after = convert_datetime(created_after) if created_after else None
@@ -279,6 +285,7 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
             created_date_time_utc_start=created_after,
             created_date_time_utc_end=created_before,
             ids=translation_ids,
+            order_by=order_by,
             **kwargs
         )
 
@@ -293,14 +300,17 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
             By default, we sort by all documents descendingly by start time.
         :keyword int results_per_page: is the number of documents returned per page.
         :keyword list[str] document_ids: document IDs to filter by.
-        :keyword list[str] statuses: document statuses to filter by.
-        :keyword translated_after: get document translated after certain datetime.
-        :paramtype translated_after: Union[str, datetime.datetime]
-        :keyword translated_before: get document translated before certain datetime.
-        :paramtype translated_before: Union[str, datetime.datetime]
-        :keyword list[str] order_by: the sorting query for the documents.
-            format: ["parm1 asc/desc", "parm2 asc/desc", ...]
-            (ex: 'createdDateTimeUtc asc', 'createdDateTimeUtc desc').
+        :keyword list[str] statuses: document statuses to filter by. Options include
+            'NotStarted', 'Running', 'Succeeded', 'Failed', 'Cancelled', 'Cancelling',
+            and 'ValidationFailed'.
+        :keyword created_after: get document created after certain datetime.
+        :paramtype created_after: Union[str, datetime.datetime]
+        :keyword created_before: get document created before certain datetime.
+        :paramtype created_before: Union[str, datetime.datetime]
+        :keyword list[str] order_by: the sorting query for the documents. Currently only
+            'created_on' is supported.
+            format: ["param1 asc/desc", "param2 asc/desc", ...]
+            (ex: 'created_on asc', 'created_on desc').
         :return: A pageable of DocumentStatus.
         :rtype: ~azure.core.paging.ItemPaged[DocumentStatus]
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -314,13 +324,15 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
                 :dedent: 4
                 :caption: List all the document statuses as they are being translated.
         """
-        translated_after = kwargs.pop("translated_after", None)
-        translated_before = kwargs.pop("translated_before", None)
-        translated_after = (
-            convert_datetime(translated_after) if translated_after else None
+
+        order_by = convert_order_by(kwargs.pop("order_by", None))
+        created_after = kwargs.pop("created_after", None)
+        created_before = kwargs.pop("created_before", None)
+        created_after = (
+            convert_datetime(created_after) if created_after else None
         )
-        translated_before = (
-            convert_datetime(translated_before) if translated_before else None
+        created_before = (
+            convert_datetime(created_before) if created_before else None
         )
         results_per_page = kwargs.pop("results_per_page", None)
         document_ids = kwargs.pop("document_ids", None)
@@ -341,9 +353,10 @@ class DocumentTranslationClient(object):  # pylint: disable=r0205
             id=translation_id,
             cls=model_conversion_function,
             maxpagesize=results_per_page,
-            created_date_time_utc_start=translated_after,
-            created_date_time_utc_end=translated_before,
+            created_date_time_utc_start=created_after,
+            created_date_time_utc_end=created_before,
             ids=document_ids,
+            order_by=order_by,
             **kwargs
         )
 

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py
@@ -5,7 +5,7 @@
 # ------------------------------------
 
 import datetime
-from typing import Union
+from typing import Union, Optional
 import six
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import AzureKeyCredentialPolicy
@@ -123,3 +123,10 @@ def convert_datetime(date_time):
             except ValueError:
                 return datetime.datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S")
     raise TypeError("Bad datetime type")
+
+
+def convert_order_by(order_by):
+    # type: (Optional[list[str]]) -> Optional[list[str]]
+    if order_by:
+        order_by = [order.replace("created_on", "createdDateTimeUtc") for order in order_by]
+    return order_by

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py
@@ -5,7 +5,7 @@
 # ------------------------------------
 
 import datetime
-from typing import Union, Optional
+from typing import Union, Optional, List
 import six
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import AzureKeyCredentialPolicy
@@ -126,7 +126,7 @@ def convert_datetime(date_time):
 
 
 def convert_order_by(order_by):
-    # type: (Optional[list[str]]) -> Optional[list[str]]
+    # type: (Optional[List[str]]) -> Optional[List[str]]
     if order_by:
         order_by = [order.replace("created_on", "createdDateTimeUtc") for order in order_by]
     return order_by

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_client_async.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_client_async.py
@@ -22,6 +22,7 @@ from .._models import (
 from .._helpers import (
     get_http_logging_policy,
     convert_datetime,
+    convert_order_by,
     get_authentication_policy,
     get_translation_input,
     POLLING_INTERVAL,
@@ -243,14 +244,17 @@ class DocumentTranslationClient(object):
             By default, we sort by all submitted operations descendingly by start time.
         :keyword int results_per_page: is the number of operations returned per page.
         :keyword list[str] translation_ids: translation operations ids to filter by.
-        :keyword list[str] statuses: translation operation statuses to filter by.
+        :keyword list[str] statuses: translation operation statuses to filter by. Options include
+            'NotStarted', 'Running', 'Succeeded', 'Failed', 'Cancelled', 'Cancelling',
+            and 'ValidationFailed'.
         :keyword created_after: get operations created after certain datetime.
         :paramtype created_after: Union[str, datetime.datetime]
         :keyword created_before: get operations created before certain datetime.
         :paramtype created_before: Union[str, datetime.datetime]
-        :keyword list[str] order_by: the sorting query for the operations returned.
-            format: ["parm1 asc/desc", "parm2 asc/desc", ...]
-            (ex: 'createdDateTimeUtc asc', 'createdDateTimeUtc desc').
+        :keyword list[str] order_by: the sorting query for the operations returned. Currently only
+            'created_on' supported.
+            format: ["param1 asc/desc", "param2 asc/desc", ...]
+            (ex: 'created_on asc', 'created_on desc').
         :return: A pageable of TranslationStatus.
         :rtype: ~azure.core.paging.ItemPaged[TranslationStatus]
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -265,6 +269,7 @@ class DocumentTranslationClient(object):
                 :caption: List all submitted translations under the resource.
         """
 
+        order_by = convert_order_by(kwargs.pop("order_by", None))
         created_after = kwargs.pop("created_after", None)
         created_before = kwargs.pop("created_before", None)
         created_after = convert_datetime(created_after) if created_after else None
@@ -289,6 +294,7 @@ class DocumentTranslationClient(object):
             created_date_time_utc_start=created_after,
             created_date_time_utc_end=created_before,
             ids=translation_ids,
+            order_by=order_by,
             **kwargs
         )
 
@@ -303,14 +309,17 @@ class DocumentTranslationClient(object):
             By default, we sort by all documents descendingly by start time.
         :keyword int results_per_page: is the number of documents returned per page.
         :keyword list[str] document_ids: document IDs to filter by.
-        :keyword list[str] statuses: document statuses to filter by.
-        :keyword translated_after: get document translated after certain datetime.
-        :paramtype translated_after: Union[str, datetime.datetime]
-        :keyword translated_before: get document translated before certain datetime.
-        :paramtype translated_before: Union[str, datetime.datetime]
-        :keyword list[str] order_by: the sorting query for the documents.
-            format: ["parm1 asc/desc", "parm2 asc/desc", ...]
-            (ex: 'createdDateTimeUtc asc', 'createdDateTimeUtc desc').
+        :keyword list[str] statuses: document statuses to filter by. Options include
+            'NotStarted', 'Running', 'Succeeded', 'Failed', 'Cancelled', 'Cancelling',
+            and 'ValidationFailed'.
+        :keyword created_after: get document created after certain datetime.
+        :paramtype created_after: Union[str, datetime.datetime]
+        :keyword created_before: get document created before certain datetime.
+        :paramtype created_before: Union[str, datetime.datetime]
+        :keyword list[str] order_by: the sorting query for the documents. Currently only
+            'created_on' is supported.
+            format: ["param1 asc/desc", "param2 asc/desc", ...]
+            (ex: 'created_on asc', 'created_on desc').
         :return: A pageable of DocumentStatus.
         :rtype: ~azure.core.paging.ItemPaged[DocumentStatus]
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -324,13 +333,15 @@ class DocumentTranslationClient(object):
                 :dedent: 4
                 :caption: List all the document statuses as they are being translated.
         """
-        translated_after = kwargs.pop("translated_after", None)
-        translated_before = kwargs.pop("translated_before", None)
-        translated_after = (
-            convert_datetime(translated_after) if translated_after else None
+
+        order_by = convert_order_by(kwargs.pop("order_by", None))
+        created_after = kwargs.pop("created_after", None)
+        created_before = kwargs.pop("created_before", None)
+        created_after = (
+            convert_datetime(created_after) if created_after else None
         )
-        translated_before = (
-            convert_datetime(translated_before) if translated_before else None
+        created_before = (
+            convert_datetime(created_before) if created_before else None
         )
         results_per_page = kwargs.pop("results_per_page", None)
         document_ids = kwargs.pop("document_ids", None)
@@ -350,9 +361,10 @@ class DocumentTranslationClient(object):
             id=translation_id,
             cls=model_conversion_function,
             maxpagesize=results_per_page,
-            created_date_time_utc_start=translated_after,
-            created_date_time_utc_end=translated_before,
+            created_date_time_utc_start=created_after,
+            created_date_time_utc_end=created_before,
             ids=document_ids,
+            order_by=order_by,
             **kwargs
         )
 

--- a/sdk/translation/azure-ai-translation-document/tests/recordings/test_all_document_statuses.test_list_document_statuses_mixed_filters.yaml
+++ b/sdk/translation/azure-ai-translation-document/tests/recordings/test_all_document_statuses.test_list_document_statuses_mixed_filters.yaml
@@ -1,0 +1,1564 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D60E469"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/dcb5611a-c6f0-495e-8de1-1da0ab9c265e.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D68EC0F"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/1746100b-837e-4db9-88b2-ecdd8d616827.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D70405D"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/3d4fa2b7-4a79-4094-b3c1-1057f95a9c3f.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D787F39"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/8d03a580-0e5a-49a4-9d28-ffea87243b29.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D80E52A"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/f535484e-554a-4b12-94ef-31bf6a97fe7e.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D88AEC3"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/8c213139-3b4e-4055-bfd3-a766e5508aaa.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D909F72"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d4f8f2fb-7273-4879-99f0-4faf27bffe2e.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9D98690B"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/7ecaddd3-a1cf-4a53-9c3a-26e8ede2da37.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:47 GMT
+      etag:
+      - '"0x8D947BA9DA00B87"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/9ef596b3-f240-41c4-a738-88e0cea5d903.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      etag:
+      - '"0x8D947BA9DA7AE0B"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d7465e9f-4f54-490a-b4e1-281022bdf93f.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      etag:
+      - '"0x8D947BA9DAEDB44"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      etag:
+      - '"0x8D947BA9DC80FEF"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"inputs": [{"source": {"sourceUrl": "https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8?se=end&sp=rl&sv=2020-08-04&sr=c&sig=fake_token_value",
+      "filter": {}}, "targets": [{"targetUrl": "https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b?se=end&sp=rw&sv=2020-08-04&sr=c&sig=fake_token_value",
+      "language": "es"}]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '486'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches
+  response:
+    body:
+      string: ''
+    headers:
+      apim-request-id:
+      - 3d1b3e8a-eeba-42df-b8b2-44f42451bdd9
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Jul 2021 18:01:48 GMT
+      operation-location:
+      - https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 3d1b3e8a-eeba-42df-b8b2-44f42451bdd9
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:49.6284958Z","status":"NotStarted","summary":{"total":10,"failed":0,"success":0,"inProgress":0,"notYetStarted":10,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 1748b79f-1e29-4ebd-bb4a-e46646835918
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '294'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:49 GMT
+      etag:
+      - '"2F89E4160C7DF9498D5A85779A8F19CB8133322969D787AA239A9F2759885FD0"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 1748b79f-1e29-4ebd-bb4a-e46646835918
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:49.6284958Z","status":"NotStarted","summary":{"total":10,"failed":0,"success":0,"inProgress":0,"notYetStarted":10,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - c40f64e8-fab2-4d98-94a4-2a30ca65fef0
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '294'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:50 GMT
+      etag:
+      - '"2F89E4160C7DF9498D5A85779A8F19CB8133322969D787AA239A9F2759885FD0"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - c40f64e8-fab2-4d98-94a4-2a30ca65fef0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:49.6284958Z","status":"NotStarted","summary":{"total":10,"failed":0,"success":0,"inProgress":0,"notYetStarted":10,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 5ac941cf-2444-4b75-bf53-d5f61fc91ce0
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '294'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:51 GMT
+      etag:
+      - '"2F89E4160C7DF9498D5A85779A8F19CB8133322969D787AA239A9F2759885FD0"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 5ac941cf-2444-4b75-bf53-d5f61fc91ce0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:49.6284958Z","status":"NotStarted","summary":{"total":10,"failed":0,"success":0,"inProgress":0,"notYetStarted":10,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 5b28a27a-4114-4361-9ad0-162a194ef0ef
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '294'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:53 GMT
+      etag:
+      - '"2F89E4160C7DF9498D5A85779A8F19CB8133322969D787AA239A9F2759885FD0"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 5b28a27a-4114-4361-9ad0-162a194ef0ef
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:49.6284958Z","status":"NotStarted","summary":{"total":10,"failed":0,"success":0,"inProgress":0,"notYetStarted":10,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - f340146d-9512-41ac-9591-ef811d126252
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '294'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:54 GMT
+      etag:
+      - '"2F89E4160C7DF9498D5A85779A8F19CB8133322969D787AA239A9F2759885FD0"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - f340146d-9512-41ac-9591-ef811d126252
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:55.6188963Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 4f495dfd-818c-4b3d-bcce-ddb4b24baea4
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:55 GMT
+      etag:
+      - '"BBD005D34479EB958180DF899ECFD8D8CF57D473D843BB9A1615ADBB356A3C83"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 4f495dfd-818c-4b3d-bcce-ddb4b24baea4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 313bc4fe-b40d-4a83-ab41-ebbf7c6c320b
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:56 GMT
+      etag:
+      - '"8605FB2C2E25F6C5EBF83BBEFABA0D2CD101C53FF7C4182FF102F6B228AEA8A4"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 313bc4fe-b40d-4a83-ab41-ebbf7c6c320b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 6ab1ffe7-af03-438f-bcad-11e0502b01e8
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:57 GMT
+      etag:
+      - '"8605FB2C2E25F6C5EBF83BBEFABA0D2CD101C53FF7C4182FF102F6B228AEA8A4"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 6ab1ffe7-af03-438f-bcad-11e0502b01e8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 56502aa3-56fb-40ca-9dd3-38fb1574ef2b
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:58 GMT
+      etag:
+      - '"8605FB2C2E25F6C5EBF83BBEFABA0D2CD101C53FF7C4182FF102F6B228AEA8A4"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 56502aa3-56fb-40ca-9dd3-38fb1574ef2b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 676220eb-834e-49a5-8b48-6f4bfd0cd327
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:01:59 GMT
+      etag:
+      - '"8605FB2C2E25F6C5EBF83BBEFABA0D2CD101C53FF7C4182FF102F6B228AEA8A4"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 676220eb-834e-49a5-8b48-6f4bfd0cd327
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 4a881170-7f14-4208-99d4-277dca201383
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:00 GMT
+      etag:
+      - '"8605FB2C2E25F6C5EBF83BBEFABA0D2CD101C53FF7C4182FF102F6B228AEA8A4"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 4a881170-7f14-4208-99d4-277dca201383
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - 3438a764-90be-4521-8e7d-bb231b8f7ad5
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:01 GMT
+      etag:
+      - '"8605FB2C2E25F6C5EBF83BBEFABA0D2CD101C53FF7C4182FF102F6B228AEA8A4"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 3438a764-90be-4521-8e7d-bb231b8f7ad5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":0,"inProgress":10,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id:
+      - fce223f0-cd03-4757-9cbc-30248f2f663d
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:02 GMT
+      etag:
+      - '"8605FB2C2E25F6C5EBF83BBEFABA0D2CD101C53FF7C4182FF102F6B228AEA8A4"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - fce223f0-cd03-4757-9cbc-30248f2f663d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":4,"inProgress":6,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":108}}'
+    headers:
+      apim-request-id:
+      - 21583371-41b7-4c59-aa51-852c3bc66e8b
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '292'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:03 GMT
+      etag:
+      - '"CB5CFCE1334E2F7982A259390C02D76425C59CE4891CB8A8CD01AA3B354C3F34"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 21583371-41b7-4c59-aa51-852c3bc66e8b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Running","summary":{"total":10,"failed":0,"success":7,"inProgress":3,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":189}}'
+    headers:
+      apim-request-id:
+      - e8f9f338-f7d1-44f0-9443-000934804a9c
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '292'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:04 GMT
+      etag:
+      - '"B4F7D042907D4F87127A90683D607941741C3F9F4171DA393FB849031375C239"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - e8f9f338-f7d1-44f0-9443-000934804a9c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043
+  response:
+    body:
+      string: '{"id":"1bf528a0-fff4-4c40-8671-039e8006b043","createdDateTimeUtc":"2021-07-15T18:01:49.1334339Z","lastActionDateTimeUtc":"2021-07-15T18:01:56.4628855Z","status":"Succeeded","summary":{"total":10,"failed":0,"success":10,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":270}}'
+    headers:
+      apim-request-id:
+      - fd6d8447-c685-4519-a051-4e5d89d4f31b
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '295'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:05 GMT
+      etag:
+      - '"A75D4DE016BF27F5E666C9DFCC7DB2D04CF95236037F62DB7ACB3C6476EA4F3D"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - fd6d8447-c685-4519-a051-4e5d89d4f31b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043/documents?$skip=0
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/d7465e9f-4f54-490a-b4e1-281022bdf93f.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d7465e9f-4f54-490a-b4e1-281022bdf93f.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3533953Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.454981Z","status":"Succeeded","to":"es","progress":1,"id":"000969a0-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/f535484e-554a-4b12-94ef-31bf6a97fe7e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/f535484e-554a-4b12-94ef-31bf6a97fe7e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3520882Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.4079921Z","status":"Succeeded","to":"es","progress":1,"id":"000969a2-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/d4f8f2fb-7273-4879-99f0-4faf27bffe2e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d4f8f2fb-7273-4879-99f0-4faf27bffe2e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3455513Z","lastActionDateTimeUtc":"2021-07-15T18:02:06.3162334Z","status":"Succeeded","to":"es","progress":1,"id":"0009699f-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/dcb5611a-c6f0-495e-8de1-1da0ab9c265e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/dcb5611a-c6f0-495e-8de1-1da0ab9c265e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3385059Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.4552725Z","status":"Succeeded","to":"es","progress":1,"id":"000969a1-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/8d03a580-0e5a-49a4-9d28-ffea87243b29.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/8d03a580-0e5a-49a4-9d28-ffea87243b29.txt","createdDateTimeUtc":"2021-07-15T18:01:54.9015079Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.8717663Z","status":"Succeeded","to":"es","progress":1,"id":"0009699d-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/9ef596b3-f240-41c4-a738-88e0cea5d903.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/9ef596b3-f240-41c4-a738-88e0cea5d903.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8975644Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.8315023Z","status":"Succeeded","to":"es","progress":1,"id":"0009699e-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/8c213139-3b4e-4055-bfd3-a766e5508aaa.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/8c213139-3b4e-4055-bfd3-a766e5508aaa.txt","createdDateTimeUtc":"2021-07-15T18:01:54.842708Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.6345661Z","status":"Succeeded","to":"es","progress":1,"id":"0009699c-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/7ecaddd3-a1cf-4a53-9c3a-26e8ede2da37.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/7ecaddd3-a1cf-4a53-9c3a-26e8ede2da37.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8368144Z","lastActionDateTimeUtc":"2021-07-15T18:02:06.3482401Z","status":"Succeeded","to":"es","progress":1,"id":"0009699b-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/3d4fa2b7-4a79-4094-b3c1-1057f95a9c3f.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/3d4fa2b7-4a79-4094-b3c1-1057f95a9c3f.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8189424Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.7852131Z","status":"Succeeded","to":"es","progress":1,"id":"0009699a-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/1746100b-837e-4db9-88b2-ecdd8d616827.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/1746100b-837e-4db9-88b2-ecdd8d616827.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8007966Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.8202184Z","status":"Succeeded","to":"es","progress":1,"id":"00096999-0000-0000-0000-000000000000","characterCharged":27}]}'
+    headers:
+      apim-request-id:
+      - 2a479a83-6831-412d-8034-bc21e1a6b5b3
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '4949'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:06 GMT
+      etag:
+      - '"1AEC8311D57168E96E6951971226F6280ADBEB148C99D2FBC7BB6C105E24354D"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 2a479a83-6831-412d-8034-bc21e1a6b5b3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043/documents?$skip=0
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/d7465e9f-4f54-490a-b4e1-281022bdf93f.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d7465e9f-4f54-490a-b4e1-281022bdf93f.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3533953Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.454981Z","status":"Succeeded","to":"es","progress":1,"id":"000969a0-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/f535484e-554a-4b12-94ef-31bf6a97fe7e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/f535484e-554a-4b12-94ef-31bf6a97fe7e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3520882Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.4079921Z","status":"Succeeded","to":"es","progress":1,"id":"000969a2-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/d4f8f2fb-7273-4879-99f0-4faf27bffe2e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d4f8f2fb-7273-4879-99f0-4faf27bffe2e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3455513Z","lastActionDateTimeUtc":"2021-07-15T18:02:06.3162334Z","status":"Succeeded","to":"es","progress":1,"id":"0009699f-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/dcb5611a-c6f0-495e-8de1-1da0ab9c265e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/dcb5611a-c6f0-495e-8de1-1da0ab9c265e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3385059Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.4552725Z","status":"Succeeded","to":"es","progress":1,"id":"000969a1-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/8d03a580-0e5a-49a4-9d28-ffea87243b29.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/8d03a580-0e5a-49a4-9d28-ffea87243b29.txt","createdDateTimeUtc":"2021-07-15T18:01:54.9015079Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.8717663Z","status":"Succeeded","to":"es","progress":1,"id":"0009699d-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/9ef596b3-f240-41c4-a738-88e0cea5d903.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/9ef596b3-f240-41c4-a738-88e0cea5d903.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8975644Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.8315023Z","status":"Succeeded","to":"es","progress":1,"id":"0009699e-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/8c213139-3b4e-4055-bfd3-a766e5508aaa.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/8c213139-3b4e-4055-bfd3-a766e5508aaa.txt","createdDateTimeUtc":"2021-07-15T18:01:54.842708Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.6345661Z","status":"Succeeded","to":"es","progress":1,"id":"0009699c-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/7ecaddd3-a1cf-4a53-9c3a-26e8ede2da37.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/7ecaddd3-a1cf-4a53-9c3a-26e8ede2da37.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8368144Z","lastActionDateTimeUtc":"2021-07-15T18:02:06.3482401Z","status":"Succeeded","to":"es","progress":1,"id":"0009699b-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/3d4fa2b7-4a79-4094-b3c1-1057f95a9c3f.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/3d4fa2b7-4a79-4094-b3c1-1057f95a9c3f.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8189424Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.7852131Z","status":"Succeeded","to":"es","progress":1,"id":"0009699a-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/1746100b-837e-4db9-88b2-ecdd8d616827.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/1746100b-837e-4db9-88b2-ecdd8d616827.txt","createdDateTimeUtc":"2021-07-15T18:01:54.8007966Z","lastActionDateTimeUtc":"2021-07-15T18:02:03.8202184Z","status":"Succeeded","to":"es","progress":1,"id":"00096999-0000-0000-0000-000000000000","characterCharged":27}]}'
+    headers:
+      apim-request-id:
+      - 1d378751-e87f-4efd-8d23-5a0fd08420c7
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '4949'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:06 GMT
+      etag:
+      - '"1AEC8311D57168E96E6951971226F6280ADBEB148C99D2FBC7BB6C105E24354D"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 1d378751-e87f-4efd-8d23-5a0fd08420c7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043/documents?$skip=1&$maxpagesize=2&ids=000969a0-0000-0000-0000-000000000000,000969a2-0000-0000-0000-000000000000,0009699f-0000-0000-0000-000000000000,000969a1-0000-0000-0000-000000000000,0009699d-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc%20asc
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/dcb5611a-c6f0-495e-8de1-1da0ab9c265e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/dcb5611a-c6f0-495e-8de1-1da0ab9c265e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3385059Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.4552725Z","status":"Succeeded","to":"es","progress":1,"id":"000969a1-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/d4f8f2fb-7273-4879-99f0-4faf27bffe2e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d4f8f2fb-7273-4879-99f0-4faf27bffe2e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3455513Z","lastActionDateTimeUtc":"2021-07-15T18:02:06.3162334Z","status":"Succeeded","to":"es","progress":1,"id":"0009699f-0000-0000-0000-000000000000","characterCharged":27}],"@nextLink":"https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043/documents?$skip=3&$top=2&$maxpagesize=2&ids=000969a0-0000-0000-0000-000000000000,000969a2-0000-0000-0000-000000000000,0009699f-0000-0000-0000-000000000000,000969a1-0000-0000-0000-000000000000,0009699d-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc
+        asc"}'
+    headers:
+      apim-request-id:
+      - 1a53b38f-1e75-43d5-916c-df6665a19a26
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '1429'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:06 GMT
+      etag:
+      - '"8198C51233076EBEADC0DCC25E7857A0A8E2D221BE95C3A6F4F6319F4A424FCF"'
+      set-cookie:
+      - ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 1a53b38f-1e75-43d5-916c-df6665a19a26
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1bf528a0-fff4-4c40-8671-039e8006b043/documents?$skip=3&$top=2&$maxpagesize=2&ids=000969a0-0000-0000-0000-000000000000,000969a2-0000-0000-0000-000000000000,0009699f-0000-0000-0000-000000000000,000969a1-0000-0000-0000-000000000000,0009699d-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc%20asc
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/f535484e-554a-4b12-94ef-31bf6a97fe7e.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/f535484e-554a-4b12-94ef-31bf6a97fe7e.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3520882Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.4079921Z","status":"Succeeded","to":"es","progress":1,"id":"000969a2-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targetf5702d5b-b4c2-4613-820c-41cde6734f1b/d7465e9f-4f54-490a-b4e1-281022bdf93f.txt","sourcePath":"https://redacted.blob.core.windows.net/srcfd217f14-10b1-4b10-bad5-381c19f336c8/d7465e9f-4f54-490a-b4e1-281022bdf93f.txt","createdDateTimeUtc":"2021-07-15T18:01:55.3533953Z","lastActionDateTimeUtc":"2021-07-15T18:02:05.454981Z","status":"Succeeded","to":"es","progress":1,"id":"000969a0-0000-0000-0000-000000000000","characterCharged":27}]}'
+    headers:
+      apim-request-id:
+      - 1ebf13f8-fe91-4254-946f-3cc36af28910
+      cache-control:
+      - public,max-age=1
+      content-length:
+      - '998'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 15 Jul 2021 18:02:06 GMT
+      etag:
+      - '"BA44AA8781D59097D33C31375E3334A971F9C626A0ED1F8DB0B6FA348706DE35"'
+      set-cookie:
+      - ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      - ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      x-requestid:
+      - 1ebf13f8-fe91-4254-946f-3cc36af28910
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/translation/azure-ai-translation-document/tests/recordings/test_all_document_statuses_async.test_list_document_statuses_mixed_filters.yaml
+++ b/sdk/translation/azure-ai-translation-document/tests/recordings/test_all_document_statuses_async.test_list_document_statuses_mixed_filters.yaml
@@ -1,0 +1,1945 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Jul 2021 18:05:55 GMT
+      etag:
+      - '"0x8D947BB319E726C"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/992f8ee3-59f4-4a7d-9943-b8caba7589df.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:55 GMT
+      etag:
+      - '"0x8D947BB31AB825B"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/0c2bdcc8-05ab-4b2a-8d83-273289762e2e.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:55 GMT
+      etag:
+      - '"0x8D947BB31B4F9F4"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/6791c79b-d91a-43db-82bd-c3edb3d2f869.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:55 GMT
+      etag:
+      - '"0x8D947BB31C88575"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/b01fabe9-b224-4d90-b87e-8eb9dd3f4735.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB31D383F0"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/99a8434e-84e2-4452-b1ab-cf170eb4781e.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB31E624F0"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d116b2a0-8fb0-47c5-82c3-d0a4a0a316f9.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB31F5B81E"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/82bed5c9-a538-4c0c-baa5-38a1080d2d37.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB32057261"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c3a072f0-ffa6-4ccd-94be-e32f2eb29301.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB3214DE7B"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/a4b6571d-6098-43d7-ae49-a1b1acf87075.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB321EF267"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/1aa9bf48-f20e-4f87-bf94-e309f416c798.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB322CD79A"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c6803dae-75ca-4f8f-ba30-e4f1dfc138d5.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB323712A4"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/7d988b63-5883-4ec9-8a9c-17d1f1aa3d61.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB32419BD3"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/ff8e447c-84b8-48cd-ac27-699b42e02d76.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB324F59FF"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/4fa36fd0-13d7-4344-8bcb-cf3c5f1bed8e.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB3258D17D"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/dfcd8867-ae6f-4a07-b397-f0fdd0b8cea2.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:56 GMT
+      etag:
+      - '"0x8D947BB3262702F"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d798469f-4f71-4032-b608-80cb978c47cc.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB326C0ED9"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/722509ad-cb3d-4821-b4ef-ef8935ff44f3.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB3276BF2A"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/430019fa-b2a9-48bf-869e-c0b096d69036.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB3282CF40"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/f4767205-0fd3-40be-bd03-cc3c1b849919.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB328C1FC5"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/18ac9925-c209-4dbf-8bfe-6956a263420d.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB3298F367"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/8b62c7c3-3178-4126-bd34-b48d6d6e29ef.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB32A32E64"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e7931449-83c4-4fc6-97d9-ec530174acd0.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB32B113A5"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/4683ca62-d699-4e09-8611-bf525c8917df.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB32BF46FF"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/463175ec-a7b4-4e06-b8b3-6a5ac4bc5fec.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB32C8BE93"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: This is written in english.
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e69f3f1c-9b1d-49c9-88b0-b43d715fa9b1.txt
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - mYgA0QpY6baiB+xZp8Hk+A==
+      date:
+      - Thu, 15 Jul 2021 18:05:57 GMT
+      etag:
+      - '"0x8D947BB32D51CE5"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - NB4xBtawP6g=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.9.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      x-ms-version:
+      - '2020-08-04'
+    method: PUT
+    uri: https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      etag:
+      - '"0x8D947BB32FBE27A"'
+      last-modified:
+      - Thu, 15 Jul 2021 18:05:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-08-04'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"inputs": [{"source": {"sourceUrl": "https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab?se=end&sp=rl&sv=2020-08-04&sr=c&sig=fake_token_value",
+      "filter": {}}, "targets": [{"targetUrl": "https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62?se=end&sp=rw&sv=2020-08-04&sr=c&sig=fake_token_value",
+      "language": "es"}]}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '484'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches
+  response:
+    body:
+      string: ''
+    headers:
+      apim-request-id: 2cd9b485-8b61-4e19-8bb2-1a3ee4cac0e1
+      content-length: '0'
+      date: Thu, 15 Jul 2021 18:05:59 GMT
+      operation-location: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 2cd9b485-8b61-4e19-8bb2-1a3ee4cac0e1
+    status:
+      code: 202
+      message: Accepted
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:00.1285205Z","status":"NotStarted","summary":{"total":25,"failed":0,"success":0,"inProgress":0,"notYetStarted":25,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: e80ee21b-dd1a-4ab9-ad39-29410e788119
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:00 GMT
+      etag: '"BE85166F03523C5035BF7CB223D75D50477E3F66EC877DE6208E9649A0B8A9A2"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: e80ee21b-dd1a-4ab9-ad39-29410e788119
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:00.1285205Z","status":"NotStarted","summary":{"total":25,"failed":0,"success":0,"inProgress":0,"notYetStarted":25,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: 331c7487-8d68-4da8-8be0-a1dd262fbc96
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:01 GMT
+      etag: '"BE85166F03523C5035BF7CB223D75D50477E3F66EC877DE6208E9649A0B8A9A2"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 331c7487-8d68-4da8-8be0-a1dd262fbc96
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:01.9175633Z","status":"Running","summary":{"total":25,"failed":0,"success":0,"inProgress":4,"notYetStarted":21,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: ba17059f-530a-4e15-ae0e-0e94e5f1c5ac
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:02 GMT
+      etag: '"9E7F6A0B248ADB9E289B506145D9D4FB710195FFE325044862AD9484C12EFD0A"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: ba17059f-530a-4e15-ae0e-0e94e5f1c5ac
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:03.6408043Z","status":"Running","summary":{"total":25,"failed":0,"success":0,"inProgress":6,"notYetStarted":19,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: 9e768ed0-a357-4d7d-9089-85d26241c4ab
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:03 GMT
+      etag: '"9057E6E7C6ADFCFAFF759CEA098CED8A4C509AFC356463B05F2AEC7EC2478B15"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 9e768ed0-a357-4d7d-9089-85d26241c4ab
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:04.6847816Z","status":"Running","summary":{"total":25,"failed":0,"success":0,"inProgress":19,"notYetStarted":6,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: f9686bf0-de21-4f31-9c3d-1cd68f7bc14b
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:04 GMT
+      etag: '"B3DBD0AE9AD4CDD1AADD87278596346265C30C584080A22451343A48966B421D"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: f9686bf0-de21-4f31-9c3d-1cd68f7bc14b
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":0,"inProgress":25,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: 0ead357f-3262-417a-aefe-65a581001d77
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:05 GMT
+      etag: '"34CF7C397B5C2426A2ED63B7923EB14431A6844F9754B3ADBB791C915D5A6225"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 0ead357f-3262-417a-aefe-65a581001d77
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":0,"inProgress":25,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: 9e453357-4b99-4779-82ba-2f0e3dc224cc
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:06 GMT
+      etag: '"34CF7C397B5C2426A2ED63B7923EB14431A6844F9754B3ADBB791C915D5A6225"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 9e453357-4b99-4779-82ba-2f0e3dc224cc
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":0,"inProgress":25,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: bb573863-4018-4e04-9ba2-fdca6ce6a739
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:07 GMT
+      etag: '"34CF7C397B5C2426A2ED63B7923EB14431A6844F9754B3ADBB791C915D5A6225"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: bb573863-4018-4e04-9ba2-fdca6ce6a739
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":0,"inProgress":25,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":0}}'
+    headers:
+      apim-request-id: 1ef05c8f-0578-46f5-a513-bbf6f4a1d95a
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:08 GMT
+      etag: '"34CF7C397B5C2426A2ED63B7923EB14431A6844F9754B3ADBB791C915D5A6225"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 1ef05c8f-0578-46f5-a513-bbf6f4a1d95a
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":4,"inProgress":21,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":108}}'
+    headers:
+      apim-request-id: 195dc032-e5f6-49c1-87f6-0339215cd3e9
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:09 GMT
+      etag: '"5823C15E6D9FE72F66E0C6983AA6E0AAA867813819FD8F5330194F54B781595A"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 195dc032-e5f6-49c1-87f6-0339215cd3e9
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":7,"inProgress":18,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":189}}'
+    headers:
+      apim-request-id: 64c757fa-37e1-4cdc-ac5e-c5a3117ff8b1
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:10 GMT
+      etag: '"912C3EEC229767B2496B26FB64DC6881704BE2D530F5658FD639899C389B7548"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 64c757fa-37e1-4cdc-ac5e-c5a3117ff8b1
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":10,"inProgress":15,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":270}}'
+    headers:
+      apim-request-id: 45da6b8b-980e-4df0-88c3-0e26ba93eab9
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:11 GMT
+      etag: '"342A5FC411095310E801C44FB4F896A91EBF38ED437DD37F2860C30FDE56D931"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 45da6b8b-980e-4df0-88c3-0e26ba93eab9
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Running","summary":{"total":25,"failed":0,"success":13,"inProgress":12,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":351}}'
+    headers:
+      apim-request-id: f6fe21f7-069f-4d5f-87c4-7741f8e76d08
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:12 GMT
+      etag: '"B2734D52501EDB2973E9D63DEFB836DF34B171BCA2D524DAF423FD023A6F5222"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: f6fe21f7-069f-4d5f-87c4-7741f8e76d08
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+  response:
+    body:
+      string: '{"id":"ff00ddc4-8578-4cc4-81d0-989f758ab12a","createdDateTimeUtc":"2021-07-15T18:05:59.3426425Z","lastActionDateTimeUtc":"2021-07-15T18:06:05.5794657Z","status":"Succeeded","summary":{"total":25,"failed":0,"success":25,"inProgress":0,"notYetStarted":0,"cancelled":0,"totalCharacterCharged":675}}'
+    headers:
+      apim-request-id: f0714bc4-fb1a-435e-9efd-a04dc483f92f
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"B4A0C284AA9B641105B3EAE6A9C8995F8C292B509C50365B7F80A83CCD941CFE"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: f0714bc4-fb1a-435e-9efd-a04dc483f92f
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=0
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/ff8e447c-84b8-48cd-ac27-699b42e02d76.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/ff8e447c-84b8-48cd-ac27-699b42e02d76.txt","createdDateTimeUtc":"2021-07-15T18:06:05.2969192Z","lastActionDateTimeUtc":"2021-07-15T18:06:14.1466189Z","status":"Succeeded","to":"es","progress":1,"id":"000969bb-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/f4767205-0fd3-40be-bd03-cc3c1b849919.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/f4767205-0fd3-40be-bd03-cc3c1b849919.txt","createdDateTimeUtc":"2021-07-15T18:06:05.024265Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.902162Z","status":"Succeeded","to":"es","progress":1,"id":"000969a4-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/e7931449-83c4-4fc6-97d9-ec530174acd0.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e7931449-83c4-4fc6-97d9-ec530174acd0.txt","createdDateTimeUtc":"2021-07-15T18:06:05.0173563Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9715159Z","status":"Succeeded","to":"es","progress":1,"id":"000969a5-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/d798469f-4f71-4032-b608-80cb978c47cc.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d798469f-4f71-4032-b608-80cb978c47cc.txt","createdDateTimeUtc":"2021-07-15T18:06:04.8335718Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.4546764Z","status":"Succeeded","to":"es","progress":1,"id":"000969a8-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/dfcd8867-ae6f-4a07-b397-f0fdd0b8cea2.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/dfcd8867-ae6f-4a07-b397-f0fdd0b8cea2.txt","createdDateTimeUtc":"2021-07-15T18:06:04.8236547Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.0816416Z","status":"Succeeded","to":"es","progress":1,"id":"000969a7-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/e69f3f1c-9b1d-49c9-88b0-b43d715fa9b1.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e69f3f1c-9b1d-49c9-88b0-b43d715fa9b1.txt","createdDateTimeUtc":"2021-07-15T18:06:04.799523Z","lastActionDateTimeUtc":"2021-07-15T18:06:14.148579Z","status":"Succeeded","to":"es","progress":1,"id":"000969a6-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/d116b2a0-8fb0-47c5-82c3-d0a4a0a316f9.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d116b2a0-8fb0-47c5-82c3-d0a4a0a316f9.txt","createdDateTimeUtc":"2021-07-15T18:06:04.7067102Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9224793Z","status":"Succeeded","to":"es","progress":1,"id":"000969a9-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/c6803dae-75ca-4f8f-ba30-e4f1dfc138d5.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c6803dae-75ca-4f8f-ba30-e4f1dfc138d5.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3793964Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9666217Z","status":"Succeeded","to":"es","progress":1,"id":"000969aa-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/c3a072f0-ffa6-4ccd-94be-e32f2eb29301.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c3a072f0-ffa6-4ccd-94be-e32f2eb29301.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3564831Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.1447474Z","status":"Succeeded","to":"es","progress":1,"id":"000969ab-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/b01fabe9-b224-4d90-b87e-8eb9dd3f4735.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/b01fabe9-b224-4d90-b87e-8eb9dd3f4735.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3382303Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.8490484Z","status":"Succeeded","to":"es","progress":1,"id":"000969ac-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/a4b6571d-6098-43d7-ae49-a1b1acf87075.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/a4b6571d-6098-43d7-ae49-a1b1acf87075.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3301719Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.1992914Z","status":"Succeeded","to":"es","progress":1,"id":"000969ad-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/99a8434e-84e2-4452-b1ab-cf170eb4781e.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/99a8434e-84e2-4452-b1ab-cf170eb4781e.txt","createdDateTimeUtc":"2021-07-15T18:06:04.2975286Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.4516756Z","status":"Succeeded","to":"es","progress":1,"id":"000969ae-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/992f8ee3-59f4-4a7d-9943-b8caba7589df.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/992f8ee3-59f4-4a7d-9943-b8caba7589df.txt","createdDateTimeUtc":"2021-07-15T18:06:04.2693101Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.4800174Z","status":"Succeeded","to":"es","progress":1,"id":"000969af-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/82bed5c9-a538-4c0c-baa5-38a1080d2d37.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/82bed5c9-a538-4c0c-baa5-38a1080d2d37.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8880362Z","lastActionDateTimeUtc":"2021-07-15T18:06:11.190704Z","status":"Succeeded","to":"es","progress":1,"id":"000969b1-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/8b62c7c3-3178-4126-bd34-b48d6d6e29ef.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/8b62c7c3-3178-4126-bd34-b48d6d6e29ef.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8597835Z","lastActionDateTimeUtc":"2021-07-15T18:06:12.1260104Z","status":"Succeeded","to":"es","progress":1,"id":"000969b0-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/722509ad-cb3d-4821-b4ef-ef8935ff44f3.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/722509ad-cb3d-4821-b4ef-ef8935ff44f3.txt","createdDateTimeUtc":"2021-07-15T18:06:03.851252Z","lastActionDateTimeUtc":"2021-07-15T18:06:10.6192154Z","status":"Succeeded","to":"es","progress":1,"id":"000969b3-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/7d988b63-5883-4ec9-8a9c-17d1f1aa3d61.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/7d988b63-5883-4ec9-8a9c-17d1f1aa3d61.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8437499Z","lastActionDateTimeUtc":"2021-07-15T18:06:11.5070524Z","status":"Succeeded","to":"es","progress":1,"id":"000969b2-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/6791c79b-d91a-43db-82bd-c3edb3d2f869.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/6791c79b-d91a-43db-82bd-c3edb3d2f869.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8023786Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.1856162Z","status":"Succeeded","to":"es","progress":1,"id":"000969b4-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/4fa36fd0-13d7-4344-8bcb-cf3c5f1bed8e.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/4fa36fd0-13d7-4344-8bcb-cf3c5f1bed8e.txt","createdDateTimeUtc":"2021-07-15T18:06:03.7743932Z","lastActionDateTimeUtc":"2021-07-15T18:06:11.5995445Z","status":"Succeeded","to":"es","progress":1,"id":"000969b5-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/4683ca62-d699-4e09-8611-bf525c8917df.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/4683ca62-d699-4e09-8611-bf525c8917df.txt","createdDateTimeUtc":"2021-07-15T18:06:02.6168253Z","lastActionDateTimeUtc":"2021-07-15T18:06:10.6341481Z","status":"Succeeded","to":"es","progress":1,"id":"000969b6-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/463175ec-a7b4-4e06-b8b3-6a5ac4bc5fec.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/463175ec-a7b4-4e06-b8b3-6a5ac4bc5fec.txt","createdDateTimeUtc":"2021-07-15T18:06:02.6152342Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.2491833Z","status":"Succeeded","to":"es","progress":1,"id":"000969b7-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/430019fa-b2a9-48bf-869e-c0b096d69036.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/430019fa-b2a9-48bf-869e-c0b096d69036.txt","createdDateTimeUtc":"2021-07-15T18:06:01.930702Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.4749063Z","status":"Succeeded","to":"es","progress":1,"id":"000969b8-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/1aa9bf48-f20e-4f87-bf94-e309f416c798.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/1aa9bf48-f20e-4f87-bf94-e309f416c798.txt","createdDateTimeUtc":"2021-07-15T18:06:01.9029173Z","lastActionDateTimeUtc":"2021-07-15T18:06:10.7615385Z","status":"Succeeded","to":"es","progress":1,"id":"000969b9-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/18ac9925-c209-4dbf-8bfe-6956a263420d.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/18ac9925-c209-4dbf-8bfe-6956a263420d.txt","createdDateTimeUtc":"2021-07-15T18:06:01.8974523Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.3740614Z","status":"Succeeded","to":"es","progress":1,"id":"000969ba-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/0c2bdcc8-05ab-4b2a-8d83-273289762e2e.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/0c2bdcc8-05ab-4b2a-8d83-273289762e2e.txt","createdDateTimeUtc":"2021-07-15T18:06:01.8549127Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.3771647Z","status":"Succeeded","to":"es","progress":1,"id":"000969a3-0000-0000-0000-000000000000","characterCharged":27}]}'
+    headers:
+      apim-request-id: 5ba5652f-1d1d-4b63-b717-adfa34c30101
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"FD421C370D9E0DBB0E36FAC121F34A7081B76BD80EE79EC687582645A5188A47"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 5ba5652f-1d1d-4b63-b717-adfa34c30101
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=0
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/ff8e447c-84b8-48cd-ac27-699b42e02d76.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/ff8e447c-84b8-48cd-ac27-699b42e02d76.txt","createdDateTimeUtc":"2021-07-15T18:06:05.2969192Z","lastActionDateTimeUtc":"2021-07-15T18:06:14.1466189Z","status":"Succeeded","to":"es","progress":1,"id":"000969bb-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/f4767205-0fd3-40be-bd03-cc3c1b849919.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/f4767205-0fd3-40be-bd03-cc3c1b849919.txt","createdDateTimeUtc":"2021-07-15T18:06:05.024265Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.902162Z","status":"Succeeded","to":"es","progress":1,"id":"000969a4-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/e7931449-83c4-4fc6-97d9-ec530174acd0.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e7931449-83c4-4fc6-97d9-ec530174acd0.txt","createdDateTimeUtc":"2021-07-15T18:06:05.0173563Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9715159Z","status":"Succeeded","to":"es","progress":1,"id":"000969a5-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/d798469f-4f71-4032-b608-80cb978c47cc.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d798469f-4f71-4032-b608-80cb978c47cc.txt","createdDateTimeUtc":"2021-07-15T18:06:04.8335718Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.4546764Z","status":"Succeeded","to":"es","progress":1,"id":"000969a8-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/dfcd8867-ae6f-4a07-b397-f0fdd0b8cea2.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/dfcd8867-ae6f-4a07-b397-f0fdd0b8cea2.txt","createdDateTimeUtc":"2021-07-15T18:06:04.8236547Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.0816416Z","status":"Succeeded","to":"es","progress":1,"id":"000969a7-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/e69f3f1c-9b1d-49c9-88b0-b43d715fa9b1.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e69f3f1c-9b1d-49c9-88b0-b43d715fa9b1.txt","createdDateTimeUtc":"2021-07-15T18:06:04.799523Z","lastActionDateTimeUtc":"2021-07-15T18:06:14.148579Z","status":"Succeeded","to":"es","progress":1,"id":"000969a6-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/d116b2a0-8fb0-47c5-82c3-d0a4a0a316f9.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d116b2a0-8fb0-47c5-82c3-d0a4a0a316f9.txt","createdDateTimeUtc":"2021-07-15T18:06:04.7067102Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9224793Z","status":"Succeeded","to":"es","progress":1,"id":"000969a9-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/c6803dae-75ca-4f8f-ba30-e4f1dfc138d5.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c6803dae-75ca-4f8f-ba30-e4f1dfc138d5.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3793964Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9666217Z","status":"Succeeded","to":"es","progress":1,"id":"000969aa-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/c3a072f0-ffa6-4ccd-94be-e32f2eb29301.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c3a072f0-ffa6-4ccd-94be-e32f2eb29301.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3564831Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.1447474Z","status":"Succeeded","to":"es","progress":1,"id":"000969ab-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/b01fabe9-b224-4d90-b87e-8eb9dd3f4735.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/b01fabe9-b224-4d90-b87e-8eb9dd3f4735.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3382303Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.8490484Z","status":"Succeeded","to":"es","progress":1,"id":"000969ac-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/a4b6571d-6098-43d7-ae49-a1b1acf87075.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/a4b6571d-6098-43d7-ae49-a1b1acf87075.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3301719Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.1992914Z","status":"Succeeded","to":"es","progress":1,"id":"000969ad-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/99a8434e-84e2-4452-b1ab-cf170eb4781e.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/99a8434e-84e2-4452-b1ab-cf170eb4781e.txt","createdDateTimeUtc":"2021-07-15T18:06:04.2975286Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.4516756Z","status":"Succeeded","to":"es","progress":1,"id":"000969ae-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/992f8ee3-59f4-4a7d-9943-b8caba7589df.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/992f8ee3-59f4-4a7d-9943-b8caba7589df.txt","createdDateTimeUtc":"2021-07-15T18:06:04.2693101Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.4800174Z","status":"Succeeded","to":"es","progress":1,"id":"000969af-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/82bed5c9-a538-4c0c-baa5-38a1080d2d37.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/82bed5c9-a538-4c0c-baa5-38a1080d2d37.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8880362Z","lastActionDateTimeUtc":"2021-07-15T18:06:11.190704Z","status":"Succeeded","to":"es","progress":1,"id":"000969b1-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/8b62c7c3-3178-4126-bd34-b48d6d6e29ef.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/8b62c7c3-3178-4126-bd34-b48d6d6e29ef.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8597835Z","lastActionDateTimeUtc":"2021-07-15T18:06:12.1260104Z","status":"Succeeded","to":"es","progress":1,"id":"000969b0-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/722509ad-cb3d-4821-b4ef-ef8935ff44f3.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/722509ad-cb3d-4821-b4ef-ef8935ff44f3.txt","createdDateTimeUtc":"2021-07-15T18:06:03.851252Z","lastActionDateTimeUtc":"2021-07-15T18:06:10.6192154Z","status":"Succeeded","to":"es","progress":1,"id":"000969b3-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/7d988b63-5883-4ec9-8a9c-17d1f1aa3d61.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/7d988b63-5883-4ec9-8a9c-17d1f1aa3d61.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8437499Z","lastActionDateTimeUtc":"2021-07-15T18:06:11.5070524Z","status":"Succeeded","to":"es","progress":1,"id":"000969b2-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/6791c79b-d91a-43db-82bd-c3edb3d2f869.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/6791c79b-d91a-43db-82bd-c3edb3d2f869.txt","createdDateTimeUtc":"2021-07-15T18:06:03.8023786Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.1856162Z","status":"Succeeded","to":"es","progress":1,"id":"000969b4-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/4fa36fd0-13d7-4344-8bcb-cf3c5f1bed8e.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/4fa36fd0-13d7-4344-8bcb-cf3c5f1bed8e.txt","createdDateTimeUtc":"2021-07-15T18:06:03.7743932Z","lastActionDateTimeUtc":"2021-07-15T18:06:11.5995445Z","status":"Succeeded","to":"es","progress":1,"id":"000969b5-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/4683ca62-d699-4e09-8611-bf525c8917df.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/4683ca62-d699-4e09-8611-bf525c8917df.txt","createdDateTimeUtc":"2021-07-15T18:06:02.6168253Z","lastActionDateTimeUtc":"2021-07-15T18:06:10.6341481Z","status":"Succeeded","to":"es","progress":1,"id":"000969b6-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/463175ec-a7b4-4e06-b8b3-6a5ac4bc5fec.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/463175ec-a7b4-4e06-b8b3-6a5ac4bc5fec.txt","createdDateTimeUtc":"2021-07-15T18:06:02.6152342Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.2491833Z","status":"Succeeded","to":"es","progress":1,"id":"000969b7-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/430019fa-b2a9-48bf-869e-c0b096d69036.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/430019fa-b2a9-48bf-869e-c0b096d69036.txt","createdDateTimeUtc":"2021-07-15T18:06:01.930702Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.4749063Z","status":"Succeeded","to":"es","progress":1,"id":"000969b8-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/1aa9bf48-f20e-4f87-bf94-e309f416c798.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/1aa9bf48-f20e-4f87-bf94-e309f416c798.txt","createdDateTimeUtc":"2021-07-15T18:06:01.9029173Z","lastActionDateTimeUtc":"2021-07-15T18:06:10.7615385Z","status":"Succeeded","to":"es","progress":1,"id":"000969b9-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/18ac9925-c209-4dbf-8bfe-6956a263420d.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/18ac9925-c209-4dbf-8bfe-6956a263420d.txt","createdDateTimeUtc":"2021-07-15T18:06:01.8974523Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.3740614Z","status":"Succeeded","to":"es","progress":1,"id":"000969ba-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/0c2bdcc8-05ab-4b2a-8d83-273289762e2e.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/0c2bdcc8-05ab-4b2a-8d83-273289762e2e.txt","createdDateTimeUtc":"2021-07-15T18:06:01.8549127Z","lastActionDateTimeUtc":"2021-07-15T18:06:09.3771647Z","status":"Succeeded","to":"es","progress":1,"id":"000969a3-0000-0000-0000-000000000000","characterCharged":27}]}'
+    headers:
+      apim-request-id: 33d9b1a3-90bf-4e33-bf15-042e817037cc
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"FD421C370D9E0DBB0E36FAC121F34A7081B76BD80EE79EC687582645A5188A47"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 33d9b1a3-90bf-4e33-bf15-042e817037cc
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=3&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc%20asc
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/c3a072f0-ffa6-4ccd-94be-e32f2eb29301.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c3a072f0-ffa6-4ccd-94be-e32f2eb29301.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3564831Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.1447474Z","status":"Succeeded","to":"es","progress":1,"id":"000969ab-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/c6803dae-75ca-4f8f-ba30-e4f1dfc138d5.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/c6803dae-75ca-4f8f-ba30-e4f1dfc138d5.txt","createdDateTimeUtc":"2021-07-15T18:06:04.3793964Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9666217Z","status":"Succeeded","to":"es","progress":1,"id":"000969aa-0000-0000-0000-000000000000","characterCharged":27}],"@nextLink":"https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=5&$top=7&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc
+        asc"}'
+    headers:
+      apim-request-id: b2f8bd51-64e9-4aae-a985-15d3c77c198b
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"5BC620FDC377066CBCA4BF1D3A44C829C05ADC889AD7A39749B05591C3C6757F"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: b2f8bd51-64e9-4aae-a985-15d3c77c198b
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=3&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc%20asc
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=5&$top=7&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/d116b2a0-8fb0-47c5-82c3-d0a4a0a316f9.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d116b2a0-8fb0-47c5-82c3-d0a4a0a316f9.txt","createdDateTimeUtc":"2021-07-15T18:06:04.7067102Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9224793Z","status":"Succeeded","to":"es","progress":1,"id":"000969a9-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/e69f3f1c-9b1d-49c9-88b0-b43d715fa9b1.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e69f3f1c-9b1d-49c9-88b0-b43d715fa9b1.txt","createdDateTimeUtc":"2021-07-15T18:06:04.799523Z","lastActionDateTimeUtc":"2021-07-15T18:06:14.148579Z","status":"Succeeded","to":"es","progress":1,"id":"000969a6-0000-0000-0000-000000000000","characterCharged":27}],"@nextLink":"https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=7&$top=5&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc
+        asc"}'
+    headers:
+      apim-request-id: 6bbf564b-915d-4e92-93fb-37f21b5feb66
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"0E3A0CC99DF46FBD64FA07907544F3648F8AE22460E98BF5CF9A717CFD9A3882"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 6bbf564b-915d-4e92-93fb-37f21b5feb66
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=5&$top=7&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=7&$top=5&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/dfcd8867-ae6f-4a07-b397-f0fdd0b8cea2.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/dfcd8867-ae6f-4a07-b397-f0fdd0b8cea2.txt","createdDateTimeUtc":"2021-07-15T18:06:04.8236547Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.0816416Z","status":"Succeeded","to":"es","progress":1,"id":"000969a7-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/d798469f-4f71-4032-b608-80cb978c47cc.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/d798469f-4f71-4032-b608-80cb978c47cc.txt","createdDateTimeUtc":"2021-07-15T18:06:04.8335718Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.4546764Z","status":"Succeeded","to":"es","progress":1,"id":"000969a8-0000-0000-0000-000000000000","characterCharged":27}],"@nextLink":"https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=9&$top=3&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc
+        asc"}'
+    headers:
+      apim-request-id: f56d28eb-f740-4560-9fd0-f0e2f817f9e8
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"76E78FD74DBC38023267AC77046193FEEEF080E33FDED2FD22E9E28A08BA6AB6"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: f56d28eb-f740-4560-9fd0-f0e2f817f9e8
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=7&$top=5&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=9&$top=3&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/e7931449-83c4-4fc6-97d9-ec530174acd0.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/e7931449-83c4-4fc6-97d9-ec530174acd0.txt","createdDateTimeUtc":"2021-07-15T18:06:05.0173563Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.9715159Z","status":"Succeeded","to":"es","progress":1,"id":"000969a5-0000-0000-0000-000000000000","characterCharged":27},{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/f4767205-0fd3-40be-bd03-cc3c1b849919.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/f4767205-0fd3-40be-bd03-cc3c1b849919.txt","createdDateTimeUtc":"2021-07-15T18:06:05.024265Z","lastActionDateTimeUtc":"2021-07-15T18:06:13.902162Z","status":"Succeeded","to":"es","progress":1,"id":"000969a4-0000-0000-0000-000000000000","characterCharged":27}],"@nextLink":"https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=11&$top=1&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc
+        asc"}'
+    headers:
+      apim-request-id: 92f8432a-33a5-4cbb-9251-809e59b51709
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"4B5BE70967621955D6D9B0B8816C1B5CCAF201757B0730B8179C3B92468C901D"'
+      set-cookie: ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 92f8432a-33a5-4cbb-9251-809e59b51709
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=9&$top=3&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-translation-document/1.0.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=11&$top=1&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+  response:
+    body:
+      string: '{"value":[{"path":"https://redacted.blob.core.windows.net/targeta69a3e8d-00e1-4520-954a-c04c87ca3a62/ff8e447c-84b8-48cd-ac27-699b42e02d76.txt","sourcePath":"https://redacted.blob.core.windows.net/src2b4d8020-530b-44fb-93a9-2b55494e68ab/ff8e447c-84b8-48cd-ac27-699b42e02d76.txt","createdDateTimeUtc":"2021-07-15T18:06:05.2969192Z","lastActionDateTimeUtc":"2021-07-15T18:06:14.1466189Z","status":"Succeeded","to":"es","progress":1,"id":"000969bb-0000-0000-0000-000000000000","characterCharged":27}]}'
+    headers:
+      apim-request-id: 65989e7a-63a0-4456-938d-79f0cf063de3
+      cache-control: public,max-age=1
+      content-type: application/json; charset=utf-8
+      date: Thu, 15 Jul 2021 18:06:13 GMT
+      etag: '"401E0D73F00C4FF4C89A7396B765B4209D1C35027F23014C65C2752C3B531D27"'
+      set-cookie: ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      vary: Accept-Encoding
+      x-content-type-options: nosniff
+      x-powered-by: ASP.NET
+      x-requestid: 65989e7a-63a0-4456-938d-79f0cf063de3
+    status:
+      code: 200
+      message: OK
+    url: https://redacted.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ff00ddc4-8578-4cc4-81d0-989f758ab12a/documents?$skip=11&$top=1&$maxpagesize=2&ids=000969bb-0000-0000-0000-000000000000,000969a4-0000-0000-0000-000000000000,000969a5-0000-0000-0000-000000000000,000969a8-0000-0000-0000-000000000000,000969a7-0000-0000-0000-000000000000,000969a6-0000-0000-0000-000000000000,000969a9-0000-0000-0000-000000000000,000969aa-0000-0000-0000-000000000000,000969ab-0000-0000-0000-000000000000,000969ac-0000-0000-0000-000000000000,000969ad-0000-0000-0000-000000000000,000969ae-0000-0000-0000-000000000000&statuses=Succeeded&$orderBy=createdDateTimeUtc+asc
+version: 1

--- a/sdk/translation/azure-ai-translation-document/tests/test_all_document_statuses.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_all_document_statuses.py
@@ -130,7 +130,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
         poller = self._begin_and_validate_translation_with_multiple_docs(client, docs_count, language_code=target_language, wait=True)
 
         # check doc statuses
-        doc_statuses = list(client.list_all_document_statuses(poller.id, order_by=["createdDateTimeUtc asc"])) # convert from generic iterator to list
+        doc_statuses = list(client.list_all_document_statuses(poller.id, order_by=["created_on asc"])) # convert from generic iterator to list
         self.assertEqual(len(doc_statuses), docs_count)
 
         curr = datetime.min
@@ -149,7 +149,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
         poller = self._begin_and_validate_translation_with_multiple_docs(client, docs_count, language_code=target_language, wait=True)
 
         # check doc statuses
-        doc_statuses = list(client.list_all_document_statuses(poller.id, order_by=["createdDateTimeUtc desc"])) # convert from generic iterator to list
+        doc_statuses = list(client.list_all_document_statuses(poller.id, order_by=["created_on desc"])) # convert from generic iterator to list
         self.assertEqual(len(doc_statuses), docs_count)
 
         curr = datetime.max
@@ -157,14 +157,12 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
             assert(document.created_on.replace(tzinfo=None) <= curr.replace(tzinfo=None))
             curr = document.created_on
 
-
-    @pytest.mark.skip(reason="not working! - list returned is empty")
     @DocumentTranslationPreparer()
     @DocumentTranslationClientPreparer()
     def test_list_document_statuses_mixed_filters(self, client):
-        docs_count = 25
+        docs_count = 10
         target_language = "es"
-        skip = 3
+        skip = 1
         results_per_page = 2
         statuses = ["Succeeded"]
 
@@ -183,7 +181,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
             document_ids=ids,
             statuses=statuses,
             # ordering
-            order_by=["createdDateTimeUtc asc"],
+            order_by=["created_on asc"],
             # paging
             skip=skip,
             results_per_page=results_per_page

--- a/sdk/translation/azure-ai-translation-document/tests/test_all_document_statuses_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_all_document_statuses_async.py
@@ -153,7 +153,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
         poller = await self._begin_and_validate_translation_with_multiple_docs_async(client, docs_count, language_code=target_language, wait=True)
 
         # check doc statuses
-        doc_statuses = client.list_all_document_statuses(poller.id, order_by=["createdDateTimeUtc asc"])
+        doc_statuses = client.list_all_document_statuses(poller.id, order_by=["created_on asc"])
 
         curr = datetime.min
         docs = []
@@ -175,7 +175,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
         poller = await self._begin_and_validate_translation_with_multiple_docs_async(client, docs_count, language_code=target_language, wait=True)
 
         # check doc statuses
-        doc_statuses = client.list_all_document_statuses(poller.id, order_by=["createdDateTimeUtc desc"])
+        doc_statuses = client.list_all_document_statuses(poller.id, order_by=["created_on desc"])
 
         curr = datetime.max
         docs = []
@@ -186,8 +186,6 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
 
         self.assertEqual(len(docs), docs_count)
 
-
-    @pytest.mark.skip(reason="not working! - list returned is empty")
     @DocumentTranslationPreparer()
     @DocumentTranslationClientPreparer()
     async def test_list_document_statuses_mixed_filters(self, client):
@@ -212,7 +210,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
             document_ids=ids,
             statuses=statuses,
             # ordering
-            order_by=["createdDateTimeUtc asc"],
+            order_by=["created_on asc"],
             # paging
             skip=skip,
             results_per_page=results_per_page


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/19802

- Renamed `translated_before` and `translated_after` kwargs to `created_before` and `created_after`, respectively,
for `list_all_document_statuses`. Reasoning is that documents which failed to translate will show up in the query and saying "translated_xx" is not totally correct in this case. Also aligns with .NET naming.
- Renamed `order_by` sorting query option `createdDateTimeUtc` to `created_on` for `list_all_translation_statuses` and
`list_all_document_statuses`. So people can map this sorting query option to the property on the result model.
- Updated tests and enabled the mixed filters tests to test when statuses == "Succeeded" since service fixed this bug recently.