### PR TITLE
Last remaining references

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/swaggertosdk/SwaggerToSdkCore.py
+++ b/tools/azure-sdk-tools/packaging_tools/swaggertosdk/SwaggerToSdkCore.py
@@ -170,7 +170,7 @@ def read_config(sdk_git_folder, config_file):
         return json.loads(config_fd.read())
 
 
-def read_config_from_github(sdk_id, branch="master", gh_token=None):
+def read_config_from_github(sdk_id, branch="main", gh_token=None):
     raw_link = str(get_configuration_github_path(sdk_id, branch))
     _LOGGER.debug("Will try to download: %s", raw_link)
     _LOGGER.debug("Token is defined: %s", gh_token is not None)

--- a/tools/azure-sdk-tools/packaging_tools/swaggertosdk/SwaggerToSdkNewCLI.py
+++ b/tools/azure-sdk-tools/packaging_tools/swaggertosdk/SwaggerToSdkNewCLI.py
@@ -202,7 +202,7 @@ def generate_sdk_from_git_object(
     sdk_git_id,
     base_branch_names,
     *,
-    fallback_base_branch_name="master",
+    fallback_base_branch_name="main",
     sdk_tag=None,
 ):
     """Generate SDK from a commit or a PR object.


### PR DESCRIPTION
swagger repo is defaulting to `main` now. No harm to this update.