### PR TITLE
Fix get_client_from_cli_profile

### DIFF
--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -69,7 +69,7 @@ class _CliCredentials(object):
             resource = scope
 
         credentials = self._get_cred(resource)
-        _, token, fulltoken = credentials._token_retriever()  # pylint:disable=protected-access
+        _, token, fulltoken = credentials._token_retriever(resource)  # pylint:disable=protected-access
 
         return _AccessToken(token, int(fulltoken['expiresIn'] + time.time()))
 


### PR DESCRIPTION
While trying to get a `StorageManagementClient` client using the `get_client_from_cli_profile` method I'm getting:

```
❯ python bb.py
Traceback (most recent call last):
  File "/Users/aneci/gits/bb.py", line 13, in <module>
    print([value.value for value in client.storage_accounts.list_by_resource_group("aneci")])
  File "/Users/aneci/gits/bb.py", line 13, in <listcomp>
    print([value.value for value in client.storage_accounts.list_by_resource_group("aneci")])
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/paging.py", line 129, in __next__
    return next(self._page_iterator)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/paging.py", line 76, in __next__
    self._response = self._get_next(self.continuation_token)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/mgmt/storage/v2021_04_01/operations/_storage_accounts_operations.py", line 577, in get_next
    pipeline_response = self._client._pipeline.run(request, stream=False, **kwargs)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/_base.py", line 211, in run
    return first_node.send(pipeline_request)  # type: ignore
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/_base.py", line 71, in send
    response = self.next.send(request)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/mgmt/core/policies/_base.py", line 47, in send
    response = self.next.send(request)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/_base.py", line 71, in send
    response = self.next.send(request)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/_base.py", line 71, in send
    response = self.next.send(request)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/_base.py", line 71, in send
    response = self.next.send(request)
  [Previous line repeated 1 more time]
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/policies/_redirect.py", line 158, in send
    response = self.next.send(request)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/policies/_retry.py", line 445, in send
    response = self.next.send(request)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/policies/_authentication.py", line 117, in send
    self.on_request(request)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/core/pipeline/policies/_authentication.py", line 94, in on_request
    self._token = self._credential.get_token(*self._scopes)
  File "/Users/aneci/.virtualenvs/k8s-infra/lib/python3.9/site-packages/azure/common/credentials.py", line 72, in get_token
    _, token, fulltoken = credentials._token_retriever()  # pylint:disable=protected-access
TypeError: _retrieve_token() missing 1 required positional argument: 'token_resource'
```

In order to reproduce it run the below script:
```
❯ cat bb.py
from azure.common.client_factory import get_client_from_cli_profile
from azure.mgmt.storage import StorageManagementClient

client = get_client_from_cli_profile(StorageManagementClient)
print([value.name for value in client.storage_accounts.list_by_resource_group("aneci")])
```

This PR adds missing parameter while calling the protected method `_token_retriever`