### PR TITLE
Suppress CredScan warnings for test certs and fake password examples

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -11,6 +11,7 @@
                 "kt#_gahr!@aGERDXA",
                 "Aa1!zyx_",
                 "Aa!1()-xyz",
+                ":code:`<pfx-file-password>`",
                 "000000000000000000000000000000000000000000000000000",
                 "UsernameAndPassword",
                 "123456",
@@ -37,8 +38,11 @@
         {
             "file":[
                 "eng/common/testproxy/dotnet-devcert.pfx",
+                "sdk/confidentialledger/azure-confidentialledger/tests/_shared/constants.py",
                 "sdk/keyvault/azure-keyvault-certificates/tests/ca.key",
                 "sdk/identity/azure-identity/tests/ec-certificate.pem",
+                "sdk/identity/azure-identity/tests/certificate.pfx",
+                "sdk/identity/azure-identity/tests/certificate-with-password.pfx",
                 "sdk/core/azure-servicemanagement-legacy/tests/legacy_mgmt_settings_fake.py",
                 "sdk/storage/azure-storage-blob/tests/blob_settings_fake.py",
                 "sdk/storage/azure-storage-file-datalake/tests/data_lake_settings_fake.py",


### PR DESCRIPTION
This should address https://github.com/Azure/azure-sdk-for-python-pr/issues/659, https://github.com/Azure/azure-sdk-for-python-pr/issues/660, https://github.com/Azure/azure-sdk-for-python-pr/issues/661, and [warnings](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1064526&view=logs&j=0874ffeb-2919-5b4b-20de-16a97970b94c&t=439e917e-962a-53e0-8a4b-b8bb4f8ed372&l=57) from new Identity test certificates.

The ```":code:`<pfx-file-password>\`"``` value is an example password value that shows up in many generated docstrings (one such example [here](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/compute/azure-mgmt-compute/azure/mgmt/compute/v2015_06_15/models/_models.py#L3115)).