### PR TITLE
fix for service principal environment vars

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/tests/settings/testcase.py
+++ b/sdk/storage/azure-storage-blob-changefeed/tests/settings/testcase.py
@@ -44,9 +44,9 @@ os.environ['AZURE_SKIP_LIVE_RECORDING'] = os.environ.get('AZURE_SKIP_LIVE_RECORD
 os.environ['PROTOCOL'] = PROTOCOL
 os.environ['ACCOUNT_URL_SUFFIX'] = ACCOUNT_URL_SUFFIX
 
-os.environ['AZURE_TENANT_ID'] = os.environ.get('AZURE_TENANT_ID', None) or TENANT_ID
-os.environ['AZURE_CLIENT_ID'] = os.environ.get('AZURE_CLIENT_ID', None) or CLIENT_ID
-os.environ['AZURE_CLIENT_SECRET'] = os.environ.get('AZURE_CLIENT_SECRET', None) or CLIENT_SECRET
+os.environ['STORAGE_TENANT_ID'] = os.environ.get('STORAGE_TENANT_ID', None) or TENANT_ID
+os.environ['STORAGE_CLIENT_ID'] = os.environ.get('STORAGE_CLIENT_ID', None) or CLIENT_ID
+os.environ['STORAGE_CLIENT_SECRET'] = os.environ.get('STORAGE_CLIENT_SECRET', None) or CLIENT_SECRET
 
 ChangeFeedPreparer = functools.partial(
     PowerShellPreparer, "storage",

--- a/sdk/storage/azure-storage-blob/tests/settings/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/settings/testcase.py
@@ -44,9 +44,9 @@ os.environ['AZURE_SKIP_LIVE_RECORDING'] = os.environ.get('AZURE_SKIP_LIVE_RECORD
 os.environ['PROTOCOL'] = PROTOCOL
 os.environ['ACCOUNT_URL_SUFFIX'] = ACCOUNT_URL_SUFFIX
 
-os.environ['AZURE_TENANT_ID'] = os.environ.get('AZURE_TENANT_ID', None) or TENANT_ID
-os.environ['AZURE_CLIENT_ID'] = os.environ.get('AZURE_CLIENT_ID', None) or CLIENT_ID
-os.environ['AZURE_CLIENT_SECRET'] = os.environ.get('AZURE_CLIENT_SECRET', None) or CLIENT_SECRET
+os.environ['STORAGE_TENANT_ID'] = os.environ.get('STORAGE_TENANT_ID', None) or TENANT_ID
+os.environ['STORAGE_CLIENT_ID'] = os.environ.get('STORAGE_CLIENT_ID', None) or CLIENT_ID
+os.environ['STORAGE_CLIENT_SECRET'] = os.environ.get('STORAGE_CLIENT_SECRET', None) or CLIENT_SECRET
 
 BlobPreparer = functools.partial(
     PowerShellPreparer, "storage",

--- a/sdk/storage/azure-storage-file-datalake/tests/settings/testcase.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/settings/testcase.py
@@ -34,9 +34,9 @@ os.environ['AZURE_SKIP_LIVE_RECORDING'] = os.environ.get('AZURE_SKIP_LIVE_RECORD
 os.environ['PROTOCOL'] = PROTOCOL
 os.environ['ACCOUNT_URL_SUFFIX'] = ACCOUNT_URL_SUFFIX
 
-os.environ['AZURE_TENANT_ID'] = os.environ.get('AZURE_TENANT_ID', None) or TENANT_ID
-os.environ['AZURE_CLIENT_ID'] = os.environ.get('AZURE_CLIENT_ID', None) or CLIENT_ID
-os.environ['AZURE_CLIENT_SECRET'] = os.environ.get('AZURE_CLIENT_SECRET', None) or CLIENT_SECRET
+os.environ['STORAGE_TENANT_ID'] = os.environ.get('STORAGE_TENANT_ID', None) or TENANT_ID
+os.environ['STORAGE_CLIENT_ID'] = os.environ.get('STORAGE_CLIENT_ID', None) or CLIENT_ID
+os.environ['STORAGE_CLIENT_SECRET'] = os.environ.get('STORAGE_CLIENT_SECRET', None) or CLIENT_SECRET
 
 DataLakePreparer = functools.partial(
     PowerShellPreparer, "storage",

--- a/sdk/storage/azure-storage-file-share/tests/settings/testcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/settings/testcase.py
@@ -49,9 +49,9 @@ os.environ['AZURE_SKIP_LIVE_RECORDING'] = os.environ.get('AZURE_SKIP_LIVE_RECORD
 os.environ['PROTOCOL'] = PROTOCOL
 os.environ['ACCOUNT_URL_SUFFIX'] = ACCOUNT_URL_SUFFIX
 
-os.environ['AZURE_TENANT_ID'] = os.environ.get('AZURE_TENANT_ID', None) or TENANT_ID
-os.environ['AZURE_CLIENT_ID'] = os.environ.get('AZURE_CLIENT_ID', None) or CLIENT_ID
-os.environ['AZURE_CLIENT_SECRET'] = os.environ.get('AZURE_CLIENT_SECRET', None) or CLIENT_SECRET
+os.environ['STORAGE_TENANT_ID'] = os.environ.get('STORAGE_TENANT_ID', None) or TENANT_ID
+os.environ['STORAGE_CLIENT_ID'] = os.environ.get('STORAGE_CLIENT_ID', None) or CLIENT_ID
+os.environ['STORAGE_CLIENT_SECRET'] = os.environ.get('STORAGE_CLIENT_SECRET', None) or CLIENT_SECRET
 
 
 FileSharePreparer = functools.partial(

--- a/sdk/storage/azure-storage-queue/tests/settings/testcase.py
+++ b/sdk/storage/azure-storage-queue/tests/settings/testcase.py
@@ -38,9 +38,9 @@ os.environ['AZURE_SKIP_LIVE_RECORDING'] = os.environ.get('AZURE_SKIP_LIVE_RECORD
 os.environ['PROTOCOL'] = PROTOCOL
 os.environ['ACCOUNT_URL_SUFFIX'] = ACCOUNT_URL_SUFFIX
 
-os.environ['AZURE_TENANT_ID'] = os.environ.get('AZURE_TENANT_ID', None) or TENANT_ID
-os.environ['AZURE_CLIENT_ID'] = os.environ.get('AZURE_CLIENT_ID', None) or CLIENT_ID
-os.environ['AZURE_CLIENT_SECRET'] = os.environ.get('AZURE_CLIENT_SECRET', None) or CLIENT_SECRET
+os.environ['STORAGE_TENANT_ID'] = os.environ.get('STORAGE_TENANT_ID', None) or TENANT_ID
+os.environ['STORAGE_CLIENT_ID'] = os.environ.get('STORAGE_CLIENT_ID', None) or CLIENT_ID
+os.environ['STORAGE_CLIENT_SECRET'] = os.environ.get('STORAGE_CLIENT_SECRET', None) or CLIENT_SECRET
 
 QueuePreparer = functools.partial(
     PowerShellPreparer, "storage",


### PR DESCRIPTION
PowerShellPreparer looks for all env vars with "storage", so we need STORAGE_TENANT_ID instead of AZURE_TENANT_ID. Because after PowerShellPreparer found STORAGE_TENANT_ID it helps turn into AZURE_TENANT_ID.