### PR TITLE
Automate Python docs.ms onboarding

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -11,7 +11,12 @@ jobs:
       DocRepoOwner: MicrosoftDocs
       DocRepoName: azure-docs-sdk-python
     steps:
-      # Sync docs repo (this can be sparse)
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.6'
+        inputs:
+          versionSpec: '3.6'
+
+      # Sync docs repo onboarding files/folders
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:
           SkipDefaultCheckout: true

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -11,12 +11,14 @@ jobs:
       DocRepoOwner: MicrosoftDocs
       DocRepoName: azure-docs-sdk-python
     steps:
+      # Docs CI uses Python 3.6.8
       - task: UsePythonVersion@0
-        displayName: 'Use Python 3.6'
+        displayName: 'Use Python 3.6.8'
         inputs:
-          versionSpec: '3.6'
+          versionSpec: '3.6.8'
 
-      - pwsh: pip install --upgrade setuptools pip
+      # Docs CI upgrades pip, wheel, and setuptools
+      - pwsh: pip install --upgrade pip wheel setuptools
         displayName: Update python tools for package verification
 
       # Sync docs repo onboarding files/folders

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -16,6 +16,9 @@ jobs:
         inputs:
           versionSpec: '3.6'
 
+      - pwsh: pip install --upgrade setuptools pip
+        displayName: Update python tools for package verification
+
       # Sync docs repo onboarding files/folders
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -38,7 +38,8 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:
-          BaseRepoBranch: $(DefaultBranch)
+          # Should be $(DefaultBranch)
+          BaseRepoBranch: djurek/validate-docs-onboarding-from-docindex
           BaseRepoOwner: $(DocRepoOwner)
           CommitMsg: "Update docs CI configuration"
           TargetRepoName: $(DocRepoName)

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -2,3 +2,45 @@ trigger: none
 
 jobs:
   - template: /eng/common/pipelines/templates/jobs/docindex.yml
+
+  - job: UpdateDocsMsBuildConfig
+    pool:
+      vmImage: ubuntu-20.04
+    variables:
+      DocRepoLocation: $(Pipeline.Workspace)/docs
+      DocRepoOwner: MicrosoftDocs
+      DocRepoName: azure-docs-sdk-node
+    steps:
+      # Sync docs repo (this can be sparse)
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
+          SkipDefaultCheckout: true
+          Paths:
+            - ci-configs/packages-latest.json
+            - ci-configs/packages-preview.json
+            - metadata/
+          Repositories:
+            - Name: $(DocRepoOwner)/$(DocRepoName)
+              WorkingDirectory: $(DocRepoLocation)
+
+      # Call update docs ci script to onboard packages
+      - task: Powershell@2
+        inputs:
+          pwsh: true
+          filePath: eng/common/scripts/Update-DocsMsPackages.ps1
+          arguments: -DocRepoLocation $(DocRepoLocation)
+        displayName: Update Docs Onboarding
+
+      # Push changes to docs repo
+      - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+        parameters:
+          WorkingDirectory: $(DocRepoLocation)
+
+      - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+        parameters:
+          BaseRepoBranch: $(DefaultBranch)
+          BaseRepoOwner: $(DocRepoOwner)
+          CommitMsg: "Update docs CI configuration"
+          TargetRepoName: $(DocRepoName)
+          TargetRepoOwner: $(DocRepoOwner)
+          WorkingDirectory: $(DocRepoLocation)

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -38,8 +38,7 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:
-          # Should be $(DefaultBranch)
-          BaseRepoBranch: djurek/validate-docs-onboarding-from-docindex
+          BaseRepoBranch: $(DefaultBranch)
           BaseRepoOwner: $(DocRepoOwner)
           CommitMsg: "Update docs CI configuration"
           TargetRepoName: $(DocRepoName)

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -9,7 +9,7 @@ jobs:
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
       DocRepoOwner: MicrosoftDocs
-      DocRepoName: azure-docs-sdk-node
+      DocRepoName: azure-docs-sdk-python
     steps:
       # Sync docs repo (this can be sparse)
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -11,11 +11,11 @@ jobs:
       DocRepoOwner: MicrosoftDocs
       DocRepoName: azure-docs-sdk-python
     steps:
-      # Docs CI uses Python 3.6.8
+      # Docs CI uses Python 3.6.8 but that is not available on this image
       - task: UsePythonVersion@0
-        displayName: 'Use Python 3.6.8'
+        displayName: 'Use Python 3.6'
         inputs:
-          versionSpec: '3.6.8'
+          versionSpec: '3.6'
 
       # Docs CI upgrades pip, wheel, and setuptools
       - pwsh: pip install --upgrade pip wheel setuptools

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -48,8 +48,7 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:
-          # Should be $(DefaultBranch)
-          BaseRepoBranch: djurek/validate-docs-onboarding-from-docindex
+          BaseRepoBranch: $(DefaultBranch)
           BaseRepoOwner: $(DocRepoOwner)
           CommitMsg: "Update docs CI configuration"
           TargetRepoName: $(DocRepoName)

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -170,10 +170,11 @@ function ValidatePackage($packageName, $packageVersion, $workingDirectory) {
 
   # TODO: Additional checks for package validation in docs build.
   try {
-    Write-Host "pip install $packageExpression --target $installTargetFolder"
+    Write-Host "pip install $packageExpression --no-cache-dir --target $installTargetFolder"
     $pipInstallOutput = pip `
       install `
       $packageExpression `
+      --no-cache-dir `
       --target $installTargetFolder 2>&1
     if ($LASTEXITCODE -ne 0) {
       LogWarning "pip install failed for $packageExpression"
@@ -181,8 +182,9 @@ function ValidatePackage($packageName, $packageVersion, $workingDirectory) {
       return $false
     }
   } catch {
-    LogWarning "pip install failed for $packageExpression"
-    Write-Host $pipInstallOutput
+    LogWarning "pip install failed for $packageExpression with exception"
+    LogWarning $_.Exception
+    LogWarning $_.Exception.StackTrace
     return $false
   }
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -182,6 +182,7 @@ function ValidatePackage($packageName, $packageVersion, $workingDirectory) {
     }
   } catch {
     LogWarning "pip install failed for $packageExpression"
+    Write-Host $pipInstallOutput
     return $false
   }
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -249,19 +249,20 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
       continue
     }
 
-    $packageVersion = "==$($matchingPublishedPackage.VersionGA)"
     if ($Mode -eq 'latest' -and !$matchingPublishedPackage.VersionGA.Trim()) { 
       LogWarning "Metadata is missing GA version for GA package $packageName. Keeping existing package."
       $outputPackages += $package
       continue
     }
+
+    $packageVersion = "==$($matchingPublishedPackage.VersionGA)"
     if ($Mode -eq 'preview') {
       if (!$matchingPublishedPackage.VersionPreview.Trim()) { 
         LogWarning "Metadata is missing preview version for preview package $packageName. Keeping existing package."
         $outputPackages += $package
         continue
       }
-      $packageVersion = ">=$($matchingPublishedPackage.VersionPreview)"
+      $packageVersion = "==$($matchingPublishedPackage.VersionPreview)"
     }
 
     # If upgrading the package, run basic sanity checks against the package
@@ -311,7 +312,7 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
     $packageName = $package.Package
     $packageVersion = "==$($package.VersionGA)"
     if ($Mode -eq 'preview') {
-      $packageVersion = ">=$($package.VersionPreview)"
+      $packageVersion = "==$($package.VersionPreview)"
     }
 
     if (!(ValidatePackage -packageName $packageName -packageVersion $packageVersion)) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -168,7 +168,9 @@ function ValidatePackage($packageName, $packageVersion, $workingDirectory) {
   $installTargetFolder = Join-Path $workingDirectory $packageName
   New-Item -ItemType Directory -Force -Path $installTargetFolder | Out-Null
 
-  # TODO: Additional checks for package validation in docs build.
+  # Add more validation by replicating as much of the docs CI process as
+  # possible
+  # https://github.com/Azure/azure-sdk-for-python/issues/20109
   try {
     Write-Host "pip install $packageExpression --no-cache-dir --target $installTargetFolder"
     $pipInstallOutput = pip `


### PR DESCRIPTION
Automates onboarding of packages for docs.ms CI. Includes validation to ensure that new and updated packages install properly. Does not re-validate packages that have not changed. 

docindex successful run (pushing against a test branch, not main): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1030266&view=logs&j=293d82b9-e70f-547c-66fb-8f46778b3a20

docs CI running against test branch: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=244126&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=e69637ba-916f-5e3a-caa0-a58126252db6