### PR TITLE
[Key Vault] Address archboard feedback

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Features Added
 
 ### Breaking Changes
+> These changes do not impact the API of stable versions such as 4.4.0.
+> Only code written against a beta version such as 4.5.0b1 may be affected.
+- `KeyClient.get_random_bytes` now returns bytes instead of RandomBytes. The RandomBytes class
+  has been removed.
+- Renamed the `version` keyword-only argument in `KeyClient.get_cryptography_client` to
+  `key_version`.
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/__init__.py
@@ -13,7 +13,6 @@ from ._models import (
     KeyRotationPolicy,
     KeyVaultKey,
     KeyVaultKeyIdentifier,
-    RandomBytes,
     ReleaseKeyResult,
 )
 from ._client import KeyClient
@@ -34,7 +33,6 @@ __all__ = [
     "KeyReleasePolicy",
     "KeyRotationLifetimeAction",
     "KeyRotationPolicy",
-    "RandomBytes",
     "ReleaseKeyResult",
 ]
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -9,7 +9,7 @@ from .crypto import CryptographyClient
 from ._shared import KeyVaultClientBase
 from ._shared.exceptions import error_map as _error_map
 from ._shared._polling import DeleteRecoverPollingMethod, KeyVaultOperationPoller
-from ._models import DeletedKey, KeyVaultKey, KeyProperties, KeyRotationPolicy, RandomBytes, ReleaseKeyResult
+from ._models import DeletedKey, KeyVaultKey, KeyProperties, KeyRotationPolicy, ReleaseKeyResult
 
 try:
     from typing import TYPE_CHECKING
@@ -728,13 +728,13 @@ class KeyClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_random_bytes(self, count, **kwargs):
-        # type: (int, **Any) -> RandomBytes
+        # type: (int, **Any) -> bytes
         """Get the requested number of random bytes from a managed HSM.
 
         :param int count: The requested number of random bytes.
 
         :return: The random bytes.
-        :rtype: ~azure.keyvault.keys.RandomBytes
+        :rtype: bytes
         :raises:
             :class:`ValueError` if less than one random byte is requested,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -751,7 +751,7 @@ class KeyClient(KeyVaultClientBase):
             raise ValueError("At least one random byte must be requested")
         parameters = self._models.GetRandomBytesRequest(count=count)
         result = self._client.get_random_bytes(vault_base_url=self._vault_url, parameters=parameters, **kwargs)
-        return RandomBytes(value=result.value)
+        return result.value
 
     @distributed_trace
     def get_key_rotation_policy(self, name, **kwargs):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -67,13 +67,13 @@ class KeyClient(KeyVaultClientBase):
 
         :param str key_name: The name of the key used to perform cryptographic operations.
 
-        :keyword str version: Optional version of the key used to perform cryptographic operations.
+        :keyword str key_version: Optional version of the key used to perform cryptographic operations.
 
         :returns: A :class:`~azure.keyvault.keys.crypto.CryptographyClient` using the same options, credentials, and
             HTTP client as this :class:`~azure.keyvault.keys.KeyClient`.
         :rtype: ~azure.keyvault.keys.crypto.CryptographyClient
         """
-        key_id = _get_key_id(self._vault_url, key_name, kwargs.get("version"))
+        key_id = _get_key_id(self._vault_url, key_name, kwargs.get("key_version"))
 
         # We provide a fake credential because the generated client already has the KeyClient's real credential
         return CryptographyClient(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -573,13 +573,3 @@ class DeletedKey(KeyVaultKey):
         :rtype: ~datetime.datetime or None
         """
         return self._scheduled_purge_date
-
-
-class RandomBytes(object):
-    """Contains random bytes returned from a managed HSM.
-
-    :param bytes value: the random bytes
-    """
-
-    def __init__(self, value):
-        self.value = value

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -68,13 +68,13 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :param str key_name: The name of the key used to perform cryptographic operations.
 
-        :keyword str version: Optional version of the key used to perform cryptographic operations.
+        :keyword str key_version: Optional version of the key used to perform cryptographic operations.
 
         :returns: A :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` using the same options, credentials, and
             HTTP client as this :class:`~azure.keyvault.keys.aio.KeyClient`.
         :rtype: ~azure.keyvault.keys.crypto.aio.CryptographyClient
         """
-        key_id = _get_key_id(self._vault_url, key_name, kwargs.get("version"))
+        key_id = _get_key_id(self._vault_url, key_name, kwargs.get("key_version"))
 
         # We provide a fake credential because the generated client already has the KeyClient's real credential
         return CryptographyClient(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -19,7 +19,6 @@ from .. import (
     KeyProperties,
     KeyRotationPolicy,
     KeyVaultKey,
-    RandomBytes,
     ReleaseKeyResult,
 )
 
@@ -707,13 +706,13 @@ class KeyClient(AsyncKeyVaultClientBase):
         return ReleaseKeyResult(result.value)
 
     @distributed_trace_async
-    async def get_random_bytes(self, count: int, **kwargs: "Any") -> RandomBytes:
+    async def get_random_bytes(self, count: int, **kwargs: "Any") -> bytes:
         """Get the requested number of random bytes from a managed HSM.
 
         :param int count: The requested number of random bytes.
 
         :return: The random bytes.
-        :rtype: ~azure.keyvault.keys.RandomBytes
+        :rtype: bytes
         :raises:
             :class:`ValueError` if less than one random byte is requested,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -730,7 +729,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             raise ValueError("At least one random byte must be requested")
         parameters = self._models.GetRandomBytesRequest(count=count)
         result = await self._client.get_random_bytes(vault_base_url=self._vault_url, parameters=parameters, **kwargs)
-        return RandomBytes(value=result.value)
+        return result.value
 
     @distributed_trace_async
     async def get_key_rotation_policy(self, name: str, **kwargs: "Any") -> "KeyRotationPolicy":

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -606,7 +606,7 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
         key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
         # try specifying the key version
-        crypto_client = client.get_cryptography_client(key_name, version=key.properties.version)
+        crypto_client = client.get_cryptography_client(key_name, key_version=key.properties.version)
         # both clients should use the same generated client
         assert client._client == crypto_client._client
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -482,8 +482,7 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
         for i in range(5):
             # [START get_random_bytes]
             # get eight random bytes from a managed HSM
-            result = client.get_random_bytes(count=8)
-            random_bytes = result.value
+            random_bytes = client.get_random_bytes(count=8)
             # [END get_random_bytes]
             assert len(random_bytes) == 8
             assert all(random_bytes != rb for rb in generated_random_bytes)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -603,7 +603,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         key = await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
         # try specifying the key version
-        crypto_client = client.get_cryptography_client(key_name, version=key.properties.version)
+        crypto_client = client.get_cryptography_client(key_name, key_version=key.properties.version)
         # both clients should use the same generated client
         assert client._client == crypto_client._client
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -479,8 +479,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         for i in range(5):
             # [START get_random_bytes]
             # get eight random bytes from a managed HSM
-            result = await client.get_random_bytes(count=8)
-            random_bytes = result.value
+            random_bytes = await client.get_random_bytes(count=8)
             # [END get_random_bytes]
             assert len(random_bytes) == 8
             assert all(random_bytes != rb for rb in generated_random_bytes)


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/21365.

This renames the `version` kwarg in `get_cryptography_client` to `key_version`, and tosses the RandomBytes model in favor of returning plain bytes from `get_random_bytes`.