### PR TITLE
[translation] fix flaky id in polling

### DIFF
--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_polling.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_polling.py
@@ -94,7 +94,7 @@ class DocumentTranslationLROPollingMethod(LROBasePolling):
 
     def _get_id_from_headers(self):
         # type: () -> str
-        return self._pipeline_response.http_response.headers[
+        return self._initial_response.http_response.headers[
             "Operation-Location"
         ].split("/batches/")[1]
 

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_async_polling.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_async_polling.py
@@ -76,7 +76,7 @@ class AsyncDocumentTranslationLROPollingMethod(AsyncLROBasePolling):
         return _TranslationStatus.deserialize(self._pipeline_response)
 
     def _get_id_from_headers(self) -> str:
-        return self._pipeline_response.http_response.headers[
+        return self._initial_response.http_response.headers[
             "Operation-Location"
         ].split("/batches/")[1]
 


### PR DESCRIPTION
This helper method to set the ID on the poller should really be accessing the initial response. It has the potential to access the wrong header set from the the GET of the LRO when accessing the current pipeline response. We haven't seen this problem live, but since recordings are so fast it occurs sometimes and causes flaky tests.