### PR TITLE
{azure-mgmt-appplatform} Add license file to Python pkg

### DIFF
--- a/sdk/appplatform/azure-mgmt-appplatform/LICENSE.txt
+++ b/sdk/appplatform/azure-mgmt-appplatform/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/appplatform/azure-mgmt-appplatform/MANIFEST.in
+++ b/sdk/appplatform/azure-mgmt-appplatform/MANIFEST.in
@@ -3,4 +3,4 @@ recursive-include tests *.py *.yaml
 include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
-
+include LICENSE.txt


### PR DESCRIPTION
This is required for packaging in Fedora Linux.

Fixes: azure/azure-sdk-for-python#20035

Signed-off-by: Major Hayden <major@mhtx.net>