### PR TITLE
Use working region/subscription for search deployments

### DIFF
--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -4,6 +4,9 @@ stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       BuildTargetingString: azure-search-documents
+      # TODO: change/remove location back to default westus2 after search RP fixes deletion metadata issue
+      # https://github.com/Azure/azure-sdk-tools/issues/2216
+      Location: 'eastus2'
       ServiceDirectory: search
       EnvVars:
         AZURE_CLIENT_ID: $(SEARCH_CLIENT_ID)


### PR DESCRIPTION
We are running into deployment issues with the search RP and deletion metadata. This switches our search deployments to a working region/subscription until their fix rolls out