### PR TITLE
[Key Vault] Get default API version from sync client base

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
@@ -61,7 +61,7 @@ def parse_key_vault_id(source_id):
     path = list(filter(None, parsed_uri.path.split("/")))
 
     if len(path) < 2 or len(path) > 3:
-        raise ValueError("'{}' is not not a valid vault ID".format(source_id))
+        raise ValueError("'{}' is not not a valid ID".format(source_id))
 
     return KeyVaultResourceId(
         source_id=source_id,

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -5,7 +5,7 @@
 from typing import TYPE_CHECKING
 from azure.core.pipeline.policies import HttpLoggingPolicy
 from . import AsyncChallengeAuthPolicy
-from .client_base import ApiVersion
+from .client_base import ApiVersion, DEFAULT_VERSION
 from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 
@@ -13,14 +13,11 @@ if TYPE_CHECKING:
     try:
         # pylint:disable=unused-import
         from typing import Any
-        from azure.core.configuration import Configuration
-        from azure.core.pipeline.transport import AsyncHttpTransport
         from azure.core.credentials_async import AsyncTokenCredential
     except ImportError:
         # AsyncTokenCredential is a typing_extensions.Protocol; we don't depend on that package
         pass
 
-DEFAULT_VERSION = ApiVersion.V7_3_PREVIEW
 
 class AsyncKeyVaultClientBase(object):
     def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline.transport import HttpTransport
-    from azure.core.configuration import Configuration
+
 
 class ApiVersion(str, Enum):
     """Key Vault API versions supported by this package"""

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
@@ -54,14 +54,14 @@ def parse_key_vault_id(source_id):
     try:
         parsed_uri = parse.urlparse(source_id)
     except Exception:  # pylint: disable=broad-except
-        raise ValueError("'{}' is not not a valid url".format(source_id))
+        raise ValueError("'{}' is not not a valid ID".format(source_id))
     if not (parsed_uri.scheme and parsed_uri.hostname):
-        raise ValueError("'{}' is not not a valid url".format(source_id))
+        raise ValueError("'{}' is not not a valid ID".format(source_id))
 
     path = list(filter(None, parsed_uri.path.split("/")))
 
     if len(path) < 2 or len(path) > 3:
-        raise ValueError("'{}' is not not a valid vault url".format(source_id))
+        raise ValueError("'{}' is not not a valid ID".format(source_id))
 
     return KeyVaultResourceId(
         source_id=source_id,

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -5,7 +5,7 @@
 from typing import TYPE_CHECKING
 from azure.core.pipeline.policies import HttpLoggingPolicy
 from . import AsyncChallengeAuthPolicy
-from .client_base import ApiVersion
+from .client_base import ApiVersion, DEFAULT_VERSION
 from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 
@@ -13,14 +13,11 @@ if TYPE_CHECKING:
     try:
         # pylint:disable=unused-import
         from typing import Any
-        from azure.core.configuration import Configuration
-        from azure.core.pipeline.transport import AsyncHttpTransport
         from azure.core.credentials_async import AsyncTokenCredential
     except ImportError:
         # AsyncTokenCredential is a typing_extensions.Protocol; we don't depend on that package
         pass
 
-DEFAULT_VERSION = ApiVersion.V7_3_PREVIEW
 
 class AsyncKeyVaultClientBase(object):
     def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline.transport import HttpTransport
-    from azure.core.configuration import Configuration
+
 
 class ApiVersion(str, Enum):
     """Key Vault API versions supported by this package"""

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
@@ -37,11 +37,11 @@ class KeyVaultResourceId():
     """
 
     def __init__(
-            self,
-            source_id,  # type: str
-            vault_url,  # type: str
-            name,  # type: str
-            version=None  # type: Optional[str]
+        self,
+        source_id,  # type: str
+        vault_url,  # type: str
+        name,  # type: str
+        version=None  # type: Optional[str]
     ):
         self.source_id = source_id
         self.vault_url = vault_url
@@ -54,14 +54,14 @@ def parse_key_vault_id(source_id):
     try:
         parsed_uri = parse.urlparse(source_id)
     except Exception:  # pylint: disable=broad-except
-        raise ValueError("'{}' is not not a valid url".format(source_id))
+        raise ValueError("'{}' is not not a valid ID".format(source_id))
     if not (parsed_uri.scheme and parsed_uri.hostname):
-        raise ValueError("'{}' is not not a valid url".format(source_id))
+        raise ValueError("'{}' is not not a valid ID".format(source_id))
 
     path = list(filter(None, parsed_uri.path.split("/")))
 
     if len(path) < 2 or len(path) > 3:
-        raise ValueError("'{}' is not not a valid vault url".format(source_id))
+        raise ValueError("'{}' is not not a valid ID".format(source_id))
 
     return KeyVaultResourceId(
         source_id=source_id,

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -5,7 +5,7 @@
 from typing import TYPE_CHECKING
 from azure.core.pipeline.policies import HttpLoggingPolicy
 from . import AsyncChallengeAuthPolicy
-from .client_base import ApiVersion
+from .client_base import ApiVersion, DEFAULT_VERSION
 from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 
@@ -13,14 +13,11 @@ if TYPE_CHECKING:
     try:
         # pylint:disable=unused-import
         from typing import Any
-        from azure.core.configuration import Configuration
-        from azure.core.pipeline.transport import AsyncHttpTransport
         from azure.core.credentials_async import AsyncTokenCredential
     except ImportError:
         # AsyncTokenCredential is a typing_extensions.Protocol; we don't depend on that package
         pass
 
-DEFAULT_VERSION = ApiVersion.V7_3_PREVIEW
 
 class AsyncKeyVaultClientBase(object):
     def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline.transport import HttpTransport
-    from azure.core.configuration import Configuration
+
 
 class ApiVersion(str, Enum):
     """Key Vault API versions supported by this package"""


### PR DESCRIPTION
Rather than redefining `DEFAULT_VERSION` in `async_client_base.py`, it's less error-prone to follow suit with `azure-keyvault-administration` and import the value from `client_base.py`. 