### PR TITLE
Fix BuildTargetingString and identity variables in search and digitaltwins live tests

### DIFF
--- a/sdk/digitaltwins/tests.yml
+++ b/sdk/digitaltwins/tests.yml
@@ -1,13 +1,13 @@
 trigger: none
 
 stages:
-  - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       AllocateResourceGroup: 'false'
-      BuildTargetingString: $(BuildTargetingString)
+      BuildTargetingString: azure-digitaltwins-core
       ServiceDirectory: digitaltwins
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_ID: $(DIGITALTWINS_CLIENT_ID)
+        AZURE_CLIENT_SECRET: $(DIGITALTWINS_CLIENT_SECRET)
+        AZURE_TENANT_ID: $(DIGITALTWINS_TENANT_ID)
         TEST_MODE: 'RunLiveNoRecord'

--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -1,14 +1,14 @@
 trigger: none
 
 stages:
-  - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      BuildTargetingString: $(BuildTargetingString)
+      BuildTargetingString: azure-search-documents
       ServiceDirectory: search
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_OID: $(aad-azure-sdk-test-client-oid)
+        AZURE_CLIENT_ID: $(SEARCH_CLIENT_ID)
+        AZURE_CLIENT_SECRET: $(SEARCH_CLIENT_SECRET)
+        AZURE_TENANT_ID: $(SEARCH_TENANT_ID)
+        AZURE_CLIENT_OID: $(SEARCH_CLIENT_OID)
         TEST_MODE: 'RunLiveNoRecord'
         AZURE_SKIP_LIVE_RECORDING: 'True'


### PR DESCRIPTION
The `BuildTargetingString` value should be hardcoded in the pipeline yaml file rather than as a pipeline variable reference. For search, the value was set manually as a pipeline variable. For digitaltwins, it's not set at all as a pipeline variable, meaning the live tests have been running as a noop this entire time.

I also updated the identity variable references to consume the variable outputs from the deployment scripts, so that they can support sovereign cloud testing if added.