### PR TITLE
Replace deprecated unittest aliases

### DIFF
--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vm.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vm.py
@@ -363,14 +363,14 @@ class MgmtComputeTest(AzureMgmtTestCase):
             result = self.mgmt_client.virtual_machines.begin_perform_maintenance(resource_group.name, VIRTUAL_MACHINE_NAME)
             result = result.result()
         except ResourceExistsError as e:
-            self.assertEquals(str(e), "(OperationNotAllowed) Operation 'performMaintenance' is not allowed on VM '%s' since the Subscription of this VM is not eligible." % (VIRTUAL_MACHINE_NAME))
+            self.assertEqual(str(e), "(OperationNotAllowed) Operation 'performMaintenance' is not allowed on VM '%s' since the Subscription of this VM is not eligible." % (VIRTUAL_MACHINE_NAME))
 
         # VirtualMachine convert to managed disks (TODO: need swagger file)
         try:
             result = self.mgmt_client.virtual_machines.begin_convert_to_managed_disks(resource_group.name, VIRTUAL_MACHINE_NAME)
             result = result.result()
         except ResourceExistsError as e:
-            self.assertEquals(str(e), "(OperationNotAllowed) VM '%s' is already using managed disks." % (VIRTUAL_MACHINE_NAME))
+            self.assertEqual(str(e), "(OperationNotAllowed) VM '%s' is already using managed disks." % (VIRTUAL_MACHINE_NAME))
 
         # TODO: Message: The Reimage and OSUpgrade Virtual Machine actions require that the virtual machine has Automatic OS Upgrades enabled.
         # Reimage a Virtual Machine.[post]
@@ -381,7 +381,7 @@ class MgmtComputeTest(AzureMgmtTestCase):
             result = self.mgmt_client.virtual_machines.begin_reimage(resource_group.name, VIRTUAL_MACHINE_NAME)
             result = result.result()
         except ResourceExistsError as e:
-            self.assertEquals(str(e), "(OperationNotAllowed) The Reimage and OSUpgrade Virtual Machine actions require that the virtual machine has Automatic OS Upgrades enabled.")
+            self.assertEqual(str(e), "(OperationNotAllowed) The Reimage and OSUpgrade Virtual Machine actions require that the virtual machine has Automatic OS Upgrades enabled.")
 
         # Delete virtual machine (TODO: need swagger file)
         result = self.mgmt_client.virtual_machines.begin_delete(resource_group.name, VIRTUAL_MACHINE_NAME)

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_watcher.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_watcher.py
@@ -149,7 +149,7 @@ class MgmtNetworkTest(AzureMgmtTestCase):
         try:
             result = result.result()
         except HttpResponseError as e:
-            self.assertEquals(str(e), "(InternalServerError) An error occurred.")
+            self.assertEqual(str(e), "(InternalServerError) An error occurred.")
         return result
 
     def create_vm(self, group_name, location, vm_name, network_name, subnet_name, interface_name):

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
@@ -296,7 +296,7 @@ class DirectoryTest(StorageTestCase):
         response = directory_client.get_access_control(etag=resp['etag'], match_condition=MatchConditions.IfNotModified)
         # Assert
         self.assertIsNotNone(response)
-        self.assertEquals(response['permissions'], 'rwxrwxrwx')
+        self.assertEqual(response['permissions'], 'rwxrwxrwx')
 
     @DataLakePreparer()
     def test_set_access_control_recursive(self, datalake_storage_account_name, datalake_storage_account_key):
@@ -937,7 +937,7 @@ class DirectoryTest(StorageTestCase):
         with self.assertRaises(HttpResponseError):
             source_directory_client.get_directory_properties()
 
-        self.assertEquals(res.url, destination_directory_client.url)
+        self.assertEqual(res.url, destination_directory_client.url)
 
     @DataLakePreparer()
     def test_rename_with_none_existing_destination_condition_and_source_unmodified_condition(self, datalake_storage_account_name, datalake_storage_account_key):
@@ -966,7 +966,7 @@ class DirectoryTest(StorageTestCase):
         with self.assertRaises(HttpResponseError):
             source_directory_client.get_directory_properties()
 
-        self.assertEquals(non_existing_dir_name, res.path_name)
+        self.assertEqual(non_existing_dir_name, res.path_name)
 
     @DataLakePreparer()
     def test_rename_to_an_non_existing_directory_in_another_file_system(self, datalake_storage_account_name, datalake_storage_account_key):
@@ -990,7 +990,7 @@ class DirectoryTest(StorageTestCase):
         with self.assertRaises(HttpResponseError):
             source_directory_client.get_directory_properties()
 
-        self.assertEquals(non_existing_dir_name, res.path_name)
+        self.assertEqual(non_existing_dir_name, res.path_name)
 
     @DataLakePreparer()
     def test_rename_directory_to_non_empty_directory(self, datalake_storage_account_name, datalake_storage_account_key):

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory_async.py
@@ -318,7 +318,7 @@ class DirectoryTest(StorageTestCase):
                                                              match_condition=MatchConditions.IfNotModified)
         # Assert
         self.assertIsNotNone(response)
-        self.assertEquals(response['permissions'], 'rwxrwxrwx')
+        self.assertEqual(response['permissions'], 'rwxrwxrwx')
 
     @DataLakePreparer()
     async def test_set_access_control_recursive_async(self, datalake_storage_account_name, datalake_storage_account_key):
@@ -903,7 +903,7 @@ class DirectoryTest(StorageTestCase):
         with self.assertRaises(HttpResponseError):
             await source_directory_client.get_directory_properties()
 
-        self.assertEquals(res.url, destination_directory_client.url)
+        self.assertEqual(res.url, destination_directory_client.url)
 
     @DataLakePreparer()
     async def test_rename_with_none_existing_destination_condition_and_source_unmodified_condition_async(self, datalake_storage_account_name, datalake_storage_account_key):
@@ -934,7 +934,7 @@ class DirectoryTest(StorageTestCase):
         with self.assertRaises(HttpResponseError):
             await source_directory_client.get_directory_properties()
 
-        self.assertEquals(non_existing_dir_name, res.path_name)
+        self.assertEqual(non_existing_dir_name, res.path_name)
 
     @DataLakePreparer()
     async def test_rename_to_an_non_existing_directory_in_another_file_system_async(self, datalake_storage_account_name, datalake_storage_account_key):
@@ -958,7 +958,7 @@ class DirectoryTest(StorageTestCase):
         with self.assertRaises(HttpResponseError):
             await source_directory_client.get_directory_properties()
 
-        self.assertEquals(non_existing_dir_name, res.path_name)
+        self.assertEqual(non_existing_dir_name, res.path_name)
 
     @DataLakePreparer()
     async def test_rename_directory_to_non_empty_directory_async(self, datalake_storage_account_name, datalake_storage_account_key):


### PR DESCRIPTION
`assertEquals` is deprecated since Python 2.7 and replaced by `assertEqual`:

https://docs.python.org/2/library/unittest.html#deprecated-aliases