### PR TITLE
Resolve `cryptography` mindependency error for keyvault, storage

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/dev_requirements.txt
+++ b/sdk/keyvault/azure-keyvault-keys/dev_requirements.txt
@@ -1,8 +1,8 @@
 -e ../../../tools/azure-devtools
 ../../core/azure-core
--e ../../identity/azure-identity
 -e ../azure-mgmt-keyvault
 -e ../../../tools/azure-sdk-tools
 ../../nspkg/azure-keyvault-nspkg
 aiohttp>=3.0; python_version >= '3.5'
+azure-identity
 parameterized>=0.7.3

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -2,6 +2,6 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
--e ../../identity/azure-identity
+azure-identity
 -e ../../storage/azure-mgmt-storage
 aiohttp>=3.0; python_version >= '3.5'

--- a/sdk/storage/azure-storage-file-share/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-share/dev_requirements.txt
@@ -2,6 +2,6 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
--e ../../identity/azure-identity
+azure-identity
 -e ../azure-storage-blob
 aiohttp>=3.0; python_version >= '3.5'

--- a/sdk/storage/azure-storage-queue/dev_requirements.txt
+++ b/sdk/storage/azure-storage-queue/dev_requirements.txt
@@ -2,5 +2,5 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
--e ../../identity/azure-identity
+azure-identity
 aiohttp>=3.0; python_version >= '3.5'


### PR DESCRIPTION
Error being resolved:

```
The conflict is caused by:
    The user requested cryptography==2.1.4
    azure-identity 1.7.0b4 depends on cryptography>=2.5
```

We have a conflict between our mindependency and what local azure-identity requires. This is due to effectively pinning our `azure-identity` version to the latest version on disk. Which _mandates_ that we update the minimum version of the `cryptography`. Instead, relax to consuming `latest azure-identity that matches our requirements as well`.