### PR TITLE
[EventHubs] update test to test async producer

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
@@ -16,7 +16,7 @@ async def test_receive_no_partition_async(connstr_senders):
 
     async def on_event(partition_context, event):
         on_event.received += 1
-        await partition_context.update_checkpoint(event, fake_kwarg="arg")  # ignores fake_kwarg
+        await partition_context.update_checkpoint(event)
         on_event.namespace = partition_context.fully_qualified_namespace
         on_event.eventhub_name = partition_context.eventhub_name
         on_event.consumer_group = partition_context.consumer_group

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
@@ -17,7 +17,7 @@ def test_receive_no_partition(connstr_senders):
 
     def on_event(partition_context, event):
         on_event.received += 1
-        partition_context.update_checkpoint(event, fake_kwarg="arg")    # ignores fake_kwarg
+        partition_context.update_checkpoint(event)
         on_event.namespace = partition_context.fully_qualified_namespace
         on_event.eventhub_name = partition_context.eventhub_name
         on_event.consumer_group = partition_context.consumer_group


### PR DESCRIPTION
- call async Producer for testing/improving code coverage
- remove passing in fake kwarg to PartitionContext; untested lines in PartitionContext can only be tested with a user implemented CheckpointStore class, so not worrying about this