### PR TITLE
Adding rudimentary support for paginating the results returned by the…

### DIFF
--- a/sdk/synapse/azure-synapse-monitoring/azure/synapse/monitoring/operations/_monitoring_operations.py
+++ b/sdk/synapse/azure-synapse-monitoring/azure/synapse/monitoring/operations/_monitoring_operations.py
@@ -78,6 +78,12 @@ class MonitoringOperations(object):
         query_parameters = {}  # type: Dict[str, Any]
         query_parameters['api-version'] = self._serialize.query("api_version", api_version, 'str')
 
+        # Add rudimentary support for paginating the results returned:
+        # See Also: <https://github.com/Azure/azure-sdk-for-python/issues/19855>
+        skip = kwargs.pop('skip', None)
+        if skip != None:
+            query_parameters['skip'] = self._serialize.query("skip", skip, 'int')
+
         # Construct headers
         header_parameters = {}  # type: Dict[str, Any]
         if x_ms_client_request_id is not None:


### PR DESCRIPTION
… Synapse monitoring client

Fixes #19855

Using kwargs for now to avoid changing the method APIs.

Issues not yet addressed:

- [ ] more complex filtering support
- [ ] pagination sizes (100 was inferred from traceing the web page requests for testing)