### PR TITLE
Enable release stage selection at queue time

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -10,9 +10,9 @@ parameters:
   TargetDocRepoName: ''
 
 stages:
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - ${{if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
     - ${{ each artifact in parameters.Artifacts }}:
-      - stage: Release_${{artifact.safeName}}
+      - stage:
         displayName: 'Release: ${{artifact.name}}'
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-python-pr'))
@@ -262,7 +262,7 @@ stages:
               $fileCount = (Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}} | ? {$_.Name -match "-[0-9]*.[0-9]*.[0-9]*a[0-9]*" } | Measure-Object).Count
 
               if ($fileCount -eq 0) {
-                Write-Host "No alpha packages for ${{artifact.safeName}} to publish."
+                Write-Host "No alpha packages for ${{artifact.name}} to publish."
                 exit 0
               }
 


### PR DESCRIPTION
- Remove the need for safeName and let Devops generate a unique identifier since we only ever use the display name. This allows us to stop setting safeName in all our artifact lists, of course that clean-up is a separate set of work.
- When you are trying to queue a manual run DevOps sets Build.Reason to empty which blocks the full generation of stages in the stage selection UI. To work around this we check for Build.Reason empty or Manual. This allows for teams to uncheck a release stage for any packages that they don't plan to release.