### PR TITLE
Remove link to private repository

### DIFF
--- a/doc/dev/get_unreleased_package_guide.md
+++ b/doc/dev/get_unreleased_package_guide.md
@@ -16,4 +16,4 @@ The following figure shows the wheel and zip of the package.Click to download th
 (1) If there is no link in the figure above, it may be folded. You can also find it in the check.
 ![img.png](unreleased_package_guide_example3.png)
 
-(2) [Private repo](https://github.com/Azure/azure-rest-api-specs-pr) can only be triggered when the target branch is `main`
+(2) The private Azure/azure-rest-api-specs-pr repo can only be triggered when the target branch is `main`


### PR DESCRIPTION
Though having a direct link to the azure-rest-api-specs-pr repo is nice, links to private repos are [considered broken](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1140021&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=2b4152c3-cd93-5340-7d50-d18544504239&l=38) because they're not accessible to most users. This references the repo by name instead to avoid the issue.