### PR TITLE
Update release date, remove INT tests since they are not supported yet.

### DIFF
--- a/sdk/communication/azure-communication-networktraversal/CHANGELOG.md
+++ b/sdk/communication/azure-communication-networktraversal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b1 (2021-08-03)
+## 1.0.0b1 (2021-08-04)
 - Preview release of `azure-communication-networktraversal`.
 
 The first preview of the Azure Communication Relay Client has the following features:

--- a/sdk/communication/azure-communication-networktraversal/CHANGELOG.md
+++ b/sdk/communication/azure-communication-networktraversal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b1 (2021-07-19)
+## 1.0.0b1 (2021-08-03)
 - Preview release of `azure-communication-networktraversal`.
 
 The first preview of the Azure Communication Relay Client has the following features:

--- a/sdk/communication/azure-communication-networktraversal/tests.yml
+++ b/sdk/communication/azure-communication-networktraversal/tests.yml
@@ -20,4 +20,4 @@ stages:
             SubscriptionConfigurations:
               - $(sub-config-communication-int-test-resources-common)
               - $(sub-config-communication-int-test-resources-python)
-      Clouds: Public,Int
+      Clouds: Public


### PR DESCRIPTION
Updating release date for Python aiming August 3. 

Removing live tests against INT since they are not supported yet. 