### PR TITLE
[formrecognizer] Skip v2.0 compatibility tests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
@@ -126,6 +126,7 @@ class TestMultiapi(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
+    @pytest.mark.skip("the service is experiencing issues listing models for v2.x")
     def test_v2_0_compatibility(self, client, formrecognizer_storage_container_sas_url_v2):
         # test that the addition of new attributes in v2.1 does not break v2.0
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
@@ -125,6 +125,7 @@ class TestMultiapi(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
+    @pytest.mark.skip("the service is experiencing issues listing models for v2.x")
     async def test_v2_0_compatibility(self, client, formrecognizer_storage_container_sas_url_v2):
         # test that the addition of new attributes in v2.1 does not break v2.0
         async with client:


### PR DESCRIPTION
These tests are failing due to the service experiencing issues listing models for v2.x. 

Tracking issue for unskipping tests: #20950