### PR TITLE
respect text encoding specified in argument (#20795)

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -313,7 +313,9 @@ class AioHttpTransportResponse(AsyncHttpResponse):
         ctype = self.headers.get(aiohttp.hdrs.CONTENT_TYPE, "").lower()
         mimetype = aiohttp.helpers.parse_mimetype(ctype)
 
-        encoding = mimetype.parameters.get("charset")
+        if not encoding:
+            # extract encoding from mimetype, if caller does not specify
+            encoding = mimetype.parameters.get("charset")
         if encoding:
             try:
                 codecs.lookup(encoding)


### PR DESCRIPTION
If explicitly specified, respect `encoding` parameter of `AioHttpTransportResponse#text` method to resolve the issue #20795.