### PR TITLE
[DevTool]Call result() on LROPoller returned by begin_delete()

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
@@ -114,7 +114,7 @@ class ResourceGroupPreparer(AzureMgmtPreparer):
                         return
                     raise AzureTestError("Timed out waiting for resource group to be deleted.")
                 else:
-                    self.client.resource_groups.begin_delete(name, polling=False)
+                    self.client.resource_groups.begin_delete(name, polling=False).result()
             except Exception as err:  # NOTE: some track 1 libraries do not have azure-core installed. Cannot use HttpResponseError here
                 logging.info("Failed to delete resource group with name {}".format(name))
                 logging.info("{}".format(err))


### PR DESCRIPTION
This is a possible fix for pipeline failure https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1076986&view=results