### PR TITLE
Resolve 409 Integration Failures

### DIFF
--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -96,7 +96,7 @@ def process_requires(setup_py_path):
     requires = [
         Requirement.parse(r)
         for r in get_install_requires(setup_py_path)
-        if r.startswith("azure") and "-nspkg" not in r
+        if r.startswith("azure")
     ]
     # Find package requirements that are not available on PyPI
     requirement_to_update = {}

--- a/eng/versioning/version_increment.py
+++ b/eng/versioning/version_increment.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
 
     package_name = args.package_name.replace('_', '-')
 
-    packages = get_packages(args, package_name)
+    packages = get_packages(args, package_name, additional_excludes = ["mgmt", "-nspkg"])
 
     package_map = { pkg[1][0]: pkg for pkg in packages }
 

--- a/eng/versioning/version_shared.py
+++ b/eng/versioning/version_shared.py
@@ -34,8 +34,8 @@ DEV_STATUS_REGEX = r'(classifiers=\[(\s)*)(["\']Development Status :: .*["\'])'
 
 logging.getLogger().setLevel(logging.INFO)
 
-def path_excluded(path):
-    return "-nspkg" in path or "tests" in path or "mgmt" in path or is_metapackage(path)
+def path_excluded(path, additional_excludes):
+    return any([excl in path for excl in additional_excludes]) or "tests" in path or is_metapackage(path)
 
 # Metapackages do not have an 'azure' folder within them
 def is_metapackage(package_path):
@@ -44,13 +44,13 @@ def is_metapackage(package_path):
     azure_path = path.join(dir_path, 'azure')
     return not path.exists(azure_path)
 
-def get_setup_py_paths(glob_string, base_path):
+def get_setup_py_paths(glob_string, base_path, additional_excludes):
     setup_paths = process_glob_string(glob_string, base_path)
-    filtered_paths = [path.join(p, 'setup.py') for p in setup_paths if not path_excluded(p)]
+    filtered_paths = [path.join(p, 'setup.py') for p in setup_paths if not path_excluded(p, additional_excludes)]
     return filtered_paths
 
 
-def get_packages(args, package_name = ""):
+def get_packages(args, package_name = "", additional_excludes = []):
     # This function returns list of path to setup.py and setup info like install requires, version for all packages discovered using glob
     # Followiong are the list of arguements expected and parsed by this method
     # service, glob_string
@@ -59,7 +59,7 @@ def get_packages(args, package_name = ""):
     else:
         target_dir = root_dir
 
-    paths = get_setup_py_paths(args.glob_string, target_dir)
+    paths = get_setup_py_paths(args.glob_string, target_dir, additional_excludes)
 
     # Check if package is excluded if a package name param is passed
     if package_name and not any(filter(lambda x: package_name == os.path.basename(os.path.dirname(x)), paths)):


### PR DESCRIPTION
...by enabling dev versioning for **all packages**. However, we specifically _exclude_ these during `version increment` post-release. This way we can avoid the integration failures (without special cases) and also not cause needless headache by incrementing versions where we shouldn't.

@praveenkuttappan  can you give this a look-see when you have a couple?

- [Daily Dev Storage Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1004478&view=results)
- [Daily Dev Quantum(was failing) Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1004559&view=results)

### Known Failure Mode - 409 failure to upload integration stage because mgmt aren't being given alpha version -- #17880
    - [changeanalysis](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1000217&view=logs&j=b1e79959-24d8-5aa9-2799-72d40c3e051b&t=52817674-d19f-518b-48e6-83892d5791a6)    
    - [datalake](https://dev.azure.com/azure-sdk/internal/_build?definitionId=988)
    - [digitaltwins](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1744)
    - [elastic](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2697)
    - [healthbot](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2302)
    - [healthcareapis](https://dev.azure.com/azure-sdk/internal/_build?definitionId=998)
    - [nspkg](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=999370&view=logs&j=b1e79959-24d8-5aa9-2799-72d40c3e051b&t=24a634bc-e9df-5e52-5fda-0ace3fb109f1)
    - [search](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1000065&view=logs&j=b1e79959-24d8-5aa9-2799-72d40c3e051b&t=6e975b85-faff-5560-6b43-02f770eaad65)
    - [quantum](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2358)
    - [trafficmanager](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1037)

