### PR TITLE
Fix mypy syntax errors

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -256,7 +256,7 @@ class DataLakeFileClient(PathClient):
     def set_file_expiry(self, expiry_options,  # type: str
                         expires_on=None,   # type: Optional[Union[datetime, int]]
                         **kwargs):
-        # type: (str, Optional[Union[datetime, int]], **Any) -> None
+        # type: (...) -> None
         """Sets the time a file will expire and be deleted.
 
         :param str expiry_options:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -118,8 +118,11 @@ class PathClient(StorageAccountHostsMixin):
             quote(self.path_name, safe='~'),
             self._query_str)
 
-    def _create_path_options(self, resource_type, content_settings=None, metadata=None, **kwargs):
-        # type: (Optional[ContentSettings], Optional[Dict[str, str]], **Any) -> Dict[str, Any]
+    def _create_path_options(self, resource_type,
+                             content_settings=None,  # type: Optional[ContentSettings]
+                             metadata=None,  # type: Optional[Dict[str, str]]
+                             **kwargs):
+        # type: (...) -> Dict[str, Any]
         if self.require_encryption or (self.key_encryption_key is not None):
             raise ValueError(_ERROR_UNSUPPORTED_METHOD_FOR_ENCRYPTION)
 
@@ -211,7 +214,7 @@ class PathClient(StorageAccountHostsMixin):
 
     @staticmethod
     def _delete_path_options(**kwargs):
-        # type: (Optional[ContentSettings], Optional[Dict[str, str]], **Any) -> Dict[str, Any]
+        # type: (**Any) -> Dict[str, Any]
 
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         mod_conditions = get_mod_conditions(kwargs)
@@ -262,7 +265,7 @@ class PathClient(StorageAccountHostsMixin):
 
     @staticmethod
     def _set_access_control_options(owner=None, group=None, permissions=None, acl=None, **kwargs):
-        # type: (Optional[ContentSettings], Optional[Dict[str, str]], **Any) -> Dict[str, Any]
+        # type: (...) -> Dict[str, Any]
 
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         mod_conditions = get_mod_conditions(kwargs)
@@ -636,8 +639,11 @@ class PathClient(StorageAccountHostsMixin):
             error.continuation_token = last_continuation_token
             raise error
 
-    def _rename_path_options(self, rename_source, content_settings=None, metadata=None, **kwargs):
-        # type: (Optional[ContentSettings], Optional[Dict[str, str]], **Any) -> Dict[str, Any]
+    def _rename_path_options(self, rename_source,
+                             content_settings=None,  # type: Optional[ContentSettings]
+                             metadata=None,  # type: Optional[Dict[str, str]]
+                             **kwargs):
+        # type: (...) -> Dict[str, Any]
         if self.require_encryption or (self.key_encryption_key is not None):
             raise ValueError(_ERROR_UNSUPPORTED_METHOD_FOR_ENCRYPTION)
         if metadata or kwargs.pop('permissions', None) or kwargs.pop('umask', None):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_serialize.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_serialize.py
@@ -23,7 +23,7 @@ _SUPPORTED_API_VERSIONS = [
 
 
 def get_api_version(kwargs):
-    # type: (Dict[str, Any], str) -> str
+    # type: (Dict[str, Any]) -> str
     api_version = kwargs.get('api_version', None)
     if api_version and api_version not in _SUPPORTED_API_VERSIONS:
         versions = '\n'.join(_SUPPORTED_API_VERSIONS)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
@@ -225,7 +225,7 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
 
     async def rename_directory(self, new_name,  # type: str
                                **kwargs):
-        # type: (**Any) -> DataLakeDirectoryClient
+        # type: (...) -> DataLakeDirectoryClient
         """
         Rename the source directory.
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -226,7 +226,7 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
     async def set_file_expiry(self, expiry_options,  # type: str
                               expires_on=None,  # type: Optional[Union[datetime, int]]
                               **kwargs):
-        # type: (str, Optional[Union[datetime, int]], **Any) -> None
+        # type: (...) -> None
         """Sets the time a file will expire and be deleted.
 
         :param str expiry_options:


### PR DESCRIPTION
Fixes [issue 19290](https://github.com/Azure/azure-sdk-for-python/issues/19290).

All mypy `[syntax]` error codes are resolved:

- `Function has duplicate type signatures` resolved by using the `(...)` in the type return comment
- `Type signature has too few arguments` resolved by switching from single line type comment to multiline with `(...)` in the type return comment.  Unknown args were left unannotated.
- `Type signature has too many arguments` resolved by deleting excess type arguments