### PR TITLE
[WebPubSub] Use consistent service description and introduction across all languages

### DIFF
--- a/sdk/webpubsub/azure-messaging-webpubsubservice/README.md
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/README.md
@@ -2,8 +2,11 @@
 
 [Azure Web PubSub Service](https://aka.ms/awps/doc) is an Azure-managed service that helps developers easily build web applications with real-time features and publish-subscribe pattern. Any scenario that requires real-time publish-subscribe messaging between server and clients or among clients can use Azure Web PubSub service. Traditional real-time features that often require polling from server or submitting HTTP requests can also use Azure Web PubSub service.
 
-This library can be used to do the following actions. Details about the terms used here are described in [Key concepts](#key-concepts) section.
+You can use this library in your app server side to manage the WebSocket client connections, as shown in below diagram:
 
+![overflow](https://user-images.githubusercontent.com/668244/140014067-25a00959-04dc-47e8-ac25-6957bd0a71ce.png)
+
+Use this library to:
 - Send messages to hubs and groups. 
 - Send messages to particular users and connections.
 - Organize users and connections into groups.
@@ -33,7 +36,7 @@ You can authenticate the `WebPubSubServiceClient` using [connection string][conn
 ```python
 >>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
 
->>> service_client = WebPubSubServiceClient.from_connection_string(connection_string='<connection_string>')
+>>> service = WebPubSubServiceClient.from_connection_string(connection_string='<connection_string>')
 ```
 
 Or using the service endpoint and the access key:
@@ -42,7 +45,7 @@ Or using the service endpoint and the access key:
 >>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
 >>> from azure.core.credentials import AzureKeyCredential
 
->>> service_client = WebPubSubServiceClient(endpoint='<endpoint>', credential=AzureKeyCredential("<access_key>"))
+>>> service = WebPubSubServiceClient(endpoint='<endpoint>', credential=AzureKeyCredential("<access_key>"))
 ```
 
 Or using [Azure Active Directory][aad_doc]:
@@ -53,7 +56,7 @@ Or using [Azure Active Directory][aad_doc]:
     ```python
     >>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
     >>> from azure.identity import DefaultAzureCredential
-    >>> service_client = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
+    >>> service = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
     ```
 
 ## Key concepts
@@ -87,10 +90,10 @@ When the client is connected, it can send messages to the upstream application, 
 >>> from azure.identity import DefaultAzureCredential
 >>> from azure.core.exceptions import HttpResponseError
 
->>> service_client = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
+>>> service = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
 >>> with open('file.json', 'r') as f:
     try:
-        service_client.send_to_all('ahub', content=f, content_type='application/json')
+        service.send_to_all('ahub', content=f, content_type='application/json')
     except HttpResponseError as e:
         print('service responds error: {}'.format(e.response.json()))
 
@@ -121,14 +124,14 @@ endpoint = "<endpoint>"
 credential = DefaultAzureCredential()
 
 # This WebPubSubServiceClient will log detailed information about its HTTP sessions, at DEBUG level
-service_client = WebPubSubServiceClient(endpoint=endpoint, credential=credential, logging_enable=True)
+service = WebPubSubServiceClient(endpoint=endpoint, credential=credential, logging_enable=True)
 ```
 
 Similarly, `logging_enable` can enable detailed logging for a single call,
-even when it isn't enabled for the client:
+even when it isn't enabled for the WebPubSubServiceClient:
 
 ```python
-result = service_client.send_to_all(..., logging_enable=True)
+result = service.send_to_all(..., logging_enable=True)
 ```
 
 Http request and response details are printed to stdout with this logging config.

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/README.md
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/README.md
@@ -1,91 +1,82 @@
-# Azure WebPubSubService client library for Python
+# Azure Web PubSub service client library for Python
 
-[Azure Web PubSub Service](https://aka.ms/awps/doc) is a service that enables you to build real-time messaging web applications using WebSockets and the publish-subscribe pattern. Any platform supporting WebSocket APIs can connect to the service easily, e.g. web pages, mobile applications, edge devices, etc. The service manages the WebSocket connections for you and allows up to 100K concurrent connections. It provides powerful APIs for you to manage these clients and deliver real-time messages.
+[Azure Web PubSub Service](https://aka.ms/awps/doc) is an Azure-managed service that helps developers easily build web applications with real-time features and publish-subscribe pattern. Any scenario that requires real-time publish-subscribe messaging between server and clients or among clients can use Azure Web PubSub service. Traditional real-time features that often require polling from server or submitting HTTP requests can also use Azure Web PubSub service.
 
-Any scenario that requires real-time publish-subscribe messaging between server and clients or among clients, can use Azure Web PubSub service. Traditional real-time features that often require polling from server or submitting HTTP requests, can also use Azure Web PubSub service.
+This library can be used to do the following actions. Details about the terms used here are described in [Key concepts](#key-concepts) section.
 
-We list some examples that are good to use Azure Web PubSub service:
-
-- **High frequency data updates:** gaming, voting, polling, auction.
-- **Live dashboards and monitoring:** company dashboard, financial market data, instant sales update, multi-player game leader board, and IoT monitoring.
-- **Cross-platform live chat:** live chat room, chat bot, on-line customer support, real-time shopping assistant, messenger, in-game chat, and so on.
-- **Real-time location on map:** logistic tracking, delivery status tracking, transportation status updates, GPS apps.
-- **Real-time targeted ads:** personalized real-time push ads and offers, interactive ads.
-- **Collaborative apps:** coauthoring, whiteboard apps and team meeting software.
-- **Push instant notifications:** social network, email, game, travel alert.
-- **Real-time broadcasting:** live audio/video broadcasting, live captioning, translating, events/news broadcasting.
-- **IoT and connected devices:** real-time IoT metrics, remote control, real-time status, and location tracking.
-- **Automation:** real-time trigger from upstream events.
-
-Use the client library to:
-
-- Send messages to hubs and groups.
+- Send messages to hubs and groups. 
 - Send messages to particular users and connections.
 - Organize users and connections into groups.
 - Close connections
-- Grant/revoke/check permissions for an existing connection
+- Grant, revoke, and check permissions for an existing connection
 
-[Source code](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/webpubsub/azure-messaging-webpubsubservice) | [Package (Pypi)][package] | [API reference documentation](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/webpubsub/azure-messaging-webpubsubservice) | [Product documentation][webpubsubservice_docs]
+[Source code](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/webpubsub/azure-messaging-webpubsubservice) | [Package (Pypi)][package] | [API reference documentation](https://aka.ms/awps/sdk/python) | [Product documentation][webpubsubservice_docs]
 
 ## Getting started
 
-### Installating the package
-
-```bash
-python -m pip install azure-messaging-webpubsubservice
-```
-
-#### Prequisites
+### Prerequisites
 
 - Python 2.7, or 3.6 or later is required to use this package.
 - You need an [Azure subscription][azure_sub], and a [Azure WebPubSub service instance][webpubsubservice_docs] to use this package.
 - An existing Azure Web PubSub service instance.
 
-### Authenticating the client
+### 1. Install the package
 
-#### 1. Create the client from the service connection string
+```bash
+python -m pip install azure-messaging-webpubsubservice
+```
 
-You can get the [API key][api_key] or [Connection string][connection_string] in the [Azure Portal][azure_portal].
-Once you have the value for the API key, you can pass it as a string into an instance of [AzureKeyCredential][azure-key-credential]. 
-Use the key as the credential parameter to authenticate the client:
+### 2. Create and authenticate a WebPubSubServiceClient
+
+You can authenticate the `WebPubSubServiceClient` using [connection string][connection_string]:
+
+```python
+>>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
+
+>>> service_client = WebPubSubServiceClient.from_connection_string(connection_string='<connection_string>')
+```
+
+Or using the service endpoint and the access key:
 
 ```python
 >>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
 >>> from azure.core.credentials import AzureKeyCredential
 
->>> client = WebPubSubServiceClient(endpoint='<endpoint>', credential=AzureKeyCredential("<api_key>"))
+>>> service_client = WebPubSubServiceClient(endpoint='<endpoint>', credential=AzureKeyCredential("<access_key>"))
 ```
 
-Once you have the value for the connection string, you can pass it as a string into the function `from_connection_string` and it will 
-authenticate the client:
-```python
->>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
+Or using [Azure Active Directory][aad_doc]:
+1. [pip][pip] install [`azure-identity`][azure_identity_pip]
+2. Follow the document to [enable AAD authentication on your Webpubsub resource][aad_doc]
+3. Update code to use [DefaultAzureCredential][default_azure_credential]
 
->>> client = WebPubSubServiceClient.from_connection_string(connection_string='<connection_string>')
-```
+    ```python
+    >>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
+    >>> from azure.identity import DefaultAzureCredential
+    >>> service_client = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
+    ```
 
-#### 2. Create with an Azure Active Directory Credential
-To use an [Azure Active Directory (AAD) token credential][authenticate_with_token],
-provide an instance of the desired credential type obtained from the
-[azure-identity][azure_identity_credentials] library.
+## Key concepts
 
-To authenticate with AAD, you must first [pip][pip] install [`azure-identity`][azure_identity_pip] and
-[enable AAD authentication on your Webpubsub resource][enable_aad]
+### Connection
 
-After setup, you can choose which type of [credential][azure_identity_credentials] from azure.identity to use.
-As an example, [DefaultAzureCredential][default_azure_credential]
-can be used to authenticate the client:
+A connection, also known as a client or a client connection, represents an individual WebSocket connection connected to the Web PubSub service. When successfully connected, a unique connection ID is assigned to this connection by the Web PubSub service.
 
-Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
-AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
+### Hub
 
-Use the returned token credential to authenticate the client:
+A hub is a logical concept for a set of client connections. Usually you use one hub for one purpose, for example, a chat hub, or a notification hub. When a client connection is created, it connects to a hub, and during its lifetime, it belongs to that hub. Different applications can share one Azure Web PubSub service by using different hub names.
 
-```python
->>> from azure.messaging.webpubsubservice import WebPubSubServiceClient
->>> from azure.identity import DefaultAzureCredential
->>> client = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
-```
+### Group
+
+A group is a subset of connections to the hub. You can add a client connection to a group, or remove the client connection from the group, anytime you want. For example, when a client joins a chat room, or when a client leaves the chat room, this chat room can be considered to be a group. A client can join multiple groups, and a group can contain multiple clients.
+
+### User
+
+Connections to Web PubSub can belong to one user. A user might have multiple connections, for example when a single user is connected across multiple devices or multiple browser tabs.
+
+### Message
+
+When the client is connected, it can send messages to the upstream application, or receive messages from the upstream application, through the WebSocket connection.
 
 ## Examples
 
@@ -96,36 +87,14 @@ Use the returned token credential to authenticate the client:
 >>> from azure.identity import DefaultAzureCredential
 >>> from azure.core.exceptions import HttpResponseError
 
->>> client = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
+>>> service_client = WebPubSubServiceClient(endpoint='<endpoint>', credential=DefaultAzureCredential())
 >>> with open('file.json', 'r') as f:
     try:
-        client.send_to_all('ahub', content=f, content_type='application/json')
+        service_client.send_to_all('ahub', content=f, content_type='application/json')
     except HttpResponseError as e:
         print('service responds error: {}'.format(e.response.json()))
 
 ```
-
-## Key concepts
-
-### Connection
-
-Connections, represented by a connection id, represent an individual websocket connection to the Web PubSub service. Connection id is always unique.
-
-### Hub
-
-Hub is a logical concept for a set of connections. Connections are always connected to a specific hub. Messages that are broadcast to the hub are dispatched to all connections to that hub. Hub can be used for different applications, different applications can share one Azure Web PubSub service by using different hub names.
-
-### Group
-
-Group allow broadcast messages to a subset of connections to the hub. You can add and remove users and connections as needed. A client can join multiple groups, and a group can contain multiple clients.
-
-### User
-
-Connections to Web PubSub can belong to one user. A user might have multiple connections, for example when a single user is connected across multiple devices or multiple browser tabs.
-
-### Message
-
-Using this library, you can send messages to the client connections. A message can either be string text, JSON or binary payload.
 
 ## Troubleshooting
 
@@ -151,22 +120,22 @@ logger.addHandler(handler)
 endpoint = "<endpoint>"
 credential = DefaultAzureCredential()
 
-# This client will log detailed information about its HTTP sessions, at DEBUG level
-client = WebPubSubServiceClient(endpoint=endpoint, credential=credential, logging_enable=True)
+# This WebPubSubServiceClient will log detailed information about its HTTP sessions, at DEBUG level
+service_client = WebPubSubServiceClient(endpoint=endpoint, credential=credential, logging_enable=True)
 ```
 
 Similarly, `logging_enable` can enable detailed logging for a single call,
 even when it isn't enabled for the client:
 
 ```python
-result = client.send_to_all(..., logging_enable=True)
+result = service_client.send_to_all(..., logging_enable=True)
 ```
 
 Http request and response details are printed to stdout with this logging config.
 
 ## Next steps
 
-More examples are coming soon...
+Check [more samples here][awps_samples].
 
 ## Contributing
 
@@ -205,3 +174,5 @@ additional questions or comments.
 [connection_string]: https://docs.microsoft.com/azure/azure-web-pubsub/howto-websocket-connect?tabs=browser#authorization
 [azure_portal]: https://docs.microsoft.com/azure/azure-web-pubsub/howto-develop-create-instance
 [azure-key-credential]: https://aka.ms/azsdk-python-core-azurekeycredential
+[aad_doc]: https://aka.ms/awps/aad
+[awps_samples]: https://github.com/Azure/azure-webpubsub/tree/main/samples/python


### PR DESCRIPTION
1. To keep the service description consistent across different languages
2. Update some links
3. Use `service` instead of `client` to avoid confusion with WebSocket clients