### PR TITLE
Update AppCongiguration to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/appconfiguration/tests.yml
+++ b/sdk/appconfiguration/tests.yml
@@ -6,6 +6,7 @@ stages:
       ServiceDirectory: appconfiguration
       AllocateResourceGroup: false
       DeployArmTemplate: true
+      SupportedClouds: 'Public,UsGov,China'
       MatrixReplace:
         - TestSamples=.*/true
       EnvVars:


### PR DESCRIPTION
These changes enable AppCongiguration to run live tests against Public, UsGov and China.

Pipeline results:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1076584&view=results

@benbp , @jameszliao-msft , @lmazuel , @AlexGhiondea  for notification.

