### PR TITLE
`azure-applicationinsights` Hyperlinks need sphinx style formatting

### DIFF
--- a/sdk/applicationinsights/azure-applicationinsights/azure/applicationinsights/operations/query_operations.py
+++ b/sdk/applicationinsights/azure-applicationinsights/azure/applicationinsights/operations/query_operations.py
@@ -38,15 +38,15 @@ class QueryOperations(object):
         """Execute an Analytics query.
 
         Executes an Analytics query for data.
-        [Here](https://dev.applicationinsights.io/documentation/Using-the-API/Query)
+        
+        `Here <https://dev.applicationinsights.io/documentation/Using-the-API/Query>`_
         is an example for using POST with an Analytics query.
 
         :param app_id: ID of the application. This is Application ID from the
          API Access settings blade in the Azure portal.
         :type app_id: str
-        :param body: The Analytics query. Learn more about the [Analytics
-         query
-         syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)
+        :param body: The Analytics query. Learn more about the `Analytics
+         query syntax <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_
         :type body: ~azure.applicationinsights.models.QueryBody
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the

--- a/sdk/applicationinsights/azure-applicationinsights/azure/applicationinsights/operations/query_operations.py
+++ b/sdk/applicationinsights/azure-applicationinsights/azure/applicationinsights/operations/query_operations.py
@@ -38,7 +38,7 @@ class QueryOperations(object):
         """Execute an Analytics query.
 
         Executes an Analytics query for data.
-        
+
         `Here <https://dev.applicationinsights.io/documentation/Using-the-API/Query>`_
         is an example for using POST with an Analytics query.
 
@@ -46,7 +46,7 @@ class QueryOperations(object):
          API Access settings blade in the Azure portal.
         :type app_id: str
         :param body: The Analytics query. Learn more about the `Analytics
-         query syntax <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_
+         query syntax <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_.
         :type body: ~azure.applicationinsights.models.QueryBody
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the


### PR DESCRIPTION
Fixes #19991

Did a regex search via `\[.*\]\(.*\)` under `sdk/applicationinsights/azure-applicationinsights/**/*.py`. Didn't turn up other 
examples.

@lmazuel are there even any owners for this package anymore? The last committer that I can find is definitely someone just contributing docs fixes. 

If there are no package owners, you mind if I cut a patch release for the doc fixes here?

Before:
![image](https://user-images.githubusercontent.com/45376673/127550552-81c06218-706c-452d-80e8-ca946f7c1aff.png)

After:
![image](https://user-images.githubusercontent.com/45376673/127550876-bd7f98ab-533b-4c0d-a4ff-49d97282d11b.png)
