### PR TITLE
[Perf Framework] Use urljoin to concatenate URLs

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/perf_stress_test.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/perf_stress_test.py
@@ -6,11 +6,7 @@
 import os
 import aiohttp
 
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin
-
+from urllib.parse import urljoin
 from ._policies import PerfTestProxyPolicy
 
 


### PR DESCRIPTION
- Existing code fails if `test_proxy` option ends with `/`