### PR TITLE
Use old resolver for regression tests. 

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -168,7 +168,7 @@ jobs:
   - job: 'RunRegression'
     condition: and(succeededOrFailed(), or(eq(variables['Run.Regression'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['System.TeamProject'],'internal'))))
     displayName: 'Run Regression'
-    timeoutInMinutes: 300
+    timeoutInMinutes: 180
     variables:
     - template: ../variables/globals.yml
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -168,7 +168,7 @@ jobs:
   - job: 'RunRegression'
     condition: and(succeededOrFailed(), or(eq(variables['Run.Regression'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['System.TeamProject'],'internal'))))
     displayName: 'Run Regression'
-    timeoutInMinutes: 180
+    timeoutInMinutes: 300
     variables:
     - template: ../variables/globals.yml
 

--- a/eng/pipelines/templates/steps/test_regression.yml
+++ b/eng/pipelines/templates/steps/test_regression.yml
@@ -16,7 +16,7 @@ steps:
       targetPath: $(Build.ArtifactStagingDirectory)
 
   - script: |
-      pip install -r eng/ci_tools.txt
+      pip install -r eng/regression_tools.txt
     displayName: 'Prep Environment'
 
   - template: ../steps/set-dev-build.yml

--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -1,0 +1,37 @@
+# requirements leveraged by ci tools
+cryptography==3.1
+setuptools==44.1.0; python_version == '2.7'
+setuptools==46.4.0; python_version >= '3.5'
+virtualenv==20.0.23
+wheel==0.34.2
+Jinja2==2.11.2
+packaging==20.4
+tox==3.15.0
+tox-monorepo==0.1.2
+twine==1.15.0; python_version == '2.7' or python_version == '3.5'
+twine==3.1.1; python_version >= '3.6'
+pathlib2==2.3.5
+readme-renderer[md]==25.0
+doc-warden==0.7.1
+# we pin coverage to 4.5.4 because there is an bug with `pytest-cov`. the generated coverage files cannot be `coverage combine`ed
+coverage==4.5.4
+codecov==2.1.0
+beautifulsoup4==4.9.1
+pkginfo==1.5.0.1
+pip==20.2
+black==21.6b0; python_version >= '3.6'
+
+# locking packages defined as deps from azure-sdk-tools or azure-devtools
+pytoml==0.1.21
+pyOpenSSL==19.1.0
+json-delta==2.0
+ConfigArgParse==1.2.3
+six==1.14.0
+pyyaml==5.3.1
+pytest==5.4.2; python_version >= '3.5'
+pytest==4.6.9; python_version == '2.7'
+pytest-cov==2.8.1
+
+# local dev packages
+./tools/azure-devtools
+./tools/azure-sdk-tools

--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -1,37 +1,31 @@
-# requirements leveraged by ci tools
-cryptography==3.1
-setuptools==44.1.0; python_version == '2.7'
-setuptools==46.4.0; python_version >= '3.5'
-virtualenv==20.0.23
-wheel==0.34.2
-Jinja2==2.11.2
-packaging==20.4
-tox==3.15.0
-tox-monorepo==0.1.2
-twine==1.15.0; python_version == '2.7' or python_version == '3.5'
-twine==3.1.1; python_version >= '3.6'
-pathlib2==2.3.5
-readme-renderer[md]==25.0
-doc-warden==0.7.1
+pip==20.2
+
+# requirements leveraged by ci for testing
+pytest==4.6.9; python_version == '2.7'
+pytest==5.4.2; python_version >= '3.5'
+pytest-asyncio==0.12.0; python_version >= '3.5'
+pytest-cov==2.8.1
+pytest-custom-exit-code==0.3.0
+pytest-xdist==1.32.0
 # we pin coverage to 4.5.4 because there is an bug with `pytest-cov`. the generated coverage files cannot be `coverage combine`ed
 coverage==4.5.4
-codecov==2.1.0
-beautifulsoup4==4.9.1
-pkginfo==1.5.0.1
-pip==20.2
-black==21.6b0; python_version >= '3.6'
+bandit==1.6.2
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21
+readme-renderer[md]==25.0
 pyOpenSSL==19.1.0
 json-delta==2.0
 ConfigArgParse==1.2.3
 six==1.14.0
 pyyaml==5.3.1
-pytest==5.4.2; python_version >= '3.5'
-pytest==4.6.9; python_version == '2.7'
-pytest-cov==2.8.1
+packaging==20.4
+wheel==0.34.2
+Jinja2==2.11.2
 
-# local dev packages
-./tools/azure-devtools
-./tools/azure-sdk-tools
+# Locking pylint and required packages
+pylint==1.8.4; python_version < '3.4'
+pylint==2.5.2; python_version >= '3.4'
+
+# python-dotenv
+python-dotenv==0.15.0

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -1,0 +1,37 @@
+# requirements leveraged by ci tools
+cryptography==3.1
+setuptools==44.1.0; python_version == '2.7'
+setuptools==46.4.0; python_version >= '3.5'
+virtualenv==20.0.23
+wheel==0.34.2
+Jinja2==2.11.2
+packaging==20.4
+tox==3.15.0
+tox-monorepo==0.1.2
+twine==1.15.0; python_version == '2.7' or python_version == '3.5'
+twine==3.1.1; python_version >= '3.6'
+pathlib2==2.3.5
+readme-renderer[md]==25.0
+doc-warden==0.7.1
+# we pin coverage to 4.5.4 because there is an bug with `pytest-cov`. the generated coverage files cannot be `coverage combine`ed
+coverage==4.5.4
+codecov==2.1.0
+beautifulsoup4==4.9.1
+pkginfo==1.5.0.1
+pip==20.2
+black==21.6b0; python_version >= '3.6'
+
+# locking packages defined as deps from azure-sdk-tools or azure-devtools
+pytoml==0.1.21
+pyOpenSSL==19.1.0
+json-delta==2.0
+ConfigArgParse==1.2.3
+six==1.14.0
+pyyaml==5.3.1
+pytest==5.4.2; python_version >= '3.5'
+pytest==4.6.9; python_version == '2.7'
+pytest-cov==2.8.1
+
+# local dev packages
+./tools/azure-devtools
+./tools/azure-sdk-tools

--- a/scripts/devops_tasks/test_regression.py
+++ b/scripts/devops_tasks/test_regression.py
@@ -32,7 +32,7 @@ from git_helper import get_release_tag, git_checkout_tag, git_checkout_branch, c
 AZURE_GLOB_STRING = "azure*"
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
-test_tools_req_file = os.path.abspath(os.path.join(root_dir, "eng", "test_tools.txt"))
+test_tools_req_file = os.path.abspath(os.path.join(root_dir, "eng", "regression_test_tools.txt"))
 
 GIT_REPO_NAME = "azure-sdk-for-python"
 GIT_MASTER_BRANCH = "main"


### PR DESCRIPTION
This is to get the python - core tests green nightly. 

Issue for followup into the resolver issues is #20039

