### PR TITLE
Fix perf tests

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
@@ -90,7 +90,7 @@ def _get_persistence(allow_unencrypted, account_name, cache_name):
             if not allow_unencrypted:
                 raise ValueError(
                     "PyGObject is required to encrypt the persistent cache. Please install that library or "
-                    + 'specify "allow_unencrypted_cache=True" to store the cache without encryption.'
+                    + 'specify "allow_unencrypted_storage=True" to store the cache without encryption.'
                 )
             return msal_extensions.FilePersistence(file_path)
 

--- a/sdk/identity/azure-identity/tests/perfstress_tests/bearer_token_auth_policy.py
+++ b/sdk/identity/azure-identity/tests/perfstress_tests/bearer_token_auth_policy.py
@@ -26,12 +26,13 @@ class BearerTokenPolicyTest(PerfStressTest):
         credential = Mock(get_token=Mock(return_value=token))
         self.pipeline = Pipeline(transport=Mock(), policies=[BearerTokenCredentialPolicy(credential=credential)])
 
-        completed_future = asyncio.Future()
-        completed_future.set_result(token)
-        async_credential = Mock(get_token=Mock(return_value=completed_future))
+        get_token_future = asyncio.Future()
+        get_token_future.set_result(token)
+        async_credential = Mock(get_token=Mock(return_value=get_token_future))
 
-        # returning a token is okay because the policy does nothing with the transport's response
-        async_transport = Mock(send=Mock(return_value=completed_future))
+        send_future = asyncio.Future()
+        send_future.set_result(Mock())
+        async_transport = Mock(send=Mock(return_value=send_future))
         self.async_pipeline = AsyncPipeline(
             async_transport, policies=[AsyncBearerTokenCredentialPolicy(credential=async_credential)]
         )

--- a/sdk/identity/azure-identity/tests/perfstress_tests/persistent_cache_read.py
+++ b/sdk/identity/azure-identity/tests/perfstress_tests/persistent_cache_read.py
@@ -22,11 +22,10 @@ class PersistentCacheRead(PerfStressTest):
         client_id = self.get_from_env("AZURE_CLIENT_ID")
         tenant_id = self.get_from_env("AZURE_TENANT_ID")
         secret = self.get_from_env("AZURE_CLIENT_SECRET")
-        self.credential = ClientSecretCredential(
-            tenant_id, client_id, secret, cache_persistence_options=TokenCachePersistenceOptions()
-        )
+        cache_options = TokenCachePersistenceOptions(allow_unencrypted_storage=True)
+        self.credential = ClientSecretCredential(tenant_id, client_id, secret, cache_persistence_options=cache_options)
         self.async_credential = AsyncClientSecretCredential(
-            tenant_id, client_id, secret, cache_persistence_options=TokenCachePersistenceOptions()
+            tenant_id, client_id, secret, cache_persistence_options=cache_options
         )
         self.scope = "https://vault.azure.net/.default"
 


### PR DESCRIPTION
A few small changes to get the auth policy test working and enable the persistent cache test to run on Linux without libsecret. Also correct a parameter name in an error message.