### PR TITLE
[translation] fix poller.details

### DIFF
--- a/sdk/translation/azure-ai-translation-document/CHANGELOG.md
+++ b/sdk/translation/azure-ai-translation-document/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- The operation `id` under `details` of the poller object now populates correctly.
 
 ### Other Changes
 

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_polling.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_polling.py
@@ -67,8 +67,7 @@ class DocumentTranslationLROPoller(LROPoller):
             return TranslationStatus._from_generated(  # pylint: disable=protected-access
                 self._polling_method._current_body  # pylint: disable=protected-access
             )
-        else:
-            return TranslationStatus(id=self._polling_method._get_id_from_headers())  # pylint: disable=protected-access
+        return TranslationStatus(id=self._polling_method._get_id_from_headers())  # pylint: disable=protected-access
 
     @classmethod
     def from_continuation_token(cls, polling_method, continuation_token, **kwargs):

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_polling.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_polling.py
@@ -63,9 +63,12 @@ class DocumentTranslationLROPoller(LROPoller):
 
         :rtype: ~azure.ai.translation.document.TranslationStatus
         """
-        return TranslationStatus._from_generated(  # pylint: disable=protected-access
-            self._polling_method._current_body  # pylint: disable=protected-access
-        )
+        if self._polling_method._current_body:  # pylint: disable=protected-access
+            return TranslationStatus._from_generated(  # pylint: disable=protected-access
+                self._polling_method._current_body  # pylint: disable=protected-access
+            )
+        else:
+            return TranslationStatus(id=self._polling_method._get_id_from_headers())  # pylint: disable=protected-access
 
     @classmethod
     def from_continuation_token(cls, polling_method, continuation_token, **kwargs):

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_async_polling.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_async_polling.py
@@ -47,8 +47,7 @@ class AsyncDocumentTranslationLROPoller(AsyncLROPoller[PollingReturnType]):
             return TranslationStatus._from_generated(  # pylint: disable=protected-access
                 self._polling_method._current_body  # pylint: disable=protected-access
             )
-        else:
-            return TranslationStatus(id=self._polling_method._get_id_from_headers())  # pylint: disable=protected-access
+        return TranslationStatus(id=self._polling_method._get_id_from_headers())  # pylint: disable=protected-access
 
     @classmethod
     def from_continuation_token(

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_async_polling.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_async_polling.py
@@ -43,9 +43,12 @@ class AsyncDocumentTranslationLROPoller(AsyncLROPoller[PollingReturnType]):
 
         :rtype: ~azure.ai.translation.document.TranslationStatus
         """
-        return TranslationStatus._from_generated(  # pylint: disable=protected-access
-            self._polling_method._current_body  # pylint: disable=protected-access
-        )
+        if self._polling_method._current_body:  # pylint: disable=protected-access
+            return TranslationStatus._from_generated(  # pylint: disable=protected-access
+                self._polling_method._current_body  # pylint: disable=protected-access
+            )
+        else:
+            return TranslationStatus(id=self._polling_method._get_id_from_headers())  # pylint: disable=protected-access
 
     @classmethod
     def from_continuation_token(

--- a/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_client_async.py
+++ b/sdk/translation/azure-ai-translation-document/azure/ai/translation/document/aio/_client_async.py
@@ -271,7 +271,7 @@ class DocumentTranslationClient(object):
             format: ["param1 asc/desc", "param2 asc/desc", ...]
             (ex: 'created_on asc', 'created_on desc').
         :return: A pageable of TranslationStatus.
-        :rtype: ~azure.core.paging.ItemPaged[TranslationStatus]
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[TranslationStatus]
         :raises ~azure.core.exceptions.HttpResponseError:
 
         .. admonition:: Example:
@@ -336,7 +336,7 @@ class DocumentTranslationClient(object):
             format: ["param1 asc/desc", "param2 asc/desc", ...]
             (ex: 'created_on asc', 'created_on desc').
         :return: A pageable of DocumentStatus.
-        :rtype: ~azure.core.paging.ItemPaged[DocumentStatus]
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[DocumentStatus]
         :raises ~azure.core.exceptions.HttpResponseError:
 
         .. admonition:: Example:

--- a/sdk/translation/azure-ai-translation-document/tests/asynctestcase.py
+++ b/sdk/translation/azure-ai-translation-document/tests/asynctestcase.py
@@ -26,6 +26,7 @@ class AsyncDocumentTranslationTest(DocumentTranslationTest):
         # submit operation
         poller = await async_client.begin_translation(translation_inputs)
         self.assertIsNotNone(poller.id)
+        self.assertIsNotNone(poller.details.id)
         # wait for result
         doc_statuses = await poller.result()
         # validate

--- a/sdk/translation/azure-ai-translation-document/tests/testcase.py
+++ b/sdk/translation/azure-ai-translation-document/tests/testcase.py
@@ -236,6 +236,7 @@ class DocumentTranslationTest(AzureTestCase):
         # submit job
         poller = client.begin_translation(translation_inputs)
         self.assertIsNotNone(poller.id)
+        self.assertIsNotNone(poller.details.id)
         # wait for result
         result = poller.result()
         # validate


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/20226

Noticed this in our user study. `poller.details` represents the status metadata (TranslationStatus) returned from the GET. Depending on when a user accesses this property, that information might not be returned yet (did the POST, about to do the GET). We do, however, know the operation ID from the initial POST so we can populate that property immediately. 

Also fixed an incorrect type in the docstrings for async client.