### PR TITLE
[Key Vault] Improve/document logging tests

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -596,16 +596,20 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
 
         for message in mock_handler.messages:
             if message.levelname == "DEBUG" and message.funcName == "on_request":
-                messages_request = message.message.split("/n")
-                for m in messages_request:
+                # parts of the request are logged on new lines in a single message
+                request_sections = message.message.split("/n")
+                for section in request_sections:
                     try:
-                        body = json.loads(m)
+                        # the body of the request should be JSON
+                        body = json.loads(section)
                         if body["provider"] == "Test":
+                            mock_handler.close()
                             return
                     except (ValueError, KeyError):
-                        # this means the message is not JSON or has no kty property
+                        # this means the request section is not JSON
                         pass
 
+        mock_handler.close()
         assert False, "Expected request body wasn't logged"
 
     @logging_disabled()
@@ -622,14 +626,20 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
 
         for message in mock_handler.messages:
             if message.levelname == "DEBUG" and message.funcName == "on_request":
-                messages_request = message.message.split("/n")
-                for m in messages_request:
+                # parts of the request are logged on new lines in a single message
+                request_sections = message.message.split("/n")
+                for section in request_sections:
                     try:
-                        body = json.loads(m)
-                        assert body["provider"] != "Test", "Client request body was logged"
+                        # the body of the request should be JSON
+                        body = json.loads(section)
+                        if body["provider"] == "Test":
+                            mock_handler.close()
+                            assert False, "Client request body was logged"
                     except (ValueError, KeyError):
-                        # this means the message is not JSON or has no kty property
+                        # this means the request section is not JSON
                         pass
+
+        mock_handler.close()
 
     @only_2016_10_01()
     @client_setup

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -423,17 +423,21 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
 
         for message in mock_handler.messages:
             if message.levelname == "DEBUG" and message.funcName == "on_request":
-                messages_request = message.message.split("/n")
-                for m in messages_request:
+                # parts of the request are logged on new lines in a single message
+                request_sections = message.message.split("/n")
+                for section in request_sections:
                     try:
-                        body = json.loads(m)
+                        # the body of the request should be JSON
+                        body = json.loads(section)
                         expected_kty = "RSA-HSM" if is_hsm else "RSA"
                         if body["kty"] == expected_kty:
+                            mock_handler.close()
                             return
                     except (ValueError, KeyError):
-                        # this means the message is not JSON or has no kty property
+                        # this means the request section is not JSON or has no kty property
                         pass
 
+        mock_handler.close()
         assert False, "Expected request body wasn't logged"
 
     @logging_disabled()
@@ -450,15 +454,21 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
 
         for message in mock_handler.messages:
             if message.levelname == "DEBUG" and message.funcName == "on_request":
-                messages_request = message.message.split("/n")
-                for m in messages_request:
+                # parts of the request are logged on new lines in a single message
+                request_sections = message.message.split("/n")
+                for section in request_sections:
                     try:
-                        body = json.loads(m)
+                        # the body of the request should be JSON
+                        body = json.loads(section)
                         expected_kty = "RSA-HSM" if is_hsm else "RSA"
-                        assert body["kty"] != expected_kty, "Client request body was logged"
+                        if body["kty"] == expected_kty:
+                            mock_handler.close()
+                            assert False, "Client request body was logged"
                     except (ValueError, KeyError):
-                        # this means the message is not JSON or has no kty property
+                        # this means the request section is not JSON or has no kty property
                         pass
+
+        mock_handler.close()
 
     @only_hsm_7_3_preview()
     @client_setup

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -291,16 +291,20 @@ class KeyVaultSecretTest(SecretsTestCase, KeyVaultTestCase):
 
         for message in mock_handler.messages:
             if message.levelname == "DEBUG" and message.funcName == "on_request":
-                messages_request = message.message.split("/n")
-                for m in messages_request:
+                # parts of the request are logged on new lines in a single message
+                request_sections = message.message.split("/n")
+                for section in request_sections:
                     try:
-                        body = json.loads(m)
+                        # the body of the request should be JSON
+                        body = json.loads(section)
                         if body["value"] == "secret-value":
+                            mock_handler.close()
                             return
                     except (ValueError, KeyError):
-                        # this means the message is not JSON or has no kty property
+                        # this means the request section is not JSON
                         pass
 
+        mock_handler.close()
         assert False, "Expected request body wasn't logged"
 
     @logging_disabled()
@@ -317,14 +321,20 @@ class KeyVaultSecretTest(SecretsTestCase, KeyVaultTestCase):
 
         for message in mock_handler.messages:
             if message.levelname == "DEBUG" and message.funcName == "on_request":
-                messages_request = message.message.split("/n")
-                for m in messages_request:
+                # parts of the request are logged on new lines in a single message
+                request_sections = message.message.split("/n")
+                for section in request_sections:
                     try:
-                        body = json.loads(m)
-                        assert body["value"] != "secret-value", "Client request body was logged"
+                        # the body of the request should be JSON
+                        body = json.loads(section)
+                        if body["value"] == "secret-value":
+                            mock_handler.close()
+                            assert False, "Client request body was logged"
                     except (ValueError, KeyError):
                         # this means the message is not JSON or has no kty property
                         pass
+
+        mock_handler.close()
 
 
 def test_service_headers_allowed_in_logs():


### PR DESCRIPTION
This correctly closes handlers used in logging tests and documents what we're looking for, since inspecting these tests otherwise can be a little confusing. Thank you, Xiang, for having updated these for the consolidated logging in `azure-core`! Updating regression tests for these changes will be done soon.