### PR TITLE
Suppress CredScan warnings for test proxy devcert

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -36,6 +36,7 @@
         },
         {
             "file":[
+                "eng/common/testproxy/dotnet-devcert.pfx",
                 "sdk/keyvault/azure-keyvault-certificates/tests/ca.key",
                 "sdk/identity/azure-identity/tests/ec-certificate.pem",
                 "sdk/core/azure-servicemanagement-legacy/tests/legacy_mgmt_settings_fake.py",


### PR DESCRIPTION
This suppresses a [CredScan warning](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1051246&view=logs&j=0874ffeb-2919-5b4b-20de-16a97970b94c&t=439e917e-962a-53e0-8a4b-b8bb4f8ed372&l=55) that comes from a non-secret devcert necessary for using the new test proxy.