### PR TITLE
Bit more complicated parsing of the `requirements_to_exclude` during `install_depend_packages.py`

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -140,7 +140,7 @@ def check_req_against_exclusion(req, req_to_exclude):
         "https://docsupport.blob.core.windows.net/repackaged/cffi-1.14.6-cp310-cp310-win_amd64.whl; sys_platform=='win32' and python_version >= '3.10'",
         "msrestazure>=0.4.11", "pytest" ]
 
-    :param req_to_exclude: A valid and complete python package name. No specificiers.
+    :param req_to_exclude: A valid and complete python package name. No specifiers.
     """
     req_id = ""
     for c in req:


### PR DESCRIPTION
Before, we were relying on a simple filter of the dev_requirements.txt:

```
for req in dev_requirements.txt
   if the req starts with any of the req_to_exclude, exclude it
```

The failure in `azure-containerregistry` was caused by the fact that it has direct requirements `[ 'msrest', 'azure-core']`. FYI, any direct requirements parsed from the `setup.py` are _always_ excluded from the dev_requirements file. We don't want anything messing with the versions of the deps that we _expect_.

The issue isn't that, but the fact that in `dev_requirements.txt` there is a line

```
msrestazure>=0.4.11
```

...and it's already obvious given the `startsWith` clause in the exclusion logic above where the issue lies. 😢 

This PR adjusts the comparison such that the check is a bit more in-depth.

@YalinLi0312 , `latestdependency` of `azure-containeregistry` works just fine after this improvement.

