### PR TITLE
[ServiceBus] fix bug in session id being empty string and partition key fails to parse empty string

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fixed bug that `ServiceBusReceiver` can not connect to sessionful entity with session id being empty string.
+- Fixed bug that `ServiceBusMessage.partition_key` can not parse empty string properly.
+
 ### Other Changes
 
 ## 7.3.4 (2021-10-06)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -156,7 +156,7 @@ class ServiceBusReceiver(
 
         self._populate_attributes(**kwargs)
         self._session = (
-            ServiceBusSession(self._session_id, self) if self._session_id else None
+            None if self._session_id is None else ServiceBusSession(self._session_id, self)
         )
 
     def __iter__(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -160,7 +160,7 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
 
         self._populate_attributes(**kwargs)
         self._session = (
-            ServiceBusSession(self._session_id, self) if self._session_id else None
+            None if self._session_id is None else ServiceBusSession(self._session_id, self)
         )
 
     # Python 3.5 does not allow for yielding from a coroutine, so instead of the try-finally functional wrapper


### PR DESCRIPTION
issue: https://github.com/Azure/azure-sdk-for-python/issues/21157