### PR TITLE
Validate Application ID in User Agent

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -187,6 +187,8 @@ class UserAgentPolicy(SansIOHTTPPolicy):
     """
     _USERAGENT = "User-Agent"
     _ENV_ADDITIONAL_USER_AGENT = 'AZURE_HTTP_USER_AGENT'
+    _MAX_APPLICATION_ID_LENGTH = 24
+    _INVALID_APPLICATION_ID_LENGTH = "'applicationId' length cannot be greater than " + _MAX_APPLICATION_ID_LENGTH
 
     def __init__(self, base_user_agent=None, **kwargs):  # pylint: disable=super-init-not-called
         # type: (Optional[str], **Any) -> None
@@ -205,7 +207,13 @@ class UserAgentPolicy(SansIOHTTPPolicy):
             )
 
         if application_id:
+            if application_id.length > self._MAX_APPLICATION_ID_LENGTH:
+                raise ValueError("'applicationId' length cannot be greater than " + self._MAX_APPLICATION_ID_LENGTH)
+            if ' ' in application_id:
+                raise ValueError("'applicationId' cannot contain spaces.")
+
             self._user_agent = "{} {}".format(application_id, self._user_agent)
+
 
     @property
     def user_agent(self):

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -188,7 +188,6 @@ class UserAgentPolicy(SansIOHTTPPolicy):
     _USERAGENT = "User-Agent"
     _ENV_ADDITIONAL_USER_AGENT = 'AZURE_HTTP_USER_AGENT'
     _MAX_APPLICATION_ID_LENGTH = 24
-    _INVALID_APPLICATION_ID_LENGTH = "'applicationId' length cannot be greater than " + _MAX_APPLICATION_ID_LENGTH
 
     def __init__(self, base_user_agent=None, **kwargs):  # pylint: disable=super-init-not-called
         # type: (Optional[str], **Any) -> None
@@ -213,7 +212,6 @@ class UserAgentPolicy(SansIOHTTPPolicy):
                 raise ValueError("'applicationId' cannot contain spaces.")
 
             self._user_agent = "{} {}".format(application_id, self._user_agent)
-
 
     @property
     def user_agent(self):

--- a/sdk/core/azure-core/tests/test_user_agent_policy.py
+++ b/sdk/core/azure-core/tests/test_user_agent_policy.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # ------------------------------------
 """Tests for the user agent policy."""
+import unittest
+
 from azure.core.pipeline.policies import UserAgentPolicy
 from azure.core.pipeline.transport import HttpRequest
 from azure.core.pipeline import PipelineRequest, PipelineContext
@@ -11,30 +13,37 @@ try:
 except ImportError:
     import mock
 
-def test_user_agent_policy():
-    user_agent = UserAgentPolicy(base_user_agent='foo')
-    assert user_agent._user_agent == 'foo'
+class TestUserAgentPolicy(unittest.TestCase):
+    def test_user_agent_policy(self):
+        user_agent = UserAgentPolicy(base_user_agent='foo')
+        assert user_agent._user_agent == 'foo'
 
-    user_agent = UserAgentPolicy(sdk_moniker='foosdk/1.0.0')
-    assert user_agent._user_agent.startswith('azsdk-python-foosdk/1.0.0 Python')
+        user_agent = UserAgentPolicy(sdk_moniker='foosdk/1.0.0')
+        assert user_agent._user_agent.startswith('azsdk-python-foosdk/1.0.0 Python')
 
-    user_agent = UserAgentPolicy(base_user_agent='foo', user_agent='bar', user_agent_use_env=False)
-    assert user_agent._user_agent == 'bar foo'
-
-    request = HttpRequest('GET', 'http://127.0.0.1/')
-    pipeline_request = PipelineRequest(request, PipelineContext(None))
-
-    pipeline_request.context.options['user_agent'] = 'xyz'
-    user_agent.on_request(pipeline_request)
-    assert request.headers['User-Agent'] == 'xyz bar foo'
-
-
-def test_user_agent_environ():
-
-    with mock.patch.dict('os.environ', {'AZURE_HTTP_USER_AGENT': "mytools"}):
-        policy = UserAgentPolicy(None)
-        assert policy.user_agent.endswith("mytools")
+        user_agent = UserAgentPolicy(base_user_agent='foo', user_agent='bar', user_agent_use_env=False)
+        assert user_agent._user_agent == 'bar foo'
 
         request = HttpRequest('GET', 'http://127.0.0.1/')
-        policy.on_request(PipelineRequest(request, PipelineContext(None)))
-        assert request.headers["user-agent"].endswith("mytools")
+        pipeline_request = PipelineRequest(request, PipelineContext(None))
+
+        pipeline_request.context.options['user_agent'] = 'xyz'
+        user_agent.on_request(pipeline_request)
+        assert request.headers['User-Agent'] == 'xyz bar foo'
+
+    def test_user_agent_policy_appilication_id(self):
+        UserAgentPolicy(user_agent='ReallyLongApplicationIdentity')
+        self.assertRaises(ValueError)
+
+        UserAgentPolicy(user_agent='app id with space')
+        self.assertRaises(ValueError)
+
+
+    def test_user_agent_environ(self):
+        with mock.patch.dict('os.environ', {'AZURE_HTTP_USER_AGENT': "mytools"}):
+            policy = UserAgentPolicy(None)
+            assert policy.user_agent.endswith("mytools")
+
+            request = HttpRequest('GET', 'http://127.0.0.1/')
+            policy.on_request(PipelineRequest(request, PipelineContext(None)))
+            assert request.headers["user-agent"].endswith("mytools")


### PR DESCRIPTION
1. Application Id needs to be less or equal than 24 characters.
2. Spaces are not allowed in the application Id based on the docs.