### PR TITLE
Fixing VCR redirection

### DIFF
--- a/tools/vcrpy/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/tools/vcrpy/vcr/stubs/aiohttp_stubs/__init__.py
@@ -95,7 +95,11 @@ def play_responses(cassette, vcr_request):
     # If we're following redirects, continue playing until we reach
     # our final destination.
     while 300 <= response.status <= 399:
-        next_url = URL(response.url).with_path(response.headers["location"])
+        new_location = response.headers["location"]
+        potential_next_url = URL(new_location)
+        next_url = (potential_next_url
+            if potential_next_url.is_absolute()
+            else URL(response.url).with_path(new_location))
 
         # Make a stub VCR request that we can then use to look up the recorded
         # VCR request saved to the cassette. This feels a little hacky and


### PR DESCRIPTION
Using the location passed as part of the redirection response if
it is an absolute URL.