### PR TITLE
[Key Vault] Adjust key rotation test for preview behavior

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -337,7 +337,7 @@ class KeyRotationPolicy(object):
             return cls(
                 policy_id=policy.id,
                 lifetime_actions=lifetime_actions,
-                expires_on=policy.attributes.expiry_time,
+                expires_in=policy.attributes.expiry_time,
                 created_on=policy.attributes.created,
                 updated_on=policy.attributes.updated,
             )

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_rotation_policy_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_rotation_policy_7_3_preview_vault.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/create?api-version=7.3-preview
   response:
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 28 Sep 2021 20:28:54 GMT
+      - Wed, 06 Oct 2021 19:10:18 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +45,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -65,21 +65,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/1f1dcc214e0649298fc9d8431f133d70","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xuqdP_vk8J3YrTpuVGWdaqKyYur6DxjrNIf8ytP5gbe5FNZ6gWdR3Owy8DhQoR699a9XLLzuqa-h7DasW_n-HXoZ_yRcJq4SHi-FG4PkZdJB9rh54l8dbzFn-8anGdTcVEPqFn9B1xOdf8aSZ1QIyW2io9gpLtpWY9rvQjtK8N332KWLxDHDxgOIq7jbexsa9DDWgKzcA_g37PEwpRYSb4NtJkvk4ztMa_OhEEwL7HIzUJjCQjKZRRGIVZxNWhakMQrdb4qhxQ8PNPmMFcuY9TVJ8hzVCZHQrsristcBcE1IyhvQoHYnCnDX3dD5FLyhPAoLVqmP6Z0_2w68-k-nfQ","e":"AQAB"},"attributes":{"enabled":true,"exp":1640636935,"created":1632860935,"updated":1632860935,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/c4727665632f40458f317002b39a1504","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2gbZmgfsdB98UZQ1YbmpvHYGNOICfyClDIBjVc5UatdptqMiUQU_1mbSB7ngynjQWFXH7AOnE4XH37lQ1ZQAGSvH6Z0LjYkyLT5tSG_MdJ5TGRqyMT6tEh-46QvPRGLAMbWm6uqAbmc6pX-Qsj2nxBsueH1p7Q9qR-IH0oXVS6v8If2YkwMvBo7Uzf6mtwfquDzXYOS5jwg5rWz7PlUTiQaws4s1Fwlth7Vxr6HFYPpmVBQM327hKgR50kcv6mjXmt0VT27apBOyJykGZlGjuZZLILT5Tffc3AC4qNhSEhKXZA2uqg5f7HB8PERZrexi0fI_AzTLySwtZStzJwBC_Q","e":"AQAB"},"attributes":{"enabled":true,"exp":1641323419,"created":1633547419,"updated":1633547419,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '715'
+      - '723'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 28 Sep 2021 20:28:55 GMT
+      - Wed, 06 Oct 2021 19:10:19 GMT
       expires:
       - '-1'
       pragma:
@@ -93,100 +93,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P30D"}, "action":
-      {"type": "Rotate"}}], "attributes": {"expiryTime": "P90D"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '132'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: PUT
-    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy?api-version=7.3-preview
-  response:
-    body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1632795088,"updated":1632795088}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '327'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 28 Sep 2021 20:28:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.9.79.2
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy?api-version=7.3-preview
-  response:
-    body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1632795088,"updated":1632795088}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '327'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 28 Sep 2021 20:28:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -194,7 +101,7 @@ interactions:
       message: OK
 - request:
     body: '{"lifetimeActions": [{"trigger": {"timeAfterCreate": "P2M"}, "action":
-      {"type": "Notify"}}], "attributes": {}}'
+      {"type": "Rotate"}}], "attributes": {}}'
     headers:
       Accept:
       - application/json
@@ -207,21 +114,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy?api-version=7.3-preview
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Notify"}}],"attributes":{"created":1632795088,"updated":1632860936}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}}],"attributes":{"created":1633547268,"updated":1633547419}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '238'
+      - '237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 28 Sep 2021 20:28:55 GMT
+      - Wed, 06 Oct 2021 19:10:19 GMT
       expires:
       - '-1'
       pragma:
@@ -235,7 +142,7 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:
@@ -251,21 +158,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy?api-version=7.3-preview
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Notify"}}],"attributes":{"created":1632795088,"updated":1632860936}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}}],"attributes":{"created":1633547268,"updated":1633547419}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '238'
+      - '237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 28 Sep 2021 20:28:56 GMT
+      - Wed, 06 Oct 2021 19:10:19 GMT
       expires:
       - '-1'
       pragma:
@@ -279,7 +186,100 @@ interactions:
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.79.2
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P30D"}, "action":
+      {"type": "Notify"}}], "attributes": {"expiryTime": "P90D"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy?api-version=7.3-preview
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1633547268,"updated":1633547419}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '259'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 06 Oct 2021 19:10:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy?api-version=7.3-preview
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybd0f17af/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1633547268,"updated":1633547419}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '259'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 06 Oct 2021 19:10:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.132.3
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_rotation_policy_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_rotation_policy_7_3_preview_vault.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/create?api-version=7.3-preview
   response:
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Tue, 28 Sep 2021 20:30:13 GMT
+      date: Wed, 06 Oct 2021 19:12:17 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
@@ -29,12 +29,12 @@ interactions:
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/create?api-version=7.3-preview
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/create?api-version=7.3-preview
 - request:
     body: '{"kty": "RSA"}'
     headers:
@@ -45,95 +45,32 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/d576940c117f4f3cb9ddb667c1042a8d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tLipS2sqtYKME4ffnq8-tGTxE8vCKp0zfIWclCIrorV-I1MzWsZzNUyyVfjoKvk2h1CKTVBar8d00eCvvPRHeSd-YalDTobAfmLM58xej3MT27f5p7t_sfkK3ZP5BoGssbKHXR_7RI2vvNb_VirqzF1leJKRu-FMs0xdjBfqaiqmyWQZFSLXEPoAkE3BQ42BsIrXhQFQVixoNMaiY9_LOb2zl2_MHhvKRw2ZO9DEIJ33IWFcH5crr2UklJxkAOmCVNKfRbZkxjPeGJKUxypoyVer7kWUNdleDPhupk6RWnGta9npIxSsB0DjQSrXf8G_McNB2Q4SBymfXrJRO8RREQ","e":"AQAB"},"attributes":{"enabled":true,"exp":1640637014,"created":1632861014,"updated":1632861014,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/b12e827147874902aa31394581c24ce9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vvcEH9RDFmGTytPDVYuU_NkTTDb3o3Sf0Lanq-e8DhUi8XOAlBv_gRx5EiqHzNrW8Xhs95dTQWuZTujjhXT_7ZF4r0IlK0wLBewYHF_KjsLUMOqgCBUOe94l8fzS07cKFup-mJyGtNnwFrEn8xh9S17wkan8SESy-cR1ay4l417JoKUQ_wU9rZzrm7UTmhCq6ok9zqfS5pypld9eV0QhgblK_h1ly44F6p35JTZpAb2f0yfWotCg7jAXhtnUo7VwdAushFc7FE04NRoBIW_rynBGWbZiLoojBiNOZAifoo6Pmfuh-vyfAe5TdaoLOA-H_3UWb4R17PdcCk7XAP8gMQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633547537,"updated":1633547537,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}'
     headers:
       cache-control: no-cache
-      content-length: '715'
+      content-length: '706'
       content-type: application/json; charset=utf-8
-      date: Tue, 28 Sep 2021 20:30:14 GMT
+      date: Wed, 06 Oct 2021 19:12:17 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/create?api-version=7.3-preview
-- request:
-    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P30D"}, "action":
-      {"type": "Rotate"}}], "attributes": {"expiryTime": "P90D"}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '132'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: PUT
-    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
-  response:
-    body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1632796802,"updated":1632796802}}'
-    headers:
-      cache-control: no-cache
-      content-length: '327'
-      content-type: application/json; charset=utf-8
-      date: Tue, 28 Sep 2021 20:30:14 GMT
-      expires: '-1'
-      pragma: no-cache
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
-  response:
-    body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1632796802,"updated":1632796802}}'
-    headers:
-      cache-control: no-cache
-      content-length: '327'
-      content-type: application/json; charset=utf-8
-      date: Tue, 28 Sep 2021 20:30:14 GMT
-      expires: '-1'
-      pragma: no-cache
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/create?api-version=7.3-preview
 - request:
     body: '{"lifetimeActions": [{"trigger": {"timeAfterCreate": "P2M"}, "action":
-      {"type": "Notify"}}], "attributes": {}}'
+      {"type": "Rotate"}}], "attributes": {}}'
     headers:
       Accept:
       - application/json
@@ -142,56 +79,119 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Notify"}}],"attributes":{"created":1632796802,"updated":1632861014}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}}],"attributes":{"created":1633547538,"updated":1633547538}}'
     headers:
       cache-control: no-cache
-      content-length: '238'
+      content-length: '237'
       content-type: application/json; charset=utf-8
-      date: Tue, 28 Sep 2021 20:30:14 GMT
+      date: Wed, 06 Oct 2021 19:12:18 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Notify"}}],"attributes":{"created":1632796802,"updated":1632861014}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}}],"attributes":{"created":1633547538,"updated":1633547538}}'
     headers:
       cache-control: no-cache
-      content-length: '238'
+      content-length: '237'
       content-type: application/json; charset=utf-8
-      date: Tue, 28 Sep 2021 20:30:14 GMT
+      date: Wed, 06 Oct 2021 19:12:18 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.79.2
+      x-ms-keyvault-service-version: 1.9.132.3
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
+- request:
+    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P30D"}, "action":
+      {"type": "Notify"}}], "attributes": {"expiryTime": "P90D"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1633547538,"updated":1633547538}}'
+    headers:
+      cache-control: no-cache
+      content-length: '259'
+      content-type: application/json; charset=utf-8
+      date: Wed, 06 Oct 2021 19:12:18 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b4 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1633547538,"updated":1633547538}}'
+    headers:
+      cache-control: no-cache
+      content-length: '259'
+      content-type: application/json; charset=utf-8
+      date: Wed, 06 Oct 2021 19:12:18 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.132.3
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyc0a517c1/rotationpolicy?api-version=7.3-preview
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -547,28 +547,30 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
         key_name = self.get_resource_name("rotation-key")
         self._create_rsa_key(client, key_name)
 
-        actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE, time_before_expiry="P30D")]
-        updated_policy = client.update_key_rotation_policy(key_name, expires_in="P90D", lifetime_actions=actions)
+        actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE, time_after_create="P2M")]
+        updated_policy = client.update_key_rotation_policy(key_name, lifetime_actions=actions)
         fetched_policy = client.get_key_rotation_policy(key_name)
+        assert updated_policy.expires_in is None
         _assert_rotation_policies_equal(updated_policy, fetched_policy)
 
         updated_policy_actions = updated_policy.lifetime_actions[0]
         fetched_policy_actions = fetched_policy.lifetime_actions[0]
         assert updated_policy_actions.action == KeyRotationPolicyAction.ROTATE
-        assert updated_policy_actions.time_after_create is None
-        assert updated_policy_actions.time_before_expiry == "P30D"
+        assert updated_policy_actions.time_after_create == "P2M"
+        assert updated_policy_actions.time_before_expiry is None
         _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
 
-        new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.NOTIFY, time_after_create="P2M")]
-        new_policy = client.update_key_rotation_policy(key_name, lifetime_actions=new_actions)
+        new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.NOTIFY, time_before_expiry="P30D")]
+        new_policy = client.update_key_rotation_policy(key_name, expires_in="P90D", lifetime_actions=new_actions)
         new_fetched_policy = client.get_key_rotation_policy(key_name)
+        assert new_policy.expires_in == "P90D"
         _assert_rotation_policies_equal(new_policy, new_fetched_policy)
 
         new_policy_actions = new_policy.lifetime_actions[0]
         new_fetched_policy_actions = new_fetched_policy.lifetime_actions[0]
         assert new_policy_actions.action == KeyRotationPolicyAction.NOTIFY
-        assert new_policy_actions.time_after_create == "P2M"
-        assert new_policy_actions.time_before_expiry is None
+        assert new_policy_actions.time_after_create is None
+        assert new_policy_actions.time_before_expiry == "P30D"
         _assert_lifetime_actions_equal(new_policy_actions, new_fetched_policy_actions)
 
     @all_api_versions()

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -564,28 +564,30 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         key_name = self.get_resource_name("rotation-key")
         await self._create_rsa_key(client, key_name)
 
-        actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE, time_before_expiry="P30D")]
-        updated_policy = await client.update_key_rotation_policy(key_name, expires_in="P90D", lifetime_actions=actions)
+        actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE, time_after_create="P2M")]
+        updated_policy = await client.update_key_rotation_policy(key_name, lifetime_actions=actions)
         fetched_policy = await client.get_key_rotation_policy(key_name)
+        assert updated_policy.expires_in is None
         _assert_rotation_policies_equal(updated_policy, fetched_policy)
 
         updated_policy_actions = updated_policy.lifetime_actions[0]
         fetched_policy_actions = fetched_policy.lifetime_actions[0]
         assert updated_policy_actions.action == KeyRotationPolicyAction.ROTATE
-        assert updated_policy_actions.time_after_create is None
-        assert updated_policy_actions.time_before_expiry == "P30D"
+        assert updated_policy_actions.time_after_create == "P2M"
+        assert updated_policy_actions.time_before_expiry is None
         _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
 
-        new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.NOTIFY, time_after_create="P2M")]
-        new_policy = await client.update_key_rotation_policy(key_name, lifetime_actions=new_actions)
+        new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.NOTIFY, time_before_expiry="P30D")]
+        new_policy = await client.update_key_rotation_policy(key_name, expires_in="P90D", lifetime_actions=new_actions)
         new_fetched_policy = await client.get_key_rotation_policy(key_name)
+        assert new_policy.expires_in == "P90D"
         _assert_rotation_policies_equal(new_policy, new_fetched_policy)
 
         new_policy_actions = new_policy.lifetime_actions[0]
         new_fetched_policy_actions = new_fetched_policy.lifetime_actions[0]
         assert new_policy_actions.action == KeyRotationPolicyAction.NOTIFY
-        assert new_policy_actions.time_after_create == "P2M"
-        assert new_policy_actions.time_before_expiry is None
+        assert new_policy_actions.time_after_create is None
+        assert new_policy_actions.time_before_expiry == "P30D"
         _assert_lifetime_actions_equal(new_policy_actions, new_fetched_policy_actions)
 
     @all_api_versions()


### PR DESCRIPTION
Context: live rotation policy tests have started [failing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1129470&view=ms.vss-test-web.build-test-results-tab&runId=24486150&resultId=100322&paneView=debug) because the service has started honoring a restriction that was specified in generated enums: [rotation policies can't configure the notification time for a notifying policy in preview](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/v7_3_preview/models/_key_vault_client_enums.py#L35). This adjusts tests to use the required time before expiry for these policies, and also fixes a previously-uncaught bug in setting the expiry time for key policies.