### PR TITLE
[Identity] Align samples with other languages

### DIFF
--- a/sdk/identity/azure-identity/samples/README.md
+++ b/sdk/identity/azure-identity/samples/README.md
@@ -34,6 +34,6 @@ pip install azure-identity azure-keyvault-certificates azure-keyvault-secrets
 | File | Description |
 |-------------|-------------|
 | control_interactive_prompts.py | demonstrates controlling when interactive credentials prompt for user interaction |
-| custom_credentials.py | demonstrates custom credential implementation |
+| custom_credentials.py | demonstrates custom credential implementations using existing access tokens and an MSAL client |
 | key_vault_cert.py | demonstrates authenticating with a Key Vault certificate |
 | user_authentication.py | demonstrates user authentication and token cache persistence API for applications |

--- a/sdk/identity/azure-identity/samples/README.md
+++ b/sdk/identity/azure-identity/samples/README.md
@@ -36,4 +36,4 @@ pip install azure-identity azure-keyvault-certificates azure-keyvault-secrets
 | control_interactive_prompts.py | demonstrates controlling when interactive credentials prompt for user interaction |
 | custom_credentials.py | demonstrates custom credential implementation |
 | key_vault_cert.py | demonstrates authenticating with a Key Vault certificate |
-| user_authentication.py | demonstrates user authentication API for applications |
+| user_authentication.py | demonstrates user authentication and token cache persistence API for applications |

--- a/sdk/identity/azure-identity/samples/user_authentication.py
+++ b/sdk/identity/azure-identity/samples/user_authentication.py
@@ -25,6 +25,7 @@ credential = InteractiveBrowserCredential(cache_persistence_options=TokenCachePe
 # The 'authenticate' method begins interactive authentication. Call it whenever it's convenient
 # for your application to authenticate a user. It returns a record of the authentication.
 record = credential.authenticate()
+print("\nAuthenticated first credential")
 
 # The record contains no authentication secrets. You can serialize it to JSON for storage.
 record_json = record.serialize()
@@ -33,6 +34,7 @@ record_json = record.serialize()
 # without prompting for authentication again.
 client = SecretClient(VAULT_URL, credential)
 secret_names = [s.name for s in client.list_properties_of_secrets()]
+print("\nCompleted request with first credential")
 
 # An authentication record stored by your application enables other credentials to access data from
 # past authentications. If the cache contains sufficient data, this eliminates the need for your
@@ -45,3 +47,14 @@ new_credential = InteractiveBrowserCredential(
 # This request should also succeed without prompting for authentication.
 client = SecretClient(VAULT_URL, new_credential)
 secret_names = [s.name for s in client.list_properties_of_secrets()]
+print("\nCompleted request with credential using shared cache")
+
+# To isolate the token cache from other applications, you can provide a cache name to TokenCachePersistenceOptions.
+separate_cache_credential = InteractiveBrowserCredential(
+    cache_persistence_options=TokenCachePersistenceOptions(name="my_app"), authentication_record=deserialized_record
+)
+
+# This request should prompt for authentication since the credential is using a separate cache.
+client = SecretClient(VAULT_URL, separate_cache_credential)
+secret_names = [s.name for s in client.list_properties_of_secrets()]
+print("\nCompleted request with credential using separate cache")


### PR DESCRIPTION
Resolves #20488 and resolves #19310.

The MSAL client credential doesn't use any caching for the sake of simplicity and to align with [Java's example](https://github.com/Azure/azure-sdk-for-java/wiki/Azure-Identity-Examples#authenticating-with-msal-as-token-credential).