### PR TITLE
Chain exceptions from LibsecretPersistence

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
@@ -92,11 +92,13 @@ def _get_persistence(allow_unencrypted, account_name, cache_name):
                 file_path, cache_name, {"MsalClientID": "Microsoft.Developer.IdentityService"}, label=account_name
             )
         except Exception as ex:  # pylint:disable=broad-except
+            _LOGGER.debug('msal-extensions is unable to encrypt a persistent cache: "%s"', ex, exc_info=True)
             if not allow_unencrypted:
-                _LOGGER.debug('msal-extensions is unable to encrypt a persistent cache: "%s"', ex, exc_info=True)
                 error = ValueError(
-                    "Persistent cache encryption isn't available in this environment. Please install encryption "
-                    + 'dependencies or specify "allow_unencrypted_storage=True" to store the cache without encryption.'
+                    "Cache encryption is impossible because libsecret dependencies are not installed or are unusable,"
+                    + " for example because no display is available (as in an SSH session). The chained exception has"
+                    + ' more information. Specify "allow_unencrypted_storage=True" to store the cache unencrypted'
+                    + " instead of raising this exception."
                 )
                 six.raise_from(error, ex)
             return msal_extensions.FilePersistence(file_path)

--- a/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import logging
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -11,6 +12,8 @@ import six
 if TYPE_CHECKING:
     from typing import Any
     import msal_extensions
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TokenCachePersistenceOptions(object):
@@ -90,6 +93,7 @@ def _get_persistence(allow_unencrypted, account_name, cache_name):
             )
         except Exception as ex:  # pylint:disable=broad-except
             if not allow_unencrypted:
+                _LOGGER.debug('msal-extensions is unable to encrypt a persistent cache: "%s"', ex, exc_info=True)
                 error = ValueError(
                     "Persistent cache encryption isn't available in this environment. Please install encryption "
                     + 'dependencies or specify "allow_unencrypted_storage=True" to store the cache without encryption.'

--- a/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
@@ -6,6 +6,8 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
+import six
+
 if TYPE_CHECKING:
     from typing import Any
     import msal_extensions
@@ -86,12 +88,13 @@ def _get_persistence(allow_unencrypted, account_name, cache_name):
             return msal_extensions.LibsecretPersistence(
                 file_path, cache_name, {"MsalClientID": "Microsoft.Developer.IdentityService"}, label=account_name
             )
-        except ImportError:
+        except Exception as ex:  # pylint:disable=broad-except
             if not allow_unencrypted:
-                raise ValueError(
-                    "PyGObject is required to encrypt the persistent cache. Please install that library or "
-                    + 'specify "allow_unencrypted_storage=True" to store the cache without encryption.'
+                error = ValueError(
+                    "Persistent cache encryption isn't available in this environment. Please install encryption "
+                    + 'dependencies or specify "allow_unencrypted_storage=True" to store the cache without encryption.'
                 )
+                six.raise_from(error, ex)
             return msal_extensions.FilePersistence(file_path)
 
     raise NotImplementedError("A persistent cache is not available in this environment.")

--- a/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
@@ -101,6 +101,6 @@ def _get_persistence(allow_unencrypted, account_name, cache_name):
                     + " instead of raising this exception."
                 )
                 six.raise_from(error, ex)
-            return msal_extensions.FilePersistence(file_path)
+        return msal_extensions.FilePersistence(file_path)
 
     raise NotImplementedError("A persistent cache is not available in this environment.")


### PR DESCRIPTION
Currently we expect only ImportError, but constructing LibsecretPersistence could raise ValueError instead. The type of the exception doesn't matter for our purposes, so this PR broadens the except clause to handle all exceptions the same way: if the application allows unencrypted storage, fall back to that; if not, raise a ValueError from the LibsecretPersistence error, to preserve the msal-extensions error message explaining what went wrong.