### PR TITLE
[formrecognizer] Add parent references for to_dict and from_dict methods

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -2258,6 +2258,7 @@ class AnalyzedDocument(object):
             if self.fields
             else {},
             "confidence": self.confidence,
+            "_parent": self._parent,
         }
 
     @classmethod
@@ -2281,6 +2282,7 @@ class AnalyzedDocument(object):
             if data.get("fields")
             else {},
             confidence=data.get("confidence", None),
+            _parent=data.get("_parent", None),
         )
 
     def get_words(self, **kwargs):  # pylint: disable=unused-argument
@@ -2387,6 +2389,7 @@ class DocumentEntity(object):
             if self.spans
             else [],
             "confidence": self.confidence,
+            "_parent": self._parent,
         }
 
     @classmethod
@@ -2409,6 +2412,7 @@ class DocumentEntity(object):
             if len(data.get("spans", [])) > 0
             else [],
             confidence=data.get("confidence", None),
+            _parent=data.get("_parent", None),
         )
 
     def get_words(self, **kwargs):  # pylint: disable=unused-argument
@@ -2523,6 +2527,7 @@ class DocumentField(object):
             if self.spans
             else [],
             "confidence": self.confidence,
+            "_parent": self._parent,
         }
 
     @classmethod
@@ -2545,6 +2550,7 @@ class DocumentField(object):
             if len(data.get("spans", [])) > 0
             else [],
             confidence=data.get("confidence", None),
+            _parent=data.get("_parent", None),
         )
 
     def get_words(self, **kwargs):  # pylint: disable=unused-argument
@@ -2624,6 +2630,7 @@ class DocumentKeyValueElement(object):
             "spans": [f.to_dict() for f in self.spans]
             if self.spans
             else [],
+            "_parent": self._parent,
         }
 
     @classmethod
@@ -2643,6 +2650,7 @@ class DocumentKeyValueElement(object):
             spans=[DocumentSpan.from_dict(v) for v in data.get("spans")]  # type: ignore
             if len(data.get("spans", [])) > 0
             else [],
+            _parent=data.get("_parent", None),
         )
 
     def get_words(self, **kwargs):  # pylint: disable=unused-argument
@@ -2780,6 +2788,7 @@ class DocumentLine(object):
             "spans": [f.to_dict() for f in self.spans]
             if self.spans
             else [],
+            "_parent": self._parent,
         }
 
     @classmethod
@@ -2799,6 +2808,7 @@ class DocumentLine(object):
             spans=[DocumentSpan.from_dict(v) for v in data.get("spans")]  # type: ignore
             if len(data.get("spans", [])) > 0
             else [],
+            _parent=data.get("_parent", None),
         )
 
     def get_words(self, **kwargs):  # pylint: disable=unused-argument
@@ -3161,6 +3171,7 @@ class DocumentTable(object):
             "spans": [f.to_dict() for f in self.spans]
             if self.spans
             else [],
+            "_parent": self._parent,
         }
 
     @classmethod
@@ -3184,6 +3195,7 @@ class DocumentTable(object):
             spans=[DocumentSpan.from_dict(v) for v in data.get("spans")]  # type: ignore
             if len(data.get("spans", [])) > 0
             else [],
+            _parent=data.get("_parent", None),
         )
 
     def get_words(self, **kwargs):  # pylint: disable=unused-argument
@@ -3294,6 +3306,7 @@ class DocumentTableCell(object):
             "spans": [f.to_dict() for f in self.spans]
             if self.spans
             else [],
+            "_parent": self._parent,
         }
 
     @classmethod
@@ -3318,6 +3331,7 @@ class DocumentTableCell(object):
             spans=[DocumentSpan.from_dict(v) for v in data.get("spans")]  # type: ignore
             if len(data.get("spans", [])) > 0
             else [],
+            _parent=data.get("_parent", None),
         )
 
     def get_words(self, **kwargs):  # pylint: disable=unused-argument

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
@@ -5,7 +5,7 @@
 # ------------------------------------
 
 import functools
-from azure.ai.formrecognizer import DocumentAnalysisClient
+from azure.ai.formrecognizer import DocumentAnalysisClient, AnalyzedDocument, DocumentEntity, DocumentField, DocumentKeyValueElement, DocumentKeyValuePair, DocumentLine, DocumentTable, DocumentTableCell
 from preparers import FormRecognizerPreparer
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
@@ -24,8 +24,11 @@ class TestGetChildren(FormRecognizerTest):
 
         poller = client.begin_analyze_document("prebuilt-document", document)
         result = poller.result()
-        
-        elements = result.pages[0].lines[0].get_words()
+
+        d = result.pages[0].lines[0].to_dict()
+        elem = DocumentLine.from_dict(d)
+
+        elements = elem.get_words()
         assert len(elements) == 1
         assert elements[0].content == "Contoso"
 
@@ -39,10 +42,13 @@ class TestGetChildren(FormRecognizerTest):
         poller = client.begin_analyze_document("prebuilt-layout", document)
         result = poller.result()
         
-        elements = result.tables[0].get_words()
+        d = result.tables[0].to_dict()
+        elem = DocumentTable.from_dict(d)
+
+        elements = elem.get_words()
         assert len(elements) == 25
 
-        elements = result.tables[0].get_lines()
+        elements = elem.get_lines()
         assert len(elements) == 20
 
 
@@ -55,10 +61,13 @@ class TestGetChildren(FormRecognizerTest):
         poller = client.begin_analyze_document("prebuilt-layout", document)
         result = poller.result()
         
-        elements = result.tables[0].cells[0].get_words()
+        d = result.tables[0].cells[0].to_dict()
+        elem = DocumentTableCell.from_dict(d)
+
+        elements = elem.get_words()
         assert len(elements) == 1
 
-        elements = result.tables[0].cells[0].get_lines()
+        elements = elem.get_lines()
         assert len(elements) == 1
 
 
@@ -71,10 +80,13 @@ class TestGetChildren(FormRecognizerTest):
         poller = client.begin_analyze_document("prebuilt-invoice", document)
         result = poller.result()
         
-        elements = result.documents[0].get_words()
+        d = result.documents[0].to_dict()
+        elem = AnalyzedDocument.from_dict(d)
+
+        elements = elem.get_words()
         assert len(elements) == 132
 
-        elements = result.documents[0].get_lines()
+        elements = elem.get_lines()
         assert len(elements) == 54
 
 
@@ -87,10 +99,13 @@ class TestGetChildren(FormRecognizerTest):
         poller = client.begin_analyze_document("prebuilt-invoice", document)
         result = poller.result()
         
-        elements = result.documents[0].fields.get("InvoiceTotal").get_words()
+        d = result.documents[0].fields.get("InvoiceTotal").to_dict()
+        elem = DocumentField.from_dict(d)
+
+        elements = elem.get_words()
         assert len(elements) == 1
 
-        elements = result.documents[0].fields.get("InvoiceTotal").get_lines()
+        elements = elem.get_lines()
         assert len(elements) == 1
 
 
@@ -103,10 +118,13 @@ class TestGetChildren(FormRecognizerTest):
         poller = client.begin_analyze_document("prebuilt-document", document)
         result = poller.result()
         
-        elements = result.entities[0].get_words()
+        d = result.entities[0].to_dict()
+        elem = DocumentEntity.from_dict(d)
+
+        elements = elem.get_words()
         assert len(elements) == 1
 
-        elements = result.entities[0].get_lines()
+        elements = elem.get_lines()
         assert len(elements) == 1
 
 
@@ -119,10 +137,13 @@ class TestGetChildren(FormRecognizerTest):
         poller = client.begin_analyze_document("prebuilt-document", document)
         result = poller.result()
         
-        elements = result.key_value_pairs[0].key.get_words()
+        d = result.key_value_pairs[0].key.to_dict()
+        elem = DocumentKeyValueElement.from_dict(d)
+
+        elements = elem.get_words()
         assert len(elements) == 2
 
-        elements = result.key_value_pairs[0].key.get_lines()
+        elements = elem.get_lines()
         assert len(elements) == 0
 
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_to_dict_v3.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_to_dict_v3.py
@@ -222,9 +222,11 @@ class TestToDict(FormRecognizerTest):
                         },
                     ],
                     "confidence": 0.99,
+                    "_parent": None,
                 },
             },
             "confidence": 0.99,
+            "_parent": None,
         }
 
         assert d == final
@@ -296,6 +298,7 @@ class TestToDict(FormRecognizerTest):
                 },
             ],
             "confidence": 0.99,
+            "_parent": None,
         }
         assert d == final
 
@@ -366,6 +369,7 @@ class TestToDict(FormRecognizerTest):
                 },
             ],
             "confidence": 0.99,
+            "_parent": None,
         }
         assert d == final
 
@@ -430,6 +434,7 @@ class TestToDict(FormRecognizerTest):
                     "length": 2,
                 },
             ],
+            "_parent": None,
         }
 
         assert d == final
@@ -492,6 +497,7 @@ class TestToDict(FormRecognizerTest):
                         "length": 2,
                     },
                 ],
+                "_parent": None,
             },
             "value": {
                 "content": "value",
@@ -513,6 +519,7 @@ class TestToDict(FormRecognizerTest):
                         "length": 2,
                     },
                 ],
+                "_parent": None,
             },
             "confidence": 0.89,
         }
@@ -551,6 +558,7 @@ class TestToDict(FormRecognizerTest):
                     "length": 2,
                 },
             ],
+            "_parent": None
         }
         assert d == final
 
@@ -682,6 +690,7 @@ class TestToDict(FormRecognizerTest):
                             "length": 2,
                         },
                     ],
+                    "_parent": None,
                 },
             ],
         }
@@ -823,6 +832,7 @@ class TestToDict(FormRecognizerTest):
                             "length": 2,
                         },
                     ],
+                    "_parent": None,
                 },
             ],
             "bounding_regions": [
@@ -843,6 +853,7 @@ class TestToDict(FormRecognizerTest):
                     "length": 2,
                 },
             ],
+            "_parent": None,
         }
 
         assert d == final
@@ -896,6 +907,7 @@ class TestToDict(FormRecognizerTest):
                     "length": 2,
                 },
             ],
+            "_parent": None,
         }
 
         assert d == final
@@ -947,6 +959,7 @@ class TestToDict(FormRecognizerTest):
                     "length": 2,
                 },
             ],
+            "_parent": None,
         }
 
         assert d == final
@@ -1306,6 +1319,7 @@ class TestToDict(FormRecognizerTest):
                                     "length": 2,
                                 },
                             ],
+                            "_parent": None,
                         },
                     ],
                 },
@@ -1340,6 +1354,7 @@ class TestToDict(FormRecognizerTest):
                                     "length": 2,
                                 },
                             ],
+                            "_parent": None,
                         },
                     ],
                     "bounding_regions": [
@@ -1360,6 +1375,7 @@ class TestToDict(FormRecognizerTest):
                             "length": 2,
                         },
                     ],
+                    "_parent": None,
                 },
             ],
             "key_value_pairs": [
@@ -1384,6 +1400,7 @@ class TestToDict(FormRecognizerTest):
                                 "length": 2,
                             },
                         ],
+                        "_parent": None,
                     },
                     "value": {
                         "content": "value",
@@ -1405,6 +1422,7 @@ class TestToDict(FormRecognizerTest):
                                 "length": 2,
                             },
                         ],
+                        "_parent": None,
                     },
                     "confidence": 0.89,
                 },
@@ -1447,6 +1465,7 @@ class TestToDict(FormRecognizerTest):
                         },
                     ],
                     "confidence": 0.99,
+                    "_parent": None,
                 },
             ],
             "styles": [
@@ -1534,9 +1553,11 @@ class TestToDict(FormRecognizerTest):
                                 },
                             ],
                             "confidence": 0.99,
+                            "_parent": None,
                         },
                     },
                     "confidence": 0.99,
+                    "_parent": None,
                 },
             ],
         }


### PR DESCRIPTION
Fixes #21470 

Adding parent info in the to and from dict methods allows continued functionality for `get_words` and `get_lines` calls on models that have been converted. 