### PR TITLE
[pipeline] upgrade autorest version(autorest.core : `3.4.5` => `3.6.2`, autorest.python: `5.8.4` => `5.9.3`)

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "autorest_options": {
-      "version": "3.5.1",
-      "use": ["@autorest/python@5.8.4", "@autorest/modelerfour@4.20.0"],
+      "version": "3.6.2",
+      "use": ["@autorest/python@5.9.3", "@autorest/modelerfour@4.19.2"],
       "python": "",
       "python-mode": "update",
       "sdkrel:python-sdks-folder": "./sdk/.",

--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "autorest_options": {
-      "version": "3.4.5",
-      "use": ["@autorest/python@5.8.4", "@autorest/modelerfour@4.19.2"],
+      "version": "3.5.1",
+      "use": ["@autorest/python@5.8.4", "@autorest/modelerfour@4.20.0"],
       "python": "",
       "python-mode": "update",
       "sdkrel:python-sdks-folder": "./sdk/.",


### PR DESCRIPTION
test link:

https://github.com/openapi-env-test/azure-rest-api-specs/pull/2974 (network)
https://github.com/openapi-env-test/azure-rest-api-specs/pull/2975

https://github.com/msyyc/azure-sdk-for-python/pull/11/files ([network] compare generated code between `5.8.4` and `5.9.3` of `autorest.python`)