### PR TITLE
[Core] Enable strict checking of http content-length

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- The `Content-Length` header in a http response is strictly checked against the actual number of bytes in the body,
+  rather than silently truncating data in case the underlying tcp connection is closed prematurely.
+
 ### Other Changes
 
 ## 1.18.0 (2021-09-02)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_requests_asyncio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_requests_asyncio.py
@@ -42,7 +42,7 @@ from ._base_async import (
     AsyncHttpResponse,
     _ResponseStopIteration,
     _iterate_response_content)
-from ._requests_basic import RequestsTransportResponse, _read_raw_stream
+from ._requests_basic import RequestsTransportResponse, _read_raw_stream, _get_request_hooks
 from ._base_requests_async import RequestsAsyncTransportBase
 from .._tools import get_block_size as _get_block_size, get_internal_response as _get_internal_response
 
@@ -114,6 +114,7 @@ class AsyncioRequestsTransport(RequestsAsyncTransportBase):
                     timeout=kwargs.pop('connection_timeout', self.connection_config.timeout),
                     cert=kwargs.pop('connection_cert', self.connection_config.cert),
                     allow_redirects=False,
+                    hooks=_get_request_hooks(kwargs.pop('hooks', None)),
                     **kwargs))
 
         except urllib3.exceptions.NewConnectionError as err:

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_requests_trio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_requests_trio.py
@@ -42,7 +42,7 @@ from ._base_async import (
     AsyncHttpResponse,
     _ResponseStopIteration,
     _iterate_response_content)
-from ._requests_basic import RequestsTransportResponse, _read_raw_stream
+from ._requests_basic import RequestsTransportResponse, _read_raw_stream, _get_request_hooks
 from ._base_requests_async import RequestsAsyncTransportBase
 from .._tools import get_block_size as _get_block_size, get_internal_response as _get_internal_response
 
@@ -164,6 +164,7 @@ class TrioRequestsTransport(RequestsAsyncTransportBase):  # type: ignore
                         timeout=kwargs.pop('connection_timeout', self.connection_config.timeout),
                         cert=kwargs.pop('connection_cert', self.connection_config.cert),
                         allow_redirects=False,
+                        hooks=_get_request_hooks(kwargs.pop('hooks', None)),
                         **kwargs),
                     limiter=trio_limiter)
             except AttributeError:  # trio < 0.12.1
@@ -179,6 +180,7 @@ class TrioRequestsTransport(RequestsAsyncTransportBase):  # type: ignore
                         timeout=kwargs.pop('connection_timeout', self.connection_config.timeout),
                         cert=kwargs.pop('connection_cert', self.connection_config.cert),
                         allow_redirects=False,
+                        hooks=_get_request_hooks(kwargs.pop('hooks', None)),
                         **kwargs),
                     limiter=trio_limiter)
 

--- a/sdk/core/azure-core/tests/testserver_tests/async_tests/test_content_length_checking_async.py
+++ b/sdk/core/azure-core/tests/testserver_tests/async_tests/test_content_length_checking_async.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+from azure.core.pipeline import AsyncPipeline
+from azure.core.pipeline.transport import (
+    HttpRequest,
+    AsyncioRequestsTransport,
+    TrioRequestsTransport,
+    AioHttpTransport,
+)
+import pytest
+import trio
+
+
+@pytest.fixture(params=[True, False])
+def stream(request):
+    return request.param
+
+
+@pytest.mark.asyncio
+async def test_async_requests_transport_short_read_raises(port, stream):
+    request = HttpRequest("GET", "http://localhost:{}/errors/short-data".format(port))
+    with pytest.raises(Exception, match="IncompleteRead"):
+        async with AsyncPipeline(AsyncioRequestsTransport()) as pipeline:
+            response = await pipeline.run(request, stream=stream)
+            assert response.http_response.status_code == 200
+            await response.http_response.body()
+
+
+def test_trio_transport_short_read_raises(port, stream):
+    request = HttpRequest("GET", "http://localhost:{}/errors/short-data".format(port))
+
+    async def do():
+        with pytest.raises(Exception, match="IncompleteRead"):
+            async with AsyncPipeline(TrioRequestsTransport()) as pipeline:
+                response = await pipeline.run(request, stream=stream)
+                assert response.http_response.status_code == 200
+                await response.http_response.body()
+
+    trio.run(do)
+
+
+@pytest.mark.asyncio
+async def test_aio_transport_short_read_raises(port, stream):
+    request = HttpRequest("GET", "http://localhost:{}/errors/short-data".format(port))
+    with pytest.raises(Exception, match="payload is not completed"):
+        async with AsyncPipeline(AioHttpTransport()) as pipeline:
+            response = await pipeline.run(request, stream=stream)
+            assert response.http_response.status_code == 200
+            await response.http_response.load_body()

--- a/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/errors.py
+++ b/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/errors.py
@@ -26,3 +26,11 @@ def get_stream():
             yield b"Hello, "
             yield b"world!"
     return Response(StreamingBody(), status=500)
+
+
+@errors_api.route('/short-data', methods=['GET'])
+def get_short_data():
+    response = Response(b"X" * 4, status=200)
+    response.automatically_set_content_length = False
+    response.headers["Content-Length"] = "8"
+    return response

--- a/sdk/core/azure-core/tests/testserver_tests/test_content_length_checking.py
+++ b/sdk/core/azure-core/tests/testserver_tests/test_content_length_checking.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+from azure.core.pipeline import Pipeline
+from azure.core.pipeline.transport import (
+    HttpRequest,
+    RequestsTransport,
+)
+import pytest
+
+
+@pytest.fixture(params=[True, False])
+def stream(request):
+    return request.param
+
+
+def test_requests_transport_short_read_raises(port, stream):
+    request = HttpRequest("GET", "http://localhost:{}/errors/short-data".format(port))
+    with pytest.raises(Exception, match="IncompleteRead"):
+        with Pipeline(RequestsTransport()) as pipeline:
+            response = pipeline.run(request, stream=stream)
+            assert response.http_response.status_code == 200
+            response.http_response.body()
+
+
+def test_disable_content_length_checking_via_custom_hook(port):
+    def hook(request, **kwargs):
+        request.raw.enforce_content_length = False
+
+    request = HttpRequest("GET", "http://localhost:{}/errors/short-data".format(port))
+    with Pipeline(RequestsTransport()) as pipeline:
+        response = pipeline.run(request, hooks={"response": [hook]})
+        assert response.http_response.status_code == 200
+    # note the absence of a IncompleteRead exception
+
+
+def test_user_hooks_merged(port):
+    hook_called = [False]
+
+    def hook(request, **kwargs):
+        hook_called[0] = True
+
+    request = HttpRequest("GET", "http://localhost:{}/errors/short-data".format(port))
+    with pytest.raises(Exception, match="IncompleteRead"):
+        with Pipeline(RequestsTransport()) as pipeline:
+            response = pipeline.run(request, hooks={"response": [hook]})
+            assert response.http_response.status_code == 200
+    assert hook_called[0]
+


### PR DESCRIPTION
We have a big data application heavily relying on the azure blob store to store the data. Unfortunately, we keep running into client-side data corruption issues when reading data from the blob store: sometimes, fewer bytes are returned than expected; sometimes the returned data has the correct length, but data is corrupt.

(I reported an issue in a similar vein already as https://github.com/Azure/azure-sdk-for-python/issues/16723 . This was fixed in the meantime and has already substantially improved the situation for us.)

A potential cause for these issues are prematurely closed tcp connections: If a tcp connection is closed while in the middle of transferring the body of a http response, the azure-core library so far returned truncated data -- rather than raising an exception. This PR fixes this behavior by enabling strict checking of the http content-length. In case of a prematurely closed tcp connection, an exception is raised rather than returning the truncated body.
Note that the aiohttp backend already raised in such case, so no change was required for the aiohttp backend.

The fix boils down to setting [urllib3.response.HTTPResponse.enforce_content_length](https://urllib3.readthedocs.io/en/stable/reference/urllib3.response.html#urllib3.response.HTTPResponse) at an appropriate time: when or directly after constructing the `HTTPResponse` object, but before reading the body.
I chose to do this in a [requests hook](https://docs.python-requests.org/en/master/user/advanced/#event-hooks), as:

 * setting it in a HTTPAdapter.send (e.g. by adding `BiggerBlockSizeHTTPAdapter.send`) would also be possible in principle, but it would not cover cases in which `RequestsTransport` cannot set the adapter as it does not own the session.
 * setting it after `requests.Session.request` returns would only cover the `stream=True` case: For `stream=False`, the body of the response was already fully read once `requests.Session.request` returns, so setting `enforce_content_length` would have no effect.