### PR TITLE
Avoid passing unexpected kwarg to EnvironmentCredential

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -64,14 +64,12 @@ class AzureApplicationCredential(ChainedTokenCredential):
         # type: (**Any) -> None
         authority = kwargs.pop("authority", None)
         authority = normalize_authority(authority) if authority else get_default_authority()
+        managed_identity_client_id = kwargs.pop(
+            "managed_identity_client_id", os.environ.get(EnvironmentVariables.AZURE_CLIENT_ID)
+        )
         super(AzureApplicationCredential, self).__init__(
             EnvironmentCredential(authority=authority, **kwargs),
-            ManagedIdentityCredential(
-                client_id=kwargs.pop(
-                    "managed_identity_client_id", os.environ.get(EnvironmentVariables.AZURE_CLIENT_ID)
-                ),
-                **kwargs
-            ),
+            ManagedIdentityCredential(client_id=managed_identity_client_id, **kwargs),
         )
 
     def get_token(self, *scopes, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -63,14 +63,12 @@ class AzureApplicationCredential(ChainedTokenCredential):
     def __init__(self, **kwargs: "Any") -> None:
         authority = kwargs.pop("authority", None)
         authority = normalize_authority(authority) if authority else get_default_authority()
+        managed_identity_client_id = kwargs.pop(
+            "managed_identity_client_id", os.environ.get(EnvironmentVariables.AZURE_CLIENT_ID)
+        )
         super().__init__(
             EnvironmentCredential(authority=authority, **kwargs),
-            ManagedIdentityCredential(
-                client_id=kwargs.pop(
-                    "managed_identity_client_id", os.environ.get(EnvironmentVariables.AZURE_CLIENT_ID)
-                ),
-                **kwargs
-            ),
+            ManagedIdentityCredential(client_id=managed_identity_client_id, **kwargs),
         )
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":

--- a/sdk/identity/azure-identity/tests/test_azure_application.py
+++ b/sdk/identity/azure-identity/tests/test_azure_application.py
@@ -1,0 +1,36 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch  # type: ignore
+
+from azure.identity import AzureApplicationCredential
+from azure.identity._constants import EnvironmentVariables
+
+
+def test_managed_identity_client_id():
+    """the credential should accept a user-assigned managed identity's client ID by kwarg or environment variable"""
+
+    expected_args = {"client_id": "the client"}
+
+    ENVIRON = AzureApplicationCredential.__module__ + ".os.environ"
+    MANAGED_IDENTITY_CREDENTIAL = AzureApplicationCredential.__module__ + ".ManagedIdentityCredential"
+
+    with patch(MANAGED_IDENTITY_CREDENTIAL) as mock_credential:
+        AzureApplicationCredential(managed_identity_client_id=expected_args["client_id"])
+    mock_credential.assert_called_once_with(**expected_args)
+
+    # client id can also be specified in $AZURE_CLIENT_ID
+    with patch.dict(ENVIRON, {EnvironmentVariables.AZURE_CLIENT_ID: expected_args["client_id"]}, clear=True):
+        with patch(MANAGED_IDENTITY_CREDENTIAL) as mock_credential:
+            AzureApplicationCredential()
+    mock_credential.assert_called_once_with(**expected_args)
+
+    # keyword argument should override environment variable
+    with patch.dict(ENVIRON, {EnvironmentVariables.AZURE_CLIENT_ID: "not-" + expected_args["client_id"]}, clear=True):
+        with patch(MANAGED_IDENTITY_CREDENTIAL) as mock_credential:
+            AzureApplicationCredential(managed_identity_client_id=expected_args["client_id"])
+    mock_credential.assert_called_once_with(**expected_args)

--- a/sdk/identity/azure-identity/tests/test_azure_application_async.py
+++ b/sdk/identity/azure-identity/tests/test_azure_application_async.py
@@ -1,0 +1,33 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from unittest.mock import patch
+
+from azure.identity.aio import AzureApplicationCredential
+from azure.identity._constants import EnvironmentVariables
+
+
+def test_managed_identity_client_id():
+    """the credential should accept a user-assigned managed identity's client ID by kwarg or environment variable"""
+
+    expected_args = {"client_id": "the client"}
+
+    ENVIRON = AzureApplicationCredential.__module__ + ".os.environ"
+    MANAGED_IDENTITY_CREDENTIAL = AzureApplicationCredential.__module__ + ".ManagedIdentityCredential"
+
+    with patch(MANAGED_IDENTITY_CREDENTIAL) as mock_credential:
+        AzureApplicationCredential(managed_identity_client_id=expected_args["client_id"])
+    mock_credential.assert_called_once_with(**expected_args)
+
+    # client id can also be specified in $AZURE_CLIENT_ID
+    with patch.dict(ENVIRON, {EnvironmentVariables.AZURE_CLIENT_ID: expected_args["client_id"]}, clear=True):
+        with patch(MANAGED_IDENTITY_CREDENTIAL) as mock_credential:
+            AzureApplicationCredential()
+    mock_credential.assert_called_once_with(**expected_args)
+
+    # keyword argument should override environment variable
+    with patch.dict(ENVIRON, {EnvironmentVariables.AZURE_CLIENT_ID: "not-" + expected_args["client_id"]}, clear=True):
+        with patch(MANAGED_IDENTITY_CREDENTIAL) as mock_credential:
+            AzureApplicationCredential(managed_identity_client_id=expected_args["client_id"])
+    mock_credential.assert_called_once_with(**expected_args)


### PR DESCRIPTION
Whoops, AzureApplicationCredential passes "managed_identity_client_id" to EnvironmentCredential. It works today but is something of a time bomb, better defused sooner than later.