### PR TITLE
Update exporter OT -> AI mappings based off of common schema

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+  **Breaking Changes**
+  - Change exporter OT to AI mapping fields following common schema
+      ([#20445](https://github.com/Azure/azure-sdk-for-python/pull/20445))
+
 ## 1.0.0b4 (2021-04-06)
 
   **Features**

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -20,7 +20,7 @@ azure_monitor_context = {
     "ai.device.locale": locale.getdefaultlocale()[0],
     "ai.device.osVersion": platform.version(),
     "ai.device.type": "Other",
-    "ai.internal.sdkVersion": "py{}:ot{}:ext{}".format(
+    "ai.internal.sdkVersion": "py{}:otel{}:ext{}".format(
         platform.python_version(), opentelemetry_version, ext_version
     ),
 }

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -82,6 +82,7 @@ class AzureMonitorTraceExporter(BaseExporter, SpanExporter):
 
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-branches
+# pylint: disable=too-many-locals
 def _convert_span_to_envelope(span: Span) -> TelemetryItem:
     envelope = TelemetryItem(
         name="",

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -111,6 +111,7 @@ def _convert_span_to_envelope(span: Span) -> TelemetryItem:
         envelope.tags["ai.operation.parentId"] = "{:016x}".format(
             span.parent.span_id
         )
+    # pylint: disable=too-many-nested-blocks
     if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):
         envelope.name = "Microsoft.ApplicationInsights.Request"
         data = RequestData(
@@ -189,7 +190,7 @@ def _convert_span_to_envelope(span: Span) -> TelemetryItem:
                 # This logic assumes default ports never conflict across dependency types
                 if port != _get_default_port_http(span.attributes["http.scheme"]) and \
                     port != _get_default_port_db(span.attributes["db.system"]):
-                    target = "{}:{}".format(target,port)
+                    target = "{}:{}".format(target, port)
         if span.kind is SpanKind.CLIENT:
             if "http.method" in span.attributes:  # HTTP
                 data.type = "HTTP"
@@ -293,25 +294,23 @@ def _convert_span_to_envelope(span: Span) -> TelemetryItem:
 def _get_default_port_db(dbsystem):
     if dbsystem == "postgresql":
         return 5432
-    elif dbsystem == "mysql":
+    if dbsystem == "mysql":
         return 3306
-    elif dbsystem == "memcached":
+    if dbsystem == "memcached":
         return 11211
-    elif dbsystem == "mongodb":
+    if dbsystem == "mongodb":
         return 27017
-    elif dbsystem == "redis":
+    if dbsystem == "redis":
         return 6379
-    else:
-        return 0
+    return 0
 
 
 def _get_default_port_http(scheme):
     if scheme == "http":
         return 80
-    elif scheme == "https":
+    if scheme == "https":
         return 443
-    else:
-        return 0
+    return 0
 
 
 def _is_relational_db(dbsystem):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -230,6 +230,7 @@ class TestAzureTraceExporter(unittest.TestCase):
                 "http.url": "https://www.wikipedia.org/wiki/Rabbit",
                 "http.status_code": 200,
                 "peer.service": "service",
+                "http.user_agent": "agent",
             },
             kind=SpanKind.CLIENT,
         )
@@ -255,6 +256,7 @@ class TestAzureTraceExporter(unittest.TestCase):
             "https://www.wikipedia.org/wiki/Rabbit",
         )
         self.assertEqual(envelope.data.base_data.result_code, "200")
+        self.assertEqual(envelope.tags["ai.user.userAgent"], "agent")
 
         # Target
         span._attributes = {
@@ -378,6 +380,12 @@ class TestAzureTraceExporter(unittest.TestCase):
         }
         envelope = exporter._span_to_envelope(span)
         self.assertEqual(envelope.data.base_data.target, "testDb")
+
+        span._attributes = {
+            "db.system": "postgresql",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.target, "postgresql")
 
     def test_span_to_envelope_client_rpc(self):
         exporter = self._exporter

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import platform
 import shutil
 import unittest
 from unittest import mock
@@ -18,6 +19,7 @@ from azure.monitor.opentelemetry.exporter.export._base import ExportResult
 from azure.monitor.opentelemetry.exporter.export.trace._exporter import (
     AzureMonitorTraceExporter
 )
+from azure.monitor.opentelemetry.exporter._utils import azure_monitor_context
 
 
 def throw(exc_type, *args, **kwargs):
@@ -152,64 +154,66 @@ class TestAzureTraceExporter(unittest.TestCase):
             result = exporter.export([test_span])
             self.assertEqual(result, SpanExportResult.FAILURE)
 
-    def test_span_to_envelope_none(self):
+    def test_span_to_envelope_partA(self):
         exporter = self._exporter
-        test_span = trace._Span(
-            name="test",
-            context=SpanContext(
-                trace_id=36873507687745823477771305566750195431,
-                span_id=12030755672171557338,
-                is_remote=False,
-            ),
-        )
-        test_span.start()
-        test_span.end()
-
-    def test_span_to_envelope_tags(self):
-        exporter = self._exporter
-        test_span = trace._Span(
-            name="test",
-            context=SpanContext(
-                trace_id=36873507687745823477771305566750195431,
-                span_id=12030755672171557338,
-                is_remote=False,
-            ),
-        )
-        test_span.start()
-        test_span.end()
-        envelope = exporter._span_to_envelope(test_span)
-
-        self.assertIsNotNone(envelope.tags)
-        self.assertIsNotNone(envelope.tags.get("ai.cloud.role"))
-        self.assertEqual(envelope.tags.get("ai.cloud.role"), "unknown_service")
-        self.assertIsNone(envelope.tags.get("ai.cloud.roleInstance"))
-        self.assertIsNotNone(envelope.tags.get("ai.device.id"))
-        self.assertIsNotNone(envelope.tags.get("ai.device.locale"))
-        self.assertIsNotNone(envelope.tags.get("ai.device.osVersion"))
-        self.assertIsNotNone(envelope.tags.get("ai.device.type"))
-        self.assertIsNotNone(envelope.tags.get("ai.internal.sdkVersion"))
-
-        test_span._resource = resources.Resource(
+        resource = resources.Resource(
             {"service.name": "testServiceName",
              "service.namespace": "testServiceNamespace",
              "service.instance.id": "testServiceInstanceId"})
+        context = SpanContext(
+                trace_id=36873507687745823477771305566750195431,
+                span_id=12030755672171557338,
+                is_remote=False,
+            )
+        test_span = trace._Span(
+            name="test",
+            context=context,
+            resource=resource,
+            attributes={"enduser.id":"testId"},
+            parent=context,
+        )
+        test_span.start()
+        test_span.end()
         envelope = exporter._span_to_envelope(test_span)
+
+        self.assertEqual(envelope.instrumentation_key,
+                         "1234abcd-5678-4efa-8abc-1234567890ab")
+        self.assertIsNotNone(envelope.tags)
+        self.assertEqual(envelope.tags.get("ai.device.id"), azure_monitor_context["ai.device.id"])
+        self.assertEqual(envelope.tags.get("ai.device.locale"), azure_monitor_context["ai.device.locale"])
+        self.assertEqual(envelope.tags.get("ai.device.osVersion"), azure_monitor_context["ai.device.osVersion"])
+        self.assertEqual(envelope.tags.get("ai.device.type"), azure_monitor_context["ai.device.type"])
+        self.assertEqual(envelope.tags.get("ai.internal.sdkVersion"), azure_monitor_context["ai.internal.sdkVersion"])
+
         self.assertEqual(envelope.tags.get("ai.cloud.role"), "testServiceNamespace.testServiceName")
-        self.assertEqual(envelope.tags.get(
-            "ai.cloud.roleInstance"), "testServiceInstanceId")
+        self.assertEqual(envelope.tags.get("ai.cloud.roleInstance"), "testServiceInstanceId")
+        self.assertEqual(envelope.tags.get("ai.internal.nodeName"), "testServiceInstanceId")
+        self.assertEqual(envelope.tags.get("ai.operation.id"), "{:032x}".format(context.trace_id))
+        self.assertEqual(envelope.tags.get("ai.user.id"), "testId")
+        self.assertEqual(envelope.tags.get("ai.operation.parentId"), "{:016x}".format(context.span_id))
 
-    # pylint: disable=too-many-statements
-
-    def test_span_to_envelope(self):
-        exporter = AzureMonitorTraceExporter(
-            connection_string="InstrumentationKey=12345678-1234-5678-abcd-12345678abcd",
+    def test_span_to_envelope_partA_default(self):
+        exporter = self._exporter
+        resource = resources.Resource(
+            {"service.name": "testServiceName"})
+        context = SpanContext(
+                trace_id=36873507687745823477771305566750195431,
+                span_id=12030755672171557338,
+                is_remote=False,
+            )
+        test_span = trace._Span(
+            name="test",
+            context=context,
+            resource=resource,
         )
-        parent_span = SpanContext(
-            trace_id=36873507687745823477771305566750195431,
-            span_id=12030755672171557338,
-            is_remote=False,
-        )
+        test_span.start()
+        test_span.end()
+        envelope = exporter._span_to_envelope(test_span)
+        self.assertEqual(envelope.tags.get("ai.cloud.role"), "testServiceName")
+        self.assertEqual(envelope.tags.get("ai.cloud.roleInstance"), platform.node())
 
+    def test_span_to_envelope_client_http(self):
+        exporter = self._exporter
         start_time = 1575494316027613500
         end_time = start_time + 1001000000
 
@@ -221,32 +225,19 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "http.method": "GET",
                 "http.url": "https://www.wikipedia.org/wiki/Rabbit",
                 "http.status_code": 200,
+                "peer.service": "service",
             },
-            events=None,
-            links=[],
             kind=SpanKind.CLIENT,
         )
         span.start(start_time=start_time)
         span.end(end_time=end_time)
         span._status = Status(status_code=StatusCode.OK)
         envelope = exporter._span_to_envelope(span)
-        self.assertEqual(envelope.instrumentation_key,
-                         "12345678-1234-5678-abcd-12345678abcd")
-        self.assertEqual(
-            envelope.tags["ai.operation.parentId"], "a6f5d48acb4d31da"
-        )
-        self.assertEqual(
-            envelope.tags["ai.operation.id"],
-            "1bbd944a73a05d89eab5d3740a213ee7",
-        )
+  
         self.assertEqual(
             envelope.name, "Microsoft.ApplicationInsights.RemoteDependency"
         )
@@ -254,39 +245,58 @@ class TestAzureTraceExporter(unittest.TestCase):
         self.assertEqual(envelope.data.base_data.name, "test")
         self.assertEqual(envelope.data.base_data.id, "a6f5d48acb4d31d9")
         self.assertEqual(envelope.data.base_data.duration, "0.00:00:01.001")
-        self.assertEqual(envelope.data.base_data.result_code, "200")
         self.assertTrue(envelope.data.base_data.success)
 
         self.assertEqual(envelope.data.base_type, "RemoteDependencyData")
         self.assertEqual(envelope.data.base_data.type, "HTTP")
-        self.assertEqual(envelope.data.base_data.target, "www.wikipedia.org")
+        self.assertEqual(envelope.data.base_data.target, "service")
         self.assertEqual(
             envelope.data.base_data.data,
             "https://www.wikipedia.org/wiki/Rabbit",
         )
         self.assertEqual(envelope.data.base_data.result_code, "200")
 
+        # Target
         span._attributes = {
-            "component": "http",
             "http.method": "GET",
-            "net.peer.port": 1234,
-            "net.peer.name": "testhost",
-            "http.status_code": 200,
+            "http.scheme": "https",
+            "http.url": "https://www.example.com:1234",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertEqual(envelope.data.base_data.target, "testhost:1234")
+        self.assertEqual(envelope.data.base_data.target, "www.example.com:1234")
 
         span._attributes = {
-            "component": "http",
             "http.method": "GET",
-            "net.peer.port": 1234,
-            "net.peer.ip": "127.0.0.1",
-            "http.status_code": 200,
+            "http.scheme": "http",
+            "http.url": "http://www.example.com:80",
         }
         envelope = exporter._span_to_envelope(span)
-        self.assertEqual(envelope.data.base_data.target, "127.0.0.1:1234")
+        self.assertEqual(envelope.data.base_data.target, "www.example.com")
 
-        # SpanKind.CLIENT Database
+        span._attributes = {
+            "http.method": "GET",
+            "http.scheme": "http",
+            "http.url": "http://www.example.com:80",
+            "http.host": "www.wikipedia.org:1234",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.target, "www.wikipedia.org:1234")
+
+        span._attributes = {
+            "http.method": "GET",
+            "http.scheme": "https",
+            "http.url": "http://www.example.com:80",
+            "http.host": "www.wikipedia.org:443",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.target, "www.wikipedia.org")
+
+    def test_span_to_envelope_client_db(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
+
+        # SpanKind.CLIENT Db
         span = trace._Span(
             name="test",
             context=SpanContext(
@@ -294,27 +304,55 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
-                "db.system": "sql",
-                "db.statement": "Test Query",
-                "db.name": "test db",
+                "db.system": "postgresql",
+                "peer.service": "service",
+                "db.statement": "SELECT",
             },
-            events=None,
-            links=[],
             kind=SpanKind.CLIENT,
         )
         span.start(start_time=start_time)
         span.end(end_time=end_time)
         span._status = Status(status_code=StatusCode.OK)
         envelope = exporter._span_to_envelope(span)
+  
+        self.assertEqual(
+            envelope.name, "Microsoft.ApplicationInsights.RemoteDependency"
+        )
+        self.assertEqual(envelope.time, "2019-12-04T21:18:36.027613Z")
+        self.assertEqual(envelope.data.base_data.name, "test")
+        self.assertEqual(envelope.data.base_data.id, "a6f5d48acb4d31d9")
+        self.assertEqual(envelope.data.base_data.duration, "0.00:00:01.001")
         self.assertTrue(envelope.data.base_data.success)
-        self.assertEqual(envelope.data.base_data.type, "sql")
-        self.assertEqual(envelope.data.base_data.target, "test db")
-        self.assertEqual(envelope.data.base_data.data, "Test Query")
+
+        self.assertEqual(envelope.data.base_type, "RemoteDependencyData")
+        self.assertEqual(envelope.data.base_data.type, "SQL")
+        self.assertEqual(envelope.data.base_data.target, "service")
+        self.assertEqual(envelope.data.base_data.data, "SELECT")
+        self.assertEqual(envelope.data.base_data.result_code, "1")
+
+        # Target
+        span._attributes = {
+            "db.system": "postgresql",
+            "db.statement": "SELECT",
+            "db.name": "testDb",
+            "peer.service": "service",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.target, "service/testDb")
+
+        span._attributes = {
+            "db.system": "postgresql",
+            "db.statement": "SELECT",
+            "db.name": "testDb",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.target, "testDb")
+
+    def test_span_to_envelope_client_rpc(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
 
         # SpanKind.CLIENT rpc
         span = trace._Span(
@@ -324,27 +362,39 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "rpc.system": "rpc",
                 "rpc.service": "Test service",
             },
-            events=None,
-            links=[],
             kind=SpanKind.CLIENT,
         )
         span.start(start_time=start_time)
         span.end(end_time=end_time)
         span._status = Status(status_code=StatusCode.OK)
         envelope = exporter._span_to_envelope(span)
+  
+        self.assertEqual(
+            envelope.name, "Microsoft.ApplicationInsights.RemoteDependency"
+        )
+        self.assertEqual(envelope.time, "2019-12-04T21:18:36.027613Z")
+        self.assertEqual(envelope.data.base_data.name, "test")
+        self.assertEqual(envelope.data.base_data.id, "a6f5d48acb4d31d9")
+        self.assertEqual(envelope.data.base_data.duration, "0.00:00:01.001")
         self.assertTrue(envelope.data.base_data.success)
-        self.assertEqual(envelope.data.base_data.type, "rpc.system")
-        self.assertEqual(envelope.data.base_data.target, "Test service")
 
-        # SpanKind.CLIENT messaging
+        self.assertEqual(envelope.data.base_type, "RemoteDependencyData")
+        self.assertEqual(envelope.data.base_data.type, "rpc.system")
+        self.assertEqual(envelope.data.base_data.target, "rpc")
+        # TODO: data.data
+        # self.assertEqual(envelope.data.base_data.data, "SELECT")
+        self.assertEqual(envelope.data.base_data.result_code, "1")
+
+    def test_span_to_envelope_producer_messaging(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
+
+        # SpanKind.PRODUCER messaging
         span = trace._Span(
             name="test",
             context=SpanContext(
@@ -352,27 +402,39 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "messaging.system": "messaging",
                 "net.peer.ip": "127.0.0.1",
                 "messaging.destination": "celery",
             },
-            events=None,
-            links=[],
-            kind=SpanKind.CLIENT,
+            kind=SpanKind.PRODUCER,
         )
         span.start(start_time=start_time)
         span.end(end_time=end_time)
         span._status = Status(status_code=StatusCode.OK)
         envelope = exporter._span_to_envelope(span)
+  
+        self.assertEqual(
+            envelope.name, "Microsoft.ApplicationInsights.RemoteDependency"
+        )
+        self.assertEqual(envelope.time, "2019-12-04T21:18:36.027613Z")
+        self.assertEqual(envelope.data.base_data.name, "test")
+        self.assertEqual(envelope.data.base_data.id, "a6f5d48acb4d31d9")
+        self.assertEqual(envelope.data.base_data.duration, "0.00:00:01.001")
         self.assertTrue(envelope.data.base_data.success)
-        self.assertEqual(envelope.data.base_data.type,
-                         "Queue Message | messaging")
-        self.assertEqual(envelope.data.base_data.target, "127.0.0.1/celery")
+
+        self.assertEqual(envelope.data.base_type, "RemoteDependencyData")
+        self.assertEqual(envelope.data.base_data.type, "Queue Message")
+        # TODO: data.target
+        # self.assertEqual(envelope.data.base_data.target, "rpc")
+        # TODO: data.data
+        # self.assertEqual(envelope.data.base_data.data, "SELECT")
+        self.assertEqual(envelope.data.base_data.result_code, "1")
+
+    def test_span_to_envelope_internal(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
 
         # SpanKind.INTERNAL
         span = trace._Span(
@@ -382,25 +444,31 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
-            attributes={
-                "messaging.system": "messaging",
-                "net.peer.ip": "127.0.0.1",
-                "messaging.destination": "celery",
-            },
-            events=None,
-            links=[],
+            attributes={},
             kind=SpanKind.INTERNAL,
         )
         span.start(start_time=start_time)
         span.end(end_time=end_time)
         span._status = Status(status_code=StatusCode.OK)
         envelope = exporter._span_to_envelope(span)
+  
+        self.assertEqual(
+            envelope.name, "Microsoft.ApplicationInsights.RemoteDependency"
+        )
+        self.assertEqual(envelope.time, "2019-12-04T21:18:36.027613Z")
+        self.assertEqual(envelope.data.base_data.name, "test")
+        self.assertEqual(envelope.data.base_data.id, "a6f5d48acb4d31d9")
+        self.assertEqual(envelope.data.base_data.duration, "0.00:00:01.001")
         self.assertTrue(envelope.data.base_data.success)
+
+        self.assertEqual(envelope.data.base_type, "RemoteDependencyData")
         self.assertEqual(envelope.data.base_data.type, "InProc")
+        self.assertEqual(envelope.data.base_data.result_code, "1")
+
+    def test_span_envelope_server_http(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
 
         # SpanKind.SERVER HTTP
         span = trace._Span(
@@ -410,36 +478,23 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "http.method": "GET",
                 "http.path": "/wiki/Rabbit",
                 "http.route": "/wiki/Rabbit",
                 "http.url": "https://www.wikipedia.org/wiki/Rabbit",
                 "http.status_code": 200,
+                "http.user_agent": "agent",
+                "http.client_ip": "client_ip",
             },
-            events=None,
-            links=[],
             kind=SpanKind.SERVER,
         )
         span._status = Status(status_code=StatusCode.OK)
         span.start(start_time=start_time)
         span.end(end_time=end_time)
         envelope = exporter._span_to_envelope(span)
-        self.assertEqual(envelope.instrumentation_key,
-                         "12345678-1234-5678-abcd-12345678abcd")
         self.assertEqual(
             envelope.name, "Microsoft.ApplicationInsights.Request"
-        )
-        self.assertEqual(
-            envelope.tags["ai.operation.parentId"], "a6f5d48acb4d31da"
-        )
-        self.assertEqual(
-            envelope.tags["ai.operation.id"],
-            "1bbd944a73a05d89eab5d3740a213ee7",
         )
         self.assertEqual(envelope.data.base_type, "RequestData")
         self.assertEqual(envelope.data.base_data.name, "test")
@@ -447,17 +502,25 @@ class TestAzureTraceExporter(unittest.TestCase):
         self.assertEqual(envelope.data.base_data.duration, "0.00:00:01.001")
         self.assertEqual(envelope.data.base_data.response_code, "200")
         self.assertTrue(envelope.data.base_data.success)
-        self.assertEqual(
-            envelope.tags["ai.operation.name"], "/wiki/Rabbit"
-        )
-        self.assertEqual(
-            envelope.data.base_data.url,
-            "https://www.wikipedia.org/wiki/Rabbit",
-        )
-        self.assertEqual(
-            envelope.data.base_data.properties["request.url"],
-            "https://www.wikipedia.org/wiki/Rabbit",
-        )
+
+        self.assertEqual(envelope.tags["ai.operation.name"], "GET test")
+        self.assertEqual(envelope.tags["ai.user.userAgent"], "agent")
+        self.assertEqual(envelope.tags["ai.location.ip"], "client_ip")
+        self.assertEqual(envelope.data.base_data.url, "https://www.wikipedia.org/wiki/Rabbit")
+        self.assertEqual(envelope.data.base_data.properties["request.url"], "https://www.wikipedia.org/wiki/Rabbit")
+        
+        # location
+        span._attributes = {
+            "http.method": "GET",
+            "net.peer.ip": "peer_ip"
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.tags["ai.location.ip"], "peer_ip")
+
+    def test_span_envelope_server_messaging(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
 
         # SpanKind.SERVER messaging
         span = trace._Span(
@@ -467,30 +530,29 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "messaging.system": "messaging",
                 "net.peer.name": "test name",
                 "net.peer.ip": "127.0.0.1",
                 "messaging.destination": "celery",
             },
-            events=None,
-            links=[],
             kind=SpanKind.SERVER,
         )
         span._status = Status(status_code=StatusCode.OK)
         span.start(start_time=start_time)
         span.end(end_time=end_time)
         envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_type, "RequestData")
         self.assertEqual(envelope.data.base_data.name, "test")
-        self.assertEqual(envelope.tags["ai.operation.name"], "test")
-        self.assertEqual(
-            envelope.data.base_data.properties["source"],
-            "test name/celery",
-        )
+        self.assertEqual(envelope.data.base_data.id, "a6f5d48acb4d31d9")
+        self.assertEqual(envelope.data.base_data.duration, "0.00:00:01.001")
+        self.assertTrue(envelope.data.base_data.success)
+        # TODO: messaging
+
+    def test_span_to_envelope_success_error(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
 
         # Status/success error
         span = trace._Span(
@@ -500,18 +562,12 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "test": "asd",
                 "http.method": "GET",
                 "http.url": "https://www.wikipedia.org/wiki/Rabbit",
                 "http.status_code": 200,
             },
-            events=None,
-            links=[],
             kind=SpanKind.CLIENT,
         )
         span._status = Status(status_code=StatusCode.ERROR)
@@ -519,6 +575,11 @@ class TestAzureTraceExporter(unittest.TestCase):
         span.end(end_time=end_time)
         envelope = exporter._span_to_envelope(span)
         self.assertFalse(envelope.data.base_data.success)
+
+    def test_span_to_envelope_properties(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
 
         # Properties
         span = trace._Span(
@@ -528,18 +589,12 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "test": "asd",
                 "http.method": "GET",
                 "http.url": "https://www.wikipedia.org/wiki/Rabbit",
                 "http.status_code": 200,
             },
-            events=None,
-            links=[],
             kind=SpanKind.CLIENT,
         )
         span._status = Status(status_code=StatusCode.OK)
@@ -548,6 +603,11 @@ class TestAzureTraceExporter(unittest.TestCase):
         envelope = exporter._span_to_envelope(span)
         self.assertEqual(len(envelope.data.base_data.properties), 1)
         self.assertEqual(envelope.data.base_data.properties["test"], "asd")
+
+    def test_span_to_envelope_properties(self):
+        exporter = self._exporter
+        start_time = 1575494316027613500
+        end_time = start_time + 1001000000
 
         # Links
         links = []
@@ -567,18 +627,13 @@ class TestAzureTraceExporter(unittest.TestCase):
                 span_id=12030755672171557337,
                 is_remote=False,
             ),
-            parent=parent_span,
-            sampler=None,
-            trace_config=None,
-            resource=None,
             attributes={
                 "http.method": "GET",
                 "http.url": "https://www.wikipedia.org/wiki/Rabbit",
                 "http.status_code": 200,
             },
-            events=None,
-            links=links,
             kind=SpanKind.CLIENT,
+            links=links,
         )
         span._status = Status(status_code=StatusCode.OK)
         span.start(start_time=start_time)


### PR DESCRIPTION
Based off of: https://github.com/microsoft/common-schema/blob/main/Mappings/AzureMonitor-AI.md

Used [OT semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/) and [common schema OT semantic conventions](https://github.com/microsoft/common-schema/blob/main/Mappings/OTelSemanticConvention.md) as references.