### PR TITLE
Sample Skipping Update

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -20,6 +20,7 @@ import textwrap
 import io
 import re
 import fnmatch
+import platform
 
 # Assumes the presence of setuptools
 from pkg_resources import parse_version, parse_requirements, Requirement, WorkingSet, working_set
@@ -210,6 +211,13 @@ def filter_for_compatibility(package_set):
             collected_packages.append(pkg)
 
     return collected_packages
+
+
+def compare_python_version(version_spec):
+    current_sys_version = parse(platform.python_version())
+    spec_set = SpecifierSet(version_spec)
+
+    return current_sys_version in spec_set
 
 
 # this function is where a glob string gets translated to a list of packages

--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -10,20 +10,13 @@ import argparse
 import sys
 import os
 import logging
-import platform
 from fnmatch import fnmatch
 
 try:
     from subprocess import TimeoutExpired, check_call, CalledProcessError
 except ImportError:
     from subprocess32 import TimeoutExpired, check_call, CalledProcessError
-from common_tasks import run_check_call
-
-# this assumes the presence of "packaging". this is a safe assumption because this
-# script is only called from tox.ini, which infers the install of eng/test_tools.txt
-from packaging.specifiers import SpecifierSet
-from packaging.version import Version
-from packaging.version import parse
+from common_tasks import run_check_call, compare_python_version
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -138,14 +131,6 @@ IGNORED_SAMPLES = {
     ],
     "azure-ai-language-questionanswering": ["sample_chat.py"],
 }
-
-
-def compare_python_version(version_spec):
-    current_sys_version = parse(platform.python_version())
-    spec_set = SpecifierSet(version_spec)
-
-    return current_sys_version in spec_set
-
 
 def run_check_call_with_timeout(
     command_array,


### PR DESCRIPTION
@rakshith91 this is in reference to #21236

This PR has two purposes:

1. Add skip functionality for python versions `< 3.7`
2. Add additional `ignore` functionality for whatever versionspecifier you want.

### Ignore Functionality Details

Currently the dict looks like this:

```python
IGNORED_SAMPLES = {
    "azure-eventhub": [
        "connection_to_custom_endpoint_address.py",
        "proxy.py",
        "connection_to_custom_endpoint_address_async.py",
        "iot_hub_connection_string_receive_async.py",
        "proxy_async.py"
    ],
}
```

Now it will accept something like:

```python
IGNORED_SAMPLES = {
    "azure-eventhub": [
        "connection_to_custom_endpoint_address.py",
        "proxy.py",
        "connection_to_custom_endpoint_address_async.py",
        "iot_hub_connection_string_receive_async.py",
        "proxy_async.py"
        ("connection_string_authentication.py", "<=3.10, >=3.9.0"), # needs to match SpecifierSet from packaging
    ],
}
```