### PR TITLE
Use CredScan-suppressed dummy password in README

### DIFF
--- a/sdk/videoanalyzer/azure-media-videoanalyzer-edge/README.md
+++ b/sdk/videoanalyzer/azure-media-videoanalyzer-edge/README.md
@@ -80,7 +80,7 @@ To create a live pipeline, you need to have an existing pipeline topology.
 
 ```python
 url_param = ParameterDefinition(name="rtspUrl", value=pipeline_url)
-pass_param = ParameterDefinition(name="rtspPassword", value='testpass')
+pass_param = ParameterDefinition(name="rtspPassword", value="secret_password")
 live_pipeline_properties = LivePipelineProperties(description="Sample pipeline description", topology_name=pipeline_topology_name, parameters=[url_param])
 
 live_pipeline = LivePipeline(name=live_pipeline_name, properties=live_pipeline_properties)


### PR DESCRIPTION
Resolves a [CredScan warning](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1051246&view=logs&j=0874ffeb-2919-5b4b-20de-16a97970b94c&t=439e917e-962a-53e0-8a4b-b8bb4f8ed372&l=57) from a dummy password used in a code snippet. The value is replaced with an [already-suppressed dummy value](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/CredScanSuppression.json#L20), with fixed quotation formatting.