### PR TITLE
Protobuf 3.18.0 does not support python 2.7

### DIFF
--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -10,6 +10,7 @@ pytest-xdist==1.32.0
 # we pin coverage to 4.5.4 because there is an bug with `pytest-cov`. the generated coverage files cannot be `coverage combine`ed
 coverage==4.5.4
 bandit==1.6.2
+protobuf==3.17.3; python_version == '2.7'
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21


### PR DESCRIPTION
Pinning it to prevent test failures on py27.