### PR TITLE
Remove duplication in Monitor Query package description

### DIFF
--- a/sdk/monitor/azure-monitor-query/setup.py
+++ b/sdk/monitor/azure-monitor-query/setup.py
@@ -53,7 +53,7 @@ with open('CHANGELOG.md', encoding='utf-8') as f:
 setup(
     name=PACKAGE_NAME,
     version=version,
-    description='Microsoft Azure {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
+    description='Microsoft {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
     long_description=readme + '\n\n' + changelog,
     long_description_content_type='text/markdown',
     license='MIT License',


### PR DESCRIPTION
"Azure" currently appears twice in the PyPI package description.

![image](https://user-images.githubusercontent.com/10702007/131685780-bfa50621-e814-43c3-9f68-a6366b1de64d.png)
