### PR TITLE
[Batch] Redact test account keys in recordings

### DIFF
--- a/sdk/batch/azure-mgmt-batch/tests/recordings/test_mgmt_batch.test_mgmt_batch_account.yaml
+++ b/sdk/batch/azure-mgmt-batch/tests/recordings/test_mgmt_batch.test_mgmt_batch_account.yaml
@@ -200,7 +200,7 @@ interactions:
     uri: https://centraluseuap.management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_mgmt_batch_test_mgmt_batch_account3e1b0fe5/providers/Microsoft.Batch/batchAccounts/batch3e1b0fe5/listKeys?api-version=2021-06-01
   response:
     body:
-      string: '{"accountName":"batch3e1b0fe5","primary":"3UQ9ry1mRmgftC37/IOylMEnaC713zLTXoMqp/zBQZ1ANY8eLsv1j5lkvN3PnaSevqoKjtfjKFyJ5Vsc6SGA0w==","secondary":"6dM/Myi6VRmOwbqgMjcIv4lSS7SQvlSTCmQX3RiwLvbivKU9oFi5zgdx7oNtOATEbB9rYO8oDkYVwn8PJLaTcg=="}'
+      string: '{"accountName":"batch3e1b0fe5","primary":"redacted6f7d7a","secondary":"redacted59d978"}'
     headers:
       cache-control:
       - no-cache
@@ -248,7 +248,7 @@ interactions:
     uri: https://centraluseuap.management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_mgmt_batch_test_mgmt_batch_account3e1b0fe5/providers/Microsoft.Batch/batchAccounts/batch3e1b0fe5/regenerateKeys?api-version=2021-06-01
   response:
     body:
-      string: '{"accountName":"batch3e1b0fe5","primary":"3UQ9ry1mRmgftC37/IOylMEnaC713zLTXoMqp/zBQZ1ANY8eLsv1j5lkvN3PnaSevqoKjtfjKFyJ5Vsc6SGA0w==","secondary":"Q3pqv2ncSAxxnhTR14lumWnq9GRUVvy8exfqF2q5x6SZYGpregob+HI5eehGuFusbCaHLdzdzr3ZqBKXY3Qtyw=="}'
+      string: '{"accountName":"batch3e1b0fe5","primary":"redacted6f7d7a","secondary":"redactedebdb55"}'
     headers:
       cache-control:
       - no-cache


### PR DESCRIPTION
This resolves [CredScan warnings](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1078334&view=logs&j=0874ffeb-2919-5b4b-20de-16a97970b94c&t=439e917e-962a-53e0-8a4b-b8bb4f8ed372&l=56) raised by test account keys that are present in recordings. To redact these values while preserving test functionality (ensuring that the keys are unique), these keys are redacted with a hash of their original value.