### PR TITLE
[EventHubs] checkpointstoretable - skip tests until env vars configured

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -89,6 +89,9 @@ IGNORED_SAMPLES = {
         "iot_hub_connection_string_receive_async.py",
         "proxy_async.py"
     ],
+    "azure-eventhub-checkpointstoretable":[
+        "receive_events_using_checkpoint_store.py"
+    ],
     "azure-servicebus": [
         "mgmt_queue.py",
         "mgmt_rule.py",

--- a/sdk/eventhub/azure-eventhub-checkpointstoretable/tests/test_storage_table_partition_manager.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoretable/tests/test_storage_table_partition_manager.py
@@ -177,7 +177,7 @@ def _update_and_list_checkpoint(storage_connection_str, table_name):
 
 
 @pytest.mark.parametrize("storage_connection_str", STORAGE_CONN_STR)
-@pytest.mark.liveTest
+@pytest.mark.skip("update after adding conn str env var")
 def test_claim_ownership_exception(storage_connection_str):
     storage_connection_str, table_name = get_live_storage_table_client(
         storage_connection_str
@@ -189,7 +189,7 @@ def test_claim_ownership_exception(storage_connection_str):
 
 
 @pytest.mark.parametrize("storage_connection_str", STORAGE_CONN_STR)
-@pytest.mark.liveTest
+@pytest.mark.skip("update after adding conn str env var")
 def test_claim_and_list_ownership(storage_connection_str):
     storage_connection_str, table_name = get_live_storage_table_client(
         storage_connection_str
@@ -201,7 +201,7 @@ def test_claim_and_list_ownership(storage_connection_str):
 
 
 @pytest.mark.parametrize("storage_connection_str", STORAGE_CONN_STR)
-@pytest.mark.liveTest
+@pytest.mark.skip("update after adding conn str env var")
 def test_update_checkpoint(storage_connection_str):
     storage_connection_str, table_name = get_live_storage_table_client(
         storage_connection_str


### PR DESCRIPTION
skipping the azure-eventhub-checkpointstoretable tests for now. They will fail, since the necessary environment variables are not correctly configured. An issue was created to address this next sprint: #20276 