### PR TITLE
Use arm template parameters as sole input for live test environment variables

### DIFF
--- a/sdk/attestation/test-resources.json
+++ b/sdk/attestation/test-resources.json
@@ -16,6 +16,13 @@
         "description": "The location of the resource. By default, this is the same as the resource group."
       }
     },
+    "storageEndpointSuffix": {
+      "type": "string",
+      "defaultValue": "core.windows.net",
+      "metadata": {
+          "description": "The url suffix to use when accessing the storage data plane."
+      }
+    },
     "isolatedSigningCertificate": {
       "type": "string",
       "defaultValue": ""
@@ -47,7 +54,7 @@
       "type": "Microsoft.Attestation/attestationProviders",
       "apiVersion": "2020-10-01",
       "name": "[variables('aadTenantName')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('location')]"
     },
     {
       "type": "Microsoft.Attestation/attestationProviders",
@@ -58,6 +65,10 @@
     }
   ],
   "outputs": {
+    "ATTESTATION_STORAGE_ENDPOINT_SUFFIX": {
+        "type": "string",
+        "value": "[parameters('storageEndpointSuffix')]"
+    },
     "ATTESTATION_ISOLATED_URL": {
       "type": "string",
       "value": "[variables('isolatedUri')]"

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -86,6 +86,13 @@
             "metadata": {
                 "description": "Test attestation service for Secure Key Release."
             }
+        },
+        "storageEndpointSuffix": {
+          "type": "string",
+          "defaultValue": "core.windows.net",
+          "metadata": {
+              "description": "The url suffix to use when accessing the storage data plane."
+          }
         }
     },
     "variables": {
@@ -272,6 +279,10 @@
         "CLIENT_OBJECTID": {
             "type": "string",
             "value": "[parameters('testApplicationOid')]"
+        },
+        "KEYVAULT_STORAGE_ENDPOINT_SUFFIX": {
+            "type": "string",
+            "value": "[parameters('storageEndpointSuffix')]"
         },
         "BLOB_STORAGE_ACCOUNT_NAME": {
             "type": "string",

--- a/sdk/tables/test-resources.json
+++ b/sdk/tables/test-resources.json
@@ -10,6 +10,13 @@
             "metadata": {
                 "description": "The principal to assign the role to. This is application object id."
             }
+        },
+        "tablesStorageEndpointSuffix": {
+          "type": "string",
+          "defaultValue": "core.windows.net",
+          "metadata": {
+              "description": "The url suffix to use when accessing the storage data plane."
+          }
         }
     },
     "variables": {
@@ -107,6 +114,10 @@
         }
     ],
     "outputs": {
+        "TABLES_STORAGE_ENDPOINT_SUFFIX": {
+            "type": "string",
+            "value": "[parameters('tablesStorageEndpointSuffix')]"
+        },
         "TABLES_STORAGE_ACCOUNT_NAME": {
             "type": "string",
             "value": "[variables('primaryAccountName')]"


### PR DESCRIPTION
For sovereign cloud testing, many cloud-specific arm template parameters and environment variables get passed in from an external keyvault source. This makes them hard to manage and track. I plan to move these values into source control, and as a pre-requisite I am consolidating as many values into the arm template parameters as possible (as opposed to a mismash of parameters and env var declarations).