### PR TITLE
[Test Proxy] Update migration guide and default add_sanitizer regex

### DIFF
--- a/doc/dev/test_proxy_migration_guide.md
+++ b/doc/dev/test_proxy_migration_guide.md
@@ -108,7 +108,8 @@ adding something like the following in the package's `conftest.py` file:
 ```python
 from devtools_testutils import add_sanitizer
 
-@pytest.fixture(scope="session")
+# autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
+@pytest.fixture(scope="session", autouse=True)
 def sanitize_uris():
     add_sanitizer(ProxyRecordingSanitizer.URI, value="fakeendpoint")
 ```

--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -52,7 +52,9 @@ def add_sanitizer(sanitizer, **kwargs):
     """
     request_args = {}
     request_args["value"] = kwargs.get("value") or "fakevalue"
-    request_args["regex"] = kwargs.get("regex") or "[a-z]+(?=(?:-secondary)\\.(?:table|blob|queue)\\.core\\.windows\\.net)"
+    request_args["regex"] = (
+        kwargs.get("regex") or "(?<=\\/\\/)[a-z]+(?=(?:|-secondary)\\.(?:table|blob|queue)\\.core\\.windows\\.net)"
+    )
     request_args["group_for_replace"] = kwargs.get("group_for_replace")
 
     if sanitizer == ProxyRecordingSanitizer.URI:
@@ -62,7 +64,7 @@ def add_sanitizer(sanitizer, **kwargs):
             json={
                 "regex": request_args["regex"],
                 "value": request_args["value"],
-                "groupForReplace": request_args["group_for_replace"]
+                "groupForReplace": request_args["group_for_replace"],
             },
         )
 


### PR DESCRIPTION
This mentions that `autouse=True` should be added to session fixture declarations if users want sanitizers to be added automatically when running tests, and updates the default regex for `add_sanitizer` to correctly replace the storage account name in URLs while preserving `-secondary` suffixes