### PR TITLE
[Cosmos] Add Cross Partition Split to Limitations

### DIFF
--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -100,6 +100,7 @@ Currently the features below are **not supported**. For alternatives options, ch
 * Change Feed: Pull model.
 * Cross-partition ORDER BY for mixed types.
 * Integrated Cache using the default consistency level, that is "Session". To take advantage of the new [Cosmos DB Integrated Cache](https://docs.microsoft.com/azure/cosmos-db/integrated-cache), it is required to explicitly set CosmosClient consistency level to "Eventual": `consistency_level= Eventual`.
+* Cross partition queries do not handle partition splits (410 Gone errors)
 
 ### Control Plane Limitations:
 


### PR DESCRIPTION
Python cross partition query code does not handle partition splits. It will bubble up 410 Gone errors to the caller.