### PR TITLE
[core] remove unnecessary awaits in async rest tests

### DIFF
--- a/sdk/core/azure-core/tests/async_tests/test_rest_http_response_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_http_response_async.py
@@ -107,7 +107,6 @@ async def test_response_content_type_encoding(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/latin-1")
     )
-    await response.read()
     assert response.content_type == "text/plain; charset=latin-1"
     assert response.content == b'Latin 1: \xff'
     assert response.text() == "Latin 1: ÿ"
@@ -122,7 +121,6 @@ async def test_response_autodetect_encoding(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/latin-1")
     )
-    await response.read()
     assert response.text() == u'Latin 1: ÿ'
     assert response.encoding == "latin-1"
 
@@ -135,7 +133,6 @@ async def test_response_fallback_to_autodetect(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/invalid-codec-name")
     )
-    await response.read()
     assert response.headers["Content-Type"] == "text/plain; charset=invalid-codec-name"
     assert response.text() == "おはようございます。"
     assert response.encoding is None
@@ -168,7 +165,6 @@ async def test_response_no_charset_with_iso_8859_1_content(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/iso-8859-1"),
     )
-    await response.read()
     assert response.text() == "Accented: �sterreich"
     assert response.encoding is None
 
@@ -177,7 +173,6 @@ async def test_json(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/basic/json"),
     )
-    await response.read()
     assert response.json() == {"greeting": "hello", "recipient": "world"}
     assert response.encoding is None
 
@@ -186,7 +181,6 @@ async def test_json_with_specified_encoding(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/json"),
     )
-    await response.read()
     assert response.json() == {"greeting": "hello", "recipient": "world"}
     assert response.encoding == "utf-16"
 
@@ -195,7 +189,6 @@ async def test_emoji(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/emoji"),
     )
-    await response.read()
     assert response.text() == "👩"
 
 @pytest.mark.asyncio
@@ -203,7 +196,6 @@ async def test_emoji_family_with_skin_tone_modifier(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/emoji-family-skin-tone-modifier"),
     )
-    await response.read()
     assert response.text() == "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987"
 
 @pytest.mark.asyncio
@@ -211,7 +203,6 @@ async def test_korean_nfc(send_request):
     response = await send_request(
         request=HttpRequest("GET", "/encoding/korean"),
     )
-    await response.read()
     assert response.text() == "아가"
 
 @pytest.mark.asyncio


### PR DESCRIPTION
For non-streamed async `send_request` calls, we already call response.read() in the transport, so there's no need to have them in the tests as well