### PR TITLE
TokenCredential.supports_caching

### DIFF
--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -24,6 +24,13 @@ if TYPE_CHECKING:
             # type: (*str, **Any) -> AccessToken
             pass
 
+        def supports_caching(self):
+            # type: () -> bool
+            """Whether this TokenCredential maintains its own token cache.
+
+            An authentication policy may call this before deciding whether to establish its own cache.
+            """
+
 
 else:
     AccessToken = namedtuple("AccessToken", ["token", "expires_on"])

--- a/sdk/core/azure-core/azure/core/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/credentials_async.py
@@ -13,6 +13,13 @@ if TYPE_CHECKING:
         async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
             pass
 
+        def supports_caching(self):
+            # type: () -> bool
+            """Whether this TokenCredential maintains its own token cache.
+
+            An authentication policy may call this before deciding whether to establish its own cache.
+            """
+
         async def close(self) -> None:
             pass
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -35,6 +35,7 @@ class _BearerTokenCredentialPolicyBase(object):
         super(_BearerTokenCredentialPolicyBase, self).__init__()
         self._scopes = scopes
         self._credential = credential
+        self._credential_supports_caching = getattr(self._credential, "supports_caching", lambda: False)()
         self._token = None  # type: Optional[AccessToken]
 
     @staticmethod
@@ -68,7 +69,7 @@ class _BearerTokenCredentialPolicyBase(object):
     @property
     def _need_new_token(self):
         # type: () -> bool
-        return not self._token or self._token.expires_on - time.time() < 300
+        return self._credential_supports_caching or (not self._token or self._token.expires_on - time.time() < 300)
 
 
 class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -31,6 +31,7 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy):
         # pylint:disable=unused-argument
         super().__init__()
         self._credential = credential
+        self._credential_supports_caching = getattr(self._credential, "supports_caching", lambda: False)()
         self._lock = asyncio.Lock()
         self._scopes = scopes
         self._token = None  # type: Optional[AccessToken]
@@ -129,4 +130,5 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy):
         return False
 
     def _need_new_token(self) -> bool:
-        return not self._token or self._token.expires_on - time.time() < 300
+        return self._credential_supports_caching or (not self._token or self._token.expires_on - time.time() < 300)
+


### PR DESCRIPTION
Part of #19308. Today, BearerTokenCredentialPolicy caches the last access token it acquired and calls `get_token()` only when this cached token will soon expire. This isn't safe with on-behalf-of tokens because they contain a user assertion identifying the user on whose behalf the application accesses resources. When an application changes its intended user, a client must not continue using a token for the prior user. Our design for on-behalf-of authentication makes the credential responsible for tracking the application's user assertion changes, which is to say it requires BearerTokenCredentialPolicy to call `get_token()` every time it authorizes a request. So, this PR adds `TokenCredential.supports_caching()`. BearerTokenCredentialPolicy calls this method to learn whether a given TokenCredential maintains its own token cache. When this returns True, BearerTokenCredentialPolicy defers to the credential's cache, calling `get_token()` every time it wants to authorize a request. The policy doesn't expect all credentials to implement this method, and assumes it's safe to cache tokens from credentials which do not.