### PR TITLE
Pin wrapt version to pass on Windows with Python 2.7.

### DIFF
--- a/tools/vcrpy/setup.py
+++ b/tools/vcrpy/setup.py
@@ -24,7 +24,7 @@ class PyTest(TestCommand):
 
 install_requires = [
     "PyYAML",
-    "wrapt",
+    "wrapt<=1.12.1",
     "six>=1.5",
     'contextlib2; python_version=="2.7"',
     'mock; python_version=="2.7"',


### PR DESCRIPTION
https://github.com/GrahamDumpleton/wrapt/issues/189

This issue is failing the main branch and thus all the release builds.