### PR TITLE
[eng] have verify autorest warn instead of raise

### DIFF
--- a/eng/pipelines/templates/steps/verify-autorest.yml
+++ b/eng/pipelines/templates/steps/verify-autorest.yml
@@ -34,6 +34,7 @@ steps:
 
     - task: PythonScript@0
       displayName: 'Verify autorest'
+      continueOneError: true
       inputs:
         scriptPath: 'scripts/devops_tasks/verify_autorest.py'
         arguments: >-

--- a/eng/pipelines/templates/steps/verify-autorest.yml
+++ b/eng/pipelines/templates/steps/verify-autorest.yml
@@ -34,7 +34,7 @@ steps:
 
     - task: PythonScript@0
       displayName: 'Verify autorest'
-      continueOneError: true
+      continueOnError: true
       inputs:
         scriptPath: 'scripts/devops_tasks/verify_autorest.py'
         arguments: >-

--- a/scripts/devops_tasks/verify_autorest.py
+++ b/scripts/devops_tasks/verify_autorest.py
@@ -86,8 +86,8 @@ def check_diff(folder):
     if result:
         command = ["git", "status"]
         run_check_call(command, root_dir)
-        print(
-            "##[warning]Found difference between re-generated code and current commit. Please re-generate with the latest autorest."
+        raise ValueError(
+            "Found difference between re-generated code and current commit. Please re-generate with the latest autorest."
         )
 
 

--- a/scripts/devops_tasks/verify_autorest.py
+++ b/scripts/devops_tasks/verify_autorest.py
@@ -8,7 +8,7 @@
 import argparse
 import os
 import logging
-import sys
+import warnings
 
 from common_tasks import run_check_call
 
@@ -87,7 +87,7 @@ def check_diff(folder):
     if result:
         command = ["git", "status"]
         run_check_call(command, root_dir)
-        raise ValueError(
+        warnings.warn(
             "Found difference between re-generated code and current commit. Please re-generate with the latest autorest."
         )
 

--- a/scripts/devops_tasks/verify_autorest.py
+++ b/scripts/devops_tasks/verify_autorest.py
@@ -8,7 +8,6 @@
 import argparse
 import os
 import logging
-import warnings
 
 from common_tasks import run_check_call
 
@@ -87,8 +86,8 @@ def check_diff(folder):
     if result:
         command = ["git", "status"]
         run_check_call(command, root_dir)
-        warnings.warn(
-            "Found difference between re-generated code and current commit. Please re-generate with the latest autorest."
+        print(
+            "##[warning]Found difference between re-generated code and current commit. Please re-generate with the latest autorest."
         )
 
 

--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -29,6 +29,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: appconfiguration
+    VerifyAutorest: true
     ValidateFormatting: false
     Artifacts:
     - name: azure-appconfiguration

--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -29,7 +29,6 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: appconfiguration
-    VerifyAutorest: true
     ValidateFormatting: false
     Artifacts:
     - name: azure-appconfiguration


### PR DESCRIPTION
thank you @seankane-msft !

This pr is for appconfig, which is the only sdk using `VerifyAutorest`. Talked to @xiangyan99 and we don't really want to fail if appconfig's autorest isn't the latest, so switching to a warn

cc @scbedd 