### PR TITLE
Adjusting the ordering so pypy3 doesn't land on ubuntu 2004

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -10,7 +10,7 @@
       "windows-2019": { "OSVmImage": "MMS2019", "Pool": "azsdk-pool-mms-win-2019-general" },
       "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
-    "PythonVersion": [ "pypy3", "2.7", "3.6", "3.7", "3.8" ],
+    "PythonVersion": [ "3.6", "3.7", "3.8", "pypy3", "2.7" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },


### PR DESCRIPTION
We are seeing a wonky issue with [core nightly](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1073904&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=043d5af3-5095-567e-b1ab-52ff13dd8986).

To be clear. This PR is in place to unblock a release. I do not want to merge this. It's just a fallback option if absolutely necessary.