### PR TITLE
Fix azure.identity.aio.AzureApplicationCredential import

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed import of `azure.identity.aio.AzureApplicationCredential`
+  ([#19943](https://github.com/Azure/azure-sdk-for-python/issues/19943))
 
 ### Other Changes
 - Reduced redundant `ChainedTokenCredential` and `DefaultAzureCredential`

--- a/sdk/identity/azure-identity/azure/identity/_credentials/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/__init__.py
@@ -13,7 +13,6 @@ from .default import DefaultAzureCredential
 from .environment import EnvironmentCredential
 from .managed_identity import ManagedIdentityCredential
 from .shared_cache import SharedTokenCacheCredential
-from .azure_arc import AzureArcCredential
 from .azure_cli import AzureCliCredential
 from .device_code import DeviceCodeCredential
 from .user_password import UsernamePasswordCredential
@@ -23,7 +22,6 @@ from .vscode import VisualStudioCodeCredential
 __all__ = [
     "AuthorizationCodeCredential",
     "AzureApplicationCredential",
-    "AzureArcCredential",
     "AzureCliCredential",
     "AzurePowerShellCredential",
     "CertificateCredential",

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -6,6 +6,7 @@
 
 from ._credentials import (
     AuthorizationCodeCredential,
+    AzureApplicationCredential,
     AzureCliCredential,
     AzurePowerShellCredential,
     CertificateCredential,
@@ -21,6 +22,7 @@ from ._credentials import (
 
 __all__ = [
     "AuthorizationCodeCredential",
+    "AzureApplicationCredential",
     "AzureCliCredential",
     "AzurePowerShellCredential",
     "CertificateCredential",

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
@@ -12,7 +12,6 @@ from .managed_identity import ManagedIdentityCredential
 from .certificate import CertificateCredential
 from .client_secret import ClientSecretCredential
 from .shared_cache import SharedTokenCacheCredential
-from .azure_arc import AzureArcCredential
 from .azure_cli import AzureCliCredential
 from .vscode import VisualStudioCodeCredential
 
@@ -20,7 +19,6 @@ from .vscode import VisualStudioCodeCredential
 __all__ = [
     "AuthorizationCodeCredential",
     "AzureApplicationCredential",
-    "AzureArcCredential",
     "AzureCliCredential",
     "AzurePowerShellCredential",
     "CertificateCredential",

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from .application import AzureApplicationCredential
 from .authorization_code import AuthorizationCodeCredential
 from .azure_powershell import AzurePowerShellCredential
 from .chained import ChainedTokenCredential
@@ -18,6 +19,7 @@ from .vscode import VisualStudioCodeCredential
 
 __all__ = [
     "AuthorizationCodeCredential",
+    "AzureApplicationCredential",
     "AzureArcCredential",
     "AzureCliCredential",
     "AzurePowerShellCredential",


### PR DESCRIPTION
Making `azure.identity.aio.AzureApplicationCredential` importable and fixing the test module that should have failed trying to import it.