### PR TITLE
Package Requirement parsing fix

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -76,7 +76,7 @@ def find_released_packages(setup_py_path, dependency_type):
 
 
 def parse_req(req):
-    req_object = Requirement.parse(req)
+    req_object = Requirement.parse(req.split(";")[0])
     pkg_name = req_object.key
     spec = SpecifierSet(str(req_object).replace(pkg_name, ""))
     return pkg_name, spec

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -39,7 +39,7 @@ def locate_wheels(base_dir):
 
 def parse_req(req):
     try:
-        req_object = Requirement.parse(req)
+        req_object = Requirement.parse(req.split(";")[0])
         req_name = req_object.key
         spec = str(req_object).replace(req_name, '')
         return (req_name, spec)

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -348,7 +348,7 @@ def is_error_code_5_allowed(target_pkg, pkg_name):
 
 # This function parses requirement and return package name and specifier
 def parse_require(req):
-    req_object = Requirement.parse(req)
+    req_object = Requirement.parse(req.split(";")[0])
     pkg_name = req_object.key
     spec = SpecifierSet(str(req_object).replace(pkg_name, ""))
     return [pkg_name, spec]


### PR DESCRIPTION
`Requirement.parse` does not understand python versioning like `pip` does. Just omit it. If we ever _need_ that level of customization, we'll need to remove `requirement.parse` entirely in favor of a different solution.

CC @swathipil @yunhaoling 