### PR TITLE
Bug fix for pipeline downloading incorrect package ver

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -186,11 +186,17 @@ jobs:
         - pwsh: |
             do {
               $failure = $false
-              pip --retries 10 install -r "$(requirements)" --no-deps --upgrade --no-cache-dir 2>&1
-              if ($LASTEXITCODE -ne 0) {
-                $failure = $true
-                Write-Host "Installation failed, retrying in 3 minutes..."
-                sleep 180
+              try {
+                $ErrorActionPreference = "Stop"
+                pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir 2>&1
+              } catch {
+                if ($LASTEXITCODE -ne 0) {
+                  $failure = $true
+                  Write-Host "Installation failed, retrying in 3 minutes..."
+                  sleep 180
+                }
+              } finally {
+                $ErrorActionPreference = "Continue"
               }
             } while (($retries++ -lt 4) -and ($failure))
           displayName: Install requirements without dependencies

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -167,7 +167,7 @@ jobs:
                 return @{ "name" = $matches[1]; "version" = $matches[2] }
               }
             }
-            $dependencies = Get-Content $env:REQUIREMENTS | ForEach-Object {
+            $dependencies = Get-Content $(requirements) | ForEach-Object {
               $line = $_
               if ($line -match "([a-zA-Z\-]+)(\W+)(.*)") {
                   $override = ($artifacts | Where-Object { $_.Name -eq $matches[1] }).Version
@@ -179,51 +179,37 @@ jobs:
               return $line
             }
 
-            $dependencies | Out-File $env:REQUIREMENTS
+            $dependencies | Out-File $(requirements)
 
           displayName: Override requirements with pipeline build artifact versions
-          env:
-            REQUIREMENTS: $(requirements)
 
         - pwsh: |
-            $timeout = New-TimeSpan -Seconds 600
-            $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
             do {
               $failure = $false
-              try {
-                $ErrorActionPreference = "Stop"
-                pip --retries 10 install -r "$env:REQUIREMENTS" --no-deps --upgrade --no-cache-dir 2>&1
-              } catch {
+              pip --retries 10 install -r "$(requirements)" --no-deps --upgrade --no-cache-dir 2>&1
+              if ($LASTEXITCODE -ne 0) {
                 $failure = $true
                 Write-Host "Installation failed, retrying in 3 minutes..."
                 sleep 180
-              } finally {
-                $ErrorActionPreference = "Continue"
               }
-            } while (($stopwatch.elapsed -lt $timeout) -and ($failure))
+            } while (($retries++ -lt 4) -and ($failure))
           displayName: Install requirements without dependencies
-          env:
-            REQUIREMENTS: $(requirements)
 
       - ${{ if eq(parameters.Daily, true) }}:
         - pwsh: |
-            pip install -r "$env:REQUIREMENTS" --pre --no-deps --upgrade `
+            pip install -r "$(requirements)" --pre --no-deps --upgrade `
               --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple
 
           displayName: Install requirements from dev feed without dependencies
-          env:
-            REQUIREMENTS: $(requirements)
 
       - pwsh: pip install -r $(Build.SourcesDirectory)/common/smoketest/requirements_async.txt
         displayName: "Install requirements_async.txt"
         condition: and(succeeded(), ne(variables['SkipAsyncInstall'], true))
 
       - pwsh: |
-          python $(Build.SourcesDirectory)/common/smoketest/dependencies.py -r "$env:REQUIREMENTS" `
+          python $(Build.SourcesDirectory)/common/smoketest/dependencies.py -r "$(requirements)" `
             | Out-File $(Build.SourcesDirectory)/common/smoketest/requirements_dependencies.txt
         displayName: Create dependency list from installed packages
-        env:
-          REQUIREMENTS: $(requirements)
 
       - script: pip install -r $(Build.SourcesDirectory)/common/smoketest/requirements_dependencies.txt
         displayName: Install package dependencies from PyPI

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -183,17 +183,19 @@ jobs:
 
           displayName: Override requirements with pipeline build artifact versions
 
+        # Retry for pip install due to delay in package availability after publish
+        # The package is expected to be available for download/installation within 10 minutes 
         - pwsh: |
             $ErrorActionPreference = "Continue"
-            while ($retries++ -lt 4) {
+            while ($retries++ -lt 15) {
               Write-Host "pip install -r $(requirements) --no-deps --upgrade --no-cache-dir"
               pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir
               if ($LASTEXITCODE) {
-                if ($retries -ge 4) {
+                if ($retries -ge 15) {
                   exit $LASTEXITCODE
                 }
-                Write-Host "Installation failed, retrying in 3 minutes..."
-                sleep 180
+                Write-Host "Installation failed, retrying in 1 minute..."
+                sleep 60
               } else {
                 break
               }

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -186,12 +186,12 @@ jobs:
         - pwsh: |
             $ErrorActionPreference = "Continue"
             while ($retries++ -lt 4) {
-              if ($retries -ge 4) {
-                $ErrorActionPreference = "Stop"
-              }
               Write-Host "pip install -r $(requirements) --no-deps --upgrade --no-cache-dir"
               pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir
               if ($LASTEXITCODE) {
+                if ($retries -ge 4) {
+                  exit $LASTEXITCODE
+                }
                 Write-Host "Installation failed, retrying in 3 minutes..."
                 sleep 180
               } else {

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -159,7 +159,7 @@ jobs:
           timeoutInMinutes: 5
 
         - pwsh: |
-            $packages = Get-ChildItem "$(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*.zip"
+            $packages = Get-ChildItem "$(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*/*.zip"
             Write-Host "Artifacts found:"
             $artifacts = $packages | ForEach-Object {
               if ($_.Name -match "([a-zA-Z\-]+)\-(.*).zip") {
@@ -185,7 +185,22 @@ jobs:
           env:
             REQUIREMENTS: $(requirements)
 
-        - pwsh: pip install -r "$env:REQUIREMENTS" --no-deps --upgrade
+        - pwsh: |
+            $timeout = New-TimeSpan -Seconds 600
+            $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+            do {
+              $failure = $false
+              try {
+                $ErrorActionPreference = "Stop"
+                pip --retries 10 install -r "$env:REQUIREMENTS" --no-deps --upgrade --no-cache-dir 2>&1
+              } catch {
+                $failure = $true
+                Write-Host "Installation failed, retrying in 3 minutes..."
+                sleep 180
+              } finally {
+                $ErrorActionPreference = "Continue"
+              }
+            } while (($stopwatch.elapsed -lt $timeout) -and ($failure))
           displayName: Install requirements without dependencies
           env:
             REQUIREMENTS: $(requirements)

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -195,7 +195,6 @@ jobs:
                 Write-Host "Installation failed, retrying in 3 minutes..."
                 sleep 180
               } else {
-                $ErrorActionPreference = "Stop"
                 break
               }
             }

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -159,7 +159,7 @@ jobs:
           timeoutInMinutes: 5
 
         - pwsh: |
-            $packages = Get-ChildItem "$(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*/*.zip"
+            $packages = Get-ChildItem "$(Pipeline.Workspace)/${{ parameters.ArtifactName }}/${{ parameters.Artifact.name }}/*.zip"
             Write-Host "Artifacts found:"
             $artifacts = $packages | ForEach-Object {
               if ($_.Name -match "([a-zA-Z\-]+)\-(.*).zip") {
@@ -184,19 +184,18 @@ jobs:
           displayName: Override requirements with pipeline build artifact versions
 
         - pwsh: |
+            $ErrorActionPreference = "Continue"
             do {
               $failure = $false
-              try {
+              Write-Host "pip install -r $(requirements) --no-deps --upgrade --no-cache-dir"
+              pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir
+              if ($LASTEXITCODE) {
+                $failure = $true
+                Write-Host "Installation failed, retrying in 3 minutes..."
+                sleep 180
+              } else {
                 $ErrorActionPreference = "Stop"
-                pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir 2>&1
-              } catch {
-                if ($LASTEXITCODE -ne 0) {
-                  $failure = $true
-                  Write-Host "Installation failed, retrying in 3 minutes..."
-                  sleep 180
-                }
-              } finally {
-                $ErrorActionPreference = "Continue"
+                break
               }
             } while (($retries++ -lt 4) -and ($failure))
           displayName: Install requirements without dependencies

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -185,19 +185,20 @@ jobs:
 
         - pwsh: |
             $ErrorActionPreference = "Continue"
-            do {
-              $failure = $false
+            while ($retries++ -lt 4) {
+              if ($retries -ge 4) {
+                $ErrorActionPreference = "Stop"
+              }
               Write-Host "pip install -r $(requirements) --no-deps --upgrade --no-cache-dir"
               pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir
               if ($LASTEXITCODE) {
-                $failure = $true
                 Write-Host "Installation failed, retrying in 3 minutes..."
                 sleep 180
               } else {
                 $ErrorActionPreference = "Stop"
                 break
               }
-            } while (($retries++ -lt 4) -and ($failure))
+            }
           displayName: Install requirements without dependencies
 
       - ${{ if eq(parameters.Daily, true) }}:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -46,6 +46,7 @@ stages:
                           ForRelease: true
                     - pwsh: |
                         Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+                        Write-Host "$($artifact)"
                       workingDirectory: $(Pipeline.Workspace)
                       displayName: Output Visible Artifacts
 

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -46,7 +46,6 @@ stages:
                           ForRelease: true
                     - pwsh: |
                         Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-                        Write-Host "$($artifact)"
                       workingDirectory: $(Pipeline.Workspace)
                       displayName: Output Visible Artifacts
 


### PR DESCRIPTION
Addressing the bug in which the release pipeline's smoke test doesn't download the correct package version that was released.

**Pipeline Reference after the fix:**
Downloaded Version:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1052595&view=logs&j=811de798-cac6-5a82-8dac-ad597ae5b1be&t=70ccc55a-509b-52ea-a60f-0b83826d1abf&l=183&l=183

Retry Attempt:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1052595&view=logs&j=811de798-cac6-5a82-8dac-ad597ae5b1be&t=70ccc55a-509b-52ea-a60f-0b83826d1abf&l=183&l=166

Published Version:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1052595&view=logs&j=8a59aa26-f1cb-5dea-999b-76ab4b63e138&t=2a0c1ff9-8f40-5875-8d33-2fedc244c604&l=140

**Previous issue of version mismatch:**
Downloaded Version:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1045637&view=logs&j=811de798-cac6-5a82-8dac-ad597ae5b1be&t=299c6ba1-91d4-5571-bc9b-ca88aacc6166&l=133

Published Version:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1045637&view=logs&j=8a59aa26-f1cb-5dea-999b-76ab4b63e138&t=2a0c1ff9-8f40-5875-8d33-2fedc244c604&l=140