### PR TITLE
[rest] correctly pickle rest aiohttp responses

### DIFF
--- a/sdk/core/azure-core/azure/core/rest/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/rest/_aiohttp.py
@@ -155,7 +155,7 @@ class RestAioHttpTransportResponse(AsyncHttpResponse):
     def __getstate__(self):
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
-        state['internal_response'] = None  # aiohttp response are not pickable (see headers comments)
+        state['_internal_response'] = None  # aiohttp response are not pickable (see headers comments)
         state['headers'] = CIMultiDict(self.headers)  # MultiDictProxy is not pickable
         return state
 

--- a/sdk/core/azure-core/tests/async_tests/test_rest_polling_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_polling_async.py
@@ -118,3 +118,16 @@ async def test_delete_operation_location(lro_poller):
 async def test_request_id(lro_poller):
     result = await (await lro_poller(HttpRequest("POST", "/polling/request-id"), request_id="123456789")).result()
     assert result['status'] == "Succeeded"
+
+@pytest.mark.asyncio
+async def test_continuation_token(client, lro_poller, deserialization_callback):
+    poller = await lro_poller(HttpRequest("POST", "/polling/post/location-and-operation-location"))
+    token = poller.continuation_token()
+    new_poller = AsyncLROPoller.from_continuation_token(
+        continuation_token=token,
+        polling_method=AsyncLROBasePolling(0),
+        client=client._client,
+        deserialization_callback=deserialization_callback,
+    )
+    result = await new_poller.result()
+    assert result == {'location_result': True}

--- a/sdk/core/azure-core/tests/test_rest_polling.py
+++ b/sdk/core/azure-core/tests/test_rest_polling.py
@@ -104,3 +104,15 @@ def test_delete_operation_location(lro_poller):
 
 def test_request_id(lro_poller):
     result = lro_poller(HttpRequest("POST", "/polling/request-id"), request_id="123456789").result()
+
+def test_continuation_token(client, lro_poller, deserialization_callback):
+    poller = lro_poller(HttpRequest("POST", "/polling/post/location-and-operation-location"))
+    token = poller.continuation_token()
+    new_poller = LROPoller.from_continuation_token(
+        continuation_token=token,
+        polling_method=LROBasePolling(0),
+        client=client._client,
+        deserialization_callback=deserialization_callback,
+    )
+    result = new_poller.result()
+    assert result == {'location_result': True}


### PR DESCRIPTION
Currently, pickling for `RestAioHttpTransportResponse`s are failing, because the internal response is not being correctly removed. In `RestAioHttpTransportResponse`, the internal response is a hidden property, `._internal_response`, so we were not properly removing it in getstate