### PR TITLE
Deprecate CLI factory in azure-common

### DIFF
--- a/sdk/core/azure-common/CHANGELOG.md
+++ b/sdk/core/azure-common/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.1.28 (Unreleased)
+## 1.1.28 (2021-10-19)
+
+- Raise a NotImplementedError if trying to use CLI credentials were CLI version is higher than 2.21.0  #20657 #21313
 
 ## 1.1.27 (2021-03-23)
 

--- a/sdk/core/azure-common/CHANGELOG.md
+++ b/sdk/core/azure-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.28 (2021-12-16)
+## 1.1.28 (2022-02-03)
 
 - Raise a NotImplementedError if trying to use CLI credentials were CLI version is higher than 2.21.0  #20657 #21313
 - Deprecate all methods that needs access to CLI code using azure-cli-core, since this package is no longer importable as public API

--- a/sdk/core/azure-common/CHANGELOG.md
+++ b/sdk/core/azure-common/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 1.1.28 (2021-10-19)
+## 1.1.28 (2021-12-16)
 
 - Raise a NotImplementedError if trying to use CLI credentials were CLI version is higher than 2.21.0  #20657 #21313
+- Deprecate all methods that needs access to CLI code using azure-cli-core, since this package is no longer importable as public API
 
 ## 1.1.27 (2021-03-23)
 

--- a/sdk/core/azure-common/azure/common/client_factory.py
+++ b/sdk/core/azure-common/azure/common/client_factory.py
@@ -85,7 +85,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
     :raises: ImportError if azure-cli-core package is not available
     """
     warnings.warn(
-        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential isntead",
+        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential instead",
         DeprecationWarning
     )
 

--- a/sdk/core/azure-common/azure/common/client_factory.py
+++ b/sdk/core/azure-common/azure/common/client_factory.py
@@ -51,8 +51,8 @@ def _client_resource(client_class, cloud):
 def get_client_from_cli_profile(client_class, **kwargs):
     """Return a SDK client initialized with current CLI credentials, CLI default subscription and CLI default cloud.
 
-    *Disclaimer*: This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
-    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCliCredential. See example code below:
+    *Disclaimer*: This is NOT the recommended approach to authenticate with CLI login, this method is deprecated.
+    use https://pypi.org/project/azure-identity/ and AzureCliCredential instead. See example code below:
 
     .. code:: python
 
@@ -60,6 +60,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
         from azure.mgmt.compute import ComputeManagementClient
         client = ComputeManagementClient(AzureCliCredential(), subscription_id)
 
+    This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
 
     For compatible azure-cli-core version (< 2.20.0), This method will fill automatically the following client parameters:
     - credentials/credential
@@ -79,6 +80,8 @@ def get_client_from_cli_profile(client_class, **kwargs):
     .. versionadded:: 1.1.6
 
     .. deprecated:: 1.1.28
+
+    .. seealso:: https://aka.ms/azsdk/python/identity/migration
 
     :param client_class: A SDK client class
     :return: An instantiated client
@@ -138,11 +141,7 @@ def _is_autorest_v3(client_class):
 def get_client_from_json_dict(client_class, config_dict, **kwargs):
     """Return a SDK client initialized with a JSON auth dict.
 
-    The easiest way to obtain this content is to call the following CLI commands:
-
-    .. code:: bash
-
-        az ad sp create-for-rbac --sdk-auth
+    *Disclaimer*: This is NOT recommended approach, see https://aka.ms/azsdk/python/identity/migration for guidance.
 
     This method will fill automatically the following client parameters:
     - credentials
@@ -173,6 +172,10 @@ def get_client_from_json_dict(client_class, config_dict, **kwargs):
         client = get_client_from_json_dict(ComputeManagementClient, config_dict)
 
     .. versionadded:: 1.1.7
+
+    .. deprecated:: 1.1.28
+
+    .. seealso:: https://aka.ms/azsdk/python/identity/migration
 
     :param client_class: A SDK client class
     :param dict config_dict: A config dict.
@@ -233,11 +236,7 @@ def get_client_from_json_dict(client_class, config_dict, **kwargs):
 def get_client_from_auth_file(client_class, auth_path=None, **kwargs):
     """Return a SDK client initialized with auth file.
 
-    The easiest way to obtain this file is to call the following CLI commands:
-
-    .. code:: bash
-
-        az ad sp create-for-rbac --sdk-auth
+    *Disclaimer*: This is NOT recommended approach, see https://aka.ms/azsdk/python/identity/migration for guidance.
 
     You can specific the file path directly, or fill the environment variable AZURE_AUTH_LOCATION.
     File must be UTF-8.
@@ -275,6 +274,10 @@ def get_client_from_auth_file(client_class, auth_path=None, **kwargs):
         }
 
     .. versionadded:: 1.1.7
+
+    .. deprecated:: 1.1.28
+
+    .. seealso:: https://aka.ms/azsdk/python/identity/migration
 
     :param client_class: A SDK client class
     :param str auth_path: Path to the file.

--- a/sdk/core/azure-common/azure/common/client_factory.py
+++ b/sdk/core/azure-common/azure/common/client_factory.py
@@ -52,13 +52,13 @@ def get_client_from_cli_profile(client_class, **kwargs):
     """Return a SDK client initialized with current CLI credentials, CLI default subscription and CLI default cloud.
 
     *Disclaimer*: This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
-    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCLICredential. See example code below:
+    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCliCredential. See example code below:
 
     .. code:: python
 
-        from azure.identity import AzureCLICredential
+        from azure.identity import AzureCliCredential
         from azure.mgmt.compute import ComputeManagementClient
-        client = ComputeManagementClient(subscription_id, AzureCLICredential())
+        client = ComputeManagementClient(AzureCliCredential(), subscription_id)
 
 
     For compatible azure-cli-core version (< 2.20.0), This method will fill automatically the following client parameters:
@@ -85,7 +85,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
     :raises: ImportError if azure-cli-core package is not available
     """
     warnings.warn(
-        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCLICredential isntead",
+        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential isntead",
         DeprecationWarning
     )
 

--- a/sdk/core/azure-common/azure/common/client_factory.py
+++ b/sdk/core/azure-common/azure/common/client_factory.py
@@ -62,7 +62,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
 
     This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
 
-    For compatible azure-cli-core version (< 2.20.0), This method will fill automatically the following client parameters:
+    For compatible azure-cli-core (< 2.20.0), This method will fill automatically the following client parameters:
     - credentials/credential
     - subscription_id
     - base_url
@@ -88,7 +88,8 @@ def get_client_from_cli_profile(client_class, **kwargs):
     :raises: ImportError if azure-cli-core package is not available
     """
     warnings.warn(
-        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential instead",
+        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential instead. "+
+        "See also https://aka.ms/azsdk/python/identity/migration.",
         DeprecationWarning
     )
 
@@ -184,7 +185,7 @@ def get_client_from_json_dict(client_class, config_dict, **kwargs):
     if _is_autorest_v3(client_class):
         raise ValueError(
             "Auth file or JSON dict are deprecated auth approach and are not supported anymore. "
-            "Please read https://aka.ms/azsdk/python/azidmigration for details"
+            "See also https://aka.ms/azsdk/python/identity/migration."
         )
 
     import adal

--- a/sdk/core/azure-common/azure/common/client_factory.py
+++ b/sdk/core/azure-common/azure/common/client_factory.py
@@ -62,7 +62,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
 
     This method is not working for azure-cli-core>=2.21.0 (released in March 2021).
 
-    For compatible azure-cli-core (< 2.20.0), This method will fill automatically the following client parameters:
+    For compatible azure-cli-core (< 2.20.0), This method will automatically fill the following client parameters:
     - credentials/credential
     - subscription_id
     - base_url
@@ -142,7 +142,7 @@ def _is_autorest_v3(client_class):
 def get_client_from_json_dict(client_class, config_dict, **kwargs):
     """Return a SDK client initialized with a JSON auth dict.
 
-    *Disclaimer*: This is NOT recommended approach, see https://aka.ms/azsdk/python/identity/migration for guidance.
+    *Disclaimer*: This is NOT the recommended approach, see https://aka.ms/azsdk/python/identity/migration for guidance.
 
     This method will fill automatically the following client parameters:
     - credentials
@@ -237,7 +237,7 @@ def get_client_from_json_dict(client_class, config_dict, **kwargs):
 def get_client_from_auth_file(client_class, auth_path=None, **kwargs):
     """Return a SDK client initialized with auth file.
 
-    *Disclaimer*: This is NOT recommended approach, see https://aka.ms/azsdk/python/identity/migration for guidance.
+    *Disclaimer*: This is NOT the recommended approach, see https://aka.ms/azsdk/python/identity/migration for guidance.
 
     You can specific the file path directly, or fill the environment variable AZURE_AUTH_LOCATION.
     File must be UTF-8.

--- a/sdk/core/azure-common/azure/common/client_factory.py
+++ b/sdk/core/azure-common/azure/common/client_factory.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import warnings
 try:
     from inspect import getfullargspec as get_arg_spec
 except ImportError:
@@ -50,7 +51,17 @@ def _client_resource(client_class, cloud):
 def get_client_from_cli_profile(client_class, **kwargs):
     """Return a SDK client initialized with current CLI credentials, CLI default subscription and CLI default cloud.
 
-    This method will fill automatically the following client parameters:
+    *Disclaimer*: This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
+    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCLICredential. See example code below:
+
+    .. code:: python
+
+        from azure.identity import AzureCLICredential
+        from azure.mgmt.compute import ComputeManagementClient
+        client = ComputeManagementClient(subscription_id, AzureCLICredential())
+
+
+    For compatible azure-cli-core version (< 2.20.0), This method will fill automatically the following client parameters:
     - credentials/credential
     - subscription_id
     - base_url
@@ -67,10 +78,17 @@ def get_client_from_cli_profile(client_class, **kwargs):
 
     .. versionadded:: 1.1.6
 
+    .. deprecated:: 1.1.28
+
     :param client_class: A SDK client class
     :return: An instantiated client
     :raises: ImportError if azure-cli-core package is not available
     """
+    warnings.warn(
+        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCLICredential isntead",
+        DeprecationWarning
+    )
+
     cloud = get_cli_active_cloud()
     parameters = {}
     no_credential_sentinel = object()

--- a/sdk/core/azure-common/azure/common/client_factory.py
+++ b/sdk/core/azure-common/azure/common/client_factory.py
@@ -60,7 +60,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
         from azure.mgmt.compute import ComputeManagementClient
         client = ComputeManagementClient(AzureCliCredential(), subscription_id)
 
-    This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
+    This method is not working for azure-cli-core>=2.21.0 (released in March 2021).
 
     For compatible azure-cli-core (< 2.20.0), This method will fill automatically the following client parameters:
     - credentials/credential

--- a/sdk/core/azure-common/azure/common/cloud.py
+++ b/sdk/core/azure-common/azure/common/cloud.py
@@ -23,7 +23,7 @@ def get_cli_active_cloud():
     except ImportError:
         raise ImportError(
             "The public API of azure-cli-core has been deprecated starting 2.21.0, " +
-            "and this method no longer can no longer return a cloud instance. " +
+            "and this method no longer can return a cloud instance. " +
             "If you want to use this method, you need to install 'azure-cli-core<2.21.0'. " +
             "You may corrupt data if you use current CLI and old azure-cli-core."
         )

--- a/sdk/core/azure-common/azure/common/cloud.py
+++ b/sdk/core/azure-common/azure/common/cloud.py
@@ -7,7 +7,7 @@
 def get_cli_active_cloud():
     """Return a CLI active cloud.
 
-    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (azure-cli-core 2.21.0).
+    *Disclaimer*: This method is not working for azure-cli-core>=2.21.0 (released in March 2021).
 
     .. versionadded:: 1.1.6
 

--- a/sdk/core/azure-common/azure/common/cloud.py
+++ b/sdk/core/azure-common/azure/common/cloud.py
@@ -7,7 +7,11 @@
 def get_cli_active_cloud():
     """Return a CLI active cloud.
 
+    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
+
     .. versionadded:: 1.1.6
+
+    .. deprecated:: 1.1.28
 
     :return: A CLI Cloud
     :rtype: azure.cli.core.cloud.Cloud

--- a/sdk/core/azure-common/azure/common/cloud.py
+++ b/sdk/core/azure-common/azure/common/cloud.py
@@ -22,8 +22,8 @@ def get_cli_active_cloud():
         from azure.cli.core.cloud import get_active_cloud
     except ImportError:
         raise ImportError(
-            "Public API of azure-cli-core have been deprecated starting 2.21.0, " +
-            "and this method no longer can return a cloud instance. " +
+            "The public API of azure-cli-core has been deprecated starting 2.21.0, " +
+            "and this method no longer can no longer return a cloud instance. " +
             "If you want to use this method, you need to install 'azure-cli-core<2.21.0'. " +
             "You may corrupt data if you use current CLI and old azure-cli-core."
         )

--- a/sdk/core/azure-common/azure/common/cloud.py
+++ b/sdk/core/azure-common/azure/common/cloud.py
@@ -7,7 +7,7 @@
 def get_cli_active_cloud():
     """Return a CLI active cloud.
 
-    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
+    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (azure-cli-core 2.21.0).
 
     .. versionadded:: 1.1.6
 
@@ -21,6 +21,10 @@ def get_cli_active_cloud():
     try:
         from azure.cli.core.cloud import get_active_cloud
     except ImportError:
-        raise ImportError("You need to install 'azure-cli-core' to load CLI active Cloud")
+        raise ImportError(
+            "Public API of azure-cli-core have been deprecated starting 2.21.0, " +
+            "and this method no longer can return a cloud instance. " +
+            "If you want to use this method, you need to install 'azure-cli-core<2.21.0'. " +
+            "You may corrupt data if you use current CLI and old azure-cli-core."
+        )
     return get_active_cloud()
-

--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -6,6 +6,7 @@
 
 import os.path
 import time
+import warnings
 try:
     from azure.core.credentials import AccessToken as _AccessToken
 except ImportError:
@@ -112,6 +113,11 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     :return: tuple of Credentials and SubscriptionID (and tenant ID if with_tenant)
     :rtype: tuple
     """
+    warnings.warn(
+        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential instead",
+        DeprecationWarning
+    )
+
     azure_cli_core_check_failed = False
     try:
         import azure.cli.core
@@ -122,7 +128,7 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
         azure_cli_core_check_failed = True
 
     if azure_cli_core_check_failed:
-        raise ImportError(
+        raise NotImplementedError(
             "You need to install 'azure-cli-core<2.21.0' to load CLI credentials using this method. " +
             "You should consider using azure-identity and AzureCliCredential instead, as this method is not supported anymore."
         )

--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -16,6 +16,8 @@ except ImportError:
 def get_cli_profile():
     """Return a CLI profile class.
 
+    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
+
     .. versionadded:: 1.1.6
 
     .. deprecated:: 1.1.28
@@ -34,7 +36,6 @@ def get_cli_profile():
             "You need to install 'azure-cli-core<2.21.0' to load CLI credentials using this method. " +
             "You should consider using azure-identity and AzureCliCredential instead, as this method is not supported anymore."
         )
-
 
     azure_folder = get_config_dir()
     ACCOUNT.load(os.path.join(azure_folder, 'azureProfile.json'))
@@ -107,6 +108,8 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     .. versionadded:: 1.1.6
 
     .. deprecated:: 1.1.28
+
+    .. seealso:: https://aka.ms/azsdk/python/identity/migration
 
     :param str resource: The alternative resource for credentials if not ARM (GraphRBac, etc.)
     :param bool with_tenant: If True, return a three-tuple with last as tenant ID

--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -137,7 +137,7 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     if azure_cli_core_check_failed:
         raise NotImplementedError(
             "The public API of azure-cli-core has been deprecated starting 2.21.0, " +
-            "and this method can no longer return a valid credentials. " +
+            "and this method can no longer return a valid credential. " +
             "If you need to still use this method, you need to install 'azure-cli-core<2.21.0'. " +
             "You may corrupt data if you use current CLI and old azure-cli-core. " +
             "See also: https://aka.ms/azsdk/python/identity/migration"

--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -16,7 +16,7 @@ except ImportError:
 def get_cli_profile():
     """Return a CLI profile class.
 
-    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
+    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (azure-cli-core 2.21.0).
 
     .. versionadded:: 1.1.6
 
@@ -33,8 +33,10 @@ def get_cli_profile():
         from azure.cli.core._environment import get_config_dir
     except ImportError:
         raise ImportError(
-            "You need to install 'azure-cli-core<2.21.0' to load CLI credentials using this method. " +
-            "You should consider using azure-identity and AzureCliCredential instead, as this method is not supported anymore."
+            "Public API of azure-cli-core have been deprecated starting 2.21.0, " +
+            "and this method no longer can return a profile. " +
+            "If you need to load CLI profile using this method, you need to install 'azure-cli-core<2.21.0'. " +
+            "You may corrupt data if you use current CLI and old azure-cli-core."
         )
 
     azure_folder = get_config_dir()
@@ -90,7 +92,8 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     """Return Credentials and default SubscriptionID of current loaded profile of the CLI.
 
     *Disclaimer*: This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
-    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCliCredential. See example code below:
+    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCliCredential.
+    See example code below:
 
     .. code:: python
 
@@ -117,7 +120,8 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     :rtype: tuple
     """
     warnings.warn(
-        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential instead",
+        "get_client_from_cli_profile is deprecated, please use azure-identity and AzureCliCredential instead. " +
+        "https://aka.ms/azsdk/python/identity/migration.",
         DeprecationWarning
     )
 
@@ -132,8 +136,11 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
 
     if azure_cli_core_check_failed:
         raise NotImplementedError(
-            "You need to install 'azure-cli-core<2.21.0' to load CLI credentials using this method. " +
-            "You should consider using azure-identity and AzureCliCredential instead, as this method is not supported anymore."
+            "Public API of azure-cli-core have been deprecated starting 2.21.0, " +
+            "and this method no longer can return a valid credentials. " +
+            "If you need to still use this method, you need to install 'azure-cli-core<2.21.0'. " +
+            "You may corrupt data if you use current CLI and old azure-cli-core. " +
+            "See also: https://aka.ms/azsdk/python/identity/migration"
         )
 
     profile = get_cli_profile()

--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -33,8 +33,8 @@ def get_cli_profile():
         from azure.cli.core._environment import get_config_dir
     except ImportError:
         raise ImportError(
-            "Public API of azure-cli-core have been deprecated starting 2.21.0, " +
-            "and this method no longer can return a profile. " +
+            "The public API of azure-cli-core has been deprecated starting 2.21.0, " +
+            "and this method can no longer return a profile. " +
             "If you need to load CLI profile using this method, you need to install 'azure-cli-core<2.21.0'. " +
             "You may corrupt data if you use current CLI and old azure-cli-core."
         )
@@ -92,7 +92,7 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     """Return Credentials and default SubscriptionID of current loaded profile of the CLI.
 
     *Disclaimer*: This method is not working for azure-cli-core>=2.21.0 (released in March 2021).
-    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCliCredential.
+    It is now recommended to authenticate using https://pypi.org/project/azure-identity/ and AzureCliCredential.
     See example code below:
 
     .. code:: python
@@ -136,8 +136,8 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
 
     if azure_cli_core_check_failed:
         raise NotImplementedError(
-            "Public API of azure-cli-core have been deprecated starting 2.21.0, " +
-            "and this method no longer can return a valid credentials. " +
+            "The public API of azure-cli-core has been deprecated starting 2.21.0, " +
+            "and this method can no longer return a valid credentials. " +
             "If you need to still use this method, you need to install 'azure-cli-core<2.21.0'. " +
             "You may corrupt data if you use current CLI and old azure-cli-core. " +
             "See also: https://aka.ms/azsdk/python/identity/migration"

--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -16,7 +16,7 @@ except ImportError:
 def get_cli_profile():
     """Return a CLI profile class.
 
-    *Disclaimer*: This method is not working properly for CLI installation after 3/2021 (azure-cli-core 2.21.0).
+    *Disclaimer*: This method is not working for azure-cli-core>=2.21.0 (released in March 2021).
 
     .. versionadded:: 1.1.6
 
@@ -91,7 +91,7 @@ class _CliCredentials(object):
 def get_azure_cli_credentials(resource=None, with_tenant=False):
     """Return Credentials and default SubscriptionID of current loaded profile of the CLI.
 
-    *Disclaimer*: This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
+    *Disclaimer*: This method is not working for azure-cli-core>=2.21.0 (released in March 2021).
     Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCliCredential.
     See example code below:
 

--- a/sdk/core/azure-common/azure/common/credentials.py
+++ b/sdk/core/azure-common/azure/common/credentials.py
@@ -31,7 +31,7 @@ def get_cli_profile():
     except ImportError:
         raise ImportError(
             "You need to install 'azure-cli-core<2.21.0' to load CLI credentials using this method. " +
-            "You should consider using azure-identity and AzureCLICredential instead, as this method is not supported anymore."
+            "You should consider using azure-identity and AzureCliCredential instead, as this method is not supported anymore."
         )
 
 
@@ -88,13 +88,13 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     """Return Credentials and default SubscriptionID of current loaded profile of the CLI.
 
     *Disclaimer*: This method is not working for CLI installation after 3/2021 (version 2.21.0 of azure-cli-core).
-    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCLICredential. See example code below:
+    Recommended authentication is now to use https://pypi.org/project/azure-identity/ and AzureCliCredential. See example code below:
 
     .. code:: python
 
-        from azure.identity import AzureCLICredential
+        from azure.identity import AzureCliCredential
         from azure.mgmt.compute import ComputeManagementClient
-        client = ComputeManagementClient(subscription_id, AzureCLICredential())
+        client = ComputeManagementClient(AzureCliCredential(), subscription_id)
 
 
     For compatible azure-cli-core version (< 2.20.0), credentials will be the "az login" command:
@@ -124,7 +124,7 @@ def get_azure_cli_credentials(resource=None, with_tenant=False):
     if azure_cli_core_check_failed:
         raise ImportError(
             "You need to install 'azure-cli-core<2.21.0' to load CLI credentials using this method. " +
-            "You should consider using azure-identity and AzureCLICredential instead, as this method is not supported anymore."
+            "You should consider using azure-identity and AzureCliCredential instead, as this method is not supported anymore."
         )
 
     profile = get_cli_profile()

--- a/sdk/core/azure-common/tests/test_client_factory.py
+++ b/sdk/core/azure-common/tests/test_client_factory.py
@@ -290,7 +290,7 @@ class TestCommon(unittest.TestCase):
 
             with pytest.raises(ValueError) as excinfo:
                 get_client_from_auth_file(KeyVaultClientTrack2, temp_auth_file.name)
-            assert "https://aka.ms/azsdk/python/azidmigration" in str(excinfo.value)
+            assert "https://aka.ms/azsdk/python/identity/migration" in str(excinfo.value)
 
             os.unlink(temp_auth_file.name)
 


### PR DESCRIPTION
See https://github.com/Azure/azure-sdk-for-python/pull/20657 and https://github.com/Azure/azure-sdk-for-python/issues/21313