### PR TITLE
[Key Vault] Add KeyClient.get_cryptography_client method

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
@@ -29,31 +29,32 @@ class AsyncKeyVaultClientBase(object):
         if not vault_url:
             raise ValueError("vault_url must be the URL of an Azure Key Vault")
 
-        self._vault_url = vault_url.strip(" /")
-        client = kwargs.get("generated_client")
-        if client:
-            # caller provided a configured client -> nothing left to initialize
-            self._client = client
-            return
-
-        api_version = kwargs.pop("api_version", DEFAULT_VERSION)
-
-        pipeline = kwargs.pop("pipeline", None)
-        transport = kwargs.pop("transport", None)
-        http_logging_policy = HttpLoggingPolicy(**kwargs)
-        http_logging_policy.allowed_header_names.update(
-            {
-                "x-ms-keyvault-network-info",
-                "x-ms-keyvault-region",
-                "x-ms-keyvault-service-version"
-            }
-        )
-
-        if not transport and not pipeline:
-            from azure.core.pipeline.transport import AioHttpTransport
-            transport = AioHttpTransport(**kwargs)
-
         try:
+            api_version = kwargs.pop("api_version", DEFAULT_VERSION)
+            self._vault_url = vault_url.strip(" /")
+            client = kwargs.get("generated_client")
+            if client:
+                # caller provided a configured client -> only models left to initialize
+                self._client = client
+                models = kwargs.get("generated_models")
+                self._models = models or _KeyVaultClient.models(api_version=api_version)
+                return
+
+            pipeline = kwargs.pop("pipeline", None)
+            transport = kwargs.pop("transport", None)
+            http_logging_policy = HttpLoggingPolicy(**kwargs)
+            http_logging_policy.allowed_header_names.update(
+                {
+                    "x-ms-keyvault-network-info",
+                    "x-ms-keyvault-region",
+                    "x-ms-keyvault-service-version"
+                }
+            )
+
+            if not transport and not pipeline:
+                from azure.core.pipeline.transport import AioHttpTransport
+                transport = AioHttpTransport(**kwargs)
+
             self._client = _KeyVaultClient(
                 api_version=api_version,
                 pipeline=pipeline,
@@ -64,7 +65,7 @@ class AsyncKeyVaultClientBase(object):
                 **kwargs
             )
             self._models = _KeyVaultClient.models(api_version=api_version)
-        except NotImplementedError:
+        except ValueError:
             raise NotImplementedError(
                 "This package doesn't support API version '{}'. ".format(api_version)
                 + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
@@ -40,22 +40,24 @@ class KeyVaultClientBase(object):
         if not vault_url:
             raise ValueError("vault_url must be the URL of an Azure Key Vault")
 
-        self._vault_url = vault_url.strip(" /")
-        client = kwargs.get("generated_client")
-        if client:
-            # caller provided a configured client -> nothing left to initialize
-            self._client = client
-            return
-
-        api_version = kwargs.pop("api_version", DEFAULT_VERSION)
-
-        pipeline = kwargs.pop("pipeline", None)
-        transport = kwargs.pop("transport", RequestsTransport(**kwargs))
-        http_logging_policy = HttpLoggingPolicy(**kwargs)
-        http_logging_policy.allowed_header_names.update(
-            {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
-        )
         try:
+            api_version = kwargs.pop("api_version", DEFAULT_VERSION)
+            self._vault_url = vault_url.strip(" /")
+            client = kwargs.get("generated_client")
+            if client:
+                # caller provided a configured client -> only models left to initialize
+                self._client = client
+                models = kwargs.get("generated_models")
+                self._models = models or _KeyVaultClient.models(api_version=api_version)
+                return
+
+            pipeline = kwargs.pop("pipeline", None)
+            transport = kwargs.pop("transport", RequestsTransport(**kwargs))
+            http_logging_policy = HttpLoggingPolicy(**kwargs)
+            http_logging_policy.allowed_header_names.update(
+                {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+            )
+
             self._client = _KeyVaultClient(
                 api_version=api_version,
                 pipeline=pipeline,
@@ -66,7 +68,7 @@ class KeyVaultClientBase(object):
                 **kwargs
             )
             self._models = _KeyVaultClient.models(api_version=api_version)
-        except NotImplementedError:
+        except ValueError:
             raise NotImplementedError(
                 "This package doesn't support API version '{}'. ".format(api_version)
                 + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -28,6 +28,7 @@ class ApiVersion(str, Enum):
     V7_0 = "7.0"
     V2016_10_01 = "2016-10-01"
 
+
 DEFAULT_VERSION = ApiVersion.V7_3_PREVIEW
 
 
@@ -42,26 +43,25 @@ class KeyVaultClientBase(object):
         if not vault_url:
             raise ValueError("vault_url must be the URL of an Azure Key Vault")
 
-        self._vault_url = vault_url.strip(" /")
-        client = kwargs.get("generated_client")
-        if client:
-            # caller provided a configured client -> nothing left to initialize
-            self._client = client
-            return
-
-        self.api_version = kwargs.pop("api_version", DEFAULT_VERSION)
-
-        pipeline = kwargs.pop("pipeline", None)
-        transport = kwargs.pop("transport", RequestsTransport(**kwargs))
-        http_logging_policy = HttpLoggingPolicy(**kwargs)
-        http_logging_policy.allowed_header_names.update(
-            {
-                "x-ms-keyvault-network-info",
-                "x-ms-keyvault-region",
-                "x-ms-keyvault-service-version"
-            }
-        )
         try:
+            self.api_version = kwargs.pop("api_version", DEFAULT_VERSION)
+            self._vault_url = vault_url.strip(" /")
+
+            client = kwargs.get("generated_client")
+            if client:
+                # caller provided a configured client -> only models left to initialize
+                self._client = client
+                models = kwargs.get("generated_models")
+                self._models = models or _KeyVaultClient.models(api_version=self.api_version)
+                return
+
+            pipeline = kwargs.pop("pipeline", None)
+            transport = kwargs.pop("transport", RequestsTransport(**kwargs))
+            http_logging_policy = HttpLoggingPolicy(**kwargs)
+            http_logging_policy.allowed_header_names.update(
+                {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+            )
+
             self._client = _KeyVaultClient(
                 api_version=self.api_version,
                 pipeline=pipeline,
@@ -77,7 +77,6 @@ class KeyVaultClientBase(object):
                 "This package doesn't support API version '{}'. ".format(self.api_version)
                 + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
             )
-
 
     @property
     def vault_url(self):

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 4.5.0b4 (Unreleased)
 
 ### Features Added
+- Added `KeyClient.get_cryptography_client`, which provides a simple way to create a
+  CryptographyClient for a given key, given its full key ID
+  ([#20621](https://github.com/Azure/azure-sdk-for-python/issues/20621))
 - Added support for automated and on-demand key rotation in Azure Key Vault
   ([#19840](https://github.com/Azure/azure-sdk-for-python/issues/19840))
   - Added `KeyClient.rotate_key` to rotate a key on-demand

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Added `KeyClient.get_cryptography_client`, which provides a simple way to create a
-  CryptographyClient for a given key, given its full key ID
+  `CryptographyClient` for a key, given its name and optionally a version
   ([#20621](https://github.com/Azure/azure-sdk-for-python/issues/20621))
 - Added support for automated and on-demand key rotation in Azure Key Vault
   ([#19840](https://github.com/Azure/azure-sdk-for-python/issues/19840))
@@ -16,6 +16,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+- `CryptographyClient` no longer requires a key version when providing a key ID to its constructor
+  (though providing a version is still recommended)
 
 ## 4.5.0b3 (2021-09-09)
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -68,6 +68,7 @@ class KeyClient(KeyVaultClientBase):
             HTTP client as this :class:`~azure.keyvault.keys.KeyClient`.
         :rtype: ~azure.keyvault.keys.crypto.CryptographyClient
         """
+        # We provide a fake credential because the generated client already has the KeyClient's real credential
         return CryptographyClient(
             key, object(), generated_client=self._client, generated_models=self._models  # type: ignore
         )

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -5,6 +5,7 @@
 from functools import partial
 from azure.core.tracing.decorator import distributed_trace
 
+from .crypto import CryptographyClient
 from ._shared import KeyVaultClientBase
 from ._shared.exceptions import error_map as _error_map
 from ._shared._polling import DeleteRecoverPollingMethod, KeyVaultOperationPoller
@@ -18,6 +19,7 @@ except ImportError:
 if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Iterable, Optional, Union
+    from azure.core.credentials import TokenCredential
     from azure.core.paging import ItemPaged
     from azure.core.polling import LROPoller
     from ._models import JsonWebKey
@@ -54,6 +56,21 @@ class KeyClient(KeyVaultClientBase):
                 enabled=enabled, not_before=not_before, expires=expires_on, exportable=exportable
             )
         return None
+
+    def get_cryptography_client(self, key):
+        # type: (str) -> CryptographyClient
+        """Gets a :class:`~azure.keyvault.keys.crypto.CryptographyClient` for the given key.
+
+        :param str key: The full identifier of the key used to perform cryptographic operations. This must include the
+            key version.
+
+        :returns: A :class:`~azure.keyvault.keys.crypto.CryptographyClient` using the same options, credentials, and
+            HTTP client as this :class:`~azure.keyvault.keys.KeyClient`.
+        :rtype: ~azure.keyvault.keys.crypto.CryptographyClient
+        """
+        return CryptographyClient(
+            key, object(), generated_client=self._client, generated_models=self._models  # type: ignore
+        )
 
     @distributed_trace
     def create_key(self, name, key_type, **kwargs):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -28,6 +28,7 @@ class ApiVersion(str, Enum):
     V7_0 = "7.0"
     V2016_10_01 = "2016-10-01"
 
+
 DEFAULT_VERSION = ApiVersion.V7_3_PREVIEW
 
 
@@ -42,26 +43,25 @@ class KeyVaultClientBase(object):
         if not vault_url:
             raise ValueError("vault_url must be the URL of an Azure Key Vault")
 
-        self._vault_url = vault_url.strip(" /")
-        client = kwargs.get("generated_client")
-        if client:
-            # caller provided a configured client -> nothing left to initialize
-            self._client = client
-            return
-
-        self.api_version = kwargs.pop("api_version", DEFAULT_VERSION)
-
-        pipeline = kwargs.pop("pipeline", None)
-        transport = kwargs.pop("transport", RequestsTransport(**kwargs))
-        http_logging_policy = HttpLoggingPolicy(**kwargs)
-        http_logging_policy.allowed_header_names.update(
-            {
-                "x-ms-keyvault-network-info",
-                "x-ms-keyvault-region",
-                "x-ms-keyvault-service-version"
-            }
-        )
         try:
+            self.api_version = kwargs.pop("api_version", DEFAULT_VERSION)
+            self._vault_url = vault_url.strip(" /")
+
+            client = kwargs.get("generated_client")
+            if client:
+                # caller provided a configured client -> only models left to initialize
+                self._client = client
+                models = kwargs.get("generated_models")
+                self._models = models or _KeyVaultClient.models(api_version=self.api_version)
+                return
+
+            pipeline = kwargs.pop("pipeline", None)
+            transport = kwargs.pop("transport", RequestsTransport(**kwargs))
+            http_logging_policy = HttpLoggingPolicy(**kwargs)
+            http_logging_policy.allowed_header_names.update(
+                {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+            )
+
             self._client = _KeyVaultClient(
                 api_version=self.api_version,
                 pipeline=pipeline,
@@ -77,7 +77,6 @@ class KeyVaultClientBase(object):
                 "This package doesn't support API version '{}'. ".format(self.api_version)
                 + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
             )
-
 
     @property
     def vault_url(self):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -9,6 +9,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from ..crypto.aio import CryptographyClient
+from .._client import _get_key_id
 from .._shared._polling_async import AsyncDeleteRecoverPollingMethod
 from .._shared import AsyncKeyVaultClientBase
 from .._shared.exceptions import error_map as _error_map
@@ -61,20 +62,23 @@ class KeyClient(AsyncKeyVaultClientBase):
             )
         return None
 
-    def get_cryptography_client(self, key):
-        # type: (str) -> CryptographyClient
+    def get_cryptography_client(self, key_name, **kwargs):
+        # type: (str, **Any) -> CryptographyClient
         """Gets a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` for the given key.
 
-        :param str key: The full identifier of the key used to perform cryptographic operations. This must include the
-            key version.
+        :param str key_name: The name of the key used to perform cryptographic operations.
+
+        :keyword str version: Optional version of the key used to perform cryptographic operations.
 
         :returns: A :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` using the same options, credentials, and
             HTTP client as this :class:`~azure.keyvault.keys.aio.KeyClient`.
         :rtype: ~azure.keyvault.keys.crypto.aio.CryptographyClient
         """
+        key_id = _get_key_id(self._vault_url, key_name, kwargs.get("version"))
+
         # We provide a fake credential because the generated client already has the KeyClient's real credential
         return CryptographyClient(
-            key, object(), generated_client=self._client, generated_models=self._models  # type: ignore
+            key_id, object(), generated_client=self._client, generated_models=self._models  # type: ignore
         )
 
     @distributed_trace_async

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -8,6 +8,7 @@ from functools import partial
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 
+from ..crypto.aio import CryptographyClient
 from .._shared._polling_async import AsyncDeleteRecoverPollingMethod
 from .._shared import AsyncKeyVaultClientBase
 from .._shared.exceptions import error_map as _error_map
@@ -59,6 +60,21 @@ class KeyClient(AsyncKeyVaultClientBase):
                 enabled=enabled, not_before=not_before, expires=expires_on, exportable=exportable
             )
         return None
+
+    def get_cryptography_client(self, key):
+        # type: (str) -> CryptographyClient
+        """Gets a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` for the given key.
+
+        :param str key: The full identifier of the key used to perform cryptographic operations. This must include the
+            key version.
+
+        :returns: A :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` using the same options, credentials, and
+            HTTP client as this :class:`~azure.keyvault.keys.aio.KeyClient`.
+        :rtype: ~azure.keyvault.keys.crypto.aio.CryptographyClient
+        """
+        return CryptographyClient(
+            key, object(), generated_client=self._client, generated_models=self._models  # type: ignore
+        )
 
     @distributed_trace_async
     async def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs: "Any") -> KeyVaultKey:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -72,6 +72,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             HTTP client as this :class:`~azure.keyvault.keys.aio.KeyClient`.
         :rtype: ~azure.keyvault.keys.crypto.aio.CryptographyClient
         """
+        # We provide a fake credential because the generated client already has the KeyClient's real credential
         return CryptographyClient(
             key, object(), generated_client=self._client, generated_models=self._models  # type: ignore
         )

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -87,7 +87,7 @@ class CryptographyClient(KeyVaultClientBase):
     :param key:
         Either a :class:`~azure.keyvault.keys.KeyVaultKey` instance as returned by
         :func:`~azure.keyvault.keys.KeyClient.get_key`, or a string.
-        If a string, the value must be the full identifier of an Azure Key Vault key with a version.
+        If a string, the value must be the identifier of an Azure Key Vault key. Including a version is recommended.
     :type key: str or :class:`~azure.keyvault.keys.KeyVaultKey`
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
@@ -120,14 +120,13 @@ class CryptographyClient(KeyVaultClientBase):
         elif isinstance(key, six.string_types):
             self._key = None
             self._key_id = parse_key_vault_id(key)
+            if self._key_id.version is None:
+                self._key_id.version = ""  # to avoid an error and get the latest version when getting the key
             self._keys_get_forbidden = False
         elif self._jwk:
             self._key = key
         else:
-            raise ValueError("'key' must be a KeyVaultKey instance or a key ID string including a version")
-
-        if not (self._jwk or (self._key_id.version if self._key_id else None)):
-            raise ValueError("'key' must include a version")
+            raise ValueError("'key' must be a KeyVaultKey instance or a key ID string")
 
         if self._jwk:
             try:
@@ -196,7 +195,9 @@ class CryptographyClient(KeyVaultClientBase):
                     self._key_id.version if self._key_id else None,
                     **kwargs
                 )
-                self._key = KeyVaultKey._from_key_bundle(key_bundle).key  # pylint:disable=protected-access
+                key = KeyVaultKey._from_key_bundle(key_bundle)  # pylint:disable=protected-access
+                self._key = key.key
+                self._key_id = parse_key_vault_id(key.id)  # update the key ID in case we didn't have the version before
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -260,13 +260,21 @@ class CryptographyClient(KeyVaultClientBase):
             **kwargs
         )
 
+        result_iv = operation_result.iv if hasattr(operation_result, "iv") else None
+        result_tag = operation_result.authentication_tag if hasattr(operation_result, "authentication_tag") else None
+        result_aad = (
+            operation_result.additional_authenticated_data
+            if hasattr(operation_result, "additional_authenticated_data")
+            else None
+        )
+
         return EncryptResult(
             key_id=self.key_id,
             algorithm=algorithm,
             ciphertext=operation_result.result,
-            iv=operation_result.iv,
-            authentication_tag=operation_result.authentication_tag,
-            additional_authenticated_data=operation_result.additional_authenticated_data,
+            iv=result_iv,
+            authentication_tag=result_tag,
+            additional_authenticated_data=result_aad,
         )
 
     @distributed_trace

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -203,13 +203,21 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             **kwargs
         )
 
+        result_iv = operation_result.iv if hasattr(operation_result, "iv") else None
+        result_tag = operation_result.authentication_tag if hasattr(operation_result, "authentication_tag") else None
+        result_aad = (
+            operation_result.additional_authenticated_data
+            if hasattr(operation_result, "additional_authenticated_data")
+            else None
+        )
+
         return EncryptResult(
             key_id=self.key_id,
             algorithm=algorithm,
             ciphertext=operation_result.result,
-            iv=operation_result.iv,
-            authentication_tag=operation_result.authentication_tag,
-            additional_authenticated_data=operation_result.additional_authenticated_data,
+            iv=result_iv,
+            authentication_tag=result_tag,
+            additional_authenticated_data=result_aad,
         )
 
     @distributed_trace_async

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_2016_10_01_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_2016_10_01_vault.yaml
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:48:59 GMT
+      - Mon, 04 Oct 2021 19:24:42 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +45,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -70,7 +70,7 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ykKfQcK6mcf85B4HydLBTIN-X_55HptNrp1lcr4lL0sQDSb0EWItcOtjzGUuUx7KjracmZIE4JbzdF68PCS-3t5qQKrEkyB42LpvTQTwcKzZ7qXTOKWwMfrWOo9ztPbq0qKiNNwDF1ivBrhZ_5S6Bcpum28zZZFmjkjyHB06KKSFuAUo97VfZdZKyx2r_F9nM12E-aI28PgNcxW_8lruEoGb4kuTWZawtOFBzpla-xfcrxPTnvknOVRo9MugF7VFsboW0xRXTMlevqJy5w4HrEkMwzbBdmKT4ZxtSw12ucsQQ7lq1PAHpZZaSLJvEqnvMgEtPBzWHKjgj0p8iu-_1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074540,"updated":1633074540,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"plzPCwknLANpyWRBAgmey1NiiRVh176PsqiIllMRUgm6vaF4zycoF8jYGCh-kKgRpi9QKoeX4F5PznodZkrtEjBwDe-D3vnEBf00Zx5Z-2rOm9ew6cGdNnCcXlIK8N2RI-5_hMlG2D4QJ1Qyrbk9RZrE2wFdMrYEGJ6viLqqELWdg0N3ufShBcKWIsHkLEoC-2lIbxpRJ4cNt_eSzIYUy6iykAQsMhfeqTHhO7JrrhZL7ZL1wMH6OHW5ztn7ci5x9anInW2JfE1gNDEzuyXgJF4IaT5oXPr2MZMY1ZHijQGXFvBoQ9ZuWwwrBQfsMnx8grqGwfasjOGnNPkFZAQFjQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375484,"updated":1633375484,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:00 GMT
+      - Mon, 04 Oct 2021 19:24:44 GMT
       expires:
       - '-1'
       pragma:
@@ -93,7 +93,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -111,10 +111,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ykKfQcK6mcf85B4HydLBTIN-X_55HptNrp1lcr4lL0sQDSb0EWItcOtjzGUuUx7KjracmZIE4JbzdF68PCS-3t5qQKrEkyB42LpvTQTwcKzZ7qXTOKWwMfrWOo9ztPbq0qKiNNwDF1ivBrhZ_5S6Bcpum28zZZFmjkjyHB06KKSFuAUo97VfZdZKyx2r_F9nM12E-aI28PgNcxW_8lruEoGb4kuTWZawtOFBzpla-xfcrxPTnvknOVRo9MugF7VFsboW0xRXTMlevqJy5w4HrEkMwzbBdmKT4ZxtSw12ucsQQ7lq1PAHpZZaSLJvEqnvMgEtPBzWHKjgj0p8iu-_1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074540,"updated":1633074540,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"plzPCwknLANpyWRBAgmey1NiiRVh176PsqiIllMRUgm6vaF4zycoF8jYGCh-kKgRpi9QKoeX4F5PznodZkrtEjBwDe-D3vnEBf00Zx5Z-2rOm9ew6cGdNnCcXlIK8N2RI-5_hMlG2D4QJ1Qyrbk9RZrE2wFdMrYEGJ6viLqqELWdg0N3ufShBcKWIsHkLEoC-2lIbxpRJ4cNt_eSzIYUy6iykAQsMhfeqTHhO7JrrhZL7ZL1wMH6OHW5ztn7ci5x9anInW2JfE1gNDEzuyXgJF4IaT5oXPr2MZMY1ZHijQGXFvBoQ9ZuWwwrBQfsMnx8grqGwfasjOGnNPkFZAQFjQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375484,"updated":1633375484,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
@@ -123,7 +123,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:00 GMT
+      - Mon, 04 Oct 2021 19:24:44 GMT
       expires:
       - '-1'
       pragma:
@@ -137,7 +137,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -159,10 +159,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b/encrypt?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16/encrypt?api-version=2016-10-01
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","value":"LuBXhVMmtnGIBMRvyts9PzNgTmAv0XdEmtOPlR6o-Q_4rKMc7tY2x9zuIWF3ZL4HnZsnq7PF4RYFHzdQNg6oCliyREcR4yMQoMriQkK3Rzl-qMLAXdDOzVQvDZBqYGXW8yPD9fUztbDveIuB73-BBveb_eX0ct0hJ4SpSE6uHn1fy9WINuUTU7gNiU5fr21Tkrso56sHA2uLdk7SvYTe83ti_wdK6X-SxU_i3F2F9zsOjI14eCAo0i6s6KjhuABjVw3UJkQe177TFB92uk6Mr42ezFb7XtIyx50blB_48jSEQCJz54wgsB8u_YmJlCOnz-o0jbEnB7oXH3g_COxxwg"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16","value":"pOjk3DQlJLIApoJ97H23OlxNlhF89x65K0Ias4OMWO19wmuMbS8TsEGmFhkHeDwDcVahIINYKGXPIqo49LlAEr8cztwMpBjn8sx7gZ1FE3H1SRPbrQek7L3xyMomXlVYzJX2NK2sGfpX4aXGlKI_GjbBm4S8OQMrY7oYzZcnm-IR6panycbZG63YNEmJmq0dDckU6fa7B8DfMnbRc0NlKmyl8ZxlAIkLQZwFajSkM_YX8U6MLHokl-IgnrPU_5sAsi2v_1S5JvhoZ_jxIh8_lveX9sXFg9FtEINk6lWLU9j_u80rZQgmhE10XLgWEY-P7zMUEHSwEbuAUHC-cmcvxQ"}'
     headers:
       cache-control:
       - no-cache
@@ -171,7 +171,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:00 GMT
+      - Mon, 04 Oct 2021 19:24:44 GMT
       expires:
       - '-1'
       pragma:
@@ -185,14 +185,14 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "LuBXhVMmtnGIBMRvyts9PzNgTmAv0XdEmtOPlR6o-Q_4rKMc7tY2x9zuIWF3ZL4HnZsnq7PF4RYFHzdQNg6oCliyREcR4yMQoMriQkK3Rzl-qMLAXdDOzVQvDZBqYGXW8yPD9fUztbDveIuB73-BBveb_eX0ct0hJ4SpSE6uHn1fy9WINuUTU7gNiU5fr21Tkrso56sHA2uLdk7SvYTe83ti_wdK6X-SxU_i3F2F9zsOjI14eCAo0i6s6KjhuABjVw3UJkQe177TFB92uk6Mr42ezFb7XtIyx50blB_48jSEQCJz54wgsB8u_YmJlCOnz-o0jbEnB7oXH3g_COxxwg"}'
+    body: '{"alg": "RSA-OAEP", "value": "pOjk3DQlJLIApoJ97H23OlxNlhF89x65K0Ias4OMWO19wmuMbS8TsEGmFhkHeDwDcVahIINYKGXPIqo49LlAEr8cztwMpBjn8sx7gZ1FE3H1SRPbrQek7L3xyMomXlVYzJX2NK2sGfpX4aXGlKI_GjbBm4S8OQMrY7oYzZcnm-IR6panycbZG63YNEmJmq0dDckU6fa7B8DfMnbRc0NlKmyl8ZxlAIkLQZwFajSkM_YX8U6MLHokl-IgnrPU_5sAsi2v_1S5JvhoZ_jxIh8_lveX9sXFg9FtEINk6lWLU9j_u80rZQgmhE10XLgWEY-P7zMUEHSwEbuAUHC-cmcvxQ"}'
     headers:
       Accept:
       - application/json
@@ -207,10 +207,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b/decrypt?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16/decrypt?api-version=2016-10-01
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control:
       - no-cache
@@ -219,7 +219,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:00 GMT
+      - Mon, 04 Oct 2021 19:24:44 GMT
       expires:
       - '-1'
       pragma:
@@ -233,7 +233,147 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/?api-version=2016-10-01
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"plzPCwknLANpyWRBAgmey1NiiRVh176PsqiIllMRUgm6vaF4zycoF8jYGCh-kKgRpi9QKoeX4F5PznodZkrtEjBwDe-D3vnEBf00Zx5Z-2rOm9ew6cGdNnCcXlIK8N2RI-5_hMlG2D4QJ1Qyrbk9RZrE2wFdMrYEGJ6viLqqELWdg0N3ufShBcKWIsHkLEoC-2lIbxpRJ4cNt_eSzIYUy6iykAQsMhfeqTHhO7JrrhZL7ZL1wMH6OHW5ztn7ci5x9anInW2JfE1gNDEzuyXgJF4IaT5oXPr2MZMY1ZHijQGXFvBoQ9ZuWwwrBQfsMnx8grqGwfasjOGnNPkFZAQFjQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375484,"updated":1633375484,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16/encrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16","value":"HEtZ6OQlVOT_LCPD2tiLb7flgAwDs4C6WRD7E_KAMScNQn7_l7z9MkTPB_AL1NhgmJGmuKIoHn5iNM2jy2RX1BGMi-eJZi9PYQBICdYGlZUK289cBoucW3nom0kvLSpV_D6LU_5xHOLAhhTnEJbuqUFmDqCQms9_StZ4nsM642iCpgrnGSqQ879Y5dQkkWg7HeY3fdNi8eFGF1Sig4CCZjTVfIYdhLhS-cEVjD22FHwo0ltWEy90tK8fpFfF4rLRQQHsliDrk5l9mOkcgvbnpyGGdwpx5syS04UKiHgoukloZFH84iMrob-iKnji22DWHkt4N5BtJc2gGPnkb2W1cA"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "HEtZ6OQlVOT_LCPD2tiLb7flgAwDs4C6WRD7E_KAMScNQn7_l7z9MkTPB_AL1NhgmJGmuKIoHn5iNM2jy2RX1BGMi-eJZi9PYQBICdYGlZUK289cBoucW3nom0kvLSpV_D6LU_5xHOLAhhTnEJbuqUFmDqCQms9_StZ4nsM642iCpgrnGSqQ879Y5dQkkWg7HeY3fdNi8eFGF1Sig4CCZjTVfIYdhLhS-cEVjD22FHwo0ltWEy90tK8fpFfF4rLRQQHsliDrk5l9mOkcgvbnpyGGdwpx5syS04UKiHgoukloZFH84iMrob-iKnji22DWHkt4N5BtJc2gGPnkb2W1cA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16/decrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/a2a96b618bc242298eaf472fd11c1f16","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_2016_10_01_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_2016_10_01_vault.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '97'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:48:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ykKfQcK6mcf85B4HydLBTIN-X_55HptNrp1lcr4lL0sQDSb0EWItcOtjzGUuUx7KjracmZIE4JbzdF68PCS-3t5qQKrEkyB42LpvTQTwcKzZ7qXTOKWwMfrWOo9ztPbq0qKiNNwDF1ivBrhZ_5S6Bcpum28zZZFmjkjyHB06KKSFuAUo97VfZdZKyx2r_F9nM12E-aI28PgNcxW_8lruEoGb4kuTWZawtOFBzpla-xfcrxPTnvknOVRo9MugF7VFsboW0xRXTMlevqJy5w4HrEkMwzbBdmKT4ZxtSw12ucsQQ7lq1PAHpZZaSLJvEqnvMgEtPBzWHKjgj0p8iu-_1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074540,"updated":1633074540,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b?api-version=2016-10-01
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ykKfQcK6mcf85B4HydLBTIN-X_55HptNrp1lcr4lL0sQDSb0EWItcOtjzGUuUx7KjracmZIE4JbzdF68PCS-3t5qQKrEkyB42LpvTQTwcKzZ7qXTOKWwMfrWOo9ztPbq0qKiNNwDF1ivBrhZ_5S6Bcpum28zZZFmjkjyHB06KKSFuAUo97VfZdZKyx2r_F9nM12E-aI28PgNcxW_8lruEoGb4kuTWZawtOFBzpla-xfcrxPTnvknOVRo9MugF7VFsboW0xRXTMlevqJy5w4HrEkMwzbBdmKT4ZxtSw12ucsQQ7lq1PAHpZZaSLJvEqnvMgEtPBzWHKjgj0p8iu-_1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074540,"updated":1633074540,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b/encrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","value":"LuBXhVMmtnGIBMRvyts9PzNgTmAv0XdEmtOPlR6o-Q_4rKMc7tY2x9zuIWF3ZL4HnZsnq7PF4RYFHzdQNg6oCliyREcR4yMQoMriQkK3Rzl-qMLAXdDOzVQvDZBqYGXW8yPD9fUztbDveIuB73-BBveb_eX0ct0hJ4SpSE6uHn1fy9WINuUTU7gNiU5fr21Tkrso56sHA2uLdk7SvYTe83ti_wdK6X-SxU_i3F2F9zsOjI14eCAo0i6s6KjhuABjVw3UJkQe177TFB92uk6Mr42ezFb7XtIyx50blB_48jSEQCJz54wgsB8u_YmJlCOnz-o0jbEnB7oXH3g_COxxwg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "LuBXhVMmtnGIBMRvyts9PzNgTmAv0XdEmtOPlR6o-Q_4rKMc7tY2x9zuIWF3ZL4HnZsnq7PF4RYFHzdQNg6oCliyREcR4yMQoMriQkK3Rzl-qMLAXdDOzVQvDZBqYGXW8yPD9fUztbDveIuB73-BBveb_eX0ct0hJ4SpSE6uHn1fy9WINuUTU7gNiU5fr21Tkrso56sHA2uLdk7SvYTe83ti_wdK6X-SxU_i3F2F9zsOjI14eCAo0i6s6KjhuABjVw3UJkQe177TFB92uk6Mr42ezFb7XtIyx50blB_48jSEQCJz54wgsB8u_YmJlCOnz-o0jbEnB7oXH3g_COxxwg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b/decrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namef7f11770/419f73c50f5643d4ab5e5847e7e0fd4b","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_0_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_0_vault.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/create?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '97'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tS6v-2KnqehPS6YMsePxICb-m0DzOXSQTjNSKvQ85lxLxD0mdmZfH3kf7Oy1xjG0hak1g_2G7u6_naJ9wEFjmJS9Kng3MG7milEHUZRQYgTkSHWT9fkCmYG6_y7TerFG4mjdiNq6Ticn379ngiZbNLcSrcfUwzkU_ICjwqC8MCHOKuwaupraF7DAklNcmx94k5CnD0en7kjHiG7wVdom1MvkummwdEjFq7-rMMdhMJkXC7hTqn3wp6j01Wu2t5_l_AxvijsjM7GkZTwF7S9muzAG0MUfeavR4juZR64RSBUgadoOyqNQnCi8zlaknZr03Wajo3mAaO8ZDDgVZfGF_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074544,"updated":1633074544,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tS6v-2KnqehPS6YMsePxICb-m0DzOXSQTjNSKvQ85lxLxD0mdmZfH3kf7Oy1xjG0hak1g_2G7u6_naJ9wEFjmJS9Kng3MG7milEHUZRQYgTkSHWT9fkCmYG6_y7TerFG4mjdiNq6Ticn379ngiZbNLcSrcfUwzkU_ICjwqC8MCHOKuwaupraF7DAklNcmx94k5CnD0en7kjHiG7wVdom1MvkummwdEjFq7-rMMdhMJkXC7hTqn3wp6j01Wu2t5_l_AxvijsjM7GkZTwF7S9muzAG0MUfeavR4juZR64RSBUgadoOyqNQnCi8zlaknZr03Wajo3mAaO8ZDDgVZfGF_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074544,"updated":1633074544,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","value":"lS5k0WFEsNbBnwgTxx-zSiDX3h7bGBCMj2jzG-jxnYgshIwE4O8SwnehwdTHFAhzFWFNZZfPeTn4bdFzlLZNGomkt8uI04YVqjoc1TEIuCXf1baB-wQ0wnJKd2QOBFMnCC8VD0D94-aB6mww2PHg4tnpCGeSU8I9Lv--OV2lRm2Ns1eWzMx1y9I89_gYxYukieAM9LxgtLeWvL_22LgAoD5V44j_RS5Yv-g2UnjzGPkzHUD2LLh15_MSw-wY40ertJr9INsVbYZalZ7gSuB1bclwoVaHRLReTlkPO4XaMThUpmwadU6qBrFCo0ADfCjl2JTZmqRUCmG6GSj5rzBYUg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "lS5k0WFEsNbBnwgTxx-zSiDX3h7bGBCMj2jzG-jxnYgshIwE4O8SwnehwdTHFAhzFWFNZZfPeTn4bdFzlLZNGomkt8uI04YVqjoc1TEIuCXf1baB-wQ0wnJKd2QOBFMnCC8VD0D94-aB6mww2PHg4tnpCGeSU8I9Lv--OV2lRm2Ns1eWzMx1y9I89_gYxYukieAM9LxgtLeWvL_22LgAoD5V44j_RS5Yv-g2UnjzGPkzHUD2LLh15_MSw-wY40ertJr9INsVbYZalZ7gSuB1bclwoVaHRLReTlkPO4XaMThUpmwadU6qBrFCo0ADfCjl2JTZmqRUCmG6GSj5rzBYUg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_0_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_0_vault.yaml
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:02 GMT
+      - Mon, 04 Oct 2021 19:24:46 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +45,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -70,7 +70,7 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tS6v-2KnqehPS6YMsePxICb-m0DzOXSQTjNSKvQ85lxLxD0mdmZfH3kf7Oy1xjG0hak1g_2G7u6_naJ9wEFjmJS9Kng3MG7milEHUZRQYgTkSHWT9fkCmYG6_y7TerFG4mjdiNq6Ticn379ngiZbNLcSrcfUwzkU_ICjwqC8MCHOKuwaupraF7DAklNcmx94k5CnD0en7kjHiG7wVdom1MvkummwdEjFq7-rMMdhMJkXC7hTqn3wp6j01Wu2t5_l_AxvijsjM7GkZTwF7S9muzAG0MUfeavR4juZR64RSBUgadoOyqNQnCi8zlaknZr03Wajo3mAaO8ZDDgVZfGF_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074544,"updated":1633074544,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vH6SMijCnxg1ihZe8UOMNvIETW0Fnq07MKmgn79vxtn8wgx9iCPZ7CqgBddGXGo_2fxxovZH6BcchFLBv4vKy1ueIhtS754Ds_z8C5aAtrja7Try0h-9-8imqm5B0Fs5cA5BTh3huZ2kN2kEa3JDTz3Y0LwWRr8fpCFyYfOzl5iUuGSDvds56kug_D_ELw6UN8roRN7cnHe6cOs5nZUkyk4L13iIsh-1S4KKPI8peuZg78sGoaszivxhFUCQFHiuBjPd7kgVizXvD245b6nwZZIlsGRH1mmhD56Q7IARF6IVVzk_nA4N8dqgwF2rrSGcWCnfGNtmG4v7GF4CBzRNoQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375487,"updated":1633375487,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:03 GMT
+      - Mon, 04 Oct 2021 19:24:48 GMT
       expires:
       - '-1'
       pragma:
@@ -93,7 +93,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -111,10 +111,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tS6v-2KnqehPS6YMsePxICb-m0DzOXSQTjNSKvQ85lxLxD0mdmZfH3kf7Oy1xjG0hak1g_2G7u6_naJ9wEFjmJS9Kng3MG7milEHUZRQYgTkSHWT9fkCmYG6_y7TerFG4mjdiNq6Ticn379ngiZbNLcSrcfUwzkU_ICjwqC8MCHOKuwaupraF7DAklNcmx94k5CnD0en7kjHiG7wVdom1MvkummwdEjFq7-rMMdhMJkXC7hTqn3wp6j01Wu2t5_l_AxvijsjM7GkZTwF7S9muzAG0MUfeavR4juZR64RSBUgadoOyqNQnCi8zlaknZr03Wajo3mAaO8ZDDgVZfGF_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633074544,"updated":1633074544,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vH6SMijCnxg1ihZe8UOMNvIETW0Fnq07MKmgn79vxtn8wgx9iCPZ7CqgBddGXGo_2fxxovZH6BcchFLBv4vKy1ueIhtS754Ds_z8C5aAtrja7Try0h-9-8imqm5B0Fs5cA5BTh3huZ2kN2kEa3JDTz3Y0LwWRr8fpCFyYfOzl5iUuGSDvds56kug_D_ELw6UN8roRN7cnHe6cOs5nZUkyk4L13iIsh-1S4KKPI8peuZg78sGoaszivxhFUCQFHiuBjPd7kgVizXvD245b6nwZZIlsGRH1mmhD56Q7IARF6IVVzk_nA4N8dqgwF2rrSGcWCnfGNtmG4v7GF4CBzRNoQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375487,"updated":1633375487,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
@@ -123,7 +123,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:03 GMT
+      - Mon, 04 Oct 2021 19:24:48 GMT
       expires:
       - '-1'
       pragma:
@@ -137,7 +137,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -159,10 +159,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04/encrypt?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3/encrypt?api-version=7.0
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","value":"lS5k0WFEsNbBnwgTxx-zSiDX3h7bGBCMj2jzG-jxnYgshIwE4O8SwnehwdTHFAhzFWFNZZfPeTn4bdFzlLZNGomkt8uI04YVqjoc1TEIuCXf1baB-wQ0wnJKd2QOBFMnCC8VD0D94-aB6mww2PHg4tnpCGeSU8I9Lv--OV2lRm2Ns1eWzMx1y9I89_gYxYukieAM9LxgtLeWvL_22LgAoD5V44j_RS5Yv-g2UnjzGPkzHUD2LLh15_MSw-wY40ertJr9INsVbYZalZ7gSuB1bclwoVaHRLReTlkPO4XaMThUpmwadU6qBrFCo0ADfCjl2JTZmqRUCmG6GSj5rzBYUg"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3","value":"pAgbVqeWOlL3UO71FkkZLpBYwK3MhzQife02Nib42QpU5bX7e5-WkIdJu3l_vlXgEXZLo4dJsCll36puAn1FR-TXsADCYaNsQuZPSgnJeNFGyo3PWS6t--R7TmUstDBezckffL2ZggJUZi3iIp61vRyUbI4jbEkfMgCvmactqZnQ2yRUD0Gs1LDuPgU_vW2QHCVPMVUiuKtwwX6B8_0k8j06l_sB5nU8KR4OOSxeMxSgNUXSC7d6OmAFwsD_d08YciuJVTkW37RRgI0qrWwqywS7V8HyxgMx0QznvhStVHb6GmpDHogl_IM1B-tIaoo8NHgmwktRNEo2Ex-L2AMpPA"}'
     headers:
       cache-control:
       - no-cache
@@ -171,7 +171,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:03 GMT
+      - Mon, 04 Oct 2021 19:24:48 GMT
       expires:
       - '-1'
       pragma:
@@ -185,14 +185,14 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "lS5k0WFEsNbBnwgTxx-zSiDX3h7bGBCMj2jzG-jxnYgshIwE4O8SwnehwdTHFAhzFWFNZZfPeTn4bdFzlLZNGomkt8uI04YVqjoc1TEIuCXf1baB-wQ0wnJKd2QOBFMnCC8VD0D94-aB6mww2PHg4tnpCGeSU8I9Lv--OV2lRm2Ns1eWzMx1y9I89_gYxYukieAM9LxgtLeWvL_22LgAoD5V44j_RS5Yv-g2UnjzGPkzHUD2LLh15_MSw-wY40ertJr9INsVbYZalZ7gSuB1bclwoVaHRLReTlkPO4XaMThUpmwadU6qBrFCo0ADfCjl2JTZmqRUCmG6GSj5rzBYUg"}'
+    body: '{"alg": "RSA-OAEP", "value": "pAgbVqeWOlL3UO71FkkZLpBYwK3MhzQife02Nib42QpU5bX7e5-WkIdJu3l_vlXgEXZLo4dJsCll36puAn1FR-TXsADCYaNsQuZPSgnJeNFGyo3PWS6t--R7TmUstDBezckffL2ZggJUZi3iIp61vRyUbI4jbEkfMgCvmactqZnQ2yRUD0Gs1LDuPgU_vW2QHCVPMVUiuKtwwX6B8_0k8j06l_sB5nU8KR4OOSxeMxSgNUXSC7d6OmAFwsD_d08YciuJVTkW37RRgI0qrWwqywS7V8HyxgMx0QznvhStVHb6GmpDHogl_IM1B-tIaoo8NHgmwktRNEo2Ex-L2AMpPA"}'
     headers:
       Accept:
       - application/json
@@ -207,10 +207,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04/decrypt?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3/decrypt?api-version=7.0
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/9ee434bb9d974a32b3d4a2e2e0923a04","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control:
       - no-cache
@@ -219,7 +219,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:03 GMT
+      - Mon, 04 Oct 2021 19:24:48 GMT
       expires:
       - '-1'
       pragma:
@@ -233,7 +233,147 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vH6SMijCnxg1ihZe8UOMNvIETW0Fnq07MKmgn79vxtn8wgx9iCPZ7CqgBddGXGo_2fxxovZH6BcchFLBv4vKy1ueIhtS754Ds_z8C5aAtrja7Try0h-9-8imqm5B0Fs5cA5BTh3huZ2kN2kEa3JDTz3Y0LwWRr8fpCFyYfOzl5iUuGSDvds56kug_D_ELw6UN8roRN7cnHe6cOs5nZUkyk4L13iIsh-1S4KKPI8peuZg78sGoaszivxhFUCQFHiuBjPd7kgVizXvD245b6nwZZIlsGRH1mmhD56Q7IARF6IVVzk_nA4N8dqgwF2rrSGcWCnfGNtmG4v7GF4CBzRNoQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375487,"updated":1633375487,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3","value":"k3Lur9oA88kR8QjFERKawlXCUAwhqq5yA6XzSRQe0rA1pmumGJVJyic2DfWaRlOHWKtGlsPmuC2Ek-Fcc_D7dwJOF8bKZ_oNNY7Lu4j2b2dEU_7rl53RiPWmG-Wwwy5OpSMNIFNKE8luAgGK1IqqB1L886q2CEZDnHIVTOMLWDOP9VWHdK7TBEDUVgCao8Xargcba95ma2wTQkQwLy_lw-e73DmStEC80JWFTq7du88NBvwYVpSeHF1wJm5KGreBiYFipUg_Ek28OvR-j1YKZAXYlPmbxLXaisJj0H-s8G5Kh-LqQ--_WbfO9Y6gX1OxA2IG5rAHezmpl1YpGqQkxw"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "k3Lur9oA88kR8QjFERKawlXCUAwhqq5yA6XzSRQe0rA1pmumGJVJyic2DfWaRlOHWKtGlsPmuC2Ek-Fcc_D7dwJOF8bKZ_oNNY7Lu4j2b2dEU_7rl53RiPWmG-Wwwy5OpSMNIFNKE8luAgGK1IqqB1L886q2CEZDnHIVTOMLWDOP9VWHdK7TBEDUVgCao8Xargcba95ma2wTQkQwLy_lw-e73DmStEC80JWFTq7du88NBvwYVpSeHF1wJm5KGreBiYFipUg_Ek28OvR-j1YKZAXYlPmbxLXaisJj0H-s8G5Kh-LqQ--_WbfO9Y6gX1OxA2IG5rAHezmpl1YpGqQkxw"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61eb15ed/740b92fff1b04d419aecb559da03e6d3","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_1_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_1_vault.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/create?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '97'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/create?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0_TZ-SxU0AN5dY8-MzbNwNMViZhiDHUDP042XSgTLYZG-ominRG-Gdh3tCrbWo45j0wua3xoDrQMEJg1jT6W3QChy66oFW6dbtkOnvlH3nP4n4xMVY8JEJJhTsvpOSeTXq9EI1uZOTNrg4XMELBRsbaiBSU8JOgFVwQ8qokxAGNGHjVdK4NajnBh3KJZqgNITWdsu3HeKIR6l2UtyrGJPS46TP0GzgjfqzqE6cs0e0mhOeKhGLa7lpLifrvHRgUdM-Zbm4tRCWx9KQqFmkfOV17iGbawUGerdZHc4kP-q2Zd10N-ykQlh8-DCnC6Jr2DlQDisuFz_eKCYvPttCbFAQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074547,"updated":1633074547,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0_TZ-SxU0AN5dY8-MzbNwNMViZhiDHUDP042XSgTLYZG-ominRG-Gdh3tCrbWo45j0wua3xoDrQMEJg1jT6W3QChy66oFW6dbtkOnvlH3nP4n4xMVY8JEJJhTsvpOSeTXq9EI1uZOTNrg4XMELBRsbaiBSU8JOgFVwQ8qokxAGNGHjVdK4NajnBh3KJZqgNITWdsu3HeKIR6l2UtyrGJPS46TP0GzgjfqzqE6cs0e0mhOeKhGLa7lpLifrvHRgUdM-Zbm4tRCWx9KQqFmkfOV17iGbawUGerdZHc4kP-q2Zd10N-ykQlh8-DCnC6Jr2DlQDisuFz_eKCYvPttCbFAQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074547,"updated":1633074547,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49/encrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","value":"cV5TZOiAXTu56qicHmkRphzl1voPHa_I0OndJXw5sC8rSAAYdjt5ACHlEM1n8YdjHNiixEDjG51zjfdCOl1kKXuVgj2ofFxoD6pzNBcyZLeM_Oz6XDbFLmbazeYeALbDXMxa3MgERbC2Jqt_8ltpgX86_Z2TRjPaSPhsCWvG6M60dZ4-kPkkRWT2Bzk9UYKHoMGHnCiF5HIItZ918jNrsThfAncr3khZgC5oyyCF8CePJMh_esLc8vdO0fpGN1ljVMnKtsRai_KidUgk-m7tg47jjfKaObIXAzYRvHkh86qnt2_uSSWC1FzAsVf7xtMt0W7p01If6t3tASdCwhGEoQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cV5TZOiAXTu56qicHmkRphzl1voPHa_I0OndJXw5sC8rSAAYdjt5ACHlEM1n8YdjHNiixEDjG51zjfdCOl1kKXuVgj2ofFxoD6pzNBcyZLeM_Oz6XDbFLmbazeYeALbDXMxa3MgERbC2Jqt_8ltpgX86_Z2TRjPaSPhsCWvG6M60dZ4-kPkkRWT2Bzk9UYKHoMGHnCiF5HIItZ918jNrsThfAncr3khZgC5oyyCF8CePJMh_esLc8vdO0fpGN1ljVMnKtsRai_KidUgk-m7tg47jjfKaObIXAzYRvHkh86qnt2_uSSWC1FzAsVf7xtMt0W7p01If6t3tASdCwhGEoQ"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49/decrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_1_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_1_vault.yaml
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:06 GMT
+      - Mon, 04 Oct 2021 19:24:50 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +45,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -70,7 +70,7 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0_TZ-SxU0AN5dY8-MzbNwNMViZhiDHUDP042XSgTLYZG-ominRG-Gdh3tCrbWo45j0wua3xoDrQMEJg1jT6W3QChy66oFW6dbtkOnvlH3nP4n4xMVY8JEJJhTsvpOSeTXq9EI1uZOTNrg4XMELBRsbaiBSU8JOgFVwQ8qokxAGNGHjVdK4NajnBh3KJZqgNITWdsu3HeKIR6l2UtyrGJPS46TP0GzgjfqzqE6cs0e0mhOeKhGLa7lpLifrvHRgUdM-Zbm4tRCWx9KQqFmkfOV17iGbawUGerdZHc4kP-q2Zd10N-ykQlh8-DCnC6Jr2DlQDisuFz_eKCYvPttCbFAQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074547,"updated":1633074547,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wyC5qznOx9-mDynQIQS27KL3C_P2QLp13cgQCKrcmYdstGzcgNmOpvRAnpURfmekY1x70GeWOrPJtb1mjXplE5oX1-ufHkBRS_kVLgrrbPx4NC2pAsA7lV8XqMBxkOYNeUBSsCR0miWBYz8zQLFtcPxst9q7l7Wk77J9tMC_3yGf-FoJLMQYWLJBsOpX7Mozs_w7GG7Is7P0puS3xLH-38d12-B0w7W-VIeiP9LDA1GRI9BJ_CcL-1YP_Rz1Lqe0xJPkVHdCY8bVH9k4BAn7t9ibvvOwQRO9pzuST1V860b6IYMurXboU5VRq5hRpxXrghmQmgb0i4ix3tTEqJ5NAQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375491,"updated":1633375491,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:07 GMT
+      - Mon, 04 Oct 2021 19:24:51 GMT
       expires:
       - '-1'
       pragma:
@@ -93,7 +93,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -111,10 +111,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0_TZ-SxU0AN5dY8-MzbNwNMViZhiDHUDP042XSgTLYZG-ominRG-Gdh3tCrbWo45j0wua3xoDrQMEJg1jT6W3QChy66oFW6dbtkOnvlH3nP4n4xMVY8JEJJhTsvpOSeTXq9EI1uZOTNrg4XMELBRsbaiBSU8JOgFVwQ8qokxAGNGHjVdK4NajnBh3KJZqgNITWdsu3HeKIR6l2UtyrGJPS46TP0GzgjfqzqE6cs0e0mhOeKhGLa7lpLifrvHRgUdM-Zbm4tRCWx9KQqFmkfOV17iGbawUGerdZHc4kP-q2Zd10N-ykQlh8-DCnC6Jr2DlQDisuFz_eKCYvPttCbFAQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074547,"updated":1633074547,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wyC5qznOx9-mDynQIQS27KL3C_P2QLp13cgQCKrcmYdstGzcgNmOpvRAnpURfmekY1x70GeWOrPJtb1mjXplE5oX1-ufHkBRS_kVLgrrbPx4NC2pAsA7lV8XqMBxkOYNeUBSsCR0miWBYz8zQLFtcPxst9q7l7Wk77J9tMC_3yGf-FoJLMQYWLJBsOpX7Mozs_w7GG7Is7P0puS3xLH-38d12-B0w7W-VIeiP9LDA1GRI9BJ_CcL-1YP_Rz1Lqe0xJPkVHdCY8bVH9k4BAn7t9ibvvOwQRO9pzuST1V860b6IYMurXboU5VRq5hRpxXrghmQmgb0i4ix3tTEqJ5NAQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375491,"updated":1633375491,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -123,7 +123,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:07 GMT
+      - Mon, 04 Oct 2021 19:24:51 GMT
       expires:
       - '-1'
       pragma:
@@ -137,7 +137,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -159,10 +159,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49/encrypt?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6/encrypt?api-version=7.1
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","value":"cV5TZOiAXTu56qicHmkRphzl1voPHa_I0OndJXw5sC8rSAAYdjt5ACHlEM1n8YdjHNiixEDjG51zjfdCOl1kKXuVgj2ofFxoD6pzNBcyZLeM_Oz6XDbFLmbazeYeALbDXMxa3MgERbC2Jqt_8ltpgX86_Z2TRjPaSPhsCWvG6M60dZ4-kPkkRWT2Bzk9UYKHoMGHnCiF5HIItZ918jNrsThfAncr3khZgC5oyyCF8CePJMh_esLc8vdO0fpGN1ljVMnKtsRai_KidUgk-m7tg47jjfKaObIXAzYRvHkh86qnt2_uSSWC1FzAsVf7xtMt0W7p01If6t3tASdCwhGEoQ"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6","value":"vZd23TlS6jqzI-RUZ1wWs6FCnRmSi28Ruo3iSDbqZmIRgSW-7SW8rO_8_gKzyhEho0YuuNnzKmimPAhku4hs7ropv752OUY9SpPZOMSFSeRWiIyCEAV_ni6_D6xIJlWfIJxi1cfuWAS6bBtdJaEkNmRHBC6nydq87WQyNelm0IFfkOt8wGLnvFSXEAN4W64eLBCIxRTk_veBBsI3I9VG1ZpQ5wIE0Ni9yF4xkETAXl1Y-UDnFy5e7g_kXLzuoUqqHV9cFXI2zuvvjwOPar48vsQtzFX0gR2hpmdDX8iu2bTdBBw1PnAhuJoxG-snigFajYelRh_dqf8YyPeW9pf1YA"}'
     headers:
       cache-control:
       - no-cache
@@ -171,7 +171,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:07 GMT
+      - Mon, 04 Oct 2021 19:24:51 GMT
       expires:
       - '-1'
       pragma:
@@ -185,14 +185,14 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "cV5TZOiAXTu56qicHmkRphzl1voPHa_I0OndJXw5sC8rSAAYdjt5ACHlEM1n8YdjHNiixEDjG51zjfdCOl1kKXuVgj2ofFxoD6pzNBcyZLeM_Oz6XDbFLmbazeYeALbDXMxa3MgERbC2Jqt_8ltpgX86_Z2TRjPaSPhsCWvG6M60dZ4-kPkkRWT2Bzk9UYKHoMGHnCiF5HIItZ918jNrsThfAncr3khZgC5oyyCF8CePJMh_esLc8vdO0fpGN1ljVMnKtsRai_KidUgk-m7tg47jjfKaObIXAzYRvHkh86qnt2_uSSWC1FzAsVf7xtMt0W7p01If6t3tASdCwhGEoQ"}'
+    body: '{"alg": "RSA-OAEP", "value": "vZd23TlS6jqzI-RUZ1wWs6FCnRmSi28Ruo3iSDbqZmIRgSW-7SW8rO_8_gKzyhEho0YuuNnzKmimPAhku4hs7ropv752OUY9SpPZOMSFSeRWiIyCEAV_ni6_D6xIJlWfIJxi1cfuWAS6bBtdJaEkNmRHBC6nydq87WQyNelm0IFfkOt8wGLnvFSXEAN4W64eLBCIxRTk_veBBsI3I9VG1ZpQ5wIE0Ni9yF4xkETAXl1Y-UDnFy5e7g_kXLzuoUqqHV9cFXI2zuvvjwOPar48vsQtzFX0gR2hpmdDX8iu2bTdBBw1PnAhuJoxG-snigFajYelRh_dqf8YyPeW9pf1YA"}'
     headers:
       Accept:
       - application/json
@@ -207,10 +207,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49/decrypt?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6/decrypt?api-version=7.1
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/652742b286b34bbb8b9f188b3ad83e49","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control:
       - no-cache
@@ -219,7 +219,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:07 GMT
+      - Mon, 04 Oct 2021 19:24:51 GMT
       expires:
       - '-1'
       pragma:
@@ -233,7 +233,147 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wyC5qznOx9-mDynQIQS27KL3C_P2QLp13cgQCKrcmYdstGzcgNmOpvRAnpURfmekY1x70GeWOrPJtb1mjXplE5oX1-ufHkBRS_kVLgrrbPx4NC2pAsA7lV8XqMBxkOYNeUBSsCR0miWBYz8zQLFtcPxst9q7l7Wk77J9tMC_3yGf-FoJLMQYWLJBsOpX7Mozs_w7GG7Is7P0puS3xLH-38d12-B0w7W-VIeiP9LDA1GRI9BJ_CcL-1YP_Rz1Lqe0xJPkVHdCY8bVH9k4BAn7t9ibvvOwQRO9pzuST1V860b6IYMurXboU5VRq5hRpxXrghmQmgb0i4ix3tTEqJ5NAQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375491,"updated":1633375491,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6/encrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6","value":"eEmqat-PygM0bx2smIAbpM5HVqdGB5ek2QfbIVAAjhKsJ4G0SxIgLI4IkGWgVWfwosRZ8YYtZnxVuBjUXLlB7QdKpBUiEy14Bg4fcBSRq9VQ2IlWyEBn83hYkhXOy36PHD8_cmaIBpI0piaLm1PuPNcbrCiYbUiARDZMmvnOY_6P7l1xVjpucpLn6AMkR8TmRusYQT9pwtAJTXDO_iDkb3n883lb3RKyXGL6yC25ZLlgbjyJ4fjUeW0dl3Vsw9tchRsltMY2tCSbXW-4_qG4BrsnGFqMrE9yvTMSauHcDanhdupnLlqZQ7v_KYd-71Db0T_-4NJLxpc-ML7sAP6tUg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "eEmqat-PygM0bx2smIAbpM5HVqdGB5ek2QfbIVAAjhKsJ4G0SxIgLI4IkGWgVWfwosRZ8YYtZnxVuBjUXLlB7QdKpBUiEy14Bg4fcBSRq9VQ2IlWyEBn83hYkhXOy36PHD8_cmaIBpI0piaLm1PuPNcbrCiYbUiARDZMmvnOY_6P7l1xVjpucpLn6AMkR8TmRusYQT9pwtAJTXDO_iDkb3n883lb3RKyXGL6yC25ZLlgbjyJ4fjUeW0dl3Vsw9tchRsltMY2tCSbXW-4_qG4BrsnGFqMrE9yvTMSauHcDanhdupnLlqZQ7v_KYd-71Db0T_-4NJLxpc-ML7sAP6tUg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6/decrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f215ee/fcfb920ba6b54ef093020d9398eebdb6","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_mhsm.yaml
@@ -1,0 +1,219 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/create?api-version=7.2
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-server-latency:
+      - '0'
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA-HSM"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/create?api-version=7.2
+  response:
+    body:
+      string: '{"attributes":{"created":1633074550,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074550},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","kty":"RSA-HSM","n":"tkfFqLbweAoQMBtMx-B0mTCCv-JyNTuAWwkZRd8sGUFQW4O-vXFJW0cKVt95GrxNL3hQ6STjgEa4DR2e_WeB6DdXkMbvRUeLqe4RtK-wX0hRG5ECuRy_0bSiUwiExkziNVJubqWuRi9CHjdX0RXSK-9hJyfNkuL2OUEbkYNBif541akY3A1oC_MKuR9pA_1Vmc81kWEqFRI8hBGZYu4O9gsvtmJ8WCIfxcofkYFbMpxPXsgVvaytVA8i22QvQyQ_4pl8RowQhB0Zsa0Hey7Vk9tA5N8kDnDJ5HECI6gLeOY1HKj8PSt_yFsj50t6KI8gNM3M9DwYV1lJoXu-vg2TAw"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '734'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '339'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018?api-version=7.2
+  response:
+    body:
+      string: '{"attributes":{"created":1633074550,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074550},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","kty":"RSA-HSM","n":"tkfFqLbweAoQMBtMx-B0mTCCv-JyNTuAWwkZRd8sGUFQW4O-vXFJW0cKVt95GrxNL3hQ6STjgEa4DR2e_WeB6DdXkMbvRUeLqe4RtK-wX0hRG5ECuRy_0bSiUwiExkziNVJubqWuRi9CHjdX0RXSK-9hJyfNkuL2OUEbkYNBif541akY3A1oC_MKuR9pA_1Vmc81kWEqFRI8hBGZYu4O9gsvtmJ8WCIfxcofkYFbMpxPXsgVvaytVA8i22QvQyQ_4pl8RowQhB0Zsa0Hey7Vk9tA5N8kDnDJ5HECI6gLeOY1HKj8PSt_yFsj50t6KI8gNM3M9DwYV1lJoXu-vg2TAw"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '734'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '79'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","value":"QP9Qy_ObtB6TOnSd12me2IpyzCyrZzYSDVuioUwOPG88RmIG6z9ooan32d5mEMxiQwRsMnvJwFDbXoYyRYYsarnOVyuqOtZqkJFy3xUkwuHjY4f4OGG31wbEhSS_59nGvtJuDu-PuEPN8Jzqo130Uj8a_MCMtXw3wIL9n2Xq2GtTjlev-yMNj-xseBT6NL5aMIt-R-UJ2cD-xW1zTeMsd139ALpGoc4itsj1vY7M3UorkniS4Uuxr9PmA-tFhl7QOETgrsjl1-qE9tqR2X8jfj9_VEAqOOFZuZEj0hRkPI0RT9jU0d4ZQoNdw26PT3DhOtjSTqzLVuH4VglhKOQNAA"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '489'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "QP9Qy_ObtB6TOnSd12me2IpyzCyrZzYSDVuioUwOPG88RmIG6z9ooan32d5mEMxiQwRsMnvJwFDbXoYyRYYsarnOVyuqOtZqkJFy3xUkwuHjY4f4OGG31wbEhSS_59nGvtJuDu-PuEPN8Jzqo130Uj8a_MCMtXw3wIL9n2Xq2GtTjlev-yMNj-xseBT6NL5aMIt-R-UJ2cD-xW1zTeMsd139ALpGoc4itsj1vY7M3UorkniS4Uuxr9PmA-tFhl7QOETgrsjl1-qE9tqR2X8jfj9_VEAqOOFZuZEj0hRkPI0RT9jU0d4ZQoNdw26PT3DhOtjSTqzLVuH4VglhKOQNAA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '159'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '3'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_mhsm.yaml
@@ -61,7 +61,7 @@ interactions:
     uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/create?api-version=7.2
   response:
     body:
-      string: '{"attributes":{"created":1633074550,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074550},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","kty":"RSA-HSM","n":"tkfFqLbweAoQMBtMx-B0mTCCv-JyNTuAWwkZRd8sGUFQW4O-vXFJW0cKVt95GrxNL3hQ6STjgEa4DR2e_WeB6DdXkMbvRUeLqe4RtK-wX0hRG5ECuRy_0bSiUwiExkziNVJubqWuRi9CHjdX0RXSK-9hJyfNkuL2OUEbkYNBif541akY3A1oC_MKuR9pA_1Vmc81kWEqFRI8hBGZYu4O9gsvtmJ8WCIfxcofkYFbMpxPXsgVvaytVA8i22QvQyQ_4pl8RowQhB0Zsa0Hey7Vk9tA5N8kDnDJ5HECI6gLeOY1HKj8PSt_yFsj50t6KI8gNM3M9DwYV1lJoXu-vg2TAw"}}'
+      string: '{"attributes":{"created":1633375495,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375495},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267","kty":"RSA-HSM","n":"nwRnZH23dZ1GHz4Zwf3utyAXXhB_FF9vYUXtyolnviFFm2cipIrK8LAbpFM-eQLVfX_uTEvP679jCZBuEPQ30oQIGrBXORfVXjoccOlaR0X4o9f8qnxQlGCglOqIo1YLKmiwsDao7fjRNTg8M1fMY8c8gpll6o_HAWlfWN5a0LFJgMxnAdSsy35RaexNBZI8Ykeyr0E_dEKLKwHfUR4yhnJY7Cw04FDVuDvOutDXIe2PP7O0BwfC0h8ay1TRLhkW_06RKWra5V2X9JfaxeMTtXel3Phzs2k2WptQrWAI3wevO3CyVpjfzblg5soTckrJJbhLlz9k7gMEzC0F749HkQ"}}'
     headers:
       cache-control:
       - no-cache
@@ -82,7 +82,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-server-latency:
-      - '339'
+      - '242'
     status:
       code: 200
       message: OK
@@ -98,10 +98,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018?api-version=7.2
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267?api-version=7.2
   response:
     body:
-      string: '{"attributes":{"created":1633074550,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074550},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","kty":"RSA-HSM","n":"tkfFqLbweAoQMBtMx-B0mTCCv-JyNTuAWwkZRd8sGUFQW4O-vXFJW0cKVt95GrxNL3hQ6STjgEa4DR2e_WeB6DdXkMbvRUeLqe4RtK-wX0hRG5ECuRy_0bSiUwiExkziNVJubqWuRi9CHjdX0RXSK-9hJyfNkuL2OUEbkYNBif541akY3A1oC_MKuR9pA_1Vmc81kWEqFRI8hBGZYu4O9gsvtmJ8WCIfxcofkYFbMpxPXsgVvaytVA8i22QvQyQ_4pl8RowQhB0Zsa0Hey7Vk9tA5N8kDnDJ5HECI6gLeOY1HKj8PSt_yFsj50t6KI8gNM3M9DwYV1lJoXu-vg2TAw"}}'
+      string: '{"attributes":{"created":1633375495,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375495},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267","kty":"RSA-HSM","n":"nwRnZH23dZ1GHz4Zwf3utyAXXhB_FF9vYUXtyolnviFFm2cipIrK8LAbpFM-eQLVfX_uTEvP679jCZBuEPQ30oQIGrBXORfVXjoccOlaR0X4o9f8qnxQlGCglOqIo1YLKmiwsDao7fjRNTg8M1fMY8c8gpll6o_HAWlfWN5a0LFJgMxnAdSsy35RaexNBZI8Ykeyr0E_dEKLKwHfUR4yhnJY7Cw04FDVuDvOutDXIe2PP7O0BwfC0h8ay1TRLhkW_06RKWra5V2X9JfaxeMTtXel3Phzs2k2WptQrWAI3wevO3CyVpjfzblg5soTckrJJbhLlz9k7gMEzC0F749HkQ"}}'
     headers:
       cache-control:
       - no-cache
@@ -124,7 +124,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-server-latency:
-      - '79'
+      - '75'
     status:
       code: 200
       message: OK
@@ -144,10 +144,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018/encrypt?api-version=7.2
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267/encrypt?api-version=7.2
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","value":"QP9Qy_ObtB6TOnSd12me2IpyzCyrZzYSDVuioUwOPG88RmIG6z9ooan32d5mEMxiQwRsMnvJwFDbXoYyRYYsarnOVyuqOtZqkJFy3xUkwuHjY4f4OGG31wbEhSS_59nGvtJuDu-PuEPN8Jzqo130Uj8a_MCMtXw3wIL9n2Xq2GtTjlev-yMNj-xseBT6NL5aMIt-R-UJ2cD-xW1zTeMsd139ALpGoc4itsj1vY7M3UorkniS4Uuxr9PmA-tFhl7QOETgrsjl1-qE9tqR2X8jfj9_VEAqOOFZuZEj0hRkPI0RT9jU0d4ZQoNdw26PT3DhOtjSTqzLVuH4VglhKOQNAA"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267","value":"TfqINOab3u73xXpdgDxcasIHqSO9vQbuOGleqQRInAeHI9V-6jIY1hIPA7Kr-LVjXZcpmbvSR3mwcoUKaJR6A0fAyPxHg5bz9VKPqPGuv4Hc5kR5Z588IWwwkOkYE0aUCzvHyi6TWxTkcCD4cw6hYk_0qAcPg_cDQYVflEIv2nVaEcwxPMzm0EP_BXji1ccWVUPs5cflhVpLwG6gZcwp6NAjUk8jskbdnN7rxC_XWfVhSs5gnX-jAFAd6-QbmvExd6mKmkAaNmUv2Yklgue9jh37YqUDUzYomkSg5iqm5XCZlBLj2RqbtnnWMrXGzkEYIkn4SJ1x2zV8wSIVCvLJnw"}'
     headers:
       cache-control:
       - no-cache
@@ -173,7 +173,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "QP9Qy_ObtB6TOnSd12me2IpyzCyrZzYSDVuioUwOPG88RmIG6z9ooan32d5mEMxiQwRsMnvJwFDbXoYyRYYsarnOVyuqOtZqkJFy3xUkwuHjY4f4OGG31wbEhSS_59nGvtJuDu-PuEPN8Jzqo130Uj8a_MCMtXw3wIL9n2Xq2GtTjlev-yMNj-xseBT6NL5aMIt-R-UJ2cD-xW1zTeMsd139ALpGoc4itsj1vY7M3UorkniS4Uuxr9PmA-tFhl7QOETgrsjl1-qE9tqR2X8jfj9_VEAqOOFZuZEj0hRkPI0RT9jU0d4ZQoNdw26PT3DhOtjSTqzLVuH4VglhKOQNAA"}'
+    body: '{"alg": "RSA-OAEP", "value": "TfqINOab3u73xXpdgDxcasIHqSO9vQbuOGleqQRInAeHI9V-6jIY1hIPA7Kr-LVjXZcpmbvSR3mwcoUKaJR6A0fAyPxHg5bz9VKPqPGuv4Hc5kR5Z588IWwwkOkYE0aUCzvHyi6TWxTkcCD4cw6hYk_0qAcPg_cDQYVflEIv2nVaEcwxPMzm0EP_BXji1ccWVUPs5cflhVpLwG6gZcwp6NAjUk8jskbdnN7rxC_XWfVhSs5gnX-jAFAd6-QbmvExd6mKmkAaNmUv2Yklgue9jh37YqUDUzYomkSg5iqm5XCZlBLj2RqbtnnWMrXGzkEYIkn4SJ1x2zV8wSIVCvLJnw"}'
     headers:
       Accept:
       - application/json
@@ -188,10 +188,140 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018/decrypt?api-version=7.2
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267/decrypt?api-version=7.2
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/e0ebf7afcdac49360a98b1a042e77018","value":"cGxhaW50ZXh0"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '159'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/?api-version=7.2
+  response:
+    body:
+      string: '{"attributes":{"created":1633375495,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375495},"key":{"e":"AQAB","key_ops":["verify","sign","unwrapKey","decrypt","encrypt","wrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267","kty":"RSA-HSM","n":"nwRnZH23dZ1GHz4Zwf3utyAXXhB_FF9vYUXtyolnviFFm2cipIrK8LAbpFM-eQLVfX_uTEvP679jCZBuEPQ30oQIGrBXORfVXjoccOlaR0X4o9f8qnxQlGCglOqIo1YLKmiwsDao7fjRNTg8M1fMY8c8gpll6o_HAWlfWN5a0LFJgMxnAdSsy35RaexNBZI8Ykeyr0E_dEKLKwHfUR4yhnJY7Cw04FDVuDvOutDXIe2PP7O0BwfC0h8ay1TRLhkW_06RKWra5V2X9JfaxeMTtXel3Phzs2k2WptQrWAI3wevO3CyVpjfzblg5soTckrJJbhLlz9k7gMEzC0F749HkQ"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '734'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267","value":"XxS2T7mjAOBktc5TV3cuO2kiiLK4pl6aiITQfR3ZWHczonU0dC3aEGoc00_RrbXEzEZ4Y84dXv_cHPOJrc_QJTHQCYKMPFkxXP39_70zNH4n4Zu49AlPKtz-sY6WL45pFrLvnU3pCx3nvEcL9ERgKMU53KPP8nsnabeRhWNFpqrpCiwgnnDvxiR1WIIVUGBV2sRqewCrHEf4s-469eqCPOPL3IsKqbo0Ox4GWVY3epYp_w1rjavosg6j35WSqBUVgck_yaAgbOORFCz36f5W2_plu7UI35IIZkIWG70zQE8udlMFPWNwUKAV-UqjFfN3ihSA3n4bNYlzT0L1-1A95A"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '489'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "XxS2T7mjAOBktc5TV3cuO2kiiLK4pl6aiITQfR3ZWHczonU0dC3aEGoc00_RrbXEzEZ4Y84dXv_cHPOJrc_QJTHQCYKMPFkxXP39_70zNH4n4Zu49AlPKtz-sY6WL45pFrLvnU3pCx3nvEcL9ERgKMU53KPP8nsnabeRhWNFpqrpCiwgnnDvxiR1WIIVUGBV2sRqewCrHEf4s-469eqCPOPL3IsKqbo0Ox4GWVY3epYp_w1rjavosg6j35WSqBUVgck_yaAgbOORFCz36f5W2_plu7UI35IIZkIWG70zQE8udlMFPWNwUKAV-UqjFfN3ihSA3n4bNYlzT0L1-1A95A"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4bf81578/7c75c5205a9e4990b08c3ef4aa166267","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control:
       - no-cache

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_vault.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/create?api-version=7.2
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '97'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/create?api-version=7.2
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"nZzoRe1VB38ljPvBiGZSxuTA8feFSfqBaTZFM_UX7eCdXYWEI7IJ4RGErZeYV_vQPcP0JfclgB-IY_7SfzvMd6YthjJCnXiwVh4KM5rsgcpccO8-1p31RNS-nloCqQjptJKirW-utOooLmmb_0eDgdF4yD_wYtQgnKyinUxFqDomxprvn5j-KCXgdEgmWVpT9lbXYJAOBjlj3tne63FlDbqTmjZn3WVHXwi7nOUxijay76MzytMG6j0oYDEsEIO88NiwjUnrLmfGT1ATSK7wSrQQoW5mmegfiGL8frP4nwHwoowCfTOsCN5bpB0KXoXmFVU0Loz-uA81yDMDQA_yyQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074554,"updated":1633074554,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4?api-version=7.2
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"nZzoRe1VB38ljPvBiGZSxuTA8feFSfqBaTZFM_UX7eCdXYWEI7IJ4RGErZeYV_vQPcP0JfclgB-IY_7SfzvMd6YthjJCnXiwVh4KM5rsgcpccO8-1p31RNS-nloCqQjptJKirW-utOooLmmb_0eDgdF4yD_wYtQgnKyinUxFqDomxprvn5j-KCXgdEgmWVpT9lbXYJAOBjlj3tne63FlDbqTmjZn3WVHXwi7nOUxijay76MzytMG6j0oYDEsEIO88NiwjUnrLmfGT1ATSK7wSrQQoW5mmegfiGL8frP4nwHwoowCfTOsCN5bpB0KXoXmFVU0Loz-uA81yDMDQA_yyQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074554,"updated":1633074554,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","value":"NIH1Glbg6bHRYjaGeRopwQHT5ACtfBq3_hBE742l-pbDkzto55gvIdOKVSk_V0OGmLgIztFIVBsdFzAi0OyO4i3duKogyuGYDdcb5a7EWAQcTlHAChIyZlT93EBd5HO9Yp5eayhyKrartv9Oc51UE_U3WwFox_mO5sLG4WXvFuY0fnEQZJFp6Yfjk8OpX3Ry8X572x5ops6hWSdkihE1vklCA5OTPP-lcQHTM3EAdPIGKgQio0ZqiM-v9G8aX6sil16y4kIwBCcJI_QyPxMoCLzgI17vnCXxVlmwv8hT0ssAPAW5iPqb8KWvWMaVl6islwvxZ9iSWWhyCz1G798wBg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "NIH1Glbg6bHRYjaGeRopwQHT5ACtfBq3_hBE742l-pbDkzto55gvIdOKVSk_V0OGmLgIztFIVBsdFzAi0OyO4i3duKogyuGYDdcb5a7EWAQcTlHAChIyZlT93EBd5HO9Yp5eayhyKrartv9Oc51UE_U3WwFox_mO5sLG4WXvFuY0fnEQZJFp6Yfjk8OpX3Ry8X572x5ops6hWSdkihE1vklCA5OTPP-lcQHTM3EAdPIGKgQio0ZqiM-v9G8aX6sil16y4kIwBCcJI_QyPxMoCLzgI17vnCXxVlmwv8hT0ssAPAW5iPqb8KWvWMaVl6islwvxZ9iSWWhyCz1G798wBg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_2_vault.yaml
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:13 GMT
+      - Mon, 04 Oct 2021 19:24:57 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +45,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -70,7 +70,7 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"nZzoRe1VB38ljPvBiGZSxuTA8feFSfqBaTZFM_UX7eCdXYWEI7IJ4RGErZeYV_vQPcP0JfclgB-IY_7SfzvMd6YthjJCnXiwVh4KM5rsgcpccO8-1p31RNS-nloCqQjptJKirW-utOooLmmb_0eDgdF4yD_wYtQgnKyinUxFqDomxprvn5j-KCXgdEgmWVpT9lbXYJAOBjlj3tne63FlDbqTmjZn3WVHXwi7nOUxijay76MzytMG6j0oYDEsEIO88NiwjUnrLmfGT1ATSK7wSrQQoW5mmegfiGL8frP4nwHwoowCfTOsCN5bpB0KXoXmFVU0Loz-uA81yDMDQA_yyQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074554,"updated":1633074554,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"u1li5tcYDY65RQ3pAOUtu1PviY6pMDI3cRZ5ngyWpyAbP5MLFn_7zBcBEwCQ6GAawsCzXspvkjz6O1ZQ2LtaMq5PS0XDgzj2xKvOZdNWiyevHzAgixgB3QTeD4pk-PMgWqzJSlCt6vVUgpyKReoF6uJL9ezN5ot-Y0wNVcOS3NlwVKkRsAaujbsozfDMf6YHaSh-lXFmGNPcnYIyZzJzLfDUMhuKifBL_d2Jf9OTACvHNMfMUtxdm0FtBjWnxVqZVPfzqJ-oiLu8uWs42z6X7qy6A70qp3GshEzKDYdR6VoUsLtrdbTqvM2bQsV8-z5ivW_HpgTDSmTJHlbNuhKg0Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375498,"updated":1633375498,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:14 GMT
+      - Mon, 04 Oct 2021 19:24:58 GMT
       expires:
       - '-1'
       pragma:
@@ -93,7 +93,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -111,10 +111,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"nZzoRe1VB38ljPvBiGZSxuTA8feFSfqBaTZFM_UX7eCdXYWEI7IJ4RGErZeYV_vQPcP0JfclgB-IY_7SfzvMd6YthjJCnXiwVh4KM5rsgcpccO8-1p31RNS-nloCqQjptJKirW-utOooLmmb_0eDgdF4yD_wYtQgnKyinUxFqDomxprvn5j-KCXgdEgmWVpT9lbXYJAOBjlj3tne63FlDbqTmjZn3WVHXwi7nOUxijay76MzytMG6j0oYDEsEIO88NiwjUnrLmfGT1ATSK7wSrQQoW5mmegfiGL8frP4nwHwoowCfTOsCN5bpB0KXoXmFVU0Loz-uA81yDMDQA_yyQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074554,"updated":1633074554,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"u1li5tcYDY65RQ3pAOUtu1PviY6pMDI3cRZ5ngyWpyAbP5MLFn_7zBcBEwCQ6GAawsCzXspvkjz6O1ZQ2LtaMq5PS0XDgzj2xKvOZdNWiyevHzAgixgB3QTeD4pk-PMgWqzJSlCt6vVUgpyKReoF6uJL9ezN5ot-Y0wNVcOS3NlwVKkRsAaujbsozfDMf6YHaSh-lXFmGNPcnYIyZzJzLfDUMhuKifBL_d2Jf9OTACvHNMfMUtxdm0FtBjWnxVqZVPfzqJ-oiLu8uWs42z6X7qy6A70qp3GshEzKDYdR6VoUsLtrdbTqvM2bQsV8-z5ivW_HpgTDSmTJHlbNuhKg0Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375498,"updated":1633375498,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -123,7 +123,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:14 GMT
+      - Mon, 04 Oct 2021 19:24:58 GMT
       expires:
       - '-1'
       pragma:
@@ -137,7 +137,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -159,10 +159,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4/encrypt?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089/encrypt?api-version=7.2
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","value":"NIH1Glbg6bHRYjaGeRopwQHT5ACtfBq3_hBE742l-pbDkzto55gvIdOKVSk_V0OGmLgIztFIVBsdFzAi0OyO4i3duKogyuGYDdcb5a7EWAQcTlHAChIyZlT93EBd5HO9Yp5eayhyKrartv9Oc51UE_U3WwFox_mO5sLG4WXvFuY0fnEQZJFp6Yfjk8OpX3Ry8X572x5ops6hWSdkihE1vklCA5OTPP-lcQHTM3EAdPIGKgQio0ZqiM-v9G8aX6sil16y4kIwBCcJI_QyPxMoCLzgI17vnCXxVlmwv8hT0ssAPAW5iPqb8KWvWMaVl6islwvxZ9iSWWhyCz1G798wBg"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089","value":"HO8gvuZD6qEzO2P7okZBTjr4njgVGT5lKCJO4t7mcc8wDqUVvKx3ct5IkxYrT021opJ7fMlVjFS-5nnaRJJpDu_l9fr9DeWxzdCO6urHZw4MXTsUpmLMTE_NuUEj5X2CWopRRIgUpvsUhk7IjRc4RCyxLvcQgPOu3bSn16ZWaXTCOMUJN7FhvvqeWRJGqyG3xQnEjmRs-VPyQqeUUZaLzysK66dQuWs-SGt_R9564-2pbFtaa74bitkiLuL6AFE0eyMDD1tWZcxX2TGjNfYAmg_rANIRVhNeWM-bAU2_EaLZF5xf0hOCZgd2JnzBtx1tcFs3AmA9yKfsCZ3QUyaH2w"}'
     headers:
       cache-control:
       - no-cache
@@ -171,7 +171,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:14 GMT
+      - Mon, 04 Oct 2021 19:24:58 GMT
       expires:
       - '-1'
       pragma:
@@ -185,14 +185,14 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "NIH1Glbg6bHRYjaGeRopwQHT5ACtfBq3_hBE742l-pbDkzto55gvIdOKVSk_V0OGmLgIztFIVBsdFzAi0OyO4i3duKogyuGYDdcb5a7EWAQcTlHAChIyZlT93EBd5HO9Yp5eayhyKrartv9Oc51UE_U3WwFox_mO5sLG4WXvFuY0fnEQZJFp6Yfjk8OpX3Ry8X572x5ops6hWSdkihE1vklCA5OTPP-lcQHTM3EAdPIGKgQio0ZqiM-v9G8aX6sil16y4kIwBCcJI_QyPxMoCLzgI17vnCXxVlmwv8hT0ssAPAW5iPqb8KWvWMaVl6islwvxZ9iSWWhyCz1G798wBg"}'
+    body: '{"alg": "RSA-OAEP", "value": "HO8gvuZD6qEzO2P7okZBTjr4njgVGT5lKCJO4t7mcc8wDqUVvKx3ct5IkxYrT021opJ7fMlVjFS-5nnaRJJpDu_l9fr9DeWxzdCO6urHZw4MXTsUpmLMTE_NuUEj5X2CWopRRIgUpvsUhk7IjRc4RCyxLvcQgPOu3bSn16ZWaXTCOMUJN7FhvvqeWRJGqyG3xQnEjmRs-VPyQqeUUZaLzysK66dQuWs-SGt_R9564-2pbFtaa74bitkiLuL6AFE0eyMDD1tWZcxX2TGjNfYAmg_rANIRVhNeWM-bAU2_EaLZF5xf0hOCZgd2JnzBtx1tcFs3AmA9yKfsCZ3QUyaH2w"}'
     headers:
       Accept:
       - application/json
@@ -207,10 +207,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4/decrypt?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089/decrypt?api-version=7.2
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/50be3c4c47304357923e278fc5359fb4","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control:
       - no-cache
@@ -219,7 +219,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:14 GMT
+      - Mon, 04 Oct 2021 19:24:58 GMT
       expires:
       - '-1'
       pragma:
@@ -233,7 +233,147 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/?api-version=7.2
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"u1li5tcYDY65RQ3pAOUtu1PviY6pMDI3cRZ5ngyWpyAbP5MLFn_7zBcBEwCQ6GAawsCzXspvkjz6O1ZQ2LtaMq5PS0XDgzj2xKvOZdNWiyevHzAgixgB3QTeD4pk-PMgWqzJSlCt6vVUgpyKReoF6uJL9ezN5ot-Y0wNVcOS3NlwVKkRsAaujbsozfDMf6YHaSh-lXFmGNPcnYIyZzJzLfDUMhuKifBL_d2Jf9OTACvHNMfMUtxdm0FtBjWnxVqZVPfzqJ-oiLu8uWs42z6X7qy6A70qp3GshEzKDYdR6VoUsLtrdbTqvM2bQsV8-z5ivW_HpgTDSmTJHlbNuhKg0Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375498,"updated":1633375498,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089","value":"oFcWZyzheowbl2myLTGsOGlND33SsDRn6t-tZns89bvzP4NVris7i-Nq8olAlBKw52mWNOWEAUfsxGWMnCVbXToHrASFSUXd6pf1KdSkZPAgUVFX8HAckZjysTS2FKMK6CgENkLeRQK7UNo5wUFCAUGyXJsarQGVMdqDuX34ink0VHratQDV3ggwqX7qbVVAWd26k0fFFxr2FNsZU0WX3CTrr3MBnkL_pH69WQjZ-Utp3ZePbVLmqGneYR6mYWf_auW40xRBR0q6F7CnGvQKxYBELGJfgGFtKykLz7hzhcku-2vis2hZkZTtZh8uzexz5N0regAAZH6Ard0tzN2OOg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "oFcWZyzheowbl2myLTGsOGlND33SsDRn6t-tZns89bvzP4NVris7i-Nq8olAlBKw52mWNOWEAUfsxGWMnCVbXToHrASFSUXd6pf1KdSkZPAgUVFX8HAckZjysTS2FKMK6CgENkLeRQK7UNo5wUFCAUGyXJsarQGVMdqDuX34ink0VHratQDV3ggwqX7qbVVAWd26k0fFFxr2FNsZU0WX3CTrr3MBnkL_pH69WQjZ-Utp3ZePbVLmqGneYR6mYWf_auW40xRBR0q6F7CnGvQKxYBELGJfgGFtKykLz7hzhcku-2vis2hZkZTtZh8uzexz5N0regAAZH6Ard0tzN2OOg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name61f915ef/ae4d1f53a9c348e0ad9f8192c88b8089","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:24:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_mhsm.yaml
@@ -1,0 +1,219 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/create?api-version=7.3-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-server-latency:
+      - '1'
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA-HSM"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/create?api-version=7.3-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1633074558,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074558},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","kty":"RSA-HSM","n":"xtN6v_36QCW1q4t5o3PRSrWXDqytMbR-SdnUM0UJmmKpII_2xR-3hD3N8NiT1bI9yd70MXaVo3029h2l4Vysf82TaS0u3T6dJKz6fkx-kuilLM5CsvQO8agM5LVeDQ3W2UIU21LtylLrhxUdF-hRDAVkAMJ_pqmp0IKr84gQkHN1O3Uvu0UuEHZg0H_jSOamWlVqAuOF8CpslChKXmcMl5XvzZtl7jMIZymypxvL6JBSfyaUywTGiozGhzPa33Z6akUxh7iOaVSPfGwXyLBGIKLk393eZ6zwX7uLJ2grfZt-k8mGEcM7rD_e5giXdkAOpZ6zlctcRqEHOQUvz9Ut-Q"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '733'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '308'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba?api-version=7.3-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1633074558,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074558},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","kty":"RSA-HSM","n":"xtN6v_36QCW1q4t5o3PRSrWXDqytMbR-SdnUM0UJmmKpII_2xR-3hD3N8NiT1bI9yd70MXaVo3029h2l4Vysf82TaS0u3T6dJKz6fkx-kuilLM5CsvQO8agM5LVeDQ3W2UIU21LtylLrhxUdF-hRDAVkAMJ_pqmp0IKr84gQkHN1O3Uvu0UuEHZg0H_jSOamWlVqAuOF8CpslChKXmcMl5XvzZtl7jMIZymypxvL6JBSfyaUywTGiozGhzPa33Z6akUxh7iOaVSPfGwXyLBGIKLk393eZ6zwX7uLJ2grfZt-k8mGEcM7rD_e5giXdkAOpZ6zlctcRqEHOQUvz9Ut-Q"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '733'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '78'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","value":"Pe0URTuiYIDBGqioUcPJeEq1Awih2vJFiX3fIjB5AH_BYXX0aE0Ns8BnynJ_c9VnCHjpoBSR_nW6C-mBwfEGXGj1Mk-ZidAsdwZwlXQ9SdL4qCYcAfBmJTrsLMkgjfbm68XciU71cen3INLidD7sBhrQQVyRH5q-R80f_T0RFGZLfw1atcbHfbabkP1y2JFo7yaO0DXbtjpuHKnb1FDMRyv5TdpBI4YJZqKnUXeVPwA8FTJQIFppG3JrEbbeoijTY13QoYMhSL51IoHS_oQqbT7pXztUzcZKHv8mpW67iNmPT9WPQUh1Ol0GFibMO7BzdHfp6aooaimfD5hr1JP1zg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '488'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "Pe0URTuiYIDBGqioUcPJeEq1Awih2vJFiX3fIjB5AH_BYXX0aE0Ns8BnynJ_c9VnCHjpoBSR_nW6C-mBwfEGXGj1Mk-ZidAsdwZwlXQ9SdL4qCYcAfBmJTrsLMkgjfbm68XciU71cen3INLidD7sBhrQQVyRH5q-R80f_T0RFGZLfw1atcbHfbabkP1y2JFo7yaO0DXbtjpuHKnb1FDMRyv5TdpBI4YJZqKnUXeVPwA8FTJQIFppG3JrEbbeoijTY13QoYMhSL51IoHS_oQqbT7pXztUzcZKHv8mpW67iNmPT9WPQUh1Ol0GFibMO7BzdHfp6aooaimfD5hr1JP1zg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '158'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '2'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_mhsm.yaml
@@ -38,7 +38,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-server-latency:
-      - '1'
+      - '0'
     status:
       code: 401
       message: Unauthorized
@@ -61,7 +61,7 @@ interactions:
     uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/create?api-version=7.3-preview
   response:
     body:
-      string: '{"attributes":{"created":1633074558,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074558},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","kty":"RSA-HSM","n":"xtN6v_36QCW1q4t5o3PRSrWXDqytMbR-SdnUM0UJmmKpII_2xR-3hD3N8NiT1bI9yd70MXaVo3029h2l4Vysf82TaS0u3T6dJKz6fkx-kuilLM5CsvQO8agM5LVeDQ3W2UIU21LtylLrhxUdF-hRDAVkAMJ_pqmp0IKr84gQkHN1O3Uvu0UuEHZg0H_jSOamWlVqAuOF8CpslChKXmcMl5XvzZtl7jMIZymypxvL6JBSfyaUywTGiozGhzPa33Z6akUxh7iOaVSPfGwXyLBGIKLk393eZ6zwX7uLJ2grfZt-k8mGEcM7rD_e5giXdkAOpZ6zlctcRqEHOQUvz9Ut-Q"}}'
+      string: '{"attributes":{"created":1633375502,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375502},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e","kty":"RSA-HSM","n":"vPzgFAijDR_kdR6mZQigdGRYRDn3QwpYoR1vmtPe2OLmXWraCZukISwIQyC-JG9T1yqKVR0WqtPuqBxAW45YglQBM14mRBUgZpynv38-gj45pAmyN4pB5OAHX3gaPlx-H1FoyWM2iXLeXuBcqqKOjPryGQtYx5eAaT3zOUp-jbkf8eXSGzBwR4_zvjVkuYD_9kNNx3AxQi13-5D6J7vTBwWbOTmM9MA_pNVVRZIH0HIe8rar0qX5VqKvi2zCajGycMfsd_08BooP4tZvKEP_GEX11Syia52sEaJHgPyZg7ebxufVPy7Z5EUKnNplhRn43M5pm8ezxzy09AElTIjsHQ"}}'
     headers:
       cache-control:
       - no-cache
@@ -82,7 +82,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-server-latency:
-      - '308'
+      - '219'
     status:
       code: 200
       message: OK
@@ -98,10 +98,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba?api-version=7.3-preview
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e?api-version=7.3-preview
   response:
     body:
-      string: '{"attributes":{"created":1633074558,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633074558},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","kty":"RSA-HSM","n":"xtN6v_36QCW1q4t5o3PRSrWXDqytMbR-SdnUM0UJmmKpII_2xR-3hD3N8NiT1bI9yd70MXaVo3029h2l4Vysf82TaS0u3T6dJKz6fkx-kuilLM5CsvQO8agM5LVeDQ3W2UIU21LtylLrhxUdF-hRDAVkAMJ_pqmp0IKr84gQkHN1O3Uvu0UuEHZg0H_jSOamWlVqAuOF8CpslChKXmcMl5XvzZtl7jMIZymypxvL6JBSfyaUywTGiozGhzPa33Z6akUxh7iOaVSPfGwXyLBGIKLk393eZ6zwX7uLJ2grfZt-k8mGEcM7rD_e5giXdkAOpZ6zlctcRqEHOQUvz9Ut-Q"}}'
+      string: '{"attributes":{"created":1633375502,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375502},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e","kty":"RSA-HSM","n":"vPzgFAijDR_kdR6mZQigdGRYRDn3QwpYoR1vmtPe2OLmXWraCZukISwIQyC-JG9T1yqKVR0WqtPuqBxAW45YglQBM14mRBUgZpynv38-gj45pAmyN4pB5OAHX3gaPlx-H1FoyWM2iXLeXuBcqqKOjPryGQtYx5eAaT3zOUp-jbkf8eXSGzBwR4_zvjVkuYD_9kNNx3AxQi13-5D6J7vTBwWbOTmM9MA_pNVVRZIH0HIe8rar0qX5VqKvi2zCajGycMfsd_08BooP4tZvKEP_GEX11Syia52sEaJHgPyZg7ebxufVPy7Z5EUKnNplhRn43M5pm8ezxzy09AElTIjsHQ"}}'
     headers:
       cache-control:
       - no-cache
@@ -124,7 +124,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-server-latency:
-      - '78'
+      - '74'
     status:
       code: 200
       message: OK
@@ -144,10 +144,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba/encrypt?api-version=7.3-preview
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e/encrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","value":"Pe0URTuiYIDBGqioUcPJeEq1Awih2vJFiX3fIjB5AH_BYXX0aE0Ns8BnynJ_c9VnCHjpoBSR_nW6C-mBwfEGXGj1Mk-ZidAsdwZwlXQ9SdL4qCYcAfBmJTrsLMkgjfbm68XciU71cen3INLidD7sBhrQQVyRH5q-R80f_T0RFGZLfw1atcbHfbabkP1y2JFo7yaO0DXbtjpuHKnb1FDMRyv5TdpBI4YJZqKnUXeVPwA8FTJQIFppG3JrEbbeoijTY13QoYMhSL51IoHS_oQqbT7pXztUzcZKHv8mpW67iNmPT9WPQUh1Ol0GFibMO7BzdHfp6aooaimfD5hr1JP1zg"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e","value":"qpmbZDjFUoZr36dC_c9n9yFmXa5ZuVSTsTf-e4MU4nNZY0fjf1GgnK_nsei5gP9QIA3_lDBYYEueQSvnVMo4vP3bh_FQ0X46J4ZyrmMv2z6KWFBT6y3c9qzpjUiXW9bv7dMDS92zzdvcE-K9Bw1Z9UAYifGYnlGMwz3ng2JmTma_KFSYI8zlMg4L9ZHA8IFl2JwK_SXMlXUdCA9OVRZA5IYJ5vrRO8IspXHdy_RNyHaFId36taHVTepV_rhuQWpCdqMgRT8Lq_6b8rilP44bVFPZ1vSzXVE9Ah6hmhB9x5fd0xaG5-kSnP98aU1c8u1AyEZrzyUtCOivGc2Yz9_CVg"}'
     headers:
       cache-control:
       - no-cache
@@ -173,7 +173,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "Pe0URTuiYIDBGqioUcPJeEq1Awih2vJFiX3fIjB5AH_BYXX0aE0Ns8BnynJ_c9VnCHjpoBSR_nW6C-mBwfEGXGj1Mk-ZidAsdwZwlXQ9SdL4qCYcAfBmJTrsLMkgjfbm68XciU71cen3INLidD7sBhrQQVyRH5q-R80f_T0RFGZLfw1atcbHfbabkP1y2JFo7yaO0DXbtjpuHKnb1FDMRyv5TdpBI4YJZqKnUXeVPwA8FTJQIFppG3JrEbbeoijTY13QoYMhSL51IoHS_oQqbT7pXztUzcZKHv8mpW67iNmPT9WPQUh1Ol0GFibMO7BzdHfp6aooaimfD5hr1JP1zg"}'
+    body: '{"alg": "RSA-OAEP", "value": "qpmbZDjFUoZr36dC_c9n9yFmXa5ZuVSTsTf-e4MU4nNZY0fjf1GgnK_nsei5gP9QIA3_lDBYYEueQSvnVMo4vP3bh_FQ0X46J4ZyrmMv2z6KWFBT6y3c9qzpjUiXW9bv7dMDS92zzdvcE-K9Bw1Z9UAYifGYnlGMwz3ng2JmTma_KFSYI8zlMg4L9ZHA8IFl2JwK_SXMlXUdCA9OVRZA5IYJ5vrRO8IspXHdy_RNyHaFId36taHVTepV_rhuQWpCdqMgRT8Lq_6b8rilP44bVFPZ1vSzXVE9Ah6hmhB9x5fd0xaG5-kSnP98aU1c8u1AyEZrzyUtCOivGc2Yz9_CVg"}'
     headers:
       Accept:
       - application/json
@@ -188,10 +188,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba/decrypt?api-version=7.3-preview
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e/decrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/95f5427586e80e2eb883118a8bacd5ba","value":"cGxhaW50ZXh0"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control:
       - no-cache
@@ -213,6 +213,136 @@ interactions:
       - westus
       x-ms-server-latency:
       - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/?api-version=7.3-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1633375502,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375502},"key":{"e":"AQAB","key_ops":["verify","sign","unwrapKey","decrypt","encrypt","wrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e","kty":"RSA-HSM","n":"vPzgFAijDR_kdR6mZQigdGRYRDn3QwpYoR1vmtPe2OLmXWraCZukISwIQyC-JG9T1yqKVR0WqtPuqBxAW45YglQBM14mRBUgZpynv38-gj45pAmyN4pB5OAHX3gaPlx-H1FoyWM2iXLeXuBcqqKOjPryGQtYx5eAaT3zOUp-jbkf8eXSGzBwR4_zvjVkuYD_9kNNx3AxQi13-5D6J7vTBwWbOTmM9MA_pNVVRZIH0HIe8rar0qX5VqKvi2zCajGycMfsd_08BooP4tZvKEP_GEX11Syia52sEaJHgPyZg7ebxufVPy7Z5EUKnNplhRn43M5pm8ezxzy09AElTIjsHQ"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '733'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e","value":"SuYgyp5uKPwpixbpxDdPG-j3DTZrRZ0_NLo6V5ZsG1ivNtdMAZEIofQnt5wGcLA_-HCXwPM1OxZuLriAAmg8sO2waBE8nZaZGF96nHyz9FSrsXBb004xxyLb_XhzfdGFj3RloVypA_P2hgW6L2IJCPXaQMmJgGYOYYKPqvl_OhKlg3PLFtgqJK_OvFAqwX3CRu9qE8JjrqFANvdBRqkLnfavZwRxTIqXr9GF-4wfK7_VVaixMbXICQPn3YHn2zg4x0kjyOBu-Nq6bngaOxTm2pmmZ_A63o2yU3r87HaQEDQ2auXx-DrfFYBOA64gqRxbiPflCLBSeibOlJbB1Sz_LQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '488'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "SuYgyp5uKPwpixbpxDdPG-j3DTZrRZ0_NLo6V5ZsG1ivNtdMAZEIofQnt5wGcLA_-HCXwPM1OxZuLriAAmg8sO2waBE8nZaZGF96nHyz9FSrsXBb004xxyLb_XhzfdGFj3RloVypA_P2hgW6L2IJCPXaQMmJgGYOYYKPqvl_OhKlg3PLFtgqJK_OvFAqwX3CRu9qE8JjrqFANvdBRqkLnfavZwRxTIqXr9GF-4wfK7_VVaixMbXICQPn3YHn2zg4x0kjyOBu-Nq6bngaOxTm2pmmZ_A63o2yU3r87HaQEDQ2auXx-DrfFYBOA64gqRxbiPflCLBSeibOlJbB1Sz_LQ"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name71b18da/bde2c88803e00572af8384ed3a0fce7e","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '158'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-server-latency:
+      - '3'
     status:
       code: 200
       message: OK

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_vault.yaml
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:20 GMT
+      - Mon, 04 Oct 2021 19:25:04 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +45,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -70,7 +70,7 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"y1Rd6lRxUkAgjySnGDoVzbgRIcMewiWUh3TxJqQ4b5SdjBcoB2eDzuZj3tIjroylIr-2aKMjV_xC_YVUUGKGIeUBN-6H4guzA6k3Un2iG3i1umXPpvQHiO7Z6V1-YcGwQlYMFt4jqK4CzPB97Q1f6yNEICZ7Kvkrzh4vQh_tjxX2dpfodHx-MskYaFB3nNPSGcO9htPGUBf1rXcvfTHAPxhDtXQAv9JqEt_IJzPWGpe7GEvtx5tdNauMCZdIjoEm_Jw5CBqmbkKpVtugYHHtkkt4XaEdBAVZDgrfbrwrgxYOcOsaA13spjUCB2imZRkIBnyuK9HBgaHEyBAs8W8oKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074561,"updated":1633074561,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mqZhCThTgFfdvRuVUNkV0VpMVgmEW8sgKJg_51r5F8NCTv4iKhnUlTyZrwjVJofi223gmySmyaohGFDi0nRR1Zr1gkD_h2Vh-XzFN037uH02GTNnr9aUJGf0c7JsQgCwHWQQS2_pQ9hPU4iP6sUpcpEjThq3Eepzy1EO_MBPuARglj-fqjSOjECognV02kEuVngRPqOm876oPYpn7Bz49yjpc6JpwLSS9xuDVjBG2PXeyCGT3h6pogD5pQkDwhKi3QptIIjqdJWw6miViK241b_wxIzY3LxhSriHhIvw7z-1iHsz30SB1X52QAncykO8jucbpdcmUeVKVZvn1rDRIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375505,"updated":1633375505,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:21 GMT
+      - Mon, 04 Oct 2021 19:25:05 GMT
       expires:
       - '-1'
       pragma:
@@ -93,7 +93,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -111,10 +111,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"y1Rd6lRxUkAgjySnGDoVzbgRIcMewiWUh3TxJqQ4b5SdjBcoB2eDzuZj3tIjroylIr-2aKMjV_xC_YVUUGKGIeUBN-6H4guzA6k3Un2iG3i1umXPpvQHiO7Z6V1-YcGwQlYMFt4jqK4CzPB97Q1f6yNEICZ7Kvkrzh4vQh_tjxX2dpfodHx-MskYaFB3nNPSGcO9htPGUBf1rXcvfTHAPxhDtXQAv9JqEt_IJzPWGpe7GEvtx5tdNauMCZdIjoEm_Jw5CBqmbkKpVtugYHHtkkt4XaEdBAVZDgrfbrwrgxYOcOsaA13spjUCB2imZRkIBnyuK9HBgaHEyBAs8W8oKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074561,"updated":1633074561,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mqZhCThTgFfdvRuVUNkV0VpMVgmEW8sgKJg_51r5F8NCTv4iKhnUlTyZrwjVJofi223gmySmyaohGFDi0nRR1Zr1gkD_h2Vh-XzFN037uH02GTNnr9aUJGf0c7JsQgCwHWQQS2_pQ9hPU4iP6sUpcpEjThq3Eepzy1EO_MBPuARglj-fqjSOjECognV02kEuVngRPqOm876oPYpn7Bz49yjpc6JpwLSS9xuDVjBG2PXeyCGT3h6pogD5pQkDwhKi3QptIIjqdJWw6miViK241b_wxIzY3LxhSriHhIvw7z-1iHsz30SB1X52QAncykO8jucbpdcmUeVKVZvn1rDRIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375505,"updated":1633375505,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -123,7 +123,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:21 GMT
+      - Mon, 04 Oct 2021 19:25:05 GMT
       expires:
       - '-1'
       pragma:
@@ -137,7 +137,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -159,10 +159,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603/encrypt?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3/encrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","value":"IJxy4_5pUNwktRmXTEu2Hfs3jadF3PpTga2IWReWb15hY5Jn2-yhE4ALlAhfR0Qebdybfjp8SKfEb68FriIlHNvc1Z8fy7eKjXY7V8l1rYqmh-RO8-OSSJny_GZUoLet8lMX8lXsP4GOoYIwCWmfx-u4pQgqQjcb0r8cnzKzTI8xi06cBE-Oms6gMyGZ55V1o4xqPDporvVOUOQr7m56ExsUKY7F3q899GE-KMovfd3QmJmfaHv_PSEGbdAPyTIOfbAKyO2UGNiBarxK-znZdzKKkhbSjaO0xaVMiWeN7fWCWygZIYX6o2Lrlr-fP8SFK_91CTwYqxhKHhyDxLNGDA"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3","value":"dUs1PIwj3_6oB5agztzBX1jR0zJEpKiwYdAD4DSF_h5UM0cH2joFAhswwD05hvxftCbUdlfhTyh2jWsY2g7nUJjuxv6uYK5SE_6233LM_ltOi4p2i_lFDGqPMIlQWYsMPiJBDdQ-A1u7werpNLWLv_d7niSQS_d8OPcGz7RU3C5WolF969KcDmx3UsYsbV61l6zTal2mxwWTQFaSxIPN1AK6pqDjMsSAe5t7Rtlq5tpGv1YIFJURznz4IT2LIOfx_NeT2bze_tR8iDSiixmkIKk4eKtouiO9xcSA5FkPL6gkuEgteuIgZx-phuwSW-CAyNY_3RTqXueGrghGssZ2Sg"}'
     headers:
       cache-control:
       - no-cache
@@ -171,7 +171,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:21 GMT
+      - Mon, 04 Oct 2021 19:25:05 GMT
       expires:
       - '-1'
       pragma:
@@ -185,14 +185,14 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "IJxy4_5pUNwktRmXTEu2Hfs3jadF3PpTga2IWReWb15hY5Jn2-yhE4ALlAhfR0Qebdybfjp8SKfEb68FriIlHNvc1Z8fy7eKjXY7V8l1rYqmh-RO8-OSSJny_GZUoLet8lMX8lXsP4GOoYIwCWmfx-u4pQgqQjcb0r8cnzKzTI8xi06cBE-Oms6gMyGZ55V1o4xqPDporvVOUOQr7m56ExsUKY7F3q899GE-KMovfd3QmJmfaHv_PSEGbdAPyTIOfbAKyO2UGNiBarxK-znZdzKKkhbSjaO0xaVMiWeN7fWCWygZIYX6o2Lrlr-fP8SFK_91CTwYqxhKHhyDxLNGDA"}'
+    body: '{"alg": "RSA-OAEP", "value": "dUs1PIwj3_6oB5agztzBX1jR0zJEpKiwYdAD4DSF_h5UM0cH2joFAhswwD05hvxftCbUdlfhTyh2jWsY2g7nUJjuxv6uYK5SE_6233LM_ltOi4p2i_lFDGqPMIlQWYsMPiJBDdQ-A1u7werpNLWLv_d7niSQS_d8OPcGz7RU3C5WolF969KcDmx3UsYsbV61l6zTal2mxwWTQFaSxIPN1AK6pqDjMsSAe5t7Rtlq5tpGv1YIFJURznz4IT2LIOfx_NeT2bze_tR8iDSiixmkIKk4eKtouiO9xcSA5FkPL6gkuEgteuIgZx-phuwSW-CAyNY_3RTqXueGrghGssZ2Sg"}'
     headers:
       Accept:
       - application/json
@@ -207,10 +207,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603/decrypt?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3/decrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control:
       - no-cache
@@ -219,7 +219,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 01 Oct 2021 07:49:21 GMT
+      - Mon, 04 Oct 2021 19:25:05 GMT
       expires:
       - '-1'
       pragma:
@@ -233,7 +233,147 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/?api-version=7.3-preview
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mqZhCThTgFfdvRuVUNkV0VpMVgmEW8sgKJg_51r5F8NCTv4iKhnUlTyZrwjVJofi223gmySmyaohGFDi0nRR1Zr1gkD_h2Vh-XzFN037uH02GTNnr9aUJGf0c7JsQgCwHWQQS2_pQ9hPU4iP6sUpcpEjThq3Eepzy1EO_MBPuARglj-fqjSOjECognV02kEuVngRPqOm876oPYpn7Bz49yjpc6JpwLSS9xuDVjBG2PXeyCGT3h6pogD5pQkDwhKi3QptIIjqdJWw6miViK241b_wxIzY3LxhSriHhIvw7z-1iHsz30SB1X52QAncykO8jucbpdcmUeVKVZvn1rDRIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375505,"updated":1633375505,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:25:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3","value":"SR6yO8bsn3nKRlOwmuPX00hkyFFIcversL4KUsSP2pkMDxk4pcPNgOPRDBNBe4VOwOisg2LDXKTZ0Qer_aZZ2fc0pdAPQ80iSenK1gI584ABcNVy_tej1EbQSX0e6YebSWrqoXQYQTW0Q915uQFBDuSnKHvpAbxr-dvghWM5WNFWLp-IjejWj7uGHahnbmdPPvx6VtpYFklewAUocK5sekeGaQuzVJvU8glsv5_VjYZFMd75tQUJ4zOi7Foqr32DPcRUNar51B9bFXtjJMSLTYjqIVFHMsBUr4DPBfsft4phyywuP_X8YSW5xukdjmQbv_Ry3NFRMnFHeiXoa1TDZw"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:25:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "SR6yO8bsn3nKRlOwmuPX00hkyFFIcversL4KUsSP2pkMDxk4pcPNgOPRDBNBe4VOwOisg2LDXKTZ0Qer_aZZ2fc0pdAPQ80iSenK1gI584ABcNVy_tej1EbQSX0e6YebSWrqoXQYQTW0Q915uQFBDuSnKHvpAbxr-dvghWM5WNFWLp-IjejWj7uGHahnbmdPPvx6VtpYFklewAUocK5sekeGaQuzVJvU8glsv5_VjYZFMd75tQUJ4zOi7Foqr32DPcRUNar51B9bFXtjJMSLTYjqIVFHMsBUr4DPBfsft4phyywuP_X8YSW5xukdjmQbv_Ry3NFRMnFHeiXoa1TDZw"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/430d41e1bb444b2da81225c2615dc1c3","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 04 Oct 2021 19:25:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_get_cryptography_client_7_3_preview_vault.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/create?api-version=7.3-preview
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '97'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/create?api-version=7.3-preview
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"y1Rd6lRxUkAgjySnGDoVzbgRIcMewiWUh3TxJqQ4b5SdjBcoB2eDzuZj3tIjroylIr-2aKMjV_xC_YVUUGKGIeUBN-6H4guzA6k3Un2iG3i1umXPpvQHiO7Z6V1-YcGwQlYMFt4jqK4CzPB97Q1f6yNEICZ7Kvkrzh4vQh_tjxX2dpfodHx-MskYaFB3nNPSGcO9htPGUBf1rXcvfTHAPxhDtXQAv9JqEt_IJzPWGpe7GEvtx5tdNauMCZdIjoEm_Jw5CBqmbkKpVtugYHHtkkt4XaEdBAVZDgrfbrwrgxYOcOsaA13spjUCB2imZRkIBnyuK9HBgaHEyBAs8W8oKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074561,"updated":1633074561,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603?api-version=7.3-preview
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"y1Rd6lRxUkAgjySnGDoVzbgRIcMewiWUh3TxJqQ4b5SdjBcoB2eDzuZj3tIjroylIr-2aKMjV_xC_YVUUGKGIeUBN-6H4guzA6k3Un2iG3i1umXPpvQHiO7Z6V1-YcGwQlYMFt4jqK4CzPB97Q1f6yNEICZ7Kvkrzh4vQh_tjxX2dpfodHx-MskYaFB3nNPSGcO9htPGUBf1rXcvfTHAPxhDtXQAv9JqEt_IJzPWGpe7GEvtx5tdNauMCZdIjoEm_Jw5CBqmbkKpVtugYHHtkkt4XaEdBAVZDgrfbrwrgxYOcOsaA13spjUCB2imZRkIBnyuK9HBgaHEyBAs8W8oKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633074561,"updated":1633074561,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","value":"IJxy4_5pUNwktRmXTEu2Hfs3jadF3PpTga2IWReWb15hY5Jn2-yhE4ALlAhfR0Qebdybfjp8SKfEb68FriIlHNvc1Z8fy7eKjXY7V8l1rYqmh-RO8-OSSJny_GZUoLet8lMX8lXsP4GOoYIwCWmfx-u4pQgqQjcb0r8cnzKzTI8xi06cBE-Oms6gMyGZ55V1o4xqPDporvVOUOQr7m56ExsUKY7F3q899GE-KMovfd3QmJmfaHv_PSEGbdAPyTIOfbAKyO2UGNiBarxK-znZdzKKkhbSjaO0xaVMiWeN7fWCWygZIYX6o2Lrlr-fP8SFK_91CTwYqxhKHhyDxLNGDA"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "IJxy4_5pUNwktRmXTEu2Hfs3jadF3PpTga2IWReWb15hY5Jn2-yhE4ALlAhfR0Qebdybfjp8SKfEb68FriIlHNvc1Z8fy7eKjXY7V8l1rYqmh-RO8-OSSJny_GZUoLet8lMX8lXsP4GOoYIwCWmfx-u4pQgqQjcb0r8cnzKzTI8xi06cBE-Oms6gMyGZ55V1o4xqPDporvVOUOQr7m56ExsUKY7F3q899GE-KMovfd3QmJmfaHv_PSEGbdAPyTIOfbAKyO2UGNiBarxK-znZdzKKkhbSjaO0xaVMiWeN7fWCWygZIYX6o2Lrlr-fP8SFK_91CTwYqxhKHhyDxLNGDA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name207e1951/0f1943c11a2143e4abac6a901093b603","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Oct 2021 07:49:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.79.2
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_2016_10_01_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_2016_10_01_vault.yaml
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:20 GMT
+      date: Mon, 04 Oct 2021 19:23:46 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
@@ -29,7 +29,7 @@ interactions:
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 401
@@ -50,19 +50,19 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vGwr4IQ9J5LCsxj2vEIc3ZqLy3crt_LMg7jYp1XUdAofPKgWhKAFWnZAeDTSvATE7GRu_VCMnxgnolDnmtW1SfVqRqVuGYx0EbQQ4tlk4yZWrXJ7L-PvWBBN-n8uP4XNZ5RO5W5yclLWDCjE28oP735rAJOddHE9CsVpLCFxWHAL8ddKNQUZEHrLQJua96Bd68Aki2JhBJ3zT5fq57eCuGY5Q_255IOob809yQ7qRc7wBC7Qbin1bKXVMfvbK61FjhSImbplvuKhRngsuksuqZ-ald-0DWmQsXtoIqLIYXOQPYRUROAlWBoYArFozILyWCj5v72YkgkJ5MuIaxNkMQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075581,"updated":1633075581,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1_Nzj2e71vWrr0ETe0HWKColPPV9SuFMP4mh1bP0uaSz4x21t8rPwl77NcPOvhq2jy8IcNn9OyhBbe5mh6GSkdKbjhQw6ORajmWPivDy2306qP-_XKwxEzCfAVj3hSJ-n9Opwn3o2qvvru4g-yl2gjD07qIY8CaVfilIhlZfVRc98GTQzlfG3GWJHJ0idwJD_6XFjUYXNBrkpl8HFU9zNuvBBq70P2rxgSbeEn1cgFSuE1sC5GrKAFVc_dgV85URhqvfQcURtAt8bE3TlU8RUtKTaPeQEFE2T-zJ_qjPVGTSPLrxmHMOCP3JBwiVRfjw6u5qX_O88M3DM09LgPcKrQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375427,"updated":1633375427,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control: no-cache
       content-length: '673'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:21 GMT
+      date: Mon, 04 Oct 2021 19:23:47 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
@@ -76,27 +76,27 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vGwr4IQ9J5LCsxj2vEIc3ZqLy3crt_LMg7jYp1XUdAofPKgWhKAFWnZAeDTSvATE7GRu_VCMnxgnolDnmtW1SfVqRqVuGYx0EbQQ4tlk4yZWrXJ7L-PvWBBN-n8uP4XNZ5RO5W5yclLWDCjE28oP735rAJOddHE9CsVpLCFxWHAL8ddKNQUZEHrLQJua96Bd68Aki2JhBJ3zT5fq57eCuGY5Q_255IOob809yQ7qRc7wBC7Qbin1bKXVMfvbK61FjhSImbplvuKhRngsuksuqZ-ald-0DWmQsXtoIqLIYXOQPYRUROAlWBoYArFozILyWCj5v72YkgkJ5MuIaxNkMQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075581,"updated":1633075581,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1_Nzj2e71vWrr0ETe0HWKColPPV9SuFMP4mh1bP0uaSz4x21t8rPwl77NcPOvhq2jy8IcNn9OyhBbe5mh6GSkdKbjhQw6ORajmWPivDy2306qP-_XKwxEzCfAVj3hSJ-n9Opwn3o2qvvru4g-yl2gjD07qIY8CaVfilIhlZfVRc98GTQzlfG3GWJHJ0idwJD_6XFjUYXNBrkpl8HFU9zNuvBBq70P2rxgSbeEn1cgFSuE1sC5GrKAFVc_dgV85URhqvfQcURtAt8bE3TlU8RUtKTaPeQEFE2T-zJ_qjPVGTSPLrxmHMOCP3JBwiVRfjw6u5qX_O88M3DM09LgPcKrQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375427,"updated":1633375427,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control: no-cache
       content-length: '673'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:21 GMT
+      date: Mon, 04 Oct 2021 19:23:47 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b?api-version=2016-10-01
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de?api-version=2016-10-01
 - request:
     body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
     headers:
@@ -109,29 +109,29 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/encrypt?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/encrypt?api-version=2016-10-01
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","value":"Vp7jl0LlEu9VhShbk_NikADx5LuWXz0-tHvj86EexXMR6xlWZyzts2fOubKaxSDHabf-v96OsxgfxNXulRSdqH2YKcJ4vJv0VKPtjHAKPXyBI9G304cN3uGPVYmCkv9k4sFaoG48OL7U5bKKwR3gd-QUKSvg1C-WYoQWpjMDXXx5W767Cf6BQ5cFdYw8YWjzy58d4jB32vA8PtK6tETRB8ZsIKms9bn0Lews3fAIkLxVGhqB5z9ioVBqmG9nbbPSHcRWogzAreBAJa3utXB3LmQJaHTLCvxEqQ8ufjascdOnF2U0bvqhGZA-AY4kQATfhqInnWQRhURElrMd15LQHA"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de","value":"ohYGFKNVrOwSJ6vA-ZEfjPbs3q3zw3-PTaMZM6Gho6Fc0HoW4GzahZuxF4xe7rc72LJlaHDXHAGKl1XfPnBz4SoY1Y7calKBrvcG3m6G98TNBnHxwkc11sXFdau-9bezMBD3kPzsdsE9g0xsXho_CwiPGoOFf1IcTZ63fVpccM-fk-EIl3YviP_ordZ_Jz41ZjFOlmUPeqYpy27rL1fU0JQlhdh40BigULGn_DPyCmpf3TdJvcEDvQgY1oSGXNi4cHcYSnCgfR-78gXCmuUPx8TyJmTDu05G2Rg-seEg08HwBTq4iSR7uT5OAojT9DnzsZ8Pexyn8bJx3CMLkOnVXA"}'
     headers:
       cache-control: no-cache
       content-length: '464'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:21 GMT
+      date: Mon, 04 Oct 2021 19:23:47 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/encrypt?api-version=2016-10-01
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/encrypt?api-version=2016-10-01
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "Vp7jl0LlEu9VhShbk_NikADx5LuWXz0-tHvj86EexXMR6xlWZyzts2fOubKaxSDHabf-v96OsxgfxNXulRSdqH2YKcJ4vJv0VKPtjHAKPXyBI9G304cN3uGPVYmCkv9k4sFaoG48OL7U5bKKwR3gd-QUKSvg1C-WYoQWpjMDXXx5W767Cf6BQ5cFdYw8YWjzy58d4jB32vA8PtK6tETRB8ZsIKms9bn0Lews3fAIkLxVGhqB5z9ioVBqmG9nbbPSHcRWogzAreBAJa3utXB3LmQJaHTLCvxEqQ8ufjascdOnF2U0bvqhGZA-AY4kQATfhqInnWQRhURElrMd15LQHA"}'
+    body: '{"alg": "RSA-OAEP", "value": "ohYGFKNVrOwSJ6vA-ZEfjPbs3q3zw3-PTaMZM6Gho6Fc0HoW4GzahZuxF4xe7rc72LJlaHDXHAGKl1XfPnBz4SoY1Y7calKBrvcG3m6G98TNBnHxwkc11sXFdau-9bezMBD3kPzsdsE9g0xsXho_CwiPGoOFf1IcTZ63fVpccM-fk-EIl3YviP_ordZ_Jz41ZjFOlmUPeqYpy27rL1fU0JQlhdh40BigULGn_DPyCmpf3TdJvcEDvQgY1oSGXNi4cHcYSnCgfR-78gXCmuUPx8TyJmTDu05G2Rg-seEg08HwBTq4iSR7uT5OAojT9DnzsZ8Pexyn8bJx3CMLkOnVXA"}'
     headers:
       Accept:
       - application/json
@@ -142,25 +142,120 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/decrypt?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/decrypt?api-version=2016-10-01
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control: no-cache
       content-length: '134'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:21 GMT
+      date: Mon, 04 Oct 2021 19:23:47 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/decrypt?api-version=2016-10-01
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/decrypt?api-version=2016-10-01
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/?api-version=2016-10-01
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1_Nzj2e71vWrr0ETe0HWKColPPV9SuFMP4mh1bP0uaSz4x21t8rPwl77NcPOvhq2jy8IcNn9OyhBbe5mh6GSkdKbjhQw6ORajmWPivDy2306qP-_XKwxEzCfAVj3hSJ-n9Opwn3o2qvvru4g-yl2gjD07qIY8CaVfilIhlZfVRc98GTQzlfG3GWJHJ0idwJD_6XFjUYXNBrkpl8HFU9zNuvBBq70P2rxgSbeEn1cgFSuE1sC5GrKAFVc_dgV85URhqvfQcURtAt8bE3TlU8RUtKTaPeQEFE2T-zJ_qjPVGTSPLrxmHMOCP3JBwiVRfjw6u5qX_O88M3DM09LgPcKrQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375427,"updated":1633375427,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '673'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:47 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/?api-version=2016-10-01
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/encrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de","value":"FYw1BxW7sbukHOsIUHoPf2QmlPsBQtNPLaqEOkg11oho0__TsX0R0lSrK091X-3FYR9fWCqF_ek0tAsj8wnXo1afUKA-eQTZpNF3qUFPqQX1tdOPssPruK6hmkB_E2dakQZrKF50iGK66xqM_KR2PDInswG1b1oXezG0KtnepOxKQUXuhvrIQMduDVYUJPJvKLvx9p1keuD6Y0FRZvuIBmdmUZ7eucyFs-OwEA3Yy3o-CWC_LoM-kr0R-T3wMG8lP3Jeh2xZYyDx4qwQik4UjcP4FycQ6FYwUlov5PaTyg4G3mrtzoNo4jW4cYMEJ22VY633PF-01orzJ6HS6h_M1g"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:47 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/encrypt?api-version=2016-10-01
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "FYw1BxW7sbukHOsIUHoPf2QmlPsBQtNPLaqEOkg11oho0__TsX0R0lSrK091X-3FYR9fWCqF_ek0tAsj8wnXo1afUKA-eQTZpNF3qUFPqQX1tdOPssPruK6hmkB_E2dakQZrKF50iGK66xqM_KR2PDInswG1b1oXezG0KtnepOxKQUXuhvrIQMduDVYUJPJvKLvx9p1keuD6Y0FRZvuIBmdmUZ7eucyFs-OwEA3Yy3o-CWC_LoM-kr0R-T3wMG8lP3Jeh2xZYyDx4qwQik4UjcP4FycQ6FYwUlov5PaTyg4G3mrtzoNo4jW4cYMEJ22VY633PF-01orzJ6HS6h_M1g"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/decrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:47 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/6625d3b1e346408086eb44d4ff8604de/decrypt?api-version=2016-10-01
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_2016_10_01_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_2016_10_01_vault.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:20 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/create?api-version=2016-10-01
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vGwr4IQ9J5LCsxj2vEIc3ZqLy3crt_LMg7jYp1XUdAofPKgWhKAFWnZAeDTSvATE7GRu_VCMnxgnolDnmtW1SfVqRqVuGYx0EbQQ4tlk4yZWrXJ7L-PvWBBN-n8uP4XNZ5RO5W5yclLWDCjE28oP735rAJOddHE9CsVpLCFxWHAL8ddKNQUZEHrLQJua96Bd68Aki2JhBJ3zT5fq57eCuGY5Q_255IOob809yQ7qRc7wBC7Qbin1bKXVMfvbK61FjhSImbplvuKhRngsuksuqZ-ald-0DWmQsXtoIqLIYXOQPYRUROAlWBoYArFozILyWCj5v72YkgkJ5MuIaxNkMQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075581,"updated":1633075581,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '673'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:21 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/create?api-version=2016-10-01
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b?api-version=2016-10-01
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vGwr4IQ9J5LCsxj2vEIc3ZqLy3crt_LMg7jYp1XUdAofPKgWhKAFWnZAeDTSvATE7GRu_VCMnxgnolDnmtW1SfVqRqVuGYx0EbQQ4tlk4yZWrXJ7L-PvWBBN-n8uP4XNZ5RO5W5yclLWDCjE28oP735rAJOddHE9CsVpLCFxWHAL8ddKNQUZEHrLQJua96Bd68Aki2JhBJ3zT5fq57eCuGY5Q_255IOob809yQ7qRc7wBC7Qbin1bKXVMfvbK61FjhSImbplvuKhRngsuksuqZ-ald-0DWmQsXtoIqLIYXOQPYRUROAlWBoYArFozILyWCj5v72YkgkJ5MuIaxNkMQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075581,"updated":1633075581,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '673'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:21 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b?api-version=2016-10-01
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/encrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","value":"Vp7jl0LlEu9VhShbk_NikADx5LuWXz0-tHvj86EexXMR6xlWZyzts2fOubKaxSDHabf-v96OsxgfxNXulRSdqH2YKcJ4vJv0VKPtjHAKPXyBI9G304cN3uGPVYmCkv9k4sFaoG48OL7U5bKKwR3gd-QUKSvg1C-WYoQWpjMDXXx5W767Cf6BQ5cFdYw8YWjzy58d4jB32vA8PtK6tETRB8ZsIKms9bn0Lews3fAIkLxVGhqB5z9ioVBqmG9nbbPSHcRWogzAreBAJa3utXB3LmQJaHTLCvxEqQ8ufjascdOnF2U0bvqhGZA-AY4kQATfhqInnWQRhURElrMd15LQHA"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:21 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/encrypt?api-version=2016-10-01
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "Vp7jl0LlEu9VhShbk_NikADx5LuWXz0-tHvj86EexXMR6xlWZyzts2fOubKaxSDHabf-v96OsxgfxNXulRSdqH2YKcJ4vJv0VKPtjHAKPXyBI9G304cN3uGPVYmCkv9k4sFaoG48OL7U5bKKwR3gd-QUKSvg1C-WYoQWpjMDXXx5W767Cf6BQ5cFdYw8YWjzy58d4jB32vA8PtK6tETRB8ZsIKms9bn0Lews3fAIkLxVGhqB5z9ioVBqmG9nbbPSHcRWogzAreBAJa3utXB3LmQJaHTLCvxEqQ8ufjascdOnF2U0bvqhGZA-AY4kQATfhqInnWQRhURElrMd15LQHA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/decrypt?api-version=2016-10-01
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:21 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-namefbbd1782/9a92bc364e31476eb743d9b4fc2f3f9b/decrypt?api-version=2016-10-01
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_0_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_0_vault.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/create?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:23 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/create?api-version=7.0
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"synnOws727PzI3g3hlzhdUpAh2oW-Qfm48KyWkMFwsRZRoZFAZf8Px6rwJjklmgB00jYUh66r-l3B32I2IgsKozd7IDk4KINmfyn_hpliIaRFcji9iYOssiE_2qGDiFVtKvl9BXNG3eHz0uFpwccCzraS5nE4HGcHFWI11YBNKMPhOZX43q8StS1DTftxXxJ9a_GnsiBu3gzAqUzMSLqXK-7Fp-Z49VNVD7K6iw4L55V3TM6m8tM4FxbzeuM-k3vBU410y08hJClRjWXUktYd9UO-SKftPYf8EP3_QaEU-8zUPhHbGG0zJ4wHDws4a2edGh15XdH5K-g85a1LnZgZQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075584,"updated":1633075584,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '673'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:24 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/create?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"synnOws727PzI3g3hlzhdUpAh2oW-Qfm48KyWkMFwsRZRoZFAZf8Px6rwJjklmgB00jYUh66r-l3B32I2IgsKozd7IDk4KINmfyn_hpliIaRFcji9iYOssiE_2qGDiFVtKvl9BXNG3eHz0uFpwccCzraS5nE4HGcHFWI11YBNKMPhOZX43q8StS1DTftxXxJ9a_GnsiBu3gzAqUzMSLqXK-7Fp-Z49VNVD7K6iw4L55V3TM6m8tM4FxbzeuM-k3vBU410y08hJClRjWXUktYd9UO-SKftPYf8EP3_QaEU-8zUPhHbGG0zJ4wHDws4a2edGh15XdH5K-g85a1LnZgZQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075584,"updated":1633075584,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '673'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:24 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a?api-version=7.0
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","value":"pQv5IEgTv_tW6rI_Bg-zlPMlnyaAas25JVK3OvqcECy2x82Q0umeMk2gjjeQqA8LwduQ4FKffHtNBzuejy3rNSdppSDFCddY61hbzJZW299YfbfyEh21MWBDkOSPyhDN5uEg0znvyMktgNF68e3z2nXK7ZiJyxMb8Xus0Tj92cDSUnjeaadeiRA0uktwmtOZ3NChkCGwbveA9tOVGlrvevTXZOKuhl7XU123U_QWm0y4bPGopGTntnMu5X7qp6lAIo-2R6HRZ9JeHsxcRSnsWDq4SMAgFV7olQRrK36-uGbqeSCWmCnWQY56_U6XZEjmyHNYEomaE49LFAb9QSaGzw"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:24 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/encrypt?api-version=7.0
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "pQv5IEgTv_tW6rI_Bg-zlPMlnyaAas25JVK3OvqcECy2x82Q0umeMk2gjjeQqA8LwduQ4FKffHtNBzuejy3rNSdppSDFCddY61hbzJZW299YfbfyEh21MWBDkOSPyhDN5uEg0znvyMktgNF68e3z2nXK7ZiJyxMb8Xus0Tj92cDSUnjeaadeiRA0uktwmtOZ3NChkCGwbveA9tOVGlrvevTXZOKuhl7XU123U_QWm0y4bPGopGTntnMu5X7qp6lAIo-2R6HRZ9JeHsxcRSnsWDq4SMAgFV7olQRrK36-uGbqeSCWmCnWQY56_U6XZEjmyHNYEomaE49LFAb9QSaGzw"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:24 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/decrypt?api-version=7.0
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_0_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_0_vault.yaml
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:23 GMT
+      date: Mon, 04 Oct 2021 19:23:49 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
@@ -29,7 +29,7 @@ interactions:
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 401
@@ -50,19 +50,19 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"synnOws727PzI3g3hlzhdUpAh2oW-Qfm48KyWkMFwsRZRoZFAZf8Px6rwJjklmgB00jYUh66r-l3B32I2IgsKozd7IDk4KINmfyn_hpliIaRFcji9iYOssiE_2qGDiFVtKvl9BXNG3eHz0uFpwccCzraS5nE4HGcHFWI11YBNKMPhOZX43q8StS1DTftxXxJ9a_GnsiBu3gzAqUzMSLqXK-7Fp-Z49VNVD7K6iw4L55V3TM6m8tM4FxbzeuM-k3vBU410y08hJClRjWXUktYd9UO-SKftPYf8EP3_QaEU-8zUPhHbGG0zJ4wHDws4a2edGh15XdH5K-g85a1LnZgZQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075584,"updated":1633075584,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2PWXkNPdXLaDiRLqAXeuuynJj-ts09k4ONpR6pGHHiqMd2xzxua4aLDtuNnL1f8ffXLLv5y3X2_w2NPT0ZHTkV2sGWBwBaMN2SyBXMKE-tRUDagHWU1bDvvEYKdaHTDdcKoRYhP1mzT0Q4XBfmttzqq7svJ37-KCLqDbfaKWOnPYqkRKePWEN86orRp4-lREeJ-slBejt10vKy845zCC6dgU2BGPrWJpjq87ehArlF86u4bqd6dr9P7y91W1ryhQi753euSJAwMe4khpxyjbx1Js0cxHeoX4VD6OXheUrFZKMWYWZMz0-75A8o_ZZDUJHWJPlWO3JJicpfatAoEK5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375430,"updated":1633375430,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control: no-cache
       content-length: '673'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:24 GMT
+      date: Mon, 04 Oct 2021 19:23:50 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
@@ -76,27 +76,27 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"synnOws727PzI3g3hlzhdUpAh2oW-Qfm48KyWkMFwsRZRoZFAZf8Px6rwJjklmgB00jYUh66r-l3B32I2IgsKozd7IDk4KINmfyn_hpliIaRFcji9iYOssiE_2qGDiFVtKvl9BXNG3eHz0uFpwccCzraS5nE4HGcHFWI11YBNKMPhOZX43q8StS1DTftxXxJ9a_GnsiBu3gzAqUzMSLqXK-7Fp-Z49VNVD7K6iw4L55V3TM6m8tM4FxbzeuM-k3vBU410y08hJClRjWXUktYd9UO-SKftPYf8EP3_QaEU-8zUPhHbGG0zJ4wHDws4a2edGh15XdH5K-g85a1LnZgZQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075584,"updated":1633075584,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2PWXkNPdXLaDiRLqAXeuuynJj-ts09k4ONpR6pGHHiqMd2xzxua4aLDtuNnL1f8ffXLLv5y3X2_w2NPT0ZHTkV2sGWBwBaMN2SyBXMKE-tRUDagHWU1bDvvEYKdaHTDdcKoRYhP1mzT0Q4XBfmttzqq7svJ37-KCLqDbfaKWOnPYqkRKePWEN86orRp4-lREeJ-slBejt10vKy845zCC6dgU2BGPrWJpjq87ehArlF86u4bqd6dr9P7y91W1ryhQi753euSJAwMe4khpxyjbx1Js0cxHeoX4VD6OXheUrFZKMWYWZMz0-75A8o_ZZDUJHWJPlWO3JJicpfatAoEK5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375430,"updated":1633375430,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control: no-cache
       content-length: '673'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:24 GMT
+      date: Mon, 04 Oct 2021 19:23:50 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a?api-version=7.0
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be?api-version=7.0
 - request:
     body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
     headers:
@@ -109,29 +109,29 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/encrypt?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/encrypt?api-version=7.0
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","value":"pQv5IEgTv_tW6rI_Bg-zlPMlnyaAas25JVK3OvqcECy2x82Q0umeMk2gjjeQqA8LwduQ4FKffHtNBzuejy3rNSdppSDFCddY61hbzJZW299YfbfyEh21MWBDkOSPyhDN5uEg0znvyMktgNF68e3z2nXK7ZiJyxMb8Xus0Tj92cDSUnjeaadeiRA0uktwmtOZ3NChkCGwbveA9tOVGlrvevTXZOKuhl7XU123U_QWm0y4bPGopGTntnMu5X7qp6lAIo-2R6HRZ9JeHsxcRSnsWDq4SMAgFV7olQRrK36-uGbqeSCWmCnWQY56_U6XZEjmyHNYEomaE49LFAb9QSaGzw"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be","value":"zjxOsABeFsWcWolIvZJrw9Q5v1mkZZ8BtLi7ZWU5l112YIijVCzxJeno-NkPclSYrXZ5sI67lYSOxDKfWj3wKRGNXOwMHHbJKfD2_IloQYBVbDAawWya9FhHrKVAnlqO7VLbs5GvDrWlnDdyDxcdKUlMX8rv0qBUatZ4LZYlHsKWnUBDp2iv2hRsd-1FEpG4372HAv81s_3NAwCky14GqVNuW6jqwSzA7BXvJVpE5t31pkd5iMHYT22UYXQo6VOHi7qraYpL-IkOUGzdiO294oKAJZZiNuw-AG7ZB2eKQcBwsfJAfSSyihFRIkAQcXn-ptISTO9zbcqvA8YrEgo1JA"}'
     headers:
       cache-control: no-cache
       content-length: '464'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:24 GMT
+      date: Mon, 04 Oct 2021 19:23:50 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/encrypt?api-version=7.0
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/encrypt?api-version=7.0
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "pQv5IEgTv_tW6rI_Bg-zlPMlnyaAas25JVK3OvqcECy2x82Q0umeMk2gjjeQqA8LwduQ4FKffHtNBzuejy3rNSdppSDFCddY61hbzJZW299YfbfyEh21MWBDkOSPyhDN5uEg0znvyMktgNF68e3z2nXK7ZiJyxMb8Xus0Tj92cDSUnjeaadeiRA0uktwmtOZ3NChkCGwbveA9tOVGlrvevTXZOKuhl7XU123U_QWm0y4bPGopGTntnMu5X7qp6lAIo-2R6HRZ9JeHsxcRSnsWDq4SMAgFV7olQRrK36-uGbqeSCWmCnWQY56_U6XZEjmyHNYEomaE49LFAb9QSaGzw"}'
+    body: '{"alg": "RSA-OAEP", "value": "zjxOsABeFsWcWolIvZJrw9Q5v1mkZZ8BtLi7ZWU5l112YIijVCzxJeno-NkPclSYrXZ5sI67lYSOxDKfWj3wKRGNXOwMHHbJKfD2_IloQYBVbDAawWya9FhHrKVAnlqO7VLbs5GvDrWlnDdyDxcdKUlMX8rv0qBUatZ4LZYlHsKWnUBDp2iv2hRsd-1FEpG4372HAv81s_3NAwCky14GqVNuW6jqwSzA7BXvJVpE5t31pkd5iMHYT22UYXQo6VOHi7qraYpL-IkOUGzdiO294oKAJZZiNuw-AG7ZB2eKQcBwsfJAfSSyihFRIkAQcXn-ptISTO9zbcqvA8YrEgo1JA"}'
     headers:
       Accept:
       - application/json
@@ -142,25 +142,120 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/decrypt?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/decrypt?api-version=7.0
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control: no-cache
       content-length: '134'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:24 GMT
+      date: Mon, 04 Oct 2021 19:23:50 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/deb79ed8960c41628f76b64f6f924f9a/decrypt?api-version=7.0
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/decrypt?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2PWXkNPdXLaDiRLqAXeuuynJj-ts09k4ONpR6pGHHiqMd2xzxua4aLDtuNnL1f8ffXLLv5y3X2_w2NPT0ZHTkV2sGWBwBaMN2SyBXMKE-tRUDagHWU1bDvvEYKdaHTDdcKoRYhP1mzT0Q4XBfmttzqq7svJ37-KCLqDbfaKWOnPYqkRKePWEN86orRp4-lREeJ-slBejt10vKy845zCC6dgU2BGPrWJpjq87ehArlF86u4bqd6dr9P7y91W1ryhQi753euSJAwMe4khpxyjbx1Js0cxHeoX4VD6OXheUrFZKMWYWZMz0-75A8o_ZZDUJHWJPlWO3JJicpfatAoEK5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375430,"updated":1633375430,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '673'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:50 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/?api-version=7.0
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be","value":"p7IRgnivm8i_7Xgoag8Z6PfcukKcWBUNvfay8jaKUx2hqLrM8riruAFKEr31SITiKFIfPH0p7N-EBcqIeZs8WlDcX7zNr6skFi--VujTTc2EIxSYGXhJCAaszaefE9JLmjSEOg5tnlV1_AuniGjCxlFzyI-xj4AmhWdP0z6Iygqaw5JhIDDJ1RPpn3cy9ZcLpyeKKtmeVWP_hGaaBybhhSVFO5Ph1hjTYQ6r12wM6lbvuxHR3MjxjjiRWzhcwrNqNDrNXlDG3v-7hq_LVqPVT_QttFjIwKK4QNwMGzY6S9N9TwgZq_XD9ExbFg5Tb5QRAy19Ux0DLKUpi_xe2yjn0A"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:50 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/encrypt?api-version=7.0
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "p7IRgnivm8i_7Xgoag8Z6PfcukKcWBUNvfay8jaKUx2hqLrM8riruAFKEr31SITiKFIfPH0p7N-EBcqIeZs8WlDcX7zNr6skFi--VujTTc2EIxSYGXhJCAaszaefE9JLmjSEOg5tnlV1_AuniGjCxlFzyI-xj4AmhWdP0z6Iygqaw5JhIDDJ1RPpn3cy9ZcLpyeKKtmeVWP_hGaaBybhhSVFO5Ph1hjTYQ6r12wM6lbvuxHR3MjxjjiRWzhcwrNqNDrNXlDG3v-7hq_LVqPVT_QttFjIwKK4QNwMGzY6S9N9TwgZq_XD9ExbFg5Tb5QRAy19Ux0DLKUpi_xe2yjn0A"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:50 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name653915ff/58fbbd651bfb443f9a6abcea3554e1be/decrypt?api-version=7.0
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_1_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_1_vault.yaml
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:26 GMT
+      date: Mon, 04 Oct 2021 19:23:53 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
@@ -29,7 +29,7 @@ interactions:
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 401
@@ -50,19 +50,19 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sS1aS4BLWfZX7H-a1ylATB4yBYqFlvIGEHeey4vpTAkWPiJ2WVAlBSGEwZzMhmdXIWkvAvU1lkyMCzOvMgziNfKmNmiVHKhdscu4evwXrnJxP3E_tjXfMxMPfwEDuyMFhWnT3rJ_RGOSqWcfcgMWAoUP_W1R7T0dHKqviEHfFF1cQIUMCZCIp0Eu-c0rmYrcy8_6gHrQxwTfqe4jBIKdxCBtycVe3OiJO3t_m2YC22puVq_bd2HG4ieEOHj3ODW6hP3Do_F7gxDEocEpx-0MFiZhXqVGdCdEqXmdLeZLZs0ZSkHNk2myYy1pE6TgHTXFdhCK_XsiaUej-pHepBWQnQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075586,"updated":1633075586,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vRA6q8KkuCnsxU62mseCqWjqnJ6492QA_stTnIL_tXURKKnVI07LRhyqN91Qw8pRV7h8dQ6_aTdYjF82Y6R1SzUhgfPk7w9gePpdmH3fY3N4732Vnh70DLD8_wQ0w2fNcvm89zQ64vEr6JxufhV-I4dJgLDDkUUROsjKXyX8DpKgfpig3jG8fxzaYvhA47waQhQ2gYTOSQOKCQDZrSxzXzX_Q_7M9hI1kiPjvGdDSUk_RbOHhJ5Grgazp1exET2T5InxvdahICvIxyYrniPnO4kiNpLYzuRriPDjfBBNo5lZPZlwucIM7VFKgPj6JLoHx-O_9GMmbrW7GMP3_M6piQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375433,"updated":1633375433,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
       content-length: '694'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:26 GMT
+      date: Mon, 04 Oct 2021 19:23:53 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
@@ -76,27 +76,27 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sS1aS4BLWfZX7H-a1ylATB4yBYqFlvIGEHeey4vpTAkWPiJ2WVAlBSGEwZzMhmdXIWkvAvU1lkyMCzOvMgziNfKmNmiVHKhdscu4evwXrnJxP3E_tjXfMxMPfwEDuyMFhWnT3rJ_RGOSqWcfcgMWAoUP_W1R7T0dHKqviEHfFF1cQIUMCZCIp0Eu-c0rmYrcy8_6gHrQxwTfqe4jBIKdxCBtycVe3OiJO3t_m2YC22puVq_bd2HG4ieEOHj3ODW6hP3Do_F7gxDEocEpx-0MFiZhXqVGdCdEqXmdLeZLZs0ZSkHNk2myYy1pE6TgHTXFdhCK_XsiaUej-pHepBWQnQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075586,"updated":1633075586,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vRA6q8KkuCnsxU62mseCqWjqnJ6492QA_stTnIL_tXURKKnVI07LRhyqN91Qw8pRV7h8dQ6_aTdYjF82Y6R1SzUhgfPk7w9gePpdmH3fY3N4732Vnh70DLD8_wQ0w2fNcvm89zQ64vEr6JxufhV-I4dJgLDDkUUROsjKXyX8DpKgfpig3jG8fxzaYvhA47waQhQ2gYTOSQOKCQDZrSxzXzX_Q_7M9hI1kiPjvGdDSUk_RbOHhJ5Grgazp1exET2T5InxvdahICvIxyYrniPnO4kiNpLYzuRriPDjfBBNo5lZPZlwucIM7VFKgPj6JLoHx-O_9GMmbrW7GMP3_M6piQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375433,"updated":1633375433,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
       content-length: '694'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:26 GMT
+      date: Mon, 04 Oct 2021 19:23:53 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5?api-version=7.1
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea?api-version=7.1
 - request:
     body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
     headers:
@@ -109,29 +109,29 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/encrypt?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/encrypt?api-version=7.1
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","value":"hEKum9eE2Y9xyGULSjGObGeY3gvtLCDSODkhq8l-XHBU1f2u10MzYXGjOf4enEWi6EHa3rrfGu1cNIS93QATUbJDs8yD16CD4VAxvh--9LehCFKNzCO-5ZANBS0p0AhR4B8AD8BVr4WO87BgWy7DyqPZ1AO3k4e3tfubZrGXWmQOGg2G6lsSR6RKm_THmuLxmqLTD-LOjp5l6i-DLF-2-IrfSenq0ZuFdqIZt10LzN5E0qYt4mN4fdKYO6K7-3HdSCQF6hSakHK5urmPhX18AyqLPoCjR8TEAfe-MfHvFdi6mXKXxM1wzpqfnObrvaOocRRoQfwWGefnXcsmFrECbw"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea","value":"A0yskvN6wk_8meFKb60Vj7V8MXjLxoBI44Yc6g0EOdp2RMIdUotjDeeYUCgZ_I8HbgwxcFJeOjOiXLb81WIWrtn8Ai8ZEJ2K5zdQlzKvYTXn2Yv_d0yRSKsl35a1rM7UcK8gFyq43NOLyiPEVM_NRKuBrzcbzh0M_fDrRtKWG2bKdV3YvoJnsOehQNkGC0CpzWUuHJadjr11XxSgdIhU6jOUtMVPaDm3RFlo3jAkDlih7TA5n5DTZ-uKpOTXY3QR5C3-O8FlcOKkr2s6Nyqkc98V-GiHwvTXZdCoESRaO4NIMDml07ccfDwXygjrALrQRLGLT8WMOUJazCgYSVgZdg"}'
     headers:
       cache-control: no-cache
       content-length: '464'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:26 GMT
+      date: Mon, 04 Oct 2021 19:23:53 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/encrypt?api-version=7.1
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/encrypt?api-version=7.1
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "hEKum9eE2Y9xyGULSjGObGeY3gvtLCDSODkhq8l-XHBU1f2u10MzYXGjOf4enEWi6EHa3rrfGu1cNIS93QATUbJDs8yD16CD4VAxvh--9LehCFKNzCO-5ZANBS0p0AhR4B8AD8BVr4WO87BgWy7DyqPZ1AO3k4e3tfubZrGXWmQOGg2G6lsSR6RKm_THmuLxmqLTD-LOjp5l6i-DLF-2-IrfSenq0ZuFdqIZt10LzN5E0qYt4mN4fdKYO6K7-3HdSCQF6hSakHK5urmPhX18AyqLPoCjR8TEAfe-MfHvFdi6mXKXxM1wzpqfnObrvaOocRRoQfwWGefnXcsmFrECbw"}'
+    body: '{"alg": "RSA-OAEP", "value": "A0yskvN6wk_8meFKb60Vj7V8MXjLxoBI44Yc6g0EOdp2RMIdUotjDeeYUCgZ_I8HbgwxcFJeOjOiXLb81WIWrtn8Ai8ZEJ2K5zdQlzKvYTXn2Yv_d0yRSKsl35a1rM7UcK8gFyq43NOLyiPEVM_NRKuBrzcbzh0M_fDrRtKWG2bKdV3YvoJnsOehQNkGC0CpzWUuHJadjr11XxSgdIhU6jOUtMVPaDm3RFlo3jAkDlih7TA5n5DTZ-uKpOTXY3QR5C3-O8FlcOKkr2s6Nyqkc98V-GiHwvTXZdCoESRaO4NIMDml07ccfDwXygjrALrQRLGLT8WMOUJazCgYSVgZdg"}'
     headers:
       Accept:
       - application/json
@@ -142,25 +142,120 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/decrypt?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/decrypt?api-version=7.1
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control: no-cache
       content-length: '134'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:26 GMT
+      date: Mon, 04 Oct 2021 19:23:53 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/decrypt?api-version=7.1
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/decrypt?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vRA6q8KkuCnsxU62mseCqWjqnJ6492QA_stTnIL_tXURKKnVI07LRhyqN91Qw8pRV7h8dQ6_aTdYjF82Y6R1SzUhgfPk7w9gePpdmH3fY3N4732Vnh70DLD8_wQ0w2fNcvm89zQ64vEr6JxufhV-I4dJgLDDkUUROsjKXyX8DpKgfpig3jG8fxzaYvhA47waQhQ2gYTOSQOKCQDZrSxzXzX_Q_7M9hI1kiPjvGdDSUk_RbOHhJ5Grgazp1exET2T5InxvdahICvIxyYrniPnO4kiNpLYzuRriPDjfBBNo5lZPZlwucIM7VFKgPj6JLoHx-O_9GMmbrW7GMP3_M6piQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375433,"updated":1633375433,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:53 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/?api-version=7.1
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/encrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea","value":"b2_KXEuzJiMgN-sTBB1SSud54btbOo6fP6BS4zSZkH2vY5c8aDa_-2Fllh6CdYj4IkpempIerBwcXA-qxwrR_-rsf4Qu64hckUnuXiF3CKg7h4zRgNdIHO1OpbYX1iCY-Q5WauoSiFeId25eRTCrCWuZo1rJL6MIlzSE6MUFXls7N6J_RElPIHHw-LjbTvNT6H3u5K5rwAUjYdMZqQP4JdGDC-1twrJVxRql3WMnBT4VPbvw21GqlG6wJBIvZbZLSsAhEuDnQBkqAJldtRNfAWF1TRh_n7AMTg6xdH9Fs95fm5XGIHJUPgYSlAYJDX13goeiBJqWGKLx_ekdtDEtfg"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:53 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/encrypt?api-version=7.1
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "b2_KXEuzJiMgN-sTBB1SSud54btbOo6fP6BS4zSZkH2vY5c8aDa_-2Fllh6CdYj4IkpempIerBwcXA-qxwrR_-rsf4Qu64hckUnuXiF3CKg7h4zRgNdIHO1OpbYX1iCY-Q5WauoSiFeId25eRTCrCWuZo1rJL6MIlzSE6MUFXls7N6J_RElPIHHw-LjbTvNT6H3u5K5rwAUjYdMZqQP4JdGDC-1twrJVxRql3WMnBT4VPbvw21GqlG6wJBIvZbZLSsAhEuDnQBkqAJldtRNfAWF1TRh_n7AMTg6xdH9Fs95fm5XGIHJUPgYSlAYJDX13goeiBJqWGKLx_ekdtDEtfg"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/decrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:53 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/a5549edbb4e343f6a0585c7cf81cf2ea/decrypt?api-version=7.1
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_1_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_1_vault.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/create?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:26 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/create?api-version=7.1
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/create?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sS1aS4BLWfZX7H-a1ylATB4yBYqFlvIGEHeey4vpTAkWPiJ2WVAlBSGEwZzMhmdXIWkvAvU1lkyMCzOvMgziNfKmNmiVHKhdscu4evwXrnJxP3E_tjXfMxMPfwEDuyMFhWnT3rJ_RGOSqWcfcgMWAoUP_W1R7T0dHKqviEHfFF1cQIUMCZCIp0Eu-c0rmYrcy8_6gHrQxwTfqe4jBIKdxCBtycVe3OiJO3t_m2YC22puVq_bd2HG4ieEOHj3ODW6hP3Do_F7gxDEocEpx-0MFiZhXqVGdCdEqXmdLeZLZs0ZSkHNk2myYy1pE6TgHTXFdhCK_XsiaUej-pHepBWQnQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075586,"updated":1633075586,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:26 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/create?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sS1aS4BLWfZX7H-a1ylATB4yBYqFlvIGEHeey4vpTAkWPiJ2WVAlBSGEwZzMhmdXIWkvAvU1lkyMCzOvMgziNfKmNmiVHKhdscu4evwXrnJxP3E_tjXfMxMPfwEDuyMFhWnT3rJ_RGOSqWcfcgMWAoUP_W1R7T0dHKqviEHfFF1cQIUMCZCIp0Eu-c0rmYrcy8_6gHrQxwTfqe4jBIKdxCBtycVe3OiJO3t_m2YC22puVq_bd2HG4ieEOHj3ODW6hP3Do_F7gxDEocEpx-0MFiZhXqVGdCdEqXmdLeZLZs0ZSkHNk2myYy1pE6TgHTXFdhCK_XsiaUej-pHepBWQnQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075586,"updated":1633075586,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:26 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5?api-version=7.1
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/encrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","value":"hEKum9eE2Y9xyGULSjGObGeY3gvtLCDSODkhq8l-XHBU1f2u10MzYXGjOf4enEWi6EHa3rrfGu1cNIS93QATUbJDs8yD16CD4VAxvh--9LehCFKNzCO-5ZANBS0p0AhR4B8AD8BVr4WO87BgWy7DyqPZ1AO3k4e3tfubZrGXWmQOGg2G6lsSR6RKm_THmuLxmqLTD-LOjp5l6i-DLF-2-IrfSenq0ZuFdqIZt10LzN5E0qYt4mN4fdKYO6K7-3HdSCQF6hSakHK5urmPhX18AyqLPoCjR8TEAfe-MfHvFdi6mXKXxM1wzpqfnObrvaOocRRoQfwWGefnXcsmFrECbw"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:26 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/encrypt?api-version=7.1
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "hEKum9eE2Y9xyGULSjGObGeY3gvtLCDSODkhq8l-XHBU1f2u10MzYXGjOf4enEWi6EHa3rrfGu1cNIS93QATUbJDs8yD16CD4VAxvh--9LehCFKNzCO-5ZANBS0p0AhR4B8AD8BVr4WO87BgWy7DyqPZ1AO3k4e3tfubZrGXWmQOGg2G6lsSR6RKm_THmuLxmqLTD-LOjp5l6i-DLF-2-IrfSenq0ZuFdqIZt10LzN5E0qYt4mN4fdKYO6K7-3HdSCQF6hSakHK5urmPhX18AyqLPoCjR8TEAfe-MfHvFdi6mXKXxM1wzpqfnObrvaOocRRoQfwWGefnXcsmFrECbw"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/decrypt?api-version=7.1
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:26 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65401600/ece22c0a5fcc4c8d9dc445d6dabefdd5/decrypt?api-version=7.1
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_mhsm.yaml
@@ -45,7 +45,7 @@ interactions:
     uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/create?api-version=7.2
   response:
     body:
-      string: '{"attributes":{"created":1633075589,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075589},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","kty":"RSA-HSM","n":"3membpdG0z2v7ZuYv1kgfivS_vbgOi2zPw9N1Kc4p7JQnd47fE0okJcTQNVgJ8qIrNAoyqQAu4k9DHt5_SRhOYM7_c8HDcrINMEn16wFA9u4JEk7vHiePA05ZnVxFGvgKMcglL1yzCRFOuwYQMSsjFtdMI3ryP4sYEW-Fu8V5Qaz7G87yG-0F87WMcQ63GVs9BYRgSEQwxA-rqCJyjeJ3q6HmymIfeOOZMpDvMyc8kJyRh5ZtvfGCMZ0QXGGcSJ9rgQsU8xePAsjm475vPCoRpSrmUL9XlD5OD-VCHibK4hEVjdnzshT8EMwSxgwrjoOdfX4JDfCiD9tXbmgOiAPDQ"}}'
+      string: '{"attributes":{"created":1633375437,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375437},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787","kty":"RSA-HSM","n":"s6FXP4oXEDxDMB_NCVeh8FSRjeUQNeFr7y3Fm6H061NjD9r3V406ZJzAuEJp2ueG7v4CRcb_qLyVKweaj4myQP2-bx-_JlLUHLqJyuydZK4wjoIAABwfIPLx7SfkdxZ04Ghwy5bV3BI31ghs2f0tww9bdnndnJ7nFe9QgIe4BnWB7YoOCsNpA66qawHpa6tDWGr2X8cq7cGXsK4fzAhS_U-Zi_3zOtIlEpHX98EXQW2yj3fqMmI3hcaaazoEmn1qObZR4gtyo7X7dhxq9HWySM3eq1mqf-aF0XOu_OmMbd_QDAjHz6Lifo72ANxi6kJbJNLpNjhKhmfD4MJ0NmArIw"}}'
     headers:
       cache-control: no-cache
       content-length: '734'
@@ -56,7 +56,7 @@ interactions:
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
       x-ms-keyvault-region: westus
-      x-ms-server-latency: '297'
+      x-ms-server-latency: '304'
     status:
       code: 200
       message: OK
@@ -69,10 +69,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004?api-version=7.2
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787?api-version=7.2
   response:
     body:
-      string: '{"attributes":{"created":1633075589,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075589},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","kty":"RSA-HSM","n":"3membpdG0z2v7ZuYv1kgfivS_vbgOi2zPw9N1Kc4p7JQnd47fE0okJcTQNVgJ8qIrNAoyqQAu4k9DHt5_SRhOYM7_c8HDcrINMEn16wFA9u4JEk7vHiePA05ZnVxFGvgKMcglL1yzCRFOuwYQMSsjFtdMI3ryP4sYEW-Fu8V5Qaz7G87yG-0F87WMcQ63GVs9BYRgSEQwxA-rqCJyjeJ3q6HmymIfeOOZMpDvMyc8kJyRh5ZtvfGCMZ0QXGGcSJ9rgQsU8xePAsjm475vPCoRpSrmUL9XlD5OD-VCHibK4hEVjdnzshT8EMwSxgwrjoOdfX4JDfCiD9tXbmgOiAPDQ"}}'
+      string: '{"attributes":{"created":1633375437,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375437},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787","kty":"RSA-HSM","n":"s6FXP4oXEDxDMB_NCVeh8FSRjeUQNeFr7y3Fm6H061NjD9r3V406ZJzAuEJp2ueG7v4CRcb_qLyVKweaj4myQP2-bx-_JlLUHLqJyuydZK4wjoIAABwfIPLx7SfkdxZ04Ghwy5bV3BI31ghs2f0tww9bdnndnJ7nFe9QgIe4BnWB7YoOCsNpA66qawHpa6tDWGr2X8cq7cGXsK4fzAhS_U-Zi_3zOtIlEpHX98EXQW2yj3fqMmI3hcaaazoEmn1qObZR4gtyo7X7dhxq9HWySM3eq1mqf-aF0XOu_OmMbd_QDAjHz6Lifo72ANxi6kJbJNLpNjhKhmfD4MJ0NmArIw"}}'
     headers:
       cache-control: no-cache
       content-length: '734'
@@ -84,11 +84,11 @@ interactions:
       x-ms-build-version: 1.0.20210907-1-d3b7f466-develop
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
       x-ms-keyvault-region: westus
-      x-ms-server-latency: '71'
+      x-ms-server-latency: '84'
     status:
       code: 200
       message: OK
-    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004?api-version=7.2
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787?api-version=7.2
 - request:
     body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
     headers:
@@ -101,10 +101,100 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/encrypt?api-version=7.2
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/encrypt?api-version=7.2
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","value":"WO0dmyt0K6lzuoB84iUORM6SRIv174NeWs8HhRtu0Q_EnbLKSL5NtaTnb_ASrAPcMGDeCn28uKL9bPKKYPQI5zDIhZ-KyDBa6Hp7BBNSofg_sV1Z9e0pPHpK2yLyWd1tPROr-Ga1_c6_Atl6sK7njUQRnfsW3zofZZxznhO6s3dNPpG1zNc93obKhkM7AduhRTQgYCeETAZ5Kq0Buwswe0Uq0UuaNcWl3-riMtEc273pqTktW8PmC_QIbHpv6ZQ3vxDbxRyXzv0eirt_8ZISdc4tU8YkWj94fZ8lCfztPnBCjlL1ub1Kkfs9ei6Pj7kKVoyHulmzN-CudBW2UzeQ7Q"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787","value":"WpQrkLcbko7IoSu9i3_zi0_EgW7RUZPfZ7cafB4ivUVnq057pU3S73J3ukl7-JfYIawvsQoqSqOwwB8DjC796mEaRfHWZXBJe0ukQRa-0GpyxySEzh4yvedsFkNzdHABRhqE2y7hLVxsQ-XhJHNxXmiY1Jcqi2L-wrQYNwlGW0q59Wuv-6DH8rVecGvjMh-yZx19gr5j-M-imAWflVd62dSOG1ZAEQTypBvqRSs8pPIxpimHBMjvuMRWT6qY3fsZHe55D6RS8b5R96IjIEa_9w83N_EMM7no7-L_tc-gUQLq0nOWS74IDTu8axNdH-y6whbGsswYIqTstkRVYUfBkA"}'
+    headers:
+      cache-control: no-cache
+      content-length: '489'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '1'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/encrypt?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "WpQrkLcbko7IoSu9i3_zi0_EgW7RUZPfZ7cafB4ivUVnq057pU3S73J3ukl7-JfYIawvsQoqSqOwwB8DjC796mEaRfHWZXBJe0ukQRa-0GpyxySEzh4yvedsFkNzdHABRhqE2y7hLVxsQ-XhJHNxXmiY1Jcqi2L-wrQYNwlGW0q59Wuv-6DH8rVecGvjMh-yZx19gr5j-M-imAWflVd62dSOG1ZAEQTypBvqRSs8pPIxpimHBMjvuMRWT6qY3fsZHe55D6RS8b5R96IjIEa_9w83N_EMM7no7-L_tc-gUQLq0nOWS74IDTu8axNdH-y6whbGsswYIqTstkRVYUfBkA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '159'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '2'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/decrypt?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/?api-version=7.2
+  response:
+    body:
+      string: '{"attributes":{"created":1633375437,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375437},"key":{"e":"AQAB","key_ops":["verify","sign","unwrapKey","decrypt","encrypt","wrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787","kty":"RSA-HSM","n":"s6FXP4oXEDxDMB_NCVeh8FSRjeUQNeFr7y3Fm6H061NjD9r3V406ZJzAuEJp2ueG7v4CRcb_qLyVKweaj4myQP2-bx-_JlLUHLqJyuydZK4wjoIAABwfIPLx7SfkdxZ04Ghwy5bV3BI31ghs2f0tww9bdnndnJ7nFe9QgIe4BnWB7YoOCsNpA66qawHpa6tDWGr2X8cq7cGXsK4fzAhS_U-Zi_3zOtIlEpHX98EXQW2yj3fqMmI3hcaaazoEmn1qObZR4gtyo7X7dhxq9HWySM3eq1mqf-aF0XOu_OmMbd_QDAjHz6Lifo72ANxi6kJbJNLpNjhKhmfD4MJ0NmArIw"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '734'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '1'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787","value":"O9lEDpo0J1ZEFhksM5YebBpMxCA1KZVTd734j4MDM5WdCDTCSnsXj6xty4pBRkm8emMoOyUobdfHJOd5iGaMYSYf9lg91PIwr5W5L8_3OLbxKmprE-6ubY6-x8QUYp7S3WCg_lHMBl4cKwQJ2Na53noPXqzHR_UGC-ZgtXWv1LSFWvA95DB2TpDoD7c5YJ504Zg_gXJ7I5qspqgOes03_dMxDxMi0_XUM4B4IwrN3qeB1PXynbGGEnmmqvnSYPGVv9MWXAmWvLGUuh5XLzm-ti5VXE0fa9dzMPMz8PeaOUpeVPngOvBo9kphnGHpy1y0ygPvRpT_x_rbu8Y_QneXmw"}'
     headers:
       cache-control: no-cache
       content-length: '489'
@@ -119,9 +209,9 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/encrypt?api-version=7.2
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/encrypt?api-version=7.2
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "WO0dmyt0K6lzuoB84iUORM6SRIv174NeWs8HhRtu0Q_EnbLKSL5NtaTnb_ASrAPcMGDeCn28uKL9bPKKYPQI5zDIhZ-KyDBa6Hp7BBNSofg_sV1Z9e0pPHpK2yLyWd1tPROr-Ga1_c6_Atl6sK7njUQRnfsW3zofZZxznhO6s3dNPpG1zNc93obKhkM7AduhRTQgYCeETAZ5Kq0Buwswe0Uq0UuaNcWl3-riMtEc273pqTktW8PmC_QIbHpv6ZQ3vxDbxRyXzv0eirt_8ZISdc4tU8YkWj94fZ8lCfztPnBCjlL1ub1Kkfs9ei6Pj7kKVoyHulmzN-CudBW2UzeQ7Q"}'
+    body: '{"alg": "RSA-OAEP", "value": "O9lEDpo0J1ZEFhksM5YebBpMxCA1KZVTd734j4MDM5WdCDTCSnsXj6xty4pBRkm8emMoOyUobdfHJOd5iGaMYSYf9lg91PIwr5W5L8_3OLbxKmprE-6ubY6-x8QUYp7S3WCg_lHMBl4cKwQJ2Na53noPXqzHR_UGC-ZgtXWv1LSFWvA95DB2TpDoD7c5YJ504Zg_gXJ7I5qspqgOes03_dMxDxMi0_XUM4B4IwrN3qeB1PXynbGGEnmmqvnSYPGVv9MWXAmWvLGUuh5XLzm-ti5VXE0fa9dzMPMz8PeaOUpeVPngOvBo9kphnGHpy1y0ygPvRpT_x_rbu8Y_QneXmw"}'
     headers:
       Accept:
       - application/json
@@ -132,10 +222,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/decrypt?api-version=7.2
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/decrypt?api-version=7.2
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","value":"cGxhaW50ZXh0"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control: no-cache
       content-length: '159'
@@ -150,5 +240,5 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/decrypt?api-version=7.2
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/3343f6f44e1540b983bf38b741f9a787/decrypt?api-version=7.2
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_mhsm.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/create?api-version=7.2
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      www-authenticate: Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-server-latency: '0'
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/create?api-version=7.2
+- request:
+    body: '{"kty": "RSA-HSM"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/create?api-version=7.2
+  response:
+    body:
+      string: '{"attributes":{"created":1633075589,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075589},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","kty":"RSA-HSM","n":"3membpdG0z2v7ZuYv1kgfivS_vbgOi2zPw9N1Kc4p7JQnd47fE0okJcTQNVgJ8qIrNAoyqQAu4k9DHt5_SRhOYM7_c8HDcrINMEn16wFA9u4JEk7vHiePA05ZnVxFGvgKMcglL1yzCRFOuwYQMSsjFtdMI3ryP4sYEW-Fu8V5Qaz7G87yG-0F87WMcQ63GVs9BYRgSEQwxA-rqCJyjeJ3q6HmymIfeOOZMpDvMyc8kJyRh5ZtvfGCMZ0QXGGcSJ9rgQsU8xePAsjm475vPCoRpSrmUL9XlD5OD-VCHibK4hEVjdnzshT8EMwSxgwrjoOdfX4JDfCiD9tXbmgOiAPDQ"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '734'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '297'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/create?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004?api-version=7.2
+  response:
+    body:
+      string: '{"attributes":{"created":1633075589,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075589},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","kty":"RSA-HSM","n":"3membpdG0z2v7ZuYv1kgfivS_vbgOi2zPw9N1Kc4p7JQnd47fE0okJcTQNVgJ8qIrNAoyqQAu4k9DHt5_SRhOYM7_c8HDcrINMEn16wFA9u4JEk7vHiePA05ZnVxFGvgKMcglL1yzCRFOuwYQMSsjFtdMI3ryP4sYEW-Fu8V5Qaz7G87yG-0F87WMcQ63GVs9BYRgSEQwxA-rqCJyjeJ3q6HmymIfeOOZMpDvMyc8kJyRh5ZtvfGCMZ0QXGGcSJ9rgQsU8xePAsjm475vPCoRpSrmUL9XlD5OD-VCHibK4hEVjdnzshT8EMwSxgwrjoOdfX4JDfCiD9tXbmgOiAPDQ"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '734'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '71'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","value":"WO0dmyt0K6lzuoB84iUORM6SRIv174NeWs8HhRtu0Q_EnbLKSL5NtaTnb_ASrAPcMGDeCn28uKL9bPKKYPQI5zDIhZ-KyDBa6Hp7BBNSofg_sV1Z9e0pPHpK2yLyWd1tPROr-Ga1_c6_Atl6sK7njUQRnfsW3zofZZxznhO6s3dNPpG1zNc93obKhkM7AduhRTQgYCeETAZ5Kq0Buwswe0Uq0UuaNcWl3-riMtEc273pqTktW8PmC_QIbHpv6ZQ3vxDbxRyXzv0eirt_8ZISdc4tU8YkWj94fZ8lCfztPnBCjlL1ub1Kkfs9ei6Pj7kKVoyHulmzN-CudBW2UzeQ7Q"}'
+    headers:
+      cache-control: no-cache
+      content-length: '489'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '0'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/encrypt?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "WO0dmyt0K6lzuoB84iUORM6SRIv174NeWs8HhRtu0Q_EnbLKSL5NtaTnb_ASrAPcMGDeCn28uKL9bPKKYPQI5zDIhZ-KyDBa6Hp7BBNSofg_sV1Z9e0pPHpK2yLyWd1tPROr-Ga1_c6_Atl6sK7njUQRnfsW3zofZZxznhO6s3dNPpG1zNc93obKhkM7AduhRTQgYCeETAZ5Kq0Buwswe0Uq0UuaNcWl3-riMtEc273pqTktW8PmC_QIbHpv6ZQ3vxDbxRyXzv0eirt_8ZISdc4tU8YkWj94fZ8lCfztPnBCjlL1ub1Kkfs9ei6Pj7kKVoyHulmzN-CudBW2UzeQ7Q"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '159'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '3'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-name4f34158a/48c07c75788342000afb963417f64004/decrypt?api-version=7.2
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_vault.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/create?api-version=7.2
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:32 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/create?api-version=7.2
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/create?api-version=7.2
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ubNURwDkBDnNoCzAr8FPUxiDvrkbKpjzNEA3-BSJb12X7bY55cQm-agE5iwhGRBrZ5fk7u7CkQUS5S8GIsU7ed4NJs1EoUH_eg8k-3eS2OJAPU1R8qlzxvBJXvPIcHK0oEzjbbBReQQRsIwsQECZSNuJkR020XEXFZCB8y2WZ6AS3fX1RrJEtDY1N3jM5Mq7ndLErMHzBbZ07pxlp-BBfYfwOH5ovLUtu0JnEiWhurl9ib3UkMf-rohPbH9QvyTG94LlwN8OEzoZRVQ43xy-4H4cHcOHXEc6nnOjS6K-ww0EwgljUlfNmc8oLO-GVsi_ut-1q9jQYlVsw9LdUOgobQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075592,"updated":1633075592,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:32 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/create?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70?api-version=7.2
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ubNURwDkBDnNoCzAr8FPUxiDvrkbKpjzNEA3-BSJb12X7bY55cQm-agE5iwhGRBrZ5fk7u7CkQUS5S8GIsU7ed4NJs1EoUH_eg8k-3eS2OJAPU1R8qlzxvBJXvPIcHK0oEzjbbBReQQRsIwsQECZSNuJkR020XEXFZCB8y2WZ6AS3fX1RrJEtDY1N3jM5Mq7ndLErMHzBbZ07pxlp-BBfYfwOH5ovLUtu0JnEiWhurl9ib3UkMf-rohPbH9QvyTG94LlwN8OEzoZRVQ43xy-4H4cHcOHXEc6nnOjS6K-ww0EwgljUlfNmc8oLO-GVsi_ut-1q9jQYlVsw9LdUOgobQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075592,"updated":1633075592,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:32 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","value":"A8NWLYApt5EdD83l5sArSjE2g-hF5sdu4YO23SxM6rSXBIfyoGy872Go7ogCzVv61ZYFXLIYnfS4ngoJvWwgLgAYQwynp_mal6M0mKya8QGbQ-0nOSJ-QShKsg5vurU5ZbtHxlN7966cAAQGYHbsjg5EWS24l_SGEiF-ffBq8bpjvOEzDwes-9VdoInQ98b7ntqbJf_ich45y7XFps3e2IZVGoKXCDHbES6s8-0F327Dairpb9GouKUY_aPYUPmk2MWFwbBMNqQGA5cxkR_8Cls3VHvYUjhR0lUPsU-pUXr1ZbMHFWWfwfwNODzCAsDkFVYkmXLXSn9g8rjPFNHFCQ"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:32 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/encrypt?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "A8NWLYApt5EdD83l5sArSjE2g-hF5sdu4YO23SxM6rSXBIfyoGy872Go7ogCzVv61ZYFXLIYnfS4ngoJvWwgLgAYQwynp_mal6M0mKya8QGbQ-0nOSJ-QShKsg5vurU5ZbtHxlN7966cAAQGYHbsjg5EWS24l_SGEiF-ffBq8bpjvOEzDwes-9VdoInQ98b7ntqbJf_ich45y7XFps3e2IZVGoKXCDHbES6s8-0F327Dairpb9GouKUY_aPYUPmk2MWFwbBMNqQGA5cxkR_8Cls3VHvYUjhR0lUPsU-pUXr1ZbMHFWWfwfwNODzCAsDkFVYkmXLXSn9g8rjPFNHFCQ"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:32 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/decrypt?api-version=7.2
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_2_vault.yaml
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:32 GMT
+      date: Mon, 04 Oct 2021 19:23:58 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
@@ -29,7 +29,7 @@ interactions:
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 401
@@ -50,19 +50,19 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ubNURwDkBDnNoCzAr8FPUxiDvrkbKpjzNEA3-BSJb12X7bY55cQm-agE5iwhGRBrZ5fk7u7CkQUS5S8GIsU7ed4NJs1EoUH_eg8k-3eS2OJAPU1R8qlzxvBJXvPIcHK0oEzjbbBReQQRsIwsQECZSNuJkR020XEXFZCB8y2WZ6AS3fX1RrJEtDY1N3jM5Mq7ndLErMHzBbZ07pxlp-BBfYfwOH5ovLUtu0JnEiWhurl9ib3UkMf-rohPbH9QvyTG94LlwN8OEzoZRVQ43xy-4H4cHcOHXEc6nnOjS6K-ww0EwgljUlfNmc8oLO-GVsi_ut-1q9jQYlVsw9LdUOgobQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075592,"updated":1633075592,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rhGhqya3rOArdaNvYeQ6SrCDdKDamUiyWFwZ1yJnzyxijNHDeg7FY-sLctUIkLD5gF1ndn7Pkmjn5caAZrr39olf1ESG1AJIcev_IoZUAaEsjy1hTEjxcm56qD6jchA5Y6jHy-ZLLFnzYgYccrbgeo0JJzo8l0IFt9QV1wR5gcZmsTs3izeXHt908XOf4gb4h_NRqtxxeN7c-Guy4eQxr3Dz8ZXmDnRmVx1hXD19KF3qs6hPX4bRTvUVi4YeCl6bTE7oAIVz0ItisGcH0xV6jU1RSUQBWgbUlsZfCQsJHGdOY-ypC9cxlqXwA4vGWcL5SJbs1KqCyPQVGIQWpwT5BQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375440,"updated":1633375440,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
       content-length: '694'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:32 GMT
+      date: Mon, 04 Oct 2021 19:23:59 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
@@ -76,27 +76,27 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ubNURwDkBDnNoCzAr8FPUxiDvrkbKpjzNEA3-BSJb12X7bY55cQm-agE5iwhGRBrZ5fk7u7CkQUS5S8GIsU7ed4NJs1EoUH_eg8k-3eS2OJAPU1R8qlzxvBJXvPIcHK0oEzjbbBReQQRsIwsQECZSNuJkR020XEXFZCB8y2WZ6AS3fX1RrJEtDY1N3jM5Mq7ndLErMHzBbZ07pxlp-BBfYfwOH5ovLUtu0JnEiWhurl9ib3UkMf-rohPbH9QvyTG94LlwN8OEzoZRVQ43xy-4H4cHcOHXEc6nnOjS6K-ww0EwgljUlfNmc8oLO-GVsi_ut-1q9jQYlVsw9LdUOgobQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075592,"updated":1633075592,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rhGhqya3rOArdaNvYeQ6SrCDdKDamUiyWFwZ1yJnzyxijNHDeg7FY-sLctUIkLD5gF1ndn7Pkmjn5caAZrr39olf1ESG1AJIcev_IoZUAaEsjy1hTEjxcm56qD6jchA5Y6jHy-ZLLFnzYgYccrbgeo0JJzo8l0IFt9QV1wR5gcZmsTs3izeXHt908XOf4gb4h_NRqtxxeN7c-Guy4eQxr3Dz8ZXmDnRmVx1hXD19KF3qs6hPX4bRTvUVi4YeCl6bTE7oAIVz0ItisGcH0xV6jU1RSUQBWgbUlsZfCQsJHGdOY-ypC9cxlqXwA4vGWcL5SJbs1KqCyPQVGIQWpwT5BQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375440,"updated":1633375440,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
       content-length: '694'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:32 GMT
+      date: Mon, 04 Oct 2021 19:23:59 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70?api-version=7.2
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc?api-version=7.2
 - request:
     body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
     headers:
@@ -109,29 +109,29 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/encrypt?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/encrypt?api-version=7.2
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","value":"A8NWLYApt5EdD83l5sArSjE2g-hF5sdu4YO23SxM6rSXBIfyoGy872Go7ogCzVv61ZYFXLIYnfS4ngoJvWwgLgAYQwynp_mal6M0mKya8QGbQ-0nOSJ-QShKsg5vurU5ZbtHxlN7966cAAQGYHbsjg5EWS24l_SGEiF-ffBq8bpjvOEzDwes-9VdoInQ98b7ntqbJf_ich45y7XFps3e2IZVGoKXCDHbES6s8-0F327Dairpb9GouKUY_aPYUPmk2MWFwbBMNqQGA5cxkR_8Cls3VHvYUjhR0lUPsU-pUXr1ZbMHFWWfwfwNODzCAsDkFVYkmXLXSn9g8rjPFNHFCQ"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc","value":"HRLLbeqk0hSTavQQVElefTl_gnXTWyxAVoMghrixjvQ3fd9dq_fZH3Jb-6LkjiwknjY71WVaxdQrUJPlzKDuRAXwq2ETXzbLZCB0r1e5b0xXR3PREOL9eXt5ioEe1CP44-gmecepWgv1f79KDYIqOqdG9VASfW_skpVutAxuziuEgGrP6-rAP39NdTrquc71Luswp_Ud64K2N43VuRUKccc0M93xQYZ9A2n0XRUIKahZ4phSNjBaPBugaz8cjTjxBXSvQBjjYlCPG8WgvRfNATxt5sPmm6TPuF57ffXXdTGhDxDQysIeABxtwbD7ERcYZvGvu0Xrzm-OZIQlP2pz_w"}'
     headers:
       cache-control: no-cache
       content-length: '464'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:32 GMT
+      date: Mon, 04 Oct 2021 19:23:59 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/encrypt?api-version=7.2
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/encrypt?api-version=7.2
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "A8NWLYApt5EdD83l5sArSjE2g-hF5sdu4YO23SxM6rSXBIfyoGy872Go7ogCzVv61ZYFXLIYnfS4ngoJvWwgLgAYQwynp_mal6M0mKya8QGbQ-0nOSJ-QShKsg5vurU5ZbtHxlN7966cAAQGYHbsjg5EWS24l_SGEiF-ffBq8bpjvOEzDwes-9VdoInQ98b7ntqbJf_ich45y7XFps3e2IZVGoKXCDHbES6s8-0F327Dairpb9GouKUY_aPYUPmk2MWFwbBMNqQGA5cxkR_8Cls3VHvYUjhR0lUPsU-pUXr1ZbMHFWWfwfwNODzCAsDkFVYkmXLXSn9g8rjPFNHFCQ"}'
+    body: '{"alg": "RSA-OAEP", "value": "HRLLbeqk0hSTavQQVElefTl_gnXTWyxAVoMghrixjvQ3fd9dq_fZH3Jb-6LkjiwknjY71WVaxdQrUJPlzKDuRAXwq2ETXzbLZCB0r1e5b0xXR3PREOL9eXt5ioEe1CP44-gmecepWgv1f79KDYIqOqdG9VASfW_skpVutAxuziuEgGrP6-rAP39NdTrquc71Luswp_Ud64K2N43VuRUKccc0M93xQYZ9A2n0XRUIKahZ4phSNjBaPBugaz8cjTjxBXSvQBjjYlCPG8WgvRfNATxt5sPmm6TPuF57ffXXdTGhDxDQysIeABxtwbD7ERcYZvGvu0Xrzm-OZIQlP2pz_w"}'
     headers:
       Accept:
       - application/json
@@ -142,25 +142,120 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/decrypt?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/decrypt?api-version=7.2
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control: no-cache
       content-length: '134'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:32 GMT
+      date: Mon, 04 Oct 2021 19:23:59 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/7f4bdf93481344219dbbabccf691fb70/decrypt?api-version=7.2
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/decrypt?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/?api-version=7.2
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rhGhqya3rOArdaNvYeQ6SrCDdKDamUiyWFwZ1yJnzyxijNHDeg7FY-sLctUIkLD5gF1ndn7Pkmjn5caAZrr39olf1ESG1AJIcev_IoZUAaEsjy1hTEjxcm56qD6jchA5Y6jHy-ZLLFnzYgYccrbgeo0JJzo8l0IFt9QV1wR5gcZmsTs3izeXHt908XOf4gb4h_NRqtxxeN7c-Guy4eQxr3Dz8ZXmDnRmVx1hXD19KF3qs6hPX4bRTvUVi4YeCl6bTE7oAIVz0ItisGcH0xV6jU1RSUQBWgbUlsZfCQsJHGdOY-ypC9cxlqXwA4vGWcL5SJbs1KqCyPQVGIQWpwT5BQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633375440,"updated":1633375440,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:59 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/encrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc","value":"EI2ADQpHko-KoydfZGcJrOs2UOqeGP-Nt6--S7Jf-siw8oajBS9PXWWzzfnafKGkqrBXXjCdEcUhvSD8U2kvO4b8t5iX7ikbmx6YphL_B1TUg6RDhwfDYjMRHIA2XFg5OeBKP07XugBviJo2fXeEYLE57dYLgHLusNpmlUhh1m80z8x92vZyb2t7Yz6dW4vIthFQ4FAYZxXayk89fOcdwQbY_Xks15P6lZJV9F6MKfMBSRs9Fg4jTzOwgPr5g5g3Js_7xpx29iqdIZz4ZhbTUJthF2FSgKCCkmqVo5c9wfZJOOhDBBGZYxbzZGqIGeXFjne3r9BlDorjEQnFP97Grg"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:23:59 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/encrypt?api-version=7.2
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "EI2ADQpHko-KoydfZGcJrOs2UOqeGP-Nt6--S7Jf-siw8oajBS9PXWWzzfnafKGkqrBXXjCdEcUhvSD8U2kvO4b8t5iX7ikbmx6YphL_B1TUg6RDhwfDYjMRHIA2XFg5OeBKP07XugBviJo2fXeEYLE57dYLgHLusNpmlUhh1m80z8x92vZyb2t7Yz6dW4vIthFQ4FAYZxXayk89fOcdwQbY_Xks15P6lZJV9F6MKfMBSRs9Fg4jTzOwgPr5g5g3Js_7xpx29iqdIZz4ZhbTUJthF2FSgKCCkmqVo5c9wfZJOOhDBBGZYxbzZGqIGeXFjne3r9BlDorjEQnFP97Grg"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/decrypt?api-version=7.2
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:24:00 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name65471601/6d7f48e78d124dadbeca29741de6bbfc/decrypt?api-version=7.2
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_mhsm.yaml
@@ -45,7 +45,7 @@ interactions:
     uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/create?api-version=7.3-preview
   response:
     body:
-      string: '{"attributes":{"created":1633075595,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075595},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","kty":"RSA-HSM","n":"jF2lAPZem3h2e1ObCpXzsAR0FsJ6Wooeg0lxseVCE7ouLZ4aslZ9Hmy10zl70vjv0SEn0J3HZNaMpirk7AW0cQ8GNCOBxehE3-cpcIYRUB-WQo92znqBqWaRLsSL2adVbBcCqtZmr8mnHEqXcrOBTOMTkJDm84tbjQpBIOMOPkbvOdHVqtNr8--bxVzHvaK2f4Mw_uM55dgfBtEs2QBuY8yVWCxuXdCrBbtV33VmWDBwHm2bzdwn-qyxX4WWThAG9KkTRfB3UYYKqIXwTsjTqu84pxXH7j_vYOGI3gQhGmdWjT2ZscQmmzwJr7cYLGxMr1DpzedL4v_-HB42WR1_4w"}}'
+      string: '{"attributes":{"created":1633375443,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375443},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027","kty":"RSA-HSM","n":"maf7PAPTBCgYZi-a3OaMZQ08nV00uNmpgSvi9WIdIwN7wswPCYUCZcnf-ZHrwMkIsPubHKrfYrjP0tZxkHyMj33xFQIvX3o94L0GpMFW__TgPyehtO1V397Ailmp89HEjFo4HttNdpEHDXYARGZtkTuPIR-YFxbhenbgNOgusdi3letaTDet4AUzAatpq1u6k8mD9CIyhocEn4JhBi8OzdeuSGd2Zya8qui9GB_EXRkpYCiJwZUi3YNvJ6o_gVGmKWt4uq3FblCgj4fvxkwQ-9bz2fY4zP1V_z6NXMlA2kcbu6M02DadrJuCL8oiyV8uFSaI8jarO3oxn4Tj7u3LQQ"}}'
     headers:
       cache-control: no-cache
       content-length: '733'
@@ -56,7 +56,7 @@ interactions:
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
       x-ms-keyvault-region: westus
-      x-ms-server-latency: '298'
+      x-ms-server-latency: '308'
     status:
       code: 200
       message: OK
@@ -69,10 +69,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096?api-version=7.3-preview
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027?api-version=7.3-preview
   response:
     body:
-      string: '{"attributes":{"created":1633075595,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075595},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","kty":"RSA-HSM","n":"jF2lAPZem3h2e1ObCpXzsAR0FsJ6Wooeg0lxseVCE7ouLZ4aslZ9Hmy10zl70vjv0SEn0J3HZNaMpirk7AW0cQ8GNCOBxehE3-cpcIYRUB-WQo92znqBqWaRLsSL2adVbBcCqtZmr8mnHEqXcrOBTOMTkJDm84tbjQpBIOMOPkbvOdHVqtNr8--bxVzHvaK2f4Mw_uM55dgfBtEs2QBuY8yVWCxuXdCrBbtV33VmWDBwHm2bzdwn-qyxX4WWThAG9KkTRfB3UYYKqIXwTsjTqu84pxXH7j_vYOGI3gQhGmdWjT2ZscQmmzwJr7cYLGxMr1DpzedL4v_-HB42WR1_4w"}}'
+      string: '{"attributes":{"created":1633375443,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375443},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027","kty":"RSA-HSM","n":"maf7PAPTBCgYZi-a3OaMZQ08nV00uNmpgSvi9WIdIwN7wswPCYUCZcnf-ZHrwMkIsPubHKrfYrjP0tZxkHyMj33xFQIvX3o94L0GpMFW__TgPyehtO1V397Ailmp89HEjFo4HttNdpEHDXYARGZtkTuPIR-YFxbhenbgNOgusdi3letaTDet4AUzAatpq1u6k8mD9CIyhocEn4JhBi8OzdeuSGd2Zya8qui9GB_EXRkpYCiJwZUi3YNvJ6o_gVGmKWt4uq3FblCgj4fvxkwQ-9bz2fY4zP1V_z6NXMlA2kcbu6M02DadrJuCL8oiyV8uFSaI8jarO3oxn4Tj7u3LQQ"}}'
     headers:
       cache-control: no-cache
       content-length: '733'
@@ -84,11 +84,11 @@ interactions:
       x-ms-build-version: 1.0.20210907-1-d3b7f466-develop
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
       x-ms-keyvault-region: westus
-      x-ms-server-latency: '76'
+      x-ms-server-latency: '78'
     status:
       code: 200
       message: OK
-    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096?api-version=7.3-preview
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027?api-version=7.3-preview
 - request:
     body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
     headers:
@@ -101,10 +101,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/encrypt?api-version=7.3-preview
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/encrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","value":"ad3e9CFGZZwJh1_GVoPkpzmrslKwEO68H3c3lXZIoxUNSTUAE-LqB0wEsjXzTwG7vbf0-OzD1CUYvx6z5_LeWtuvC5CMinJ8RsHidIyTfDS-Ardxda957Frg9M3SkBNgtVcWb4fc47ZDrOItYfkna4QRyHMJcB_-kDZbiynijoUYSiaSD1ykGMinkl93xAMdeAqvV54eMHI8cLMtiwsZscpsxB-ekYgDHsS2_Nuu8bKkUHc5xfmp82xANU063-b3QrAYWHztNQRz4dLSkI0jC_kzuHDKRneVtl0b6xIjEsQk-akECyVpGSiwy_dERrHLtw3CBW9cL2Z9M4oeW6DY_A"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027","value":"VTgI8dFSutSJ9UberroxoHRiPxQdr8OONbdskNnkCPXOU3B7x09xD09aXkv7BVNSd5zVK73PtRkblQV5Gws_LW21gewYGn3asA5SpmcPevgk87phfeUvlj0mfd6wpfzd0wXEqr54HTjF5hxjDjvnTUWFuiLkGPAmV-stXIbPmuTKBBaDdpXq2mRjRgTDjY-8iM_TCcMvTSIOWTqRYPQTSXBvf_pwkHehc3CgOvfvcJJNmWSSTSIuBq9TyplyjjPZw1dsVM3Hdmsc1XT0hguhEQB-RVKnNa9rqjAWRoQzo1yPYI0MT5haHLEcmsAgU_GY62wJTk-EN50Vh9o07NcbEw"}'
     headers:
       cache-control: no-cache
       content-length: '488'
@@ -119,9 +119,9 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/encrypt?api-version=7.3-preview
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/encrypt?api-version=7.3-preview
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "ad3e9CFGZZwJh1_GVoPkpzmrslKwEO68H3c3lXZIoxUNSTUAE-LqB0wEsjXzTwG7vbf0-OzD1CUYvx6z5_LeWtuvC5CMinJ8RsHidIyTfDS-Ardxda957Frg9M3SkBNgtVcWb4fc47ZDrOItYfkna4QRyHMJcB_-kDZbiynijoUYSiaSD1ykGMinkl93xAMdeAqvV54eMHI8cLMtiwsZscpsxB-ekYgDHsS2_Nuu8bKkUHc5xfmp82xANU063-b3QrAYWHztNQRz4dLSkI0jC_kzuHDKRneVtl0b6xIjEsQk-akECyVpGSiwy_dERrHLtw3CBW9cL2Z9M4oeW6DY_A"}'
+    body: '{"alg": "RSA-OAEP", "value": "VTgI8dFSutSJ9UberroxoHRiPxQdr8OONbdskNnkCPXOU3B7x09xD09aXkv7BVNSd5zVK73PtRkblQV5Gws_LW21gewYGn3asA5SpmcPevgk87phfeUvlj0mfd6wpfzd0wXEqr54HTjF5hxjDjvnTUWFuiLkGPAmV-stXIbPmuTKBBaDdpXq2mRjRgTDjY-8iM_TCcMvTSIOWTqRYPQTSXBvf_pwkHehc3CgOvfvcJJNmWSSTSIuBq9TyplyjjPZw1dsVM3Hdmsc1XT0hguhEQB-RVKnNa9rqjAWRoQzo1yPYI0MT5haHLEcmsAgU_GY62wJTk-EN50Vh9o07NcbEw"}'
     headers:
       Accept:
       - application/json
@@ -132,10 +132,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/decrypt?api-version=7.3-preview
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/decrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","value":"cGxhaW50ZXh0"}'
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control: no-cache
       content-length: '158'
@@ -150,5 +150,95 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/decrypt?api-version=7.3-preview
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/decrypt?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/?api-version=7.3-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1633375443,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633375443},"key":{"e":"AQAB","key_ops":["verify","sign","unwrapKey","decrypt","encrypt","wrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027","kty":"RSA-HSM","n":"maf7PAPTBCgYZi-a3OaMZQ08nV00uNmpgSvi9WIdIwN7wswPCYUCZcnf-ZHrwMkIsPubHKrfYrjP0tZxkHyMj33xFQIvX3o94L0GpMFW__TgPyehtO1V397Ailmp89HEjFo4HttNdpEHDXYARGZtkTuPIR-YFxbhenbgNOgusdi3letaTDet4AUzAatpq1u6k8mD9CIyhocEn4JhBi8OzdeuSGd2Zya8qui9GB_EXRkpYCiJwZUi3YNvJ6o_gVGmKWt4uq3FblCgj4fvxkwQ-9bz2fY4zP1V_z6NXMlA2kcbu6M02DadrJuCL8oiyV8uFSaI8jarO3oxn4Tj7u3LQQ"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '733'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '0'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027","value":"fXQfzb8uzUmwLEncESm9Ug4npBhU0ANLccoug9ekn5adrk_EUHo6u1GrcmGoBNBcTYMQ4FjkEy_LRyP5Z22BkH9bCmkKo16OXWPll-gXOyj9D5I0wyxOIGC4nX33g17RIjGdowP2R_LS9GwUziDrNc9mm27zSKnyA9TNO8iO_O4ZPxkF_HZ1Vt7_DRMJ_X8TSu81s8k6iYufEiOGH0AqUWO5bqBKMliSw3E4lRLFvMzic2YBw_5cf8B7c9EAgiS8mO2TbWwYnLuVxBE-XFgVGLIOOEVAItjuNy1VqbjYCefiNvZSliWgSs9FBWJiweTof2zNQG9ut2s64fnVNAs8xA"}'
+    headers:
+      cache-control: no-cache
+      content-length: '488'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '0'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/encrypt?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "fXQfzb8uzUmwLEncESm9Ug4npBhU0ANLccoug9ekn5adrk_EUHo6u1GrcmGoBNBcTYMQ4FjkEy_LRyP5Z22BkH9bCmkKo16OXWPll-gXOyj9D5I0wyxOIGC4nX33g17RIjGdowP2R_LS9GwUziDrNc9mm27zSKnyA9TNO8iO_O4ZPxkF_HZ1Vt7_DRMJ_X8TSu81s8k6iYufEiOGH0AqUWO5bqBKMliSw3E4lRLFvMzic2YBw_5cf8B7c9EAgiS8mO2TbWwYnLuVxBE-XFgVGLIOOEVAItjuNy1VqbjYCefiNvZSliWgSs9FBWJiweTof2zNQG9ut2s64fnVNAs8xA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '158'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '2'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/c0028c29b193403513f5d54331836027/decrypt?api-version=7.3-preview
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_mhsm.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/create?api-version=7.3-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      www-authenticate: Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-server-latency: '1'
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/create?api-version=7.3-preview
+- request:
+    body: '{"kty": "RSA-HSM"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/create?api-version=7.3-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1633075595,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075595},"key":{"e":"AQAB","key_ops":["wrapKey","sign","verify","encrypt","decrypt","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","kty":"RSA-HSM","n":"jF2lAPZem3h2e1ObCpXzsAR0FsJ6Wooeg0lxseVCE7ouLZ4aslZ9Hmy10zl70vjv0SEn0J3HZNaMpirk7AW0cQ8GNCOBxehE3-cpcIYRUB-WQo92znqBqWaRLsSL2adVbBcCqtZmr8mnHEqXcrOBTOMTkJDm84tbjQpBIOMOPkbvOdHVqtNr8--bxVzHvaK2f4Mw_uM55dgfBtEs2QBuY8yVWCxuXdCrBbtV33VmWDBwHm2bzdwn-qyxX4WWThAG9KkTRfB3UYYKqIXwTsjTqu84pxXH7j_vYOGI3gQhGmdWjT2ZscQmmzwJr7cYLGxMr1DpzedL4v_-HB42WR1_4w"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '733'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '298'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/create?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096?api-version=7.3-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1633075595,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1633075595},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","kty":"RSA-HSM","n":"jF2lAPZem3h2e1ObCpXzsAR0FsJ6Wooeg0lxseVCE7ouLZ4aslZ9Hmy10zl70vjv0SEn0J3HZNaMpirk7AW0cQ8GNCOBxehE3-cpcIYRUB-WQo92znqBqWaRLsSL2adVbBcCqtZmr8mnHEqXcrOBTOMTkJDm84tbjQpBIOMOPkbvOdHVqtNr8--bxVzHvaK2f4Mw_uM55dgfBtEs2QBuY8yVWCxuXdCrBbtV33VmWDBwHm2bzdwn-qyxX4WWThAG9KkTRfB3UYYKqIXwTsjTqu84pxXH7j_vYOGI3gQhGmdWjT2ZscQmmzwJr7cYLGxMr1DpzedL4v_-HB42WR1_4w"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '733'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20210907-1-d3b7f466-develop
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '76'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","value":"ad3e9CFGZZwJh1_GVoPkpzmrslKwEO68H3c3lXZIoxUNSTUAE-LqB0wEsjXzTwG7vbf0-OzD1CUYvx6z5_LeWtuvC5CMinJ8RsHidIyTfDS-Ardxda957Frg9M3SkBNgtVcWb4fc47ZDrOItYfkna4QRyHMJcB_-kDZbiynijoUYSiaSD1ykGMinkl93xAMdeAqvV54eMHI8cLMtiwsZscpsxB-ekYgDHsS2_Nuu8bKkUHc5xfmp82xANU063-b3QrAYWHztNQRz4dLSkI0jC_kzuHDKRneVtl0b6xIjEsQk-akECyVpGSiwy_dERrHLtw3CBW9cL2Z9M4oeW6DY_A"}'
+    headers:
+      cache-control: no-cache
+      content-length: '488'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '1'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/encrypt?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "ad3e9CFGZZwJh1_GVoPkpzmrslKwEO68H3c3lXZIoxUNSTUAE-LqB0wEsjXzTwG7vbf0-OzD1CUYvx6z5_LeWtuvC5CMinJ8RsHidIyTfDS-Ardxda957Frg9M3SkBNgtVcWb4fc47ZDrOItYfkna4QRyHMJcB_-kDZbiynijoUYSiaSD1ykGMinkl93xAMdeAqvV54eMHI8cLMtiwsZscpsxB-ekYgDHsS2_Nuu8bKkUHc5xfmp82xANU063-b3QrAYWHztNQRz4dLSkI0jC_kzuHDKRneVtl0b6xIjEsQk-akECyVpGSiwy_dERrHLtw3CBW9cL2Z9M4oeW6DY_A"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"alg":"RSA-OAEP","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '158'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: westus
+      x-ms-server-latency: '2'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestkey-nameae718ec/8cc01bb5b3904cb69ff8ea69cbca2096/decrypt?api-version=7.3-preview
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_vault.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/create?api-version=7.3-preview
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:37 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/create?api-version=7.3-preview
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/create?api-version=7.3-preview
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oAdYGXQyJbsI1LyZ1McsQcqDyYCnraz6tOndcPWkUPPcM8x2hu_WF19hU_DeztPztoqjQCKj2CsNDp4vfWhbSNPx-WMjqu_jMJhadg-aXR9H4x9Sf9o9jg90nMESJV674_t5zKqFjO9aol5GdaRzeHDYEoCN5yxzIUFdLVKcZoapJMM2CK4aaz8qCiuPeJUvJiNWPYhlSVWpDL0wxS7gG71KB3zybRvv6UjGhdzbkGUG12hkMccYjdC54DGl6ogxSJtVEReyKodMLFF_iBpc49ga4WTPnWnvRtUbGwzP3v48ENnjY7Ybae6UjYkJZeJJP6IocOxKO4fYszipzZmkGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075598,"updated":1633075598,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:37 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/create?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f?api-version=7.3-preview
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oAdYGXQyJbsI1LyZ1McsQcqDyYCnraz6tOndcPWkUPPcM8x2hu_WF19hU_DeztPztoqjQCKj2CsNDp4vfWhbSNPx-WMjqu_jMJhadg-aXR9H4x9Sf9o9jg90nMESJV674_t5zKqFjO9aol5GdaRzeHDYEoCN5yxzIUFdLVKcZoapJMM2CK4aaz8qCiuPeJUvJiNWPYhlSVWpDL0wxS7gG71KB3zybRvv6UjGhdzbkGUG12hkMccYjdC54DGl6ogxSJtVEReyKodMLFF_iBpc49ga4WTPnWnvRtUbGwzP3v48ENnjY7Ybae6UjYkJZeJJP6IocOxKO4fYszipzZmkGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075598,"updated":1633075598,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:38 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","value":"Uaq14DCsPe9fx_EUeWR8bgX3R9cBqyAn5DFNjTXCN3vFDGf3BXelZR1r-E_24MFifl_R_ofu79gm4TcuaJu4EMfOUSXwqc1xBcH7lwI_CyHZZhlNfjJ5VZ70QVM8pFK_8hPR6lJD6_cEyKDiLOIClnU4wQqYrgCWGi4AX1lIzLfnuntHX1WDVxGIERct4I_fbjMkqfQkneALHGVdnMqZO8tN6krXtiuVpovyUDWKkCpuNrFWS2KU-t40dd_pp8B5XYeWJq4PdglbGevp4MLb4aW_KXC_sP2gF19fFgg2b_8E41rK1UtcP0zVY5f0reTfGmhP8JRT1QttmTncS_MiAg"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:38 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/encrypt?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "Uaq14DCsPe9fx_EUeWR8bgX3R9cBqyAn5DFNjTXCN3vFDGf3BXelZR1r-E_24MFifl_R_ofu79gm4TcuaJu4EMfOUSXwqc1xBcH7lwI_CyHZZhlNfjJ5VZ70QVM8pFK_8hPR6lJD6_cEyKDiLOIClnU4wQqYrgCWGi4AX1lIzLfnuntHX1WDVxGIERct4I_fbjMkqfQkneALHGVdnMqZO8tN6krXtiuVpovyUDWKkCpuNrFWS2KU-t40dd_pp8B5XYeWJq4PdglbGevp4MLb4aW_KXC_sP2gF19fFgg2b_8E41rK1UtcP0zVY5f0reTfGmhP8JRT1QttmTncS_MiAg"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Fri, 01 Oct 2021 08:06:38 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.79.2
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/decrypt?api-version=7.3-preview
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_get_cryptography_client_7_3_preview_vault.yaml
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:37 GMT
+      date: Mon, 04 Oct 2021 19:24:06 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
@@ -29,7 +29,7 @@ interactions:
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 401
@@ -50,19 +50,19 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oAdYGXQyJbsI1LyZ1McsQcqDyYCnraz6tOndcPWkUPPcM8x2hu_WF19hU_DeztPztoqjQCKj2CsNDp4vfWhbSNPx-WMjqu_jMJhadg-aXR9H4x9Sf9o9jg90nMESJV674_t5zKqFjO9aol5GdaRzeHDYEoCN5yxzIUFdLVKcZoapJMM2CK4aaz8qCiuPeJUvJiNWPYhlSVWpDL0wxS7gG71KB3zybRvv6UjGhdzbkGUG12hkMccYjdC54DGl6ogxSJtVEReyKodMLFF_iBpc49ga4WTPnWnvRtUbGwzP3v48ENnjY7Ybae6UjYkJZeJJP6IocOxKO4fYszipzZmkGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075598,"updated":1633075598,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"09jLTgFNEzClkBWMRznJtCw316JRRlpzWnfd31p6nHGLzdKJrEqVPyilMNTbAPB6C2B9tKJrgHi1Dl8xxP1TjoOxM7WWfqb0X7GPCLbl96MpTgexiw-U3q4dCB30ab89Xt-pxvKil4XtIkTX1I047Wtdv6uDvfC8b9g6UIzEetfIyWfkd6F-IL0GCAhSz9YUEHnQ3TLDNwXDZbqoMPvzhWhW4hcJ26wZCuNwXb70sNFjeeymQ_CiHUi9DIu_gZDNUdjOo30hgCwWxDMeA92DKVPHcwpjNg6z5nEQKxn_HvBZPQhAaG35xIwb5EOpEVjC0cAcTvTopeaK4-t_gKUr_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375446,"updated":1633375446,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
       content-length: '694'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:37 GMT
+      date: Mon, 04 Oct 2021 19:24:06 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
@@ -76,27 +76,27 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oAdYGXQyJbsI1LyZ1McsQcqDyYCnraz6tOndcPWkUPPcM8x2hu_WF19hU_DeztPztoqjQCKj2CsNDp4vfWhbSNPx-WMjqu_jMJhadg-aXR9H4x9Sf9o9jg90nMESJV674_t5zKqFjO9aol5GdaRzeHDYEoCN5yxzIUFdLVKcZoapJMM2CK4aaz8qCiuPeJUvJiNWPYhlSVWpDL0wxS7gG71KB3zybRvv6UjGhdzbkGUG12hkMccYjdC54DGl6ogxSJtVEReyKodMLFF_iBpc49ga4WTPnWnvRtUbGwzP3v48ENnjY7Ybae6UjYkJZeJJP6IocOxKO4fYszipzZmkGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633075598,"updated":1633075598,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"09jLTgFNEzClkBWMRznJtCw316JRRlpzWnfd31p6nHGLzdKJrEqVPyilMNTbAPB6C2B9tKJrgHi1Dl8xxP1TjoOxM7WWfqb0X7GPCLbl96MpTgexiw-U3q4dCB30ab89Xt-pxvKil4XtIkTX1I047Wtdv6uDvfC8b9g6UIzEetfIyWfkd6F-IL0GCAhSz9YUEHnQ3TLDNwXDZbqoMPvzhWhW4hcJ26wZCuNwXb70sNFjeeymQ_CiHUi9DIu_gZDNUdjOo30hgCwWxDMeA92DKVPHcwpjNg6z5nEQKxn_HvBZPQhAaG35xIwb5EOpEVjC0cAcTvTopeaK4-t_gKUr_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375446,"updated":1633375446,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
       content-length: '694'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:38 GMT
+      date: Mon, 04 Oct 2021 19:24:06 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f?api-version=7.3-preview
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d?api-version=7.3-preview
 - request:
     body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
     headers:
@@ -109,29 +109,29 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/encrypt?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/encrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","value":"Uaq14DCsPe9fx_EUeWR8bgX3R9cBqyAn5DFNjTXCN3vFDGf3BXelZR1r-E_24MFifl_R_ofu79gm4TcuaJu4EMfOUSXwqc1xBcH7lwI_CyHZZhlNfjJ5VZ70QVM8pFK_8hPR6lJD6_cEyKDiLOIClnU4wQqYrgCWGi4AX1lIzLfnuntHX1WDVxGIERct4I_fbjMkqfQkneALHGVdnMqZO8tN6krXtiuVpovyUDWKkCpuNrFWS2KU-t40dd_pp8B5XYeWJq4PdglbGevp4MLb4aW_KXC_sP2gF19fFgg2b_8E41rK1UtcP0zVY5f0reTfGmhP8JRT1QttmTncS_MiAg"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d","value":"ZA5emTaEIbUKC1s-v5-EP5gZNN3d_a2mcdfpyAaTfco2gtyAM3vpW2uwXscVMcNbx0oRtOuoiJkHkjf3rg1_eHYQUVWjaIKvIE6N1xMjUoB9h-j_aP05xxHX2PpPvBXmiinnUBNTEmVC-7w_xkzYO2kENnJE1wqxq6mFEYLKVTIhGU9XFFsDVNgvkNNPT-tjxHWFht8KXC3_QWaOxKptHhla-_dxfQWpVX9R4B41F1ePvp1As3EUqLuSn1bwl4l2iBURXL23cZ03MWkLCDq0heXwRhkK_7XvxXvX2uLlDror_aKk6Ut5E0UGz3SRW0Wpwu3Fh6kAwap3NT1EyPdBVw"}'
     headers:
       cache-control: no-cache
       content-length: '464'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:38 GMT
+      date: Mon, 04 Oct 2021 19:24:06 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/encrypt?api-version=7.3-preview
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/encrypt?api-version=7.3-preview
 - request:
-    body: '{"alg": "RSA-OAEP", "value": "Uaq14DCsPe9fx_EUeWR8bgX3R9cBqyAn5DFNjTXCN3vFDGf3BXelZR1r-E_24MFifl_R_ofu79gm4TcuaJu4EMfOUSXwqc1xBcH7lwI_CyHZZhlNfjJ5VZ70QVM8pFK_8hPR6lJD6_cEyKDiLOIClnU4wQqYrgCWGi4AX1lIzLfnuntHX1WDVxGIERct4I_fbjMkqfQkneALHGVdnMqZO8tN6krXtiuVpovyUDWKkCpuNrFWS2KU-t40dd_pp8B5XYeWJq4PdglbGevp4MLb4aW_KXC_sP2gF19fFgg2b_8E41rK1UtcP0zVY5f0reTfGmhP8JRT1QttmTncS_MiAg"}'
+    body: '{"alg": "RSA-OAEP", "value": "ZA5emTaEIbUKC1s-v5-EP5gZNN3d_a2mcdfpyAaTfco2gtyAM3vpW2uwXscVMcNbx0oRtOuoiJkHkjf3rg1_eHYQUVWjaIKvIE6N1xMjUoB9h-j_aP05xxHX2PpPvBXmiinnUBNTEmVC-7w_xkzYO2kENnJE1wqxq6mFEYLKVTIhGU9XFFsDVNgvkNNPT-tjxHWFht8KXC3_QWaOxKptHhla-_dxfQWpVX9R4B41F1ePvp1As3EUqLuSn1bwl4l2iBURXL23cZ03MWkLCDq0heXwRhkK_7XvxXvX2uLlDror_aKk6Ut5E0UGz3SRW0Wpwu3Fh6kAwap3NT1EyPdBVw"}'
     headers:
       Accept:
       - application/json
@@ -142,25 +142,120 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/decrypt?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/decrypt?api-version=7.3-preview
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f","value":"cGxhaW50ZXh0"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d","value":"cGxhaW50ZXh0"}'
     headers:
       cache-control: no-cache
       content-length: '134'
       content-type: application/json; charset=utf-8
-      date: Fri, 01 Oct 2021 08:06:38 GMT
+      date: Mon, 04 Oct 2021 19:24:06 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/76053a3d5d124cac8c614f99b3664f6f/decrypt?api-version=7.3-preview
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/decrypt?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/?api-version=7.3-preview
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"09jLTgFNEzClkBWMRznJtCw316JRRlpzWnfd31p6nHGLzdKJrEqVPyilMNTbAPB6C2B9tKJrgHi1Dl8xxP1TjoOxM7WWfqb0X7GPCLbl96MpTgexiw-U3q4dCB30ab89Xt-pxvKil4XtIkTX1I047Wtdv6uDvfC8b9g6UIzEetfIyWfkd6F-IL0GCAhSz9YUEHnQ3TLDNwXDZbqoMPvzhWhW4hcJ26wZCuNwXb70sNFjeeymQ_CiHUi9DIu_gZDNUdjOo30hgCwWxDMeA92DKVPHcwpjNg6z5nEQKxn_HvBZPQhAaG35xIwb5EOpEVjC0cAcTvTopeaK4-t_gKUr_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1633375446,"updated":1633375446,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:24:07 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "cGxhaW50ZXh0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/encrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d","value":"LXs_g692wTTUHpHOvtngg5riQEzMWsPBoHPqjS7xiNUYrVFcBtfoknCMYBfmRpjzya_Zllcflxx0o0bYIE8432e87uk-tcF09M-NHHX4nzAZ9RFTgIKdRXHB_BXfeZHcjfNuvEyoFSFG3EcvoXb1G1A4RfajroweEnolcdehNE7oQ44iKgHE0MWdHJFYNEiVvXMwZYr7fjoFjMm4Mu0kybt3cKNVDHWhluNXQVSOJGQFRen2cl4aBSTVq690yXbxLr0VUyH1O4z88Le_7SkOMhNIj6XmpZGkt5eexKKVSmKBahLgJG6WIBasjKCDl1BiiUEgYLggqaBkMrn_gDa-OQ"}'
+    headers:
+      cache-control: no-cache
+      content-length: '464'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:24:07 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/encrypt?api-version=7.3-preview
+- request:
+    body: '{"alg": "RSA-OAEP", "value": "LXs_g692wTTUHpHOvtngg5riQEzMWsPBoHPqjS7xiNUYrVFcBtfoknCMYBfmRpjzya_Zllcflxx0o0bYIE8432e87uk-tcF09M-NHHX4nzAZ9RFTgIKdRXHB_BXfeZHcjfNuvEyoFSFG3EcvoXb1G1A4RfajroweEnolcdehNE7oQ44iKgHE0MWdHJFYNEiVvXMwZYr7fjoFjMm4Mu0kybt3cKNVDHWhluNXQVSOJGQFRen2cl4aBSTVq690yXbxLr0VUyH1O4z88Le_7SkOMhNIj6XmpZGkt5eexKKVSmKBahLgJG6WIBasjKCDl1BiiUEgYLggqaBkMrn_gDa-OQ"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/decrypt?api-version=7.3-preview
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d","value":"cGxhaW50ZXh0"}'
+    headers:
+      cache-control: no-cache
+      content-length: '134'
+      content-type: application/json; charset=utf-8
+      date: Mon, 04 Oct 2021 19:24:07 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotest.vault.azure.net/keys/livekvtestkey-name245c1963/057c640d52314478929dc83bb121984d/decrypt?api-version=7.3-preview
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -577,19 +577,34 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
         key_name = self.get_resource_name("key-name")
         key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
-        crypto_client = client.get_cryptography_client(key.id)
+        # try specifying the key version
+        crypto_client = client.get_cryptography_client(key_name, version=key.properties.version)
         # both clients should use the same generated client
         assert client._client == crypto_client._client
 
         # the crypto client should successfully perform crypto operations
         plaintext = b"plaintext"
         result = crypto_client.encrypt("RSA-OAEP", plaintext)
-        self.assertEqual(result.key_id, key.id)
+        assert result.key_id == key.id
 
         result = crypto_client.decrypt(result.algorithm, result.ciphertext)
-        self.assertEqual(result.key_id, key.id)
-        self.assertEqual("RSA-OAEP", result.algorithm)
-        self.assertEqual(plaintext, result.plaintext)
+        assert result.key_id == key.id
+        assert "RSA-OAEP" == result.algorithm
+        assert plaintext == result.plaintext
+
+        # try ommitting the key version
+        crypto_client = client.get_cryptography_client(key_name)
+        # both clients should use the same generated client
+        assert client._client == crypto_client._client
+
+        # the crypto client should successfully perform crypto operations
+        result = crypto_client.encrypt("RSA-OAEP", plaintext)
+        assert result.key_id == key.id
+
+        result = crypto_client.decrypt(result.algorithm, result.ciphertext)
+        assert result.key_id == key.id
+        assert "RSA-OAEP" == result.algorithm
+        assert plaintext == result.plaintext
 
 
 def test_positive_bytes_count_required():

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -588,6 +588,26 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         assert new_policy_actions.time_before_expiry is None
         _assert_lifetime_actions_equal(new_policy_actions, new_fetched_policy_actions)
 
+    @all_api_versions()
+    @client_setup
+    async def test_get_cryptography_client(self, client, is_hsm, **kwargs):
+        key_name = self.get_resource_name("key-name")
+        key = await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        crypto_client = client.get_cryptography_client(key.id)
+        # both clients should use the same generated client
+        assert client._client == crypto_client._client
+
+        # the crypto client should successfully perform crypto operations
+        plaintext = b"plaintext"
+        result = await crypto_client.encrypt("RSA-OAEP", plaintext)
+        self.assertEqual(result.key_id, key.id)
+
+        result = await crypto_client.decrypt(result.algorithm, result.ciphertext)
+        self.assertEqual(result.key_id, key.id)
+        self.assertEqual("RSA-OAEP", result.algorithm)
+        self.assertEqual(plaintext, result.plaintext)
+
 
 @pytest.mark.asyncio
 async def test_positive_bytes_count_required():

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -28,6 +28,7 @@ class ApiVersion(str, Enum):
     V7_0 = "7.0"
     V2016_10_01 = "2016-10-01"
 
+
 DEFAULT_VERSION = ApiVersion.V7_3_PREVIEW
 
 
@@ -42,26 +43,25 @@ class KeyVaultClientBase(object):
         if not vault_url:
             raise ValueError("vault_url must be the URL of an Azure Key Vault")
 
-        self._vault_url = vault_url.strip(" /")
-        client = kwargs.get("generated_client")
-        if client:
-            # caller provided a configured client -> nothing left to initialize
-            self._client = client
-            return
-
-        self.api_version = kwargs.pop("api_version", DEFAULT_VERSION)
-
-        pipeline = kwargs.pop("pipeline", None)
-        transport = kwargs.pop("transport", RequestsTransport(**kwargs))
-        http_logging_policy = HttpLoggingPolicy(**kwargs)
-        http_logging_policy.allowed_header_names.update(
-            {
-                "x-ms-keyvault-network-info",
-                "x-ms-keyvault-region",
-                "x-ms-keyvault-service-version"
-            }
-        )
         try:
+            self.api_version = kwargs.pop("api_version", DEFAULT_VERSION)
+            self._vault_url = vault_url.strip(" /")
+
+            client = kwargs.get("generated_client")
+            if client:
+                # caller provided a configured client -> only models left to initialize
+                self._client = client
+                models = kwargs.get("generated_models")
+                self._models = models or _KeyVaultClient.models(api_version=self.api_version)
+                return
+
+            pipeline = kwargs.pop("pipeline", None)
+            transport = kwargs.pop("transport", RequestsTransport(**kwargs))
+            http_logging_policy = HttpLoggingPolicy(**kwargs)
+            http_logging_policy.allowed_header_names.update(
+                {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+            )
+
             self._client = _KeyVaultClient(
                 api_version=self.api_version,
                 pipeline=pipeline,
@@ -77,7 +77,6 @@ class KeyVaultClientBase(object):
                 "This package doesn't support API version '{}'. ".format(self.api_version)
                 + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
             )
-
 
     @property
     def vault_url(self):


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/20621. This also fixes three bugs:

- When providing a generated client to a KV client, we don't currently set any generated models for the created type. As a result, any reference to `self._models` from the client will raise an AttributeError
  - This updates the base client (for `administration`, `certificates`, `keys`, and `secrets`) to accept a set of generated models, and will otherwise set them based on the provided or default API version
- The base client for `azure-keyvault-administration` expects a NotImplementedError in the case of an incorrect API version, but should instead expect a ValueError (this change in the generated client happened, I think, in API version 7.2)
  - Like the other packages, `administration`'s base client will still raise a NotImplementedError in this case but will know to do so when it catches a ValueError
- We currently assume that an EncryptResult will always have an IV, authentication tag, and additional authenticated data. This is only true for recent API versions, so we get an AttributeError for older versions in some cases
  - This updates CryptographyClient to first check for these attributes on the EncryptResult we get back from the operation

It's still possible that there are API version-dependent attribute issues in some cases I didn't have time to consider; looking into that is tracked by https://github.com/Azure/azure-sdk-for-python/issues/21005.