### PR TITLE
Update docstrings for custom models.

### DIFF
--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_index.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_index.py
@@ -31,26 +31,26 @@ class SearchField(msrest.serialization.Model):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param name: Required. The name of the field, which must be unique within the fields collection
+    :keyword name: Required. The name of the field, which must be unique within the fields collection
      of the index or parent field.
-    :type name: str
-    :param type: Required. The data type of the field. Possible values include: "Edm.String",
+    :paramtype name: str
+    :keyword type: Required. The data type of the field. Possible values include: "Edm.String",
      "Edm.Int32", "Edm.Int64", "Edm.Double", "Edm.Boolean", "Edm.DateTimeOffset",
      "Edm.GeographyPoint", "Edm.ComplexType".
-    :type type: str or ~azure.search.documents.indexes.models.SearchFieldDataType
-    :param key: A value indicating whether the field uniquely identifies documents in the index.
+    :paramtype type: str or ~azure.search.documents.indexes.models.SearchFieldDataType
+    :keyword key: A value indicating whether the field uniquely identifies documents in the index.
      Exactly one top-level field in each index must be chosen as the key field and it must be of
      type Edm.String. Key fields can be used to look up documents directly and update or delete
      specific documents. Default is false for simple fields and null for complex fields.
-    :type key: bool
-    :param hidden: A value indicating whether the field can be returned in a search result.
+    :paramtype key: bool
+    :keyword hidden: A value indicating whether the field can be returned in a search result.
      You can enable this option if you want to use a field (for example, margin) as a filter,
      sorting, or scoring mechanism but do not want the field to be visible to the end user. This
      property must be False for key fields, and it must be null for complex fields. This property can
      be changed on existing fields. Enabling this property does not cause any increase in index
      storage requirements. Default is False for simple fields and null for complex fields.
-    :type hidden: bool
-    :param searchable: A value indicating whether the field is full-text searchable. This means it
+    :paramtype hidden: bool
+    :keyword searchable: A value indicating whether the field is full-text searchable. This means it
      will undergo analysis such as word-breaking during indexing. If you set a searchable field to a
      value like "sunny day", internally it will be split into the individual tokens "sunny" and
      "day". This enables full-text searches for these terms. Fields of type Edm.String or
@@ -59,15 +59,15 @@ class SearchField(msrest.serialization.Model):
      consume extra space in your index since Azure Cognitive Search will store an additional
      tokenized version of the field value for full-text searches. If you want to save space in your
      index and you don't need a field to be included in searches, set searchable to false.
-    :type searchable: bool
-    :param filterable: A value indicating whether to enable the field to be referenced in $filter
+    :paramtype searchable: bool
+    :keyword filterable: A value indicating whether to enable the field to be referenced in $filter
      queries. filterable differs from searchable in how strings are handled. Fields of type
      Edm.String or Collection(Edm.String) that are filterable do not undergo word-breaking, so
      comparisons are for exact matches only. For example, if you set such a field f to "sunny day",
      $filter=f eq 'sunny' will find no matches, but $filter=f eq 'sunny day' will. This property
      must be null for complex fields. Default is true for simple fields and null for complex fields.
-    :type filterable: bool
-    :param sortable: A value indicating whether to enable the field to be referenced in $orderby
+    :paramtype filterable: bool
+    :keyword sortable: A value indicating whether to enable the field to be referenced in $orderby
      expressions. By default Azure Cognitive Search sorts results by score, but in many experiences
      users will want to sort by fields in the documents. A simple field can be sortable only if it
      is single-valued (it has a single value in the scope of the parent document). Simple collection
@@ -77,15 +77,15 @@ class SearchField(msrest.serialization.Model):
      cannot be sortable and the sortable property must be null for such fields. The default for
      sortable is true for single-valued simple fields, false for multi-valued simple fields, and
      null for complex fields.
-    :type sortable: bool
-    :param facetable: A value indicating whether to enable the field to be referenced in facet
+    :paramtype sortable: bool
+    :keyword facetable: A value indicating whether to enable the field to be referenced in facet
      queries. Typically used in a presentation of search results that includes hit count by category
      (for example, search for digital cameras and see hits by brand, by megapixels, by price, and so
      on). This property must be null for complex fields. Fields of type Edm.GeographyPoint or
      Collection(Edm.GeographyPoint) cannot be facetable. Default is true for all other simple
      fields.
-    :type facetable: bool
-    :param analyzer_name: The name of the analyzer to use for the field. This option can be used only
+    :paramtype facetable: bool
+    :keyword analyzer_name: The name of the analyzer to use for the field. This option can be used only
      with searchable fields and it can't be set together with either searchAnalyzer or
      indexAnalyzer. Once the analyzer is chosen, it cannot be changed for the field. Must be null
      for complex fields. Possible values include: "ar.microsoft", "ar.lucene", "hy.lucene",
@@ -105,8 +105,8 @@ class SearchField(msrest.serialization.Model):
      "th.microsoft", "th.lucene", "tr.microsoft", "tr.lucene", "uk.microsoft", "ur.microsoft",
      "vi.microsoft", "standard.lucene", "standardasciifolding.lucene", "keyword", "pattern",
      "simple", "stop", "whitespace".
-    :type analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
-    :param search_analyzer_name: The name of the analyzer used at search time for the field. This option
+    :paramtype analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
+    :keyword search_analyzer_name: The name of the analyzer used at search time for the field. This option
      can be used only with searchable fields. It must be set together with indexAnalyzer and it
      cannot be set together with the analyzer option. This property cannot be set to the name of a
      language analyzer; use the analyzer property instead if you need a language analyzer. This
@@ -128,8 +128,8 @@ class SearchField(msrest.serialization.Model):
      "th.lucene", "tr.microsoft", "tr.lucene", "uk.microsoft", "ur.microsoft", "vi.microsoft",
      "standard.lucene", "standardasciifolding.lucene", "keyword", "pattern", "simple", "stop",
      "whitespace".
-    :type search_analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
-    :param index_analyzer_name: The name of the analyzer used at indexing time for the field. This
+    :paramtype search_analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
+    :keyword index_analyzer_name: The name of the analyzer used at indexing time for the field. This
      option can be used only with searchable fields. It must be set together with searchAnalyzer and
      it cannot be set together with the analyzer option.  This property cannot be set to the name of
      a language analyzer; use the analyzer property instead if you need a language analyzer. Once
@@ -151,21 +151,21 @@ class SearchField(msrest.serialization.Model):
      "th.lucene", "tr.microsoft", "tr.lucene", "uk.microsoft", "ur.microsoft", "vi.microsoft",
      "standard.lucene", "standardasciifolding.lucene", "keyword", "pattern", "simple", "stop",
      "whitespace".
-    :type index_analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
-    :param normalizer_name: The name of the normalizer to use for the field. This option can be used
+    :paramtype index_analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
+    :keyword normalizer_name: The name of the normalizer to use for the field. This option can be used
      only with fields with filterable, sortable, or facetable enabled. Once the normalizer is
      chosen, it cannot be changed for the field. Must be null for complex fields. Possible values
      include: "asciifolding", "elision", "lowercase", "standard", "uppercase".
-    :type normalizer_name: str or ~azure.search.documents.indexes.models.LexicalNormalizerName
-    :param synonym_map_names: A list of the names of synonym maps to associate with this field. This
+    :paramtype normalizer_name: str or ~azure.search.documents.indexes.models.LexicalNormalizerName
+    :keyword synonym_map_names: A list of the names of synonym maps to associate with this field. This
      option can be used only with searchable fields. Currently only one synonym map per field is
      supported. Assigning a synonym map to a field ensures that query terms targeting that field are
      expanded at query-time using the rules in the synonym map. This attribute can be changed on
      existing fields. Must be null or an empty collection for complex fields.
-    :type synonym_map_names: list[str]
-    :param fields: A list of sub-fields if this is a field of type Edm.ComplexType or
+    :paramtype synonym_map_names: list[str]
+    :keyword fields: A list of sub-fields if this is a field of type Edm.ComplexType or
      Collection(Edm.ComplexType). Must be null or empty for simple fields.
-    :type fields: list[~azure.search.documents.models.SearchField]
+    :paramtype fields: list[~azure.search.documents.models.SearchField]
     """
 
     _validation = {
@@ -268,34 +268,34 @@ def SimpleField(**kw):
     # type: (**Any) -> SearchField
     """Configure a simple field for an Azure Search Index
 
-    :param name: Required. The name of the field, which must be unique within the fields collection
+    :keyword name: Required. The name of the field, which must be unique within the fields collection
      of the index or parent field.
-    :type name: str
-    :param type: Required. The data type of the field. Possible values include: SearchFieldDataType.String,
+    :paramtype name: str
+    :keyword type: Required. The data type of the field. Possible values include: SearchFieldDataType.String,
      SearchFieldDataType.Int32, SearchFieldDataType.Int64, SearchFieldDataType.Double, SearchFieldDataType.Boolean,
      SearchFieldDataType.DateTimeOffset, SearchFieldDataType.GeographyPoint, SearchFieldDataType.ComplexType,
      from `azure.search.documents.SearchFieldDataType`.
-     :type type: str
-    :param key: A value indicating whether the field uniquely identifies documents in the index.
+     :paramtype type: str
+    :keyword key: A value indicating whether the field uniquely identifies documents in the index.
      Exactly one top-level field in each index must be chosen as the key field and it must be of
      type SearchFieldDataType.String. Key fields can be used to look up documents directly and
      update or delete specific documents. Default is False
-    :type key: bool
-    :param hidden: A value indicating whether the field can be returned in a search result.
+    :paramtype key: bool
+    :keyword hidden: A value indicating whether the field can be returned in a search result.
      You can enable this option if you want to use a field (for example, margin) as a filter,
      sorting, or scoring mechanism but do not want the field to be visible to the end user. This
      property must be False for key fields. This property can be changed on existing fields.
      Enabling this property does not cause any increase in index storage requirements. Default is
      False.
-    :type hidden: bool
-    :param filterable: A value indicating whether to enable the field to be referenced in $filter
+    :paramtype hidden: bool
+    :keyword filterable: A value indicating whether to enable the field to be referenced in $filter
      queries. filterable differs from searchable in how strings are handled. Fields of type
      SearchFieldDataType.String or Collection(SearchFieldDataType.String) that are filterable do
      not undergo word-breaking, so comparisons are for exact matches only. For example, if you
      set such a field f to "sunny day", $filter=f eq 'sunny' will find no matches, but
      $filter=f eq 'sunny day' will. This property must be null for complex fields. Default is False
-    :type filterable: bool
-    :param sortable: A value indicating whether to enable the field to be referenced in $orderby
+    :paramtype filterable: bool
+    :keyword sortable: A value indicating whether to enable the field to be referenced in $orderby
      expressions. By default Azure Cognitive Search sorts results by score, but in many experiences
      users will want to sort by fields in the documents. A simple field can be sortable only if it
      is single-valued (it has a single value in the scope of the parent document). Simple collection
@@ -303,13 +303,13 @@ def SimpleField(**kw):
      collections are also multi-valued, and therefore cannot be sortable. This is true whether it's
      an immediate parent field, or an ancestor field, that's the complex collection. The default is
      False.
-    :type sortable: bool
-    :param facetable: A value indicating whether to enable the field to be referenced in facet
+    :paramtype sortable: bool
+    :keyword facetable: A value indicating whether to enable the field to be referenced in facet
      queries. Typically used in a presentation of search results that includes hit count by category
      (for example, search for digital cameras and see hits by brand, by megapixels, by price, and so
      on). Fields of type SearchFieldDataType.GeographyPoint or
      Collection(SearchFieldDataType.GeographyPoint) cannot be facetable. Default is False.
-    :type facetable: bool
+    :paramtype facetable: bool
     """
     result = {"name": kw.get("name"), "type": kw.get("type")}  # type: Dict[str, Any]
     result["key"] = kw.get("key", False)
@@ -325,24 +325,24 @@ def SearchableField(**kw):
     # type: (**Any) -> SearchField
     """Configure a searchable text field for an Azure Search Index
 
-    :param name: Required. The name of the field, which must be unique within the fields collection
+    :keyword name: Required. The name of the field, which must be unique within the fields collection
      of the index or parent field.
-    :type name: str
-    :param collection: Whether this search field is a collection (default False)
-    :type collection: bool
-    :param key: A value indicating whether the field uniquely identifies documents in the index.
+    :paramtype name: str
+    :keyword collection: Whether this search field is a collection (default False)
+    :paramtype collection: bool
+    :keyword key: A value indicating whether the field uniquely identifies documents in the index.
      Exactly one top-level field in each index must be chosen as the key field and it must be of
      type SearchFieldDataType.String. Key fields can be used to look up documents directly and update or delete
      specific documents. Default is False
-    :type key: bool
-    :param hidden: A value indicating whether the field can be returned in a search result.
+    :paramtype key: bool
+    :keyword hidden: A value indicating whether the field can be returned in a search result.
      You can enable this option if you want to use a field (for example, margin) as a filter,
      sorting, or scoring mechanism but do not want the field to be visible to the end user. This
      property must be False for key fields. This property can be changed on existing fields.
      Enabling this property does not cause any increase in index storage requirements. Default is
      False.
-    :type hidden: bool
-    :param searchable: A value indicating whether the field is full-text searchable. This means it
+    :paramtype hidden: bool
+    :keyword searchable: A value indicating whether the field is full-text searchable. This means it
      will undergo analysis such as word-breaking during indexing. If you set a searchable field to a
      value like "sunny day", internally it will be split into the individual tokens "sunny" and
      "day". This enables full-text searches for these terms. Note: searchable fields
@@ -350,23 +350,23 @@ def SearchableField(**kw):
      tokenized version of the field value for full-text searches. If you want to save space in your
      index and you don't need a field to be included in searches, set searchable to false. Default
      is True.
-    :type searchable: bool
-    :param filterable: A value indicating whether to enable the field to be referenced in $filter
+    :paramtype searchable: bool
+    :keyword filterable: A value indicating whether to enable the field to be referenced in $filter
      queries. filterable differs from searchable in how strings are handled. Fields that are
      filterable do not undergo word-breaking, so comparisons are for exact matches only. For example,
      if you set such a field f to "sunny day", $filter=f eq 'sunny' will find no matches, but
      $filter=f eq 'sunny day' will. Default is False.
-    :type filterable: bool
-    :param sortable: A value indicating whether to enable the field to be referenced in $orderby
+    :paramtype filterable: bool
+    :keyword sortable: A value indicating whether to enable the field to be referenced in $orderby
      expressions. By default Azure Cognitive Search sorts results by score, but in many experiences
      users will want to sort by fields in the documents.  The default is true False.
-    :type sortable: bool
-    :param facetable: A value indicating whether to enable the field to be referenced in facet
+    :paramtype sortable: bool
+    :keyword facetable: A value indicating whether to enable the field to be referenced in facet
      queries. Typically used in a presentation of search results that includes hit count by category
      (for example, search for digital cameras and see hits by brand, by megapixels, by price, and so
      on). Default is False.
-    :type facetable: bool
-    :param analyzer_name: The name of the analyzer to use for the field. This option can't be set together
+    :paramtype facetable: bool
+    :keyword analyzer_name: The name of the analyzer to use for the field. This option can't be set together
      with either searchAnalyzer or indexAnalyzer. Once the analyzer is chosen, it cannot be changed
      for the field. Possible values include: 'ar.microsoft', 'ar.lucene', 'hy.lucene',
      'bn.microsoft', 'eu.lucene', 'bg.microsoft', 'bg.lucene', 'ca.microsoft', 'ca.lucene', 'zh-
@@ -385,8 +385,8 @@ def SearchableField(**kw):
      'th.microsoft', 'th.lucene', 'tr.microsoft', 'tr.lucene', 'uk.microsoft', 'ur.microsoft',
      'vi.microsoft', 'standard.lucene', 'standardasciifolding.lucene', 'keyword', 'pattern',
      'simple', 'stop', 'whitespace'.
-    :type analyzer_name: str or ~azure.search.documents.indexes.models.AnalyzerName
-    :param search_analyzer_name: The name of the analyzer used at search time for the field. It must be
+    :paramtype analyzer_name: str or ~azure.search.documents.indexes.models.AnalyzerName
+    :keyword search_analyzer_name: The name of the analyzer used at search time for the field. It must be
      set together with indexAnalyzer and it cannot be set together with the analyzer option. This
      property cannot be set to the name of a language analyzer; use the analyzer property instead
      if you need a language analyzer. This analyzer can be updated on an existing field. Possible
@@ -408,8 +408,8 @@ def SearchableField(**kw):
      'th.lucene', 'tr.microsoft', 'tr.lucene', 'uk.microsoft', 'ur.microsoft', 'vi.microsoft',
      'standard.lucene', 'standardasciifolding.lucene', 'keyword', 'pattern', 'simple', 'stop',
      'whitespace'.
-    :type search_analyzer_name: str or ~azure.search.documents.indexes.models.AnalyzerName
-    :param index_analyzer_name: The name of the analyzer used at indexing time for the field.
+    :paramtype search_analyzer_name: str or ~azure.search.documents.indexes.models.AnalyzerName
+    :keyword index_analyzer_name: The name of the analyzer used at indexing time for the field.
      It must be set together with searchAnalyzer and it cannot be set together with the analyzer
      option.  This property cannot be set to the name of a language analyzer; use the analyzer
      property instead if you need a language analyzer. Once the analyzer is chosen, it cannot be
@@ -431,12 +431,12 @@ def SearchableField(**kw):
      'th.lucene', 'tr.microsoft', 'tr.lucene', 'uk.microsoft', 'ur.microsoft', 'vi.microsoft',
      'standard.lucene', 'standardasciifolding.lucene', 'keyword', 'pattern', 'simple', 'stop',
      'whitespace'.
-    :type index_analyzer_name: str or ~azure.search.documents.indexes.models.AnalyzerName
-    :param synonym_map_names: A list of the names of synonym maps to associate with this field. Currently
+    :paramtype index_analyzer_name: str or ~azure.search.documents.indexes.models.AnalyzerName
+    :keyword synonym_map_names: A list of the names of synonym maps to associate with this field. Currently
      only one synonym map per field is supported. Assigning a synonym map to a field ensures that
      query terms targeting that field are expanded at query-time using the rules in the synonym map.
      This attribute can be changed on existing fields.
-    :type synonym_map_names: list[str]
+    :paramtype synonym_map_names: list[str]
 
     """
     typ = Collection(String) if kw.get("collection", False) else String
@@ -463,14 +463,14 @@ def ComplexField(**kw):
     """Configure a Complex or Complex collection field for an Azure Search
     Index
 
-    :param name: Required. The name of the field, which must be unique within the fields collection
+    :keyword name: Required. The name of the field, which must be unique within the fields collection
      of the index or parent field.
-    :type name: str
-    :param collection: Whether this complex field is a collection (default False)
-    :type collection: bool
-    :type type: str or ~search_service_client.models.DataType
-    :param fields: A list of sub-fields
-    :type fields: list[~search_service_client.models.Field]
+    :paramtype name: str
+    :keyword collection: Whether this complex field is a collection (default False)
+    :paramtype collection: bool
+    :paramtype type: str or ~search_service_client.models.DataType
+    :keyword fields: A list of sub-fields
+    :paramtype fields: list[~search_service_client.models.Field]
 
     """
     typ = Collection(ComplexType) if kw.get("collection", False) else ComplexType
@@ -485,32 +485,32 @@ class SearchIndex(msrest.serialization.Model):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param name: Required. The name of the index.
-    :type name: str
-    :param fields: Required. The fields of the index.
-    :type fields: list[~azure.search.documents.indexes.models.SearchField]
-    :param scoring_profiles: The scoring profiles for the index.
-    :type scoring_profiles: list[~azure.search.documents.indexes.models.ScoringProfile]
-    :param default_scoring_profile: The name of the scoring profile to use if none is specified in
+    :keyword name: Required. The name of the index.
+    :paramtype name: str
+    :keyword fields: Required. The fields of the index.
+    :paramtype fields: list[~azure.search.documents.indexes.models.SearchField]
+    :keyword scoring_profiles: The scoring profiles for the index.
+    :paramtype scoring_profiles: list[~azure.search.documents.indexes.models.ScoringProfile]
+    :keyword default_scoring_profile: The name of the scoring profile to use if none is specified in
      the query. If this property is not set and no scoring profile is specified in the query, then
      default scoring (tf-idf) will be used.
-    :type default_scoring_profile: str
-    :param cors_options: Options to control Cross-Origin Resource Sharing (CORS) for the index.
-    :type cors_options: ~azure.search.documents.indexes.models.CorsOptions
-    :param suggesters: The suggesters for the index.
-    :type suggesters: list[~azure.search.documents.indexes.models.SearchSuggester]
-    :param analyzers: The analyzers for the index.
-    :type analyzers: list[~azure.search.documents.indexes.models.LexicalAnalyzer]
-    :param tokenizers: The tokenizers for the index.
-    :type tokenizers: list[~azure.search.documents.indexes.models.LexicalTokenizer]
-    :param token_filters: The token filters for the index.
-    :type token_filters: list[~azure.search.documents.indexes.models.TokenFilter]
-    :param char_filters: The character filters for the index.
-    :type char_filters: list[~azure.search.documents.indexes.models.CharFilter]
-    :param normalizers: The normalizers for the index.
-    :type normalizers:
+    :paramtype default_scoring_profile: str
+    :keyword cors_options: Options to control Cross-Origin Resource Sharing (CORS) for the index.
+    :paramtype cors_options: ~azure.search.documents.indexes.models.CorsOptions
+    :keyword suggesters: The suggesters for the index.
+    :paramtype suggesters: list[~azure.search.documents.indexes.models.SearchSuggester]
+    :keyword analyzers: The analyzers for the index.
+    :paramtype analyzers: list[~azure.search.documents.indexes.models.LexicalAnalyzer]
+    :keyword tokenizers: The tokenizers for the index.
+    :paramtype tokenizers: list[~azure.search.documents.indexes.models.LexicalTokenizer]
+    :keyword token_filters: The token filters for the index.
+    :paramtype token_filters: list[~azure.search.documents.indexes.models.TokenFilter]
+    :keyword char_filters: The character filters for the index.
+    :paramtype char_filters: list[~azure.search.documents.indexes.models.CharFilter]
+    :keyword normalizers: The normalizers for the index.
+    :paramtype normalizers:
      list[~azure.search.documents.indexes.models.LexicalNormalizer]
-    :param encryption_key: A description of an encryption key that you create in Azure Key Vault.
+    :keyword encryption_key: A description of an encryption key that you create in Azure Key Vault.
      This key is used to provide an additional level of encryption-at-rest for your data when you
      want full assurance that no one, not even Microsoft, can decrypt your data in Azure Cognitive
      Search. Once you have encrypted your data, it will always remain encrypted. Azure Cognitive
@@ -518,14 +518,14 @@ class SearchIndex(msrest.serialization.Model):
      needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with
      customer-managed keys is not available for free search services, and is only available for paid
      services created on or after January 1, 2019.
-    :type encryption_key: ~azure.search.documents.indexes.models.SearchResourceEncryptionKey
-    :param similarity: The type of similarity algorithm to be used when scoring and ranking the
+    :paramtype encryption_key: ~azure.search.documents.indexes.models.SearchResourceEncryptionKey
+    :keyword similarity: The type of similarity algorithm to be used when scoring and ranking the
      documents matching a search query. The similarity algorithm can only be defined at index
      creation time and cannot be modified on existing indexes. If null, the ClassicSimilarity
      algorithm is used.
-    :type similarity: ~azure.search.documents.indexes.models.SimilarityAlgorithm
-    :param e_tag: The ETag of the index.
-    :type e_tag: str
+    :paramtype similarity: ~azure.search.documents.indexes.models.SimilarityAlgorithm
+    :keyword e_tag: The ETag of the index.
+    :paramtype e_tag: str
     """
 
     _validation = {

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_models.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_models.py
@@ -34,22 +34,22 @@ class SearchIndexerSkillset(_SearchIndexerSkillset):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param name: Required. The name of the skillset.
-    :type name: str
-    :param description: The description of the skillset.
-    :type description: str
-    :param skills: Required. A list of skills in the skillset.
-    :type skills: list[~azure.search.documents.indexes.models.SearchIndexerSkill]
-    :param cognitive_services_account: Details about cognitive services to be used when running
+    :keyword name: Required. The name of the skillset.
+    :paramtype name: str
+    :keyword description: The description of the skillset.
+    :paramtype description: str
+    :keyword skills: Required. A list of skills in the skillset.
+    :paramtype skills: list[~azure.search.documents.indexes.models.SearchIndexerSkill]
+    :keyword cognitive_services_account: Details about cognitive services to be used when running
      skills.
-    :type cognitive_services_account:
+    :paramtype cognitive_services_account:
      ~azure.search.documents.indexes.models.CognitiveServicesAccount
-    :param knowledge_store: Definition of additional projections to azure blob, table, or files, of
+    :keyword knowledge_store: Definition of additional projections to azure blob, table, or files, of
      enriched data.
-    :type knowledge_store: ~azure.search.documents.indexes.models.SearchIndexerKnowledgeStore
-    :param e_tag: The ETag of the skillset.
-    :type e_tag: str
-    :param encryption_key: A description of an encryption key that you create in Azure Key Vault.
+    :paramtype knowledge_store: ~azure.search.documents.indexes.models.SearchIndexerKnowledgeStore
+    :keyword e_tag: The ETag of the skillset.
+    :paramtype e_tag: str
+    :keyword encryption_key: A description of an encryption key that you create in Azure Key Vault.
      This key is used to provide an additional level of encryption-at-rest for your skillset
      definition when you want full assurance that no one, not even Microsoft, can decrypt your
      skillset definition in Azure Cognitive Search. Once you have encrypted your skillset
@@ -58,7 +58,7 @@ class SearchIndexerSkillset(_SearchIndexerSkillset):
      encryption key; Your skillset definition will be unaffected. Encryption with customer-managed
      keys is not available for free search services, and is only available for paid services created
      on or after January 1, 2019.
-    :type encryption_key: ~azure.search.documents.indexes.models.SearchResourceEncryptionKey
+    :paramtype encryption_key: ~azure.search.documents.indexes.models.SearchResourceEncryptionKey
     """
 
     def __init__(
@@ -118,48 +118,48 @@ class EntityRecognitionSkill(SearchIndexerSkill):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param odata_type: Required. Identifies the concrete type of the skill.Constant filled by
+    :keyword odata_type: Required. Identifies the concrete type of the skill.Constant filled by
      server.
-    :type odata_type: str
-    :param name: The name of the skill which uniquely identifies it within the skillset. A skill
+    :paramtype odata_type: str
+    :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
      with no name defined will be given a default name of its 1-based index in the skills array,
      prefixed with the character '#'.
-    :type name: str
-    :param description: The description of the skill which describes the inputs, outputs, and usage
+    :paramtype name: str
+    :keyword description: The description of the skill which describes the inputs, outputs, and usage
      of the skill.
-    :type description: str
-    :param context: Represents the level at which operations take place, such as the document root
+    :paramtype description: str
+    :keyword context: Represents the level at which operations take place, such as the document root
      or document content (for example, /document or /document/content). The default is /document.
-    :type context: str
-    :param inputs: Required. Inputs of the skills could be a column in the source data set, or the
+    :paramtype context: str
+    :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or the
      output of an upstream skill.
-    :type inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-    :param outputs: Required. The output of a skill is either a field in a search index, or a value
+    :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+    :keyword outputs: Required. The output of a skill is either a field in a search index, or a value
      that can be consumed as an input by another skill.
-    :type outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-    :param categories: A list of entity categories that should be extracted.
-    :type categories: list[str or ~azure.search.documents.indexes.models.EntityCategory]
-    :param default_language_code: A value indicating which language code to use. Default is en.
+    :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+    :keyword categories: A list of entity categories that should be extracted.
+    :paramtype categories: list[str or ~azure.search.documents.indexes.models.EntityCategory]
+    :keyword default_language_code: A value indicating which language code to use. Default is en.
      Possible values include: "ar", "cs", "zh-Hans", "zh-Hant", "da", "nl", "en", "fi", "fr", "de",
      "el", "hu", "it", "ja", "ko", "no", "pl", "pt-PT", "pt-BR", "ru", "es", "sv", "tr".
-    :type default_language_code: str or
+    :paramtype default_language_code: str or
      ~azure.search.documents.indexes.models.EntityRecognitionSkillLanguage
-    :param include_typeless_entities: Determines whether or not to include entities which are well
+    :keyword include_typeless_entities: Determines whether or not to include entities which are well
      known but don't conform to a pre-defined type. If this configuration is not set (default), set
      to null or set to false, entities which don't conform to one of the pre-defined types will not
      be surfaced. Only valid for skill version 1.
-    :type include_typeless_entities: bool
-    :param minimum_precision: A value between 0 and 1 that be used to only include entities whose
+    :paramtype include_typeless_entities: bool
+    :keyword minimum_precision: A value between 0 and 1 that be used to only include entities whose
      confidence score is greater than the value specified. If not set (default), or if explicitly
      set to null, all entities will be included.
-    :type minimum_precision: float
-    :param model_version: The version of the model to use when calling the Text Analytics service.
+    :paramtype minimum_precision: float
+    :keyword model_version: The version of the model to use when calling the Text Analytics service.
      It will default to the latest available when not specified. We recommend you do not specify
      this value unless absolutely necessary. Only valid from skill version 3.
-    :type model_version: str
-    :param skill_version: The version of the skill to use when calling the Text Analytics service.
+    :paramtype model_version: str
+    :keyword skill_version: The version of the skill to use when calling the Text Analytics service.
      It will default to V1 when not specified.
-    :type skill_version: ~azure.search.documents.indexes.models.EntityRecognitionSkillVersion
+    :paramtype skill_version: ~azure.search.documents.indexes.models.EntityRecognitionSkillVersion
     """
 
     _validation = {
@@ -265,41 +265,41 @@ class SentimentSkill(SearchIndexerSkill):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param odata_type: Required. Identifies the concrete type of the skill.Constant filled by
+    :keyword odata_type: Required. Identifies the concrete type of the skill.Constant filled by
      server.
-    :type odata_type: str
-    :param name: The name of the skill which uniquely identifies it within the skillset. A skill
+    :paramtype odata_type: str
+    :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
      with no name defined will be given a default name of its 1-based index in the skills array,
      prefixed with the character '#'.
-    :type name: str
-    :param description: The description of the skill which describes the inputs, outputs, and usage
+    :paramtype name: str
+    :keyword description: The description of the skill which describes the inputs, outputs, and usage
      of the skill.
-    :type description: str
-    :param context: Represents the level at which operations take place, such as the document root
+    :paramtype description: str
+    :keyword context: Represents the level at which operations take place, such as the document root
      or document content (for example, /document or /document/content). The default is /document.
-    :type context: str
-    :param inputs: Required. Inputs of the skills could be a column in the source data set, or the
+    :paramtype context: str
+    :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or the
      output of an upstream skill.
-    :type inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-    :param outputs: Required. The output of a skill is either a field in a search index, or a value
+    :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+    :keyword outputs: Required. The output of a skill is either a field in a search index, or a value
      that can be consumed as an input by another skill.
-    :type outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-    :param default_language_code: A value indicating which language code to use. Default is en.
+    :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+    :keyword default_language_code: A value indicating which language code to use. Default is en.
      Possible values include: "da", "nl", "en", "fi", "fr", "de", "el", "it", "no", "pl", "pt-PT",
      "ru", "es", "sv", "tr".
-    :type default_language_code: str or
+    :paramtype default_language_code: str or
      ~azure.search.documents.indexes.models.SentimentSkillLanguage
-    :param include_opinion_mining: If set to true, the skill output will include information from
+    :keyword include_opinion_mining: If set to true, the skill output will include information from
      Text Analytics for opinion mining, namely targets (nouns or verbs) and their associated
      assessment (adjective) in the text. Default is false.
-    :type include_opinion_mining: bool
-    :param model_version: The version of the model to use when calling the Text Analytics service.
+    :paramtype include_opinion_mining: bool
+    :keyword model_version: The version of the model to use when calling the Text Analytics service.
      It will default to the latest available when not specified. We recommend you do not specify
      this value unless absolutely necessary.
-    :type model_version: str
-    :param skill_version: The version of the skill to use when calling the Text Analytics service.
+    :paramtype model_version: str
+    :keyword skill_version: The version of the skill to use when calling the Text Analytics service.
      It will default to V1 when not specified.
-    :type skill_version: ~azure.search.documents.indexes.models.SentimentSkillVersion
+    :paramtype skill_version: ~azure.search.documents.indexes.models.SentimentSkillVersion
     """
 
     _validation = {
@@ -380,9 +380,9 @@ class AnalyzeTextOptions(msrest.serialization.Model):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param text: Required. The text to break into tokens.
-    :type text: str
-    :param analyzer_name: The name of the analyzer to use to break the given text. If this parameter is
+    :keyword text: Required. The text to break into tokens.
+    :paramtype text: str
+    :keyword analyzer_name: The name of the analyzer to use to break the given text. If this parameter is
      not specified, you must specify a tokenizer instead. The tokenizer and analyzer parameters are
      mutually exclusive. Possible values include: "ar.microsoft", "ar.lucene", "hy.lucene",
      "bn.microsoft", "eu.lucene", "bg.microsoft", "bg.lucene", "ca.microsoft", "ca.lucene", "zh-
@@ -401,22 +401,22 @@ class AnalyzeTextOptions(msrest.serialization.Model):
      "th.microsoft", "th.lucene", "tr.microsoft", "tr.lucene", "uk.microsoft", "ur.microsoft",
      "vi.microsoft", "standard.lucene", "standardasciifolding.lucene", "keyword", "pattern",
      "simple", "stop", "whitespace".
-    :type analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
-    :param tokenizer_name: The name of the tokenizer to use to break the given text. If this parameter
+    :paramtype analyzer_name: str or ~azure.search.documents.indexes.models.LexicalAnalyzerName
+    :keyword tokenizer_name: The name of the tokenizer to use to break the given text. If this parameter
      is not specified, you must specify an analyzer instead. The tokenizer and analyzer parameters
      are mutually exclusive. Possible values include: "classic", "edgeNGram", "keyword_v2",
      "letter", "lowercase", "microsoft_language_tokenizer", "microsoft_language_stemming_tokenizer",
      "nGram", "path_hierarchy_v2", "pattern", "standard_v2", "uax_url_email", "whitespace".
-    :type tokenizer_name: str or ~azure.search.documents.indexes.models.LexicalTokenizerName
-    :param normalizer_name: The name of the normalizer to use to normalize the given text. Possible
+    :paramtype tokenizer_name: str or ~azure.search.documents.indexes.models.LexicalTokenizerName
+    :keyword normalizer_name: The name of the normalizer to use to normalize the given text. Possible
      values include: "asciifolding", "elision", "lowercase", "standard", "uppercase".
-    :type normalizer_name: str or ~azure.search.documents.indexes.models.LexicalNormalizerName
-    :param token_filters: An optional list of token filters to use when breaking the given text.
+    :paramtype normalizer_name: str or ~azure.search.documents.indexes.models.LexicalNormalizerName
+    :keyword token_filters: An optional list of token filters to use when breaking the given text.
      This parameter can only be set when using the tokenizer parameter.
-    :type token_filters: list[str or ~azure.search.documents.indexes.models.TokenFilterName]
-    :param char_filters: An optional list of character filters to use when breaking the given text.
+    :paramtype token_filters: list[str or ~azure.search.documents.indexes.models.TokenFilterName]
+    :keyword char_filters: An optional list of character filters to use when breaking the given text.
      This parameter can only be set when using the tokenizer parameter.
-    :type char_filters: list[str]
+    :paramtype char_filters: list[str]
     """
 
     _validation = {
@@ -460,27 +460,27 @@ class CustomAnalyzer(LexicalAnalyzer):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param odata_type: Required. Identifies the concrete type of the analyzer.Constant filled by
+    :keyword odata_type: Required. Identifies the concrete type of the analyzer.Constant filled by
      server.
-    :type odata_type: str
-    :param name: Required. The name of the analyzer. It must only contain letters, digits, spaces,
+    :paramtype odata_type: str
+    :keyword name: Required. The name of the analyzer. It must only contain letters, digits, spaces,
      dashes or underscores, can only start and end with alphanumeric characters, and is limited to
      128 characters.
-    :type name: str
-    :param tokenizer_name: Required. The name of the tokenizer to use to divide continuous text into a
+    :paramtype name: str
+    :keyword tokenizer_name: Required. The name of the tokenizer to use to divide continuous text into a
      sequence of tokens, such as breaking a sentence into words. Possible values include: "classic",
      "edgeNGram", "keyword_v2", "letter", "lowercase", "microsoft_language_tokenizer",
      "microsoft_language_stemming_tokenizer", "nGram", "path_hierarchy_v2", "pattern",
      "standard_v2", "uax_url_email", "whitespace".
-    :type tokenizer_name: str or ~azure.search.documents.indexes.models.LexicalTokenizerName
-    :param token_filters: A list of token filters used to filter out or modify the tokens generated
+    :paramtype tokenizer_name: str or ~azure.search.documents.indexes.models.LexicalTokenizerName
+    :keyword token_filters: A list of token filters used to filter out or modify the tokens generated
      by a tokenizer. For example, you can specify a lowercase filter that converts all characters to
      lowercase. The filters are run in the order in which they are listed.
-    :type token_filters: list[str or ~azure.search.documents.indexes.models.TokenFilterName]
-    :param char_filters: A list of character filters used to prepare input text before it is
+    :paramtype token_filters: list[str or ~azure.search.documents.indexes.models.TokenFilterName]
+    :keyword char_filters: A list of character filters used to prepare input text before it is
      processed by the tokenizer. For instance, they can replace certain characters or symbols. The
      filters are run in the order in which they are listed.
-    :type char_filters: list[str]
+    :paramtype char_filters: list[str]
     """
 
     _validation = {
@@ -532,21 +532,21 @@ class PatternAnalyzer(LexicalAnalyzer):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param name: Required. The name of the analyzer. It must only contain letters, digits, spaces,
+    :keyword name: Required. The name of the analyzer. It must only contain letters, digits, spaces,
      dashes or underscores, can only start and end with alphanumeric characters, and is limited to
      128 characters.
-    :type name: str
-    :param lower_case_terms: A value indicating whether terms should be lower-cased. Default is
+    :paramtype name: str
+    :keyword lower_case_terms: A value indicating whether terms should be lower-cased. Default is
      true.
-    :type lower_case_terms: bool
-    :param pattern: A regular expression to match token separators. Default is an
+    :paramtype lower_case_terms: bool
+    :keyword pattern: A regular expression to match token separators. Default is an
      expression that matches one or more white space characters.
-    :type pattern: str
-    :param flags: List of regular expression flags. Possible values of each flag include: 'CANON_EQ',
+    :paramtype pattern: str
+    :keyword flags: List of regular expression flags. Possible values of each flag include: 'CANON_EQ',
      'CASE_INSENSITIVE', 'COMMENTS', 'DOTALL', 'LITERAL', 'MULTILINE', 'UNICODE_CASE', 'UNIX_LINES'.
-    :type flags: list[str] or list[~search_service_client.models.RegexFlags]
-    :param stopwords: A list of stopwords.
-    :type stopwords: list[str]
+    :paramtype flags: list[str] or list[~search_service_client.models.RegexFlags]
+    :keyword stopwords: A list of stopwords.
+    :paramtype stopwords: list[str]
     """
 
     _validation = {"odata_type": {"required": True}, "name": {"required": True}}
@@ -604,20 +604,20 @@ class PatternTokenizer(LexicalTokenizer):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param name: Required. The name of the tokenizer. It must only contain letters, digits, spaces,
+    :keyword name: Required. The name of the tokenizer. It must only contain letters, digits, spaces,
      dashes or underscores, can only start and end with alphanumeric characters, and is limited to
      128 characters.
-    :type name: str
-    :param pattern: A regular expression to match token separators. Default is an
+    :paramtype name: str
+    :keyword pattern: A regular expression to match token separators. Default is an
      expression that matches one or more white space characters.
-    :type pattern: str
-    :param flags: List of regular expression flags. Possible values of each flag include: 'CANON_EQ',
+    :paramtype pattern: str
+    :keyword flags: List of regular expression flags. Possible values of each flag include: 'CANON_EQ',
      'CASE_INSENSITIVE', 'COMMENTS', 'DOTALL', 'LITERAL', 'MULTILINE', 'UNICODE_CASE', 'UNIX_LINES'.
-    :type flags: list[str] or list[~search_service_client.models.RegexFlags]
-    :param group: The zero-based ordinal of the matching group in the regular expression to
+    :paramtype flags: list[str] or list[~search_service_client.models.RegexFlags]
+    :keyword group: The zero-based ordinal of the matching group in the regular expression to
      extract into tokens. Use -1 if you want to use the entire pattern to split the input into
      tokens, irrespective of matching groups. Default is -1.
-    :type group: int
+    :paramtype group: int
     """
 
     _validation = {"odata_type": {"required": True}, "name": {"required": True}}
@@ -671,22 +671,22 @@ class SearchResourceEncryptionKey(msrest.serialization.Model):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param key_name: Required. The name of your Azure Key Vault key to be used to encrypt your data
+    :keyword key_name: Required. The name of your Azure Key Vault key to be used to encrypt your data
      at rest.
-    :type key_name: str
-    :param key_version: Required. The version of your Azure Key Vault key to be used to encrypt
+    :paramtype key_name: str
+    :keyword key_version: Required. The version of your Azure Key Vault key to be used to encrypt
      your data at rest.
-    :type key_version: str
-    :param vault_uri: Required. The URI of your Azure Key Vault, also referred to as DNS name, that
+    :paramtype key_version: str
+    :keyword vault_uri: Required. The URI of your Azure Key Vault, also referred to as DNS name, that
      contains the key to be used to encrypt your data at rest. An example URI might be https://my-
      keyvault-name.vault.azure.net.
-    :type vault_uri: str
-    :param application_id: Required. An AAD Application ID that was granted the required access
+    :paramtype vault_uri: str
+    :keyword application_id: Required. An AAD Application ID that was granted the required access
      permissions to the Azure Key Vault that is to be used when encrypting your data at rest. The
      Application ID should not be confused with the Object ID for your AAD Application.
-    :type application_id: str
-    :param application_secret: The authentication key of the specified AAD application.
-    :type application_secret: str
+    :paramtype application_id: str
+    :keyword application_secret: The authentication key of the specified AAD application.
+    :paramtype application_secret: str
     """
 
     _validation = {
@@ -756,15 +756,15 @@ class SynonymMap(msrest.serialization.Model):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param name: Required. The name of the synonym map.
-    :type name: str
+    :keyword name: Required. The name of the synonym map.
+    :paramtype name: str
     :ivar format: Required. The format of the synonym map. Only the 'solr' format is currently
      supported. Default value: "solr".
     :vartype format: str
-    :param synonyms: Required. A series of synonym rules in the specified synonym map format. The
+    :keyword synonyms: Required. A series of synonym rules in the specified synonym map format. The
      rules must be separated by newlines.
-    :type synonyms: list[str]
-    :param encryption_key: A description of an encryption key that you create in Azure Key Vault.
+    :paramtype synonyms: list[str]
+    :keyword encryption_key: A description of an encryption key that you create in Azure Key Vault.
      This key is used to provide an additional level of encryption-at-rest for your data when you
      want full assurance that no one, not even Microsoft, can decrypt your data in Azure Cognitive
      Search. Once you have encrypted your data, it will always remain encrypted. Azure Cognitive
@@ -772,9 +772,9 @@ class SynonymMap(msrest.serialization.Model):
      needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with
      customer-managed keys is not available for free search services, and is only available for paid
      services created on or after January 1, 2019.
-    :type encryption_key: ~azure.search.documents.indexes.models.SearchResourceEncryptionKey
-    :param e_tag: The ETag of the synonym map.
-    :type e_tag: str
+    :paramtype encryption_key: ~azure.search.documents.indexes.models.SearchResourceEncryptionKey
+    :keyword e_tag: The ETag of the synonym map.
+    :paramtype e_tag: str
     """
 
     _validation = {
@@ -833,24 +833,24 @@ class SearchIndexerDataSourceConnection(msrest.serialization.Model):
 
     All required parameters must be populated in order to send to Azure.
 
-    :param name: Required. The name of the datasource connection.
-    :type name: str
-    :param description: The description of the datasource connection.
-    :type description: str
-    :param type: Required. The type of the datasource connection. Possible values include: "azuresql",
+    :keyword name: Required. The name of the datasource connection.
+    :paramtype name: str
+    :keyword description: The description of the datasource connection.
+    :paramtype description: str
+    :keyword type: Required. The type of the datasource connection. Possible values include: "azuresql",
      "cosmosdb", "azureblob", "azuretable", "mysql", "adlsgen2".
-    :type type: str or ~azure.search.documents.indexes.models.SearchIndexerDataSourceType
-    :param connection_string: The connection string for the datasource connection.
-    :type connection_string: str
-    :param container: Required. The data container for the datasource connection.
-    :type container: ~azure.search.documents.indexes.models.SearchIndexerDataContainer
-    :param data_change_detection_policy: The data change detection policy for the datasource connection.
-    :type data_change_detection_policy: ~azure.search.documents.models.DataChangeDetectionPolicy
-    :param data_deletion_detection_policy: The data deletion detection policy for the datasource connection.
-    :type data_deletion_detection_policy:
+    :paramtype type: str or ~azure.search.documents.indexes.models.SearchIndexerDataSourceType
+    :keyword connection_string: The connection string for the datasource connection.
+    :paramtype connection_string: str
+    :keyword container: Required. The data container for the datasource connection.
+    :paramtype container: ~azure.search.documents.indexes.models.SearchIndexerDataContainer
+    :keyword data_change_detection_policy: The data change detection policy for the datasource connection.
+    :paramtype data_change_detection_policy: ~azure.search.documents.models.DataChangeDetectionPolicy
+    :keyword data_deletion_detection_policy: The data deletion detection policy for the datasource connection.
+    :paramtype data_deletion_detection_policy:
      ~azure.search.documents.models.DataDeletionDetectionPolicy
-    :param e_tag: The ETag of the data source.
-    :type e_tag: str
+    :keyword e_tag: The ETag of the data source.
+    :paramtype e_tag: str
     """
 
     _validation = {


### PR DESCRIPTION
Updates our custom models to use `:keyword` annotations instead of `:param`. This causes them to be displayed correctly in APIView. 