### PR TITLE
Allow Tox Environments to be Configured As Skippable via platform-matrix

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -23,6 +23,9 @@ parameters:
   - name: ToxEnvParallel
     type: string
     default: '--tenvparallel'
+  - name: UnsupportedToxEnvironments
+    type: string
+    default: ''
   - name: InjectedPackages
     type: string
     default: ''
@@ -79,20 +82,14 @@ jobs:
         ServiceDirectory: "template"
         TestPipeline: ${{ parameters.TestPipeline }}
 
-    - pwsh: |
-        $toxenvvar = "whl,sdist,mindependency"
-        if ('$(System.TeamProject)' -eq 'internal') {
-          $toxenvvar = "whl,sdist,depends,latestdependency,mindependency,whl_no_aio"
-        }
-
-        # ensure that the variable is unset. if it isn't, use the value discovered there
-        if ('$(Run.ToxCustomEnvs)' -ne ('$' + '(Run.ToxCustomEnvs)'))
-        {
-          $toxenvvar = '$(Run.ToxCustomEnvs)'
-        }
-
-        echo "##vso[task.setvariable variable=toxenv]$toxenvvar"
-      displayName: "Set Tox Environment"
+    - task: PythonScript@0
+      displayName: 'Set Tox Environment'
+      inputs:
+        scriptPath: 'scripts/devops_tasks/set_tox_environment.py'
+        arguments: >-
+          --unsupported="${{ parameters.UnsupportedToxEnvironments }}"
+          --override="$(Run.ToxCustomEnvs)"
+          --team-project="$(System.TeamProject)"
 
     - template: ../steps/build-test.yml
       parameters:

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -87,7 +87,7 @@ jobs:
       inputs:
         scriptPath: 'scripts/devops_tasks/set_tox_environment.py'
         arguments: >-
-          --unsupported="${{ parameters.UnsupportedToxEnvironments }}"
+          --unsupported="$(UnsupportedToxEnvironments)"
           --override="$(Run.ToxCustomEnvs)"
           --team-project="$(System.TeamProject)"
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -55,6 +55,9 @@ parameters:
   - name: ValidateFormatting
     type: boolean
     default: false
+  - name: UnsupportedToxEnvironments
+    type: string
+    default: ''
 
 jobs:
   - job: 'Build'
@@ -137,6 +140,7 @@ jobs:
         TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
         ToxEnvParallel: ${{ parameters.ToxEnvParallel }}
         InjectedPackages: ${{ parameters.InjectedPackages }}
+        UnsupportedToxEnvironments: ${{ parameters.UnsupportedToxEnvironments }}
 
   - ${{ if gt(length(parameters.CondaArtifacts), 0) }}:
     - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml

--- a/scripts/devops_tasks/set_tox_environment.py
+++ b/scripts/devops_tasks/set_tox_environment.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import argparse
+import pdb
+
+FULL_BUILD_SET = ["whl", "sdist", "depends", "latestdependency", "mindependency", "whl_no_aio"]
+PR_BUILD_SET = ["whl", "sdist", "mindependency"]
+
+def resolve_devops_variable(var_value):
+    if var_value.startswith("$("):
+        return []
+    else:
+        return [tox_env.strip() for tox_env in var_value.split(",") if tox_env.strip()]
+
+def set_devops_value(resolved_set):
+    string_value = ",".join(resolved_set)
+
+    print("Setting environment variable toxenv with value \"{}\"".format(string_value))
+    print("##vso[task.setvariable variable=toxenv]{}".format(string_value))
+
+def remove_unsupported_values(selected_set, unsupported_values):
+    for unsupported_tox_env in unsupported_values:
+        if unsupported_tox_env in selected_set:
+            selected_set.remove(unsupported_tox_env)
+    
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="This script is used to resolve a set of arguments (that correspond to devops runtime variables) and determine which tox environments should be run for the current job."
+    )
+
+    parser.add_argument(
+        "-t",
+        "--team-project",
+        dest="team_project",
+        help="",
+        required=True
+    )
+
+    parser.add_argument(
+        "-o",
+        "--override",
+        dest="override_set",
+        help="",
+    )
+    
+    parser.add_argument(
+        "-u",
+        "--unsupported",
+        dest="unsupported",
+        help="",
+    )
+
+    args = parser.parse_args()
+
+    team_project = resolve_devops_variable(args.team_project)
+    override_set = resolve_devops_variable(args.override_set)
+    unsupported = resolve_devops_variable(args.unsupported)
+
+    # by default, we should always start with the default set
+    selected_set = PR_BUILD_SET
+
+    # however if we are internal, use the full set
+    if "internal" in team_project:
+        selected_set = FULL_BUILD_SET 
+
+    # if there is an override present, that will win ALWAYS
+    if override_set:
+        selected_set = override_set
+
+    # however we never run unsupported values
+    remove_unsupported_values(selected_set, unsupported)
+
+    # and finally output
+    set_devops_value(selected_set)

--- a/scripts/devops_tasks/set_tox_environment.py
+++ b/scripts/devops_tasks/set_tox_environment.py
@@ -6,7 +6,6 @@
 # --------------------------------------------------------------------------------------------
 
 import argparse
-import pdb
 
 FULL_BUILD_SET = ["whl", "sdist", "depends", "latestdependency", "mindependency", "whl_no_aio"]
 PR_BUILD_SET = ["whl", "sdist", "mindependency"]

--- a/scripts/devops_tasks/set_tox_environment.py
+++ b/scripts/devops_tasks/set_tox_environment.py
@@ -7,8 +7,16 @@
 
 import argparse
 
-FULL_BUILD_SET = ["whl", "sdist", "depends", "latestdependency", "mindependency", "whl_no_aio"]
+FULL_BUILD_SET = [
+    "whl",
+    "sdist",
+    "depends",
+    "latestdependency",
+    "mindependency",
+    "whl_no_aio",
+]
 PR_BUILD_SET = ["whl", "sdist", "mindependency"]
+
 
 def resolve_devops_variable(var_value):
     if var_value.startswith("$("):
@@ -16,28 +24,27 @@ def resolve_devops_variable(var_value):
     else:
         return [tox_env.strip() for tox_env in var_value.split(",") if tox_env.strip()]
 
+
 def set_devops_value(resolved_set):
     string_value = ",".join(resolved_set)
 
-    print("Setting environment variable toxenv with value \"{}\"".format(string_value))
+    print('Setting environment variable toxenv with value "{}"'.format(string_value))
     print("##vso[task.setvariable variable=toxenv]{}".format(string_value))
+
 
 def remove_unsupported_values(selected_set, unsupported_values):
     for unsupported_tox_env in unsupported_values:
         if unsupported_tox_env in selected_set:
             selected_set.remove(unsupported_tox_env)
-    
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="This script is used to resolve a set of arguments (that correspond to devops runtime variables) and determine which tox environments should be run for the current job."
     )
 
     parser.add_argument(
-        "-t",
-        "--team-project",
-        dest="team_project",
-        help="",
-        required=True
+        "-t", "--team-project", dest="team_project", help="", required=True
     )
 
     parser.add_argument(
@@ -46,7 +53,7 @@ if __name__ == "__main__":
         dest="override_set",
         help="",
     )
-    
+
     parser.add_argument(
         "-u",
         "--unsupported",
@@ -65,7 +72,7 @@ if __name__ == "__main__":
 
     # however if we are internal, use the full set
     if "internal" in team_project:
-        selected_set = FULL_BUILD_SET 
+        selected_set = FULL_BUILD_SET
 
     # if there is an override present, that will win ALWAYS
     if override_set:

--- a/sdk/identity/platform-matrix.json
+++ b/sdk/identity/platform-matrix.json
@@ -13,7 +13,8 @@
           "Pool": "azsdk-pool-mms-ubuntu-1804-general",
           "PythonVersion": "3.7",
           "CoverageArg": "--disablecov",
-          "InjectedPackages": "git+https://github.com/AzureAD/microsoft-authentication-library-for-python@dev"
+          "InjectedPackages": "git+https://github.com/AzureAD/microsoft-authentication-library-for-python@dev",
+          "UnsupportedToxEnvironments": "mindependency,latestdependency"
         }
       }
     }


### PR DESCRIPTION
This PR will allow us to resolve the nightly failure that identity is currently hitting every day.

It also:

- updates identity matrix to exclude `mindependency/latestdependency` checks for the MSAL run
- updates an inline pshell script to a python script