### PR TITLE
Update keyvault to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -95,6 +95,10 @@ def suffixed_test_name(testcase_func, param_num, param):
     )
 
 
+def is_public_cloud():
+    return (".microsoftonline.com" in os.getenv('AZURE_AUTHORITY_HOST', ''))
+
+    
 class KeysTestCase(AzureTestCase):
     def setUp(self, *args, **kwargs):
         vault_playback_url = "https://vaultname.vault.azure.net"

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_2016_10_01_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_2016_10_01_vault.yaml
@@ -13,22 +13,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key942f15c0/create?api-version=2016-10-01
   response:
     body:
-      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
-        or PoP token."}}'
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '97'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:26 GMT
+      - Mon, 06 Dec 2021 09:22:01 GMT
       expires:
       - '-1'
       pragma:
@@ -41,19 +41,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"test name": "CreateECKeyTest",
-      "purpose": "unit test"}, "kty": "EC-HSM"}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -62,26 +62,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key942f15c0/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key942f15c0/6882bfaa52864abbaee64773fe944b13","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"ff7S6Ub307Y1AmXKHrT6ctXjwaWkLBK7uaEeQYqpupY","y":"0mhRg5nJO5skgGR_2m4sbteD9WZIQlFZOYubzfd5srk"},"attributes":{"enabled":true,"created":1618855167,"updated":1618855167,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name":"CreateECKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key942f15c0/a5fe8ce988274e41b8e0fefdf8fced0f","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"p2bo6lunWzvdOzTlNXmPEfHDqr6EhgOBh3ZWuuVJBoY","y":"TRGteFt1Qy48c5aTJpuckEnjZSmx2pTnFKUrxHgjCkI"},"attributes":{"enabled":true,"created":1638782523,"updated":1638782523,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '452'
+      - '449'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:28 GMT
+      - Mon, 06 Dec 2021 09:22:03 GMT
       expires:
       - '-1'
       pragma:
@@ -91,18 +91,18 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"crv": "P-256", "kty": "EC"}'
+    body: '{"kty": "EC", "crv": "P-256"}'
     headers:
       Accept:
       - application/json
@@ -115,21 +115,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key942f15c0/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key942f15c0/a412fdad50364de88a23f45e7b30b127","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"SgXoWA2Hwy08btDo82AFbALGmlz3Ot2ny7DDiVVkqow","y":"5aVQ7g7c3hW-XioRsfwRgRO8p-LOOYIJ7RotTfWMYZM"},"attributes":{"enabled":true,"created":1618855171,"updated":1618855171,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key942f15c0/831bd9aea2b049348732c27cb7edda11","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"LSTJm_KNLWoOoFiSvhKkBtinIeFtRtOodPtOl1gY8dc","y":"3IcBwujNrpLxG4IoDt-C8mzm0QwMAKLu7O7zpOO-a_Y"},"attributes":{"enabled":true,"created":1638782525,"updated":1638782525,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '393'
+      - '394'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:30 GMT
+      - Mon, 06 Dec 2021 09:22:05 GMT
       expires:
       - '-1'
       pragma:
@@ -139,25 +139,25 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key": {"key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey",
-      "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
-      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
-      "e": "AQAB", "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
+    body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
+      "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "e": "AQAB", "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
       "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp",
-      "kty": "RSA", "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
-      "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
-      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH"}}'
+      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+      "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
+      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3"}}'
     headers:
       Accept:
       - application/json
@@ -170,12 +170,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-key942f15c0?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-key942f15c0/9641b6d2f7304753b124f9d659438334","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1618855171,"updated":1618855171,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-key942f15c0/c8e0bb8e843241ecae3cdb22a6f420f3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782526,"updated":1638782526,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
@@ -184,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:30 GMT
+      - Mon, 06 Dec 2021 09:22:05 GMT
       expires:
       - '-1'
       pragma:
@@ -194,20 +194,20 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
-      "key_size": 2048, "tags": {"test name ": "CreateRSAKeyTest", "purpose": "unit
-      test"}, "kty": "RSA"}'
+    body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
+      "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
+      ": "CreateRSAKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -220,22 +220,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tHi3OpShsyUFDrhRIc5VnKUSZfG8sLyank_O24D-2lzC-kH55fHTR4nYm3DYltJSe-nCq8W_APy2aIvMxMlnCa5fO03dFNxc_TAso7JZAlb4y7m_iB-B5ORi3llWjn18vz86e9xonEg_xjrqhSXsmFBCs4CqlmcBI2cgXkl69GsMSPZYmpqLCvpC2e7goWSKNVg1xxMRg9YA3H1-xk5Otfkcj0kuYZ9vrCvolkIYBwBDhCWH2pLmkU3Mp84V1_TGh6W2iZ4sVN459iCW-dNKEVm6DYJQQW6aW_tb_Q9P7TByTsu-7AQE6tJND1AGauK6yzDF0ArcH36Qmjs7JpgRpQ","e":"AQAB"},"attributes":{"enabled":true,"created":1618855173,"updated":1618855173,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6uCpJkw-ucNfcgYzg7Ltz9Rz7SSRD0TTvU6XHo8ovOevv4Ecg87WSw02YaEOXn354HkEypILvXemLq4J7k13T6FQJv7HhqZmrIZ5xPL-DIawivlgqCp68pRjYpr9wbfLZRz2wFIBjKYJKecqAb73dR-1ltuThhj2ZDtdzfsKg1tmJ1teak_lt66aJQvii7XcVHS8mwQIUxaQM3KM5n6H10L8tmjt2Bm57Ry6hJsF3OGhPzVM2NDLyz3aOqYM7n3xl-O4jttre5xjPimict2XRTnH0JAS7GIVojwAYGvl14gOIC208VzBKXkkqw3it35Fu1QOEskZwz4T_dT5O4kdkQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782528,"updated":1638782528,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '740'
+      - '741'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:32 GMT
+      - Mon, 06 Dec 2021 09:22:08 GMT
       expires:
       - '-1'
       pragma:
@@ -245,11 +245,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -265,22 +265,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tHi3OpShsyUFDrhRIc5VnKUSZfG8sLyank_O24D-2lzC-kH55fHTR4nYm3DYltJSe-nCq8W_APy2aIvMxMlnCa5fO03dFNxc_TAso7JZAlb4y7m_iB-B5ORi3llWjn18vz86e9xonEg_xjrqhSXsmFBCs4CqlmcBI2cgXkl69GsMSPZYmpqLCvpC2e7goWSKNVg1xxMRg9YA3H1-xk5Otfkcj0kuYZ9vrCvolkIYBwBDhCWH2pLmkU3Mp84V1_TGh6W2iZ4sVN459iCW-dNKEVm6DYJQQW6aW_tb_Q9P7TByTsu-7AQE6tJND1AGauK6yzDF0ArcH36Qmjs7JpgRpQ","e":"AQAB"},"attributes":{"enabled":true,"created":1618855173,"updated":1618855173,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6uCpJkw-ucNfcgYzg7Ltz9Rz7SSRD0TTvU6XHo8ovOevv4Ecg87WSw02YaEOXn354HkEypILvXemLq4J7k13T6FQJv7HhqZmrIZ5xPL-DIawivlgqCp68pRjYpr9wbfLZRz2wFIBjKYJKecqAb73dR-1ltuThhj2ZDtdzfsKg1tmJ1teak_lt66aJQvii7XcVHS8mwQIUxaQM3KM5n6H10L8tmjt2Bm57Ry6hJsF3OGhPzVM2NDLyz3aOqYM7n3xl-O4jttre5xjPimict2XRTnH0JAS7GIVojwAYGvl14gOIC208VzBKXkkqw3it35Fu1QOEskZwz4T_dT5O4kdkQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782528,"updated":1638782528,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '740'
+      - '741'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:33 GMT
+      - Mon, 06 Dec 2021 09:22:08 GMT
       expires:
       - '-1'
       pragma:
@@ -290,11 +290,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -310,22 +310,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tHi3OpShsyUFDrhRIc5VnKUSZfG8sLyank_O24D-2lzC-kH55fHTR4nYm3DYltJSe-nCq8W_APy2aIvMxMlnCa5fO03dFNxc_TAso7JZAlb4y7m_iB-B5ORi3llWjn18vz86e9xonEg_xjrqhSXsmFBCs4CqlmcBI2cgXkl69GsMSPZYmpqLCvpC2e7goWSKNVg1xxMRg9YA3H1-xk5Otfkcj0kuYZ9vrCvolkIYBwBDhCWH2pLmkU3Mp84V1_TGh6W2iZ4sVN459iCW-dNKEVm6DYJQQW6aW_tb_Q9P7TByTsu-7AQE6tJND1AGauK6yzDF0ArcH36Qmjs7JpgRpQ","e":"AQAB"},"attributes":{"enabled":true,"created":1618855173,"updated":1618855173,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6uCpJkw-ucNfcgYzg7Ltz9Rz7SSRD0TTvU6XHo8ovOevv4Ecg87WSw02YaEOXn354HkEypILvXemLq4J7k13T6FQJv7HhqZmrIZ5xPL-DIawivlgqCp68pRjYpr9wbfLZRz2wFIBjKYJKecqAb73dR-1ltuThhj2ZDtdzfsKg1tmJ1teak_lt66aJQvii7XcVHS8mwQIUxaQM3KM5n6H10L8tmjt2Bm57Ry6hJsF3OGhPzVM2NDLyz3aOqYM7n3xl-O4jttre5xjPimict2XRTnH0JAS7GIVojwAYGvl14gOIC208VzBKXkkqw3it35Fu1QOEskZwz4T_dT5O4kdkQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782528,"updated":1638782528,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '740'
+      - '741'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:33 GMT
+      - Mon, 06 Dec 2021 09:22:09 GMT
       expires:
       - '-1'
       pragma:
@@ -335,11 +335,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -360,22 +360,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"tHi3OpShsyUFDrhRIc5VnKUSZfG8sLyank_O24D-2lzC-kH55fHTR4nYm3DYltJSe-nCq8W_APy2aIvMxMlnCa5fO03dFNxc_TAso7JZAlb4y7m_iB-B5ORi3llWjn18vz86e9xonEg_xjrqhSXsmFBCs4CqlmcBI2cgXkl69GsMSPZYmpqLCvpC2e7goWSKNVg1xxMRg9YA3H1-xk5Otfkcj0kuYZ9vrCvolkIYBwBDhCWH2pLmkU3Mp84V1_TGh6W2iZ4sVN459iCW-dNKEVm6DYJQQW6aW_tb_Q9P7TByTsu-7AQE6tJND1AGauK6yzDF0ArcH36Qmjs7JpgRpQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855173,"updated":1618855175,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6uCpJkw-ucNfcgYzg7Ltz9Rz7SSRD0TTvU6XHo8ovOevv4Ecg87WSw02YaEOXn354HkEypILvXemLq4J7k13T6FQJv7HhqZmrIZ5xPL-DIawivlgqCp68pRjYpr9wbfLZRz2wFIBjKYJKecqAb73dR-1ltuThhj2ZDtdzfsKg1tmJ1teak_lt66aJQvii7XcVHS8mwQIUxaQM3KM5n6H10L8tmjt2Bm57Ry6hJsF3OGhPzVM2NDLyz3aOqYM7n3xl-O4jttre5xjPimict2XRTnH0JAS7GIVojwAYGvl14gOIC208VzBKXkkqw3it35Fu1QOEskZwz4T_dT5O4kdkQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782528,"updated":1638782533,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '685'
+      - '686'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:34 GMT
+      - Mon, 06 Dec 2021 09:22:12 GMT
       expires:
       - '-1'
       pragma:
@@ -385,11 +385,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -407,22 +407,22 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0","deletedDate":1618855175,"scheduledPurgeDate":1626631175,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"tHi3OpShsyUFDrhRIc5VnKUSZfG8sLyank_O24D-2lzC-kH55fHTR4nYm3DYltJSe-nCq8W_APy2aIvMxMlnCa5fO03dFNxc_TAso7JZAlb4y7m_iB-B5ORi3llWjn18vz86e9xonEg_xjrqhSXsmFBCs4CqlmcBI2cgXkl69GsMSPZYmpqLCvpC2e7goWSKNVg1xxMRg9YA3H1-xk5Otfkcj0kuYZ9vrCvolkIYBwBDhCWH2pLmkU3Mp84V1_TGh6W2iZ4sVN459iCW-dNKEVm6DYJQQW6aW_tb_Q9P7TByTsu-7AQE6tJND1AGauK6yzDF0ArcH36Qmjs7JpgRpQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855173,"updated":1618855175,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0","deletedDate":1638782533,"scheduledPurgeDate":1646558533,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6uCpJkw-ucNfcgYzg7Ltz9Rz7SSRD0TTvU6XHo8ovOevv4Ecg87WSw02YaEOXn354HkEypILvXemLq4J7k13T6FQJv7HhqZmrIZ5xPL-DIawivlgqCp68pRjYpr9wbfLZRz2wFIBjKYJKecqAb73dR-1ltuThhj2ZDtdzfsKg1tmJ1teak_lt66aJQvii7XcVHS8mwQIUxaQM3KM5n6H10L8tmjt2Bm57Ry6hJsF3OGhPzVM2NDLyz3aOqYM7n3xl-O4jttre5xjPimict2XRTnH0JAS7GIVojwAYGvl14gOIC208VzBKXkkqw3it35Fu1QOEskZwz4T_dT5O4kdkQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782528,"updated":1638782533,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '837'
+      - '839'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:34 GMT
+      - Mon, 06 Dec 2021 09:22:12 GMT
       expires:
       - '-1'
       pragma:
@@ -432,11 +432,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -452,7 +452,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
@@ -466,7 +466,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:34 GMT
+      - Mon, 06 Dec 2021 09:22:13 GMT
       expires:
       - '-1'
       pragma:
@@ -476,11 +476,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -496,7 +496,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
@@ -510,7 +510,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:36 GMT
+      - Mon, 06 Dec 2021 09:22:15 GMT
       expires:
       - '-1'
       pragma:
@@ -520,11 +520,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -540,7 +540,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:39 GMT
+      - Mon, 06 Dec 2021 09:22:17 GMT
       expires:
       - '-1'
       pragma:
@@ -564,11 +564,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -584,7 +584,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
@@ -598,7 +598,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:41 GMT
+      - Mon, 06 Dec 2021 09:22:20 GMT
       expires:
       - '-1'
       pragma:
@@ -608,11 +608,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -628,7 +628,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
@@ -642,7 +642,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:43 GMT
+      - Mon, 06 Dec 2021 09:22:22 GMT
       expires:
       - '-1'
       pragma:
@@ -652,11 +652,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -672,198 +672,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
     body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key942f15c0"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 17:59:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key942f15c0"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 17:59:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key942f15c0"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 17:59:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key942f15c0"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 17:59:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
-  response:
-    body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0","deletedDate":1618855175,"scheduledPurgeDate":1626631175,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"tHi3OpShsyUFDrhRIc5VnKUSZfG8sLyank_O24D-2lzC-kH55fHTR4nYm3DYltJSe-nCq8W_APy2aIvMxMlnCa5fO03dFNxc_TAso7JZAlb4y7m_iB-B5ORi3llWjn18vz86e9xonEg_xjrqhSXsmFBCs4CqlmcBI2cgXkl69GsMSPZYmpqLCvpC2e7goWSKNVg1xxMRg9YA3H1-xk5Otfkcj0kuYZ9vrCvolkIYBwBDhCWH2pLmkU3Mp84V1_TGh6W2iZ4sVN459iCW-dNKEVm6DYJQQW6aW_tb_Q9P7TByTsu-7AQE6tJND1AGauK6yzDF0ArcH36Qmjs7JpgRpQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855173,"updated":1618855175,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0","deletedDate":1638782533,"scheduledPurgeDate":1646558533,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6uCpJkw-ucNfcgYzg7Ltz9Rz7SSRD0TTvU6XHo8ovOevv4Ecg87WSw02YaEOXn354HkEypILvXemLq4J7k13T6FQJv7HhqZmrIZ5xPL-DIawivlgqCp68pRjYpr9wbfLZRz2wFIBjKYJKecqAb73dR-1ltuThhj2ZDtdzfsKg1tmJ1teak_lt66aJQvii7XcVHS8mwQIUxaQM3KM5n6H10L8tmjt2Bm57Ry6hJsF3OGhPzVM2NDLyz3aOqYM7n3xl-O4jttre5xjPimict2XRTnH0JAS7GIVojwAYGvl14gOIC208VzBKXkkqw3it35Fu1QOEskZwz4T_dT5O4kdkQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782528,"updated":1638782533,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '837'
+      - '839'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:53 GMT
+      - Mon, 06 Dec 2021 09:22:24 GMT
       expires:
       - '-1'
       pragma:
@@ -873,11 +697,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -893,22 +717,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0?api-version=2016-10-01
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0","deletedDate":1618855175,"scheduledPurgeDate":1626631175,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/737651535af048c885f11bac20bdf019","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"tHi3OpShsyUFDrhRIc5VnKUSZfG8sLyank_O24D-2lzC-kH55fHTR4nYm3DYltJSe-nCq8W_APy2aIvMxMlnCa5fO03dFNxc_TAso7JZAlb4y7m_iB-B5ORi3llWjn18vz86e9xonEg_xjrqhSXsmFBCs4CqlmcBI2cgXkl69GsMSPZYmpqLCvpC2e7goWSKNVg1xxMRg9YA3H1-xk5Otfkcj0kuYZ9vrCvolkIYBwBDhCWH2pLmkU3Mp84V1_TGh6W2iZ4sVN459iCW-dNKEVm6DYJQQW6aW_tb_Q9P7TByTsu-7AQE6tJND1AGauK6yzDF0ArcH36Qmjs7JpgRpQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855173,"updated":1618855175,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key942f15c0","deletedDate":1638782533,"scheduledPurgeDate":1646558533,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key942f15c0/4540ebbc1ae04cb5a4206de0bec66a42","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6uCpJkw-ucNfcgYzg7Ltz9Rz7SSRD0TTvU6XHo8ovOevv4Ecg87WSw02YaEOXn354HkEypILvXemLq4J7k13T6FQJv7HhqZmrIZ5xPL-DIawivlgqCp68pRjYpr9wbfLZRz2wFIBjKYJKecqAb73dR-1ltuThhj2ZDtdzfsKg1tmJ1teak_lt66aJQvii7XcVHS8mwQIUxaQM3KM5n6H10L8tmjt2Bm57Ry6hJsF3OGhPzVM2NDLyz3aOqYM7n3xl-O4jttre5xjPimict2XRTnH0JAS7GIVojwAYGvl14gOIC208VzBKXkkqw3it35Fu1QOEskZwz4T_dT5O4kdkQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782528,"updated":1638782533,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '837'
+      - '839'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:54 GMT
+      - Mon, 06 Dec 2021 09:22:25 GMT
       expires:
       - '-1'
       pragma:
@@ -918,11 +742,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_0_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_0_vault.yaml
@@ -13,22 +13,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key9f9143d/create?api-version=7.0
   response:
     body:
-      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
-        or PoP token."}}'
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '97'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:54 GMT
+      - Mon, 06 Dec 2021 09:22:46 GMT
       expires:
       - '-1'
       pragma:
@@ -41,19 +41,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"test name": "CreateECKeyTest",
-      "purpose": "unit test"}, "kty": "EC-HSM"}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -62,26 +62,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key9f9143d/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key9f9143d/46da7ea3c1cf4e5fbad48788b645d5e6","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"6UHWvEMEEtwTcBCWVvot2sZKtQOP6ZoagY_W7cn8QSw","y":"KNt4b58eFho4Tww6lkCcGOJ0sEK2IRcOPagu7j7NcnY"},"attributes":{"enabled":true,"created":1618855254,"updated":1618855254,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name":"CreateECKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key9f9143d/47334a22a7af4da59d584b80dd7891ea","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"Zj_FRG7yl9C1hgFB2ECh3lXUjgxkORjXa4FWMKRchIE","y":"d5gm5zrnBJorV3D_vZjPGG4iEc6t18QRJR9mXQ-uHv4"},"attributes":{"enabled":true,"created":1638782568,"updated":1638782568,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '451'
+      - '448'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:56 GMT
+      - Mon, 06 Dec 2021 09:22:48 GMT
       expires:
       - '-1'
       pragma:
@@ -91,18 +91,18 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"crv": "P-256", "kty": "EC"}'
+    body: '{"kty": "EC", "crv": "P-256"}'
     headers:
       Accept:
       - application/json
@@ -115,21 +115,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key9f9143d/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key9f9143d/9a58407a8e064656831be55ecbced2c9","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"wsIerQfDHRk6_-1lyAKzilCdksQP7U3SFhOVf6gUaMs","y":"4x8B8GLX3v-VBbO176_wBQogCqEQsX1g_DnuYyLYhW8"},"attributes":{"enabled":true,"created":1618855258,"updated":1618855258,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key9f9143d/226752b71c6748b2b5553a7474098b57","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"ZyWnx9_4Bvpw2jS7Mhpl0ljDA8Qz2uramWkvRtn4Qwo","y":"CQDylwioycu9906m4nW08jhnEr6tm2jBT1RX6P-DlhY"},"attributes":{"enabled":true,"created":1638782571,"updated":1638782571,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '392'
+      - '393'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:58 GMT
+      - Mon, 06 Dec 2021 09:22:50 GMT
       expires:
       - '-1'
       pragma:
@@ -139,25 +139,25 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key": {"key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey",
-      "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
-      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
-      "e": "AQAB", "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
+    body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
+      "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "e": "AQAB", "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
       "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp",
-      "kty": "RSA", "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
-      "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
-      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH"}}'
+      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+      "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
+      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3"}}'
     headers:
       Accept:
       - application/json
@@ -170,12 +170,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-key9f9143d?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-key9f9143d/3f12bd9c2f6f41c4a38ae278b0dd80bf","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1618855258,"updated":1618855258,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-key9f9143d/986024a5e55649b3b41e2fe0ede643a3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782571,"updated":1638782571,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
@@ -184,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:58 GMT
+      - Mon, 06 Dec 2021 09:22:51 GMT
       expires:
       - '-1'
       pragma:
@@ -194,20 +194,20 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
-      "key_size": 2048, "tags": {"test name ": "CreateRSAKeyTest", "purpose": "unit
-      test"}, "kty": "RSA"}'
+    body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
+      "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
+      ": "CreateRSAKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -220,22 +220,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ua8uYQgiUEG7FaclDaD54LZFa14Ynz-lqpO_JsEmlxXqUTBjuX7-vfTBvGtmLPgYDxf4qUdZSXrHp6eFBeTgdsVBkWTuLvTgQmEB1MKu3fM_iVa-rDbOWShdlwTMAwSnBl3Xl-wFKj7b9q3NXdqE3DynGvQT5Ko11KUdx0l6I8NgL-Y2-BuQ6phK_9moTXzfPZVydgCaIlQEIhS2G5C2vMpd0OSxK2qCdCj8yfVBgbHl_afySRCgV0raDgT1YyHkfWOaUmH39tRfbBnFiq6z4aEE2c5xyblNt5xUlHS_ptkmq5Q4dVp3ikIPKAjNzw3ph5NUa37jLn7_dbfJhz6L7Q","e":"AQAB"},"attributes":{"enabled":true,"created":1618855261,"updated":1618855261,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mH7T9eFSHmv5m31G1ej-Os4vkUoWTSK-M6wmhTFEMu5tb5b1t7lbVddex-bev3FwZ1gdgDg2Eqrqt5jdjHMkQUdkEuyiqeoRB1zFmrRJ7DOib2w2PufNIQaIrEDqcM3rF9lZKYEMx9NxUiAxZ9LeK0osrk1WreZ3M4iJKXVo6FjIQGUgID1UL5lpIvQhMvB2BowSN_5CFOkVO0QHRdh6Vj9zg6BRBTC83UW3LXGPlf2-pN-ZRzf2ptGIAjelNOqIJtQcmJHXEUOLLipMHc_otkQV8-iz8SUc49tgNg8tI1V58ILzRU2haVJEdQOjyE9D0YmYlXCw09R6YfQoR4uYbQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782574,"updated":1638782574,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '739'
+      - '740'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:01 GMT
+      - Mon, 06 Dec 2021 09:22:53 GMT
       expires:
       - '-1'
       pragma:
@@ -245,11 +245,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -265,22 +265,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ua8uYQgiUEG7FaclDaD54LZFa14Ynz-lqpO_JsEmlxXqUTBjuX7-vfTBvGtmLPgYDxf4qUdZSXrHp6eFBeTgdsVBkWTuLvTgQmEB1MKu3fM_iVa-rDbOWShdlwTMAwSnBl3Xl-wFKj7b9q3NXdqE3DynGvQT5Ko11KUdx0l6I8NgL-Y2-BuQ6phK_9moTXzfPZVydgCaIlQEIhS2G5C2vMpd0OSxK2qCdCj8yfVBgbHl_afySRCgV0raDgT1YyHkfWOaUmH39tRfbBnFiq6z4aEE2c5xyblNt5xUlHS_ptkmq5Q4dVp3ikIPKAjNzw3ph5NUa37jLn7_dbfJhz6L7Q","e":"AQAB"},"attributes":{"enabled":true,"created":1618855261,"updated":1618855261,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mH7T9eFSHmv5m31G1ej-Os4vkUoWTSK-M6wmhTFEMu5tb5b1t7lbVddex-bev3FwZ1gdgDg2Eqrqt5jdjHMkQUdkEuyiqeoRB1zFmrRJ7DOib2w2PufNIQaIrEDqcM3rF9lZKYEMx9NxUiAxZ9LeK0osrk1WreZ3M4iJKXVo6FjIQGUgID1UL5lpIvQhMvB2BowSN_5CFOkVO0QHRdh6Vj9zg6BRBTC83UW3LXGPlf2-pN-ZRzf2ptGIAjelNOqIJtQcmJHXEUOLLipMHc_otkQV8-iz8SUc49tgNg8tI1V58ILzRU2haVJEdQOjyE9D0YmYlXCw09R6YfQoR4uYbQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782574,"updated":1638782574,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '739'
+      - '740'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:01 GMT
+      - Mon, 06 Dec 2021 09:22:54 GMT
       expires:
       - '-1'
       pragma:
@@ -290,11 +290,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -310,22 +310,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ua8uYQgiUEG7FaclDaD54LZFa14Ynz-lqpO_JsEmlxXqUTBjuX7-vfTBvGtmLPgYDxf4qUdZSXrHp6eFBeTgdsVBkWTuLvTgQmEB1MKu3fM_iVa-rDbOWShdlwTMAwSnBl3Xl-wFKj7b9q3NXdqE3DynGvQT5Ko11KUdx0l6I8NgL-Y2-BuQ6phK_9moTXzfPZVydgCaIlQEIhS2G5C2vMpd0OSxK2qCdCj8yfVBgbHl_afySRCgV0raDgT1YyHkfWOaUmH39tRfbBnFiq6z4aEE2c5xyblNt5xUlHS_ptkmq5Q4dVp3ikIPKAjNzw3ph5NUa37jLn7_dbfJhz6L7Q","e":"AQAB"},"attributes":{"enabled":true,"created":1618855261,"updated":1618855261,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mH7T9eFSHmv5m31G1ej-Os4vkUoWTSK-M6wmhTFEMu5tb5b1t7lbVddex-bev3FwZ1gdgDg2Eqrqt5jdjHMkQUdkEuyiqeoRB1zFmrRJ7DOib2w2PufNIQaIrEDqcM3rF9lZKYEMx9NxUiAxZ9LeK0osrk1WreZ3M4iJKXVo6FjIQGUgID1UL5lpIvQhMvB2BowSN_5CFOkVO0QHRdh6Vj9zg6BRBTC83UW3LXGPlf2-pN-ZRzf2ptGIAjelNOqIJtQcmJHXEUOLLipMHc_otkQV8-iz8SUc49tgNg8tI1V58ILzRU2haVJEdQOjyE9D0YmYlXCw09R6YfQoR4uYbQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782574,"updated":1638782574,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '739'
+      - '740'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:01 GMT
+      - Mon, 06 Dec 2021 09:22:54 GMT
       expires:
       - '-1'
       pragma:
@@ -335,11 +335,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -360,22 +360,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ua8uYQgiUEG7FaclDaD54LZFa14Ynz-lqpO_JsEmlxXqUTBjuX7-vfTBvGtmLPgYDxf4qUdZSXrHp6eFBeTgdsVBkWTuLvTgQmEB1MKu3fM_iVa-rDbOWShdlwTMAwSnBl3Xl-wFKj7b9q3NXdqE3DynGvQT5Ko11KUdx0l6I8NgL-Y2-BuQ6phK_9moTXzfPZVydgCaIlQEIhS2G5C2vMpd0OSxK2qCdCj8yfVBgbHl_afySRCgV0raDgT1YyHkfWOaUmH39tRfbBnFiq6z4aEE2c5xyblNt5xUlHS_ptkmq5Q4dVp3ikIPKAjNzw3ph5NUa37jLn7_dbfJhz6L7Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855261,"updated":1618855262,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mH7T9eFSHmv5m31G1ej-Os4vkUoWTSK-M6wmhTFEMu5tb5b1t7lbVddex-bev3FwZ1gdgDg2Eqrqt5jdjHMkQUdkEuyiqeoRB1zFmrRJ7DOib2w2PufNIQaIrEDqcM3rF9lZKYEMx9NxUiAxZ9LeK0osrk1WreZ3M4iJKXVo6FjIQGUgID1UL5lpIvQhMvB2BowSN_5CFOkVO0QHRdh6Vj9zg6BRBTC83UW3LXGPlf2-pN-ZRzf2ptGIAjelNOqIJtQcmJHXEUOLLipMHc_otkQV8-iz8SUc49tgNg8tI1V58ILzRU2haVJEdQOjyE9D0YmYlXCw09R6YfQoR4uYbQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782574,"updated":1638782578,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '684'
+      - '685'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:02 GMT
+      - Mon, 06 Dec 2021 09:22:57 GMT
       expires:
       - '-1'
       pragma:
@@ -385,11 +385,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -407,22 +407,22 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d","deletedDate":1618855262,"scheduledPurgeDate":1626631262,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ua8uYQgiUEG7FaclDaD54LZFa14Ynz-lqpO_JsEmlxXqUTBjuX7-vfTBvGtmLPgYDxf4qUdZSXrHp6eFBeTgdsVBkWTuLvTgQmEB1MKu3fM_iVa-rDbOWShdlwTMAwSnBl3Xl-wFKj7b9q3NXdqE3DynGvQT5Ko11KUdx0l6I8NgL-Y2-BuQ6phK_9moTXzfPZVydgCaIlQEIhS2G5C2vMpd0OSxK2qCdCj8yfVBgbHl_afySRCgV0raDgT1YyHkfWOaUmH39tRfbBnFiq6z4aEE2c5xyblNt5xUlHS_ptkmq5Q4dVp3ikIPKAjNzw3ph5NUa37jLn7_dbfJhz6L7Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855261,"updated":1618855262,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d","deletedDate":1638782578,"scheduledPurgeDate":1646558578,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mH7T9eFSHmv5m31G1ej-Os4vkUoWTSK-M6wmhTFEMu5tb5b1t7lbVddex-bev3FwZ1gdgDg2Eqrqt5jdjHMkQUdkEuyiqeoRB1zFmrRJ7DOib2w2PufNIQaIrEDqcM3rF9lZKYEMx9NxUiAxZ9LeK0osrk1WreZ3M4iJKXVo6FjIQGUgID1UL5lpIvQhMvB2BowSN_5CFOkVO0QHRdh6Vj9zg6BRBTC83UW3LXGPlf2-pN-ZRzf2ptGIAjelNOqIJtQcmJHXEUOLLipMHc_otkQV8-iz8SUc49tgNg8tI1V58ILzRU2haVJEdQOjyE9D0YmYlXCw09R6YfQoR4uYbQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782574,"updated":1638782578,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '835'
+      - '837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:02 GMT
+      - Mon, 06 Dec 2021 09:22:58 GMT
       expires:
       - '-1'
       pragma:
@@ -432,11 +432,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -452,7 +452,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
   response:
@@ -466,7 +466,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:03 GMT
+      - Mon, 06 Dec 2021 09:22:58 GMT
       expires:
       - '-1'
       pragma:
@@ -476,11 +476,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -496,7 +496,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
   response:
@@ -510,7 +510,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:05 GMT
+      - Mon, 06 Dec 2021 09:23:01 GMT
       expires:
       - '-1'
       pragma:
@@ -520,11 +520,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -540,7 +540,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
   response:
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:07 GMT
+      - Mon, 06 Dec 2021 09:23:03 GMT
       expires:
       - '-1'
       pragma:
@@ -564,11 +564,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -584,550 +584,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
   response:
     body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:28 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key9f9143d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:01:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
-  response:
-    body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d","deletedDate":1618855262,"scheduledPurgeDate":1626631262,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ua8uYQgiUEG7FaclDaD54LZFa14Ynz-lqpO_JsEmlxXqUTBjuX7-vfTBvGtmLPgYDxf4qUdZSXrHp6eFBeTgdsVBkWTuLvTgQmEB1MKu3fM_iVa-rDbOWShdlwTMAwSnBl3Xl-wFKj7b9q3NXdqE3DynGvQT5Ko11KUdx0l6I8NgL-Y2-BuQ6phK_9moTXzfPZVydgCaIlQEIhS2G5C2vMpd0OSxK2qCdCj8yfVBgbHl_afySRCgV0raDgT1YyHkfWOaUmH39tRfbBnFiq6z4aEE2c5xyblNt5xUlHS_ptkmq5Q4dVp3ikIPKAjNzw3ph5NUa37jLn7_dbfJhz6L7Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855261,"updated":1618855262,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d","deletedDate":1638782578,"scheduledPurgeDate":1646558578,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mH7T9eFSHmv5m31G1ej-Os4vkUoWTSK-M6wmhTFEMu5tb5b1t7lbVddex-bev3FwZ1gdgDg2Eqrqt5jdjHMkQUdkEuyiqeoRB1zFmrRJ7DOib2w2PufNIQaIrEDqcM3rF9lZKYEMx9NxUiAxZ9LeK0osrk1WreZ3M4iJKXVo6FjIQGUgID1UL5lpIvQhMvB2BowSN_5CFOkVO0QHRdh6Vj9zg6BRBTC83UW3LXGPlf2-pN-ZRzf2ptGIAjelNOqIJtQcmJHXEUOLLipMHc_otkQV8-iz8SUc49tgNg8tI1V58ILzRU2haVJEdQOjyE9D0YmYlXCw09R6YfQoR4uYbQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782574,"updated":1638782578,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '835'
+      - '837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:34 GMT
+      - Mon, 06 Dec 2021 09:23:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1137,11 +609,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -1157,22 +629,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d?api-version=7.0
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d","deletedDate":1618855262,"scheduledPurgeDate":1626631262,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/7c80110f1e8d43e79d0fef11d6157cf5","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ua8uYQgiUEG7FaclDaD54LZFa14Ynz-lqpO_JsEmlxXqUTBjuX7-vfTBvGtmLPgYDxf4qUdZSXrHp6eFBeTgdsVBkWTuLvTgQmEB1MKu3fM_iVa-rDbOWShdlwTMAwSnBl3Xl-wFKj7b9q3NXdqE3DynGvQT5Ko11KUdx0l6I8NgL-Y2-BuQ6phK_9moTXzfPZVydgCaIlQEIhS2G5C2vMpd0OSxK2qCdCj8yfVBgbHl_afySRCgV0raDgT1YyHkfWOaUmH39tRfbBnFiq6z4aEE2c5xyblNt5xUlHS_ptkmq5Q4dVp3ikIPKAjNzw3ph5NUa37jLn7_dbfJhz6L7Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855261,"updated":1618855262,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key9f9143d","deletedDate":1638782578,"scheduledPurgeDate":1646558578,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key9f9143d/b078ce0aed16449991be259a04f370bf","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mH7T9eFSHmv5m31G1ej-Os4vkUoWTSK-M6wmhTFEMu5tb5b1t7lbVddex-bev3FwZ1gdgDg2Eqrqt5jdjHMkQUdkEuyiqeoRB1zFmrRJ7DOib2w2PufNIQaIrEDqcM3rF9lZKYEMx9NxUiAxZ9LeK0osrk1WreZ3M4iJKXVo6FjIQGUgID1UL5lpIvQhMvB2BowSN_5CFOkVO0QHRdh6Vj9zg6BRBTC83UW3LXGPlf2-pN-ZRzf2ptGIAjelNOqIJtQcmJHXEUOLLipMHc_otkQV8-iz8SUc49tgNg8tI1V58ILzRU2haVJEdQOjyE9D0YmYlXCw09R6YfQoR4uYbQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782574,"updated":1638782578,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '835'
+      - '837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:01:34 GMT
+      - Mon, 06 Dec 2021 09:23:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1182,11 +654,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_1_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_1_vault.yaml
@@ -13,22 +13,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya00143e/create?api-version=7.1
   response:
     body:
-      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
-        or PoP token."}}'
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '97'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:56 GMT
+      - Mon, 06 Dec 2021 09:23:22 GMT
       expires:
       - '-1'
       pragma:
@@ -41,19 +41,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"test name": "CreateECKeyTest",
-      "purpose": "unit test"}, "kty": "EC-HSM"}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -62,26 +62,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya00143e/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya00143e/39cdd0410eea4a4289e409911ce8fbfe","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"Ot5FhGtUSoi7xVqBz3ohrMPQpdP9sbwj_lkG-WA9Bxg","y":"2i5Em7VEw5y5ojn2rWH-E_MtHeiF_rHBj9LZDgBePbk"},"attributes":{"enabled":true,"created":1618855198,"updated":1618855198,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"test
-        name":"CreateECKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya00143e/0ab2b520b0d141d58d7b9079f01aeae4","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"uph7rxYwWaKNSmkzxYH04qQ2IPv0NP54uAV5irCy00w","y":"QWbRg8gfM6NkKGK1HQmtxS1ic4ddJuR1e2s7qCj1OLc"},"attributes":{"enabled":true,"created":1638782604,"updated":1638782604,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+        test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '472'
+      - '469'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 17:59:58 GMT
+      - Mon, 06 Dec 2021 09:23:24 GMT
       expires:
       - '-1'
       pragma:
@@ -91,18 +91,18 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"crv": "P-256", "kty": "EC"}'
+    body: '{"kty": "EC", "crv": "P-256"}'
     headers:
       Accept:
       - application/json
@@ -115,21 +115,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keya00143e/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keya00143e/9e7923dcc2b14281bd14c5b2265d2560","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"DOmZwcP4yPFWBSTZhR6HXCYfSegQMEQQo9J5HeCFeLg","y":"mjJcbcXg5ZbXMgSx_SA6HmCGBSr3mqnIcbRsAhXemGA"},"attributes":{"enabled":true,"created":1618855201,"updated":1618855201,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keya00143e/ca7f844d9a444fcb9c04a96d77a1142a","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"84zYNVcX5K4kPWa8QoopPG6sReBpAFEGdXpmQ7cwVTw","y":"3ZKppDKZ8ezHJwZDmHke5vvFtmagHTjr7J5NKTF0cbE"},"attributes":{"enabled":true,"created":1638782606,"updated":1638782606,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '413'
+      - '414'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:02 GMT
+      - Mon, 06 Dec 2021 09:23:26 GMT
       expires:
       - '-1'
       pragma:
@@ -139,25 +139,25 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key": {"key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey",
-      "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
-      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
-      "e": "AQAB", "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
+    body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
+      "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "e": "AQAB", "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
       "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp",
-      "kty": "RSA", "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
-      "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
-      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH"}}'
+      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+      "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
+      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3"}}'
     headers:
       Accept:
       - application/json
@@ -170,12 +170,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keya00143e?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keya00143e/a52be5a20f9e4247be2b531d6d85542f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1618855202,"updated":1618855202,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keya00143e/9ebae158e6ba4172bb32d8be4dccbda0","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782607,"updated":1638782607,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -184,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:02 GMT
+      - Mon, 06 Dec 2021 09:23:27 GMT
       expires:
       - '-1'
       pragma:
@@ -194,20 +194,20 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
-      "key_size": 2048, "tags": {"test name ": "CreateRSAKeyTest", "purpose": "unit
-      test"}, "kty": "RSA"}'
+    body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
+      "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
+      ": "CreateRSAKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -220,22 +220,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l3Wj5pwhyIAygXqH4rZz0iVs3V7Lki8TLcfCJACo6xRd1s7DncI9TEdjR1a1lOLeT9yEvDysKrcYQhm5jiTCcUe-FbgeeF6SML12Fn9LBuB80cWeOmRV50OugHq3OiewxWK4f9Aan0SPG1DRx4xmVaeQSHY8-v7PC1L_4ouaqGQ-8KhHwLMD5y7e4DlcGinKKxEGcnEJtJhInRN6dJo2ySzsvQljew8wNiFW29EDhE9IyJVNmdHVYmTb90SEUYBHcaWmcmR13RjxOggS0r4cT-Ctblko8siEuud72ZhqX7DmrJ1elFnOOpb-A8qmtkwTH-yIffocFnAuGkZ5BmORvQ","e":"AQAB"},"attributes":{"enabled":true,"created":1618855204,"updated":1618855204,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"7COx99iKvZMyEfgjZyRnT-PRpqilnns0Wce7GlDcw_ZAyA9ua55SAYsx-UhGsmOWcCHCgAZFIGHto7sGMju_hbkS2kJUHCPAbLmIGB8E_UvZuVX4tF2lR4a79flfsCv2DT5qJ2nsZvjpKk5LloVIzVo9okN25RiyU26JraJXn7QGt7Q9i8guClpM860k8E0CdY35D8BmxJ1c8kvcOuVjXce8AXu8gMEPQ6Y6p5i-thsH37ThNAA4ewYRMsYMi6SAhkfDVKutKdo2YCQZGRm0mL80cHJrKqRIu6Q85kbpu_9sH71lse9wAJPfLP07eYynCdTvpV37KaphictOirRQvQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782609,"updated":1638782609,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '760'
+      - '761'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:04 GMT
+      - Mon, 06 Dec 2021 09:23:29 GMT
       expires:
       - '-1'
       pragma:
@@ -245,11 +245,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -265,22 +265,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l3Wj5pwhyIAygXqH4rZz0iVs3V7Lki8TLcfCJACo6xRd1s7DncI9TEdjR1a1lOLeT9yEvDysKrcYQhm5jiTCcUe-FbgeeF6SML12Fn9LBuB80cWeOmRV50OugHq3OiewxWK4f9Aan0SPG1DRx4xmVaeQSHY8-v7PC1L_4ouaqGQ-8KhHwLMD5y7e4DlcGinKKxEGcnEJtJhInRN6dJo2ySzsvQljew8wNiFW29EDhE9IyJVNmdHVYmTb90SEUYBHcaWmcmR13RjxOggS0r4cT-Ctblko8siEuud72ZhqX7DmrJ1elFnOOpb-A8qmtkwTH-yIffocFnAuGkZ5BmORvQ","e":"AQAB"},"attributes":{"enabled":true,"created":1618855204,"updated":1618855204,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"7COx99iKvZMyEfgjZyRnT-PRpqilnns0Wce7GlDcw_ZAyA9ua55SAYsx-UhGsmOWcCHCgAZFIGHto7sGMju_hbkS2kJUHCPAbLmIGB8E_UvZuVX4tF2lR4a79flfsCv2DT5qJ2nsZvjpKk5LloVIzVo9okN25RiyU26JraJXn7QGt7Q9i8guClpM860k8E0CdY35D8BmxJ1c8kvcOuVjXce8AXu8gMEPQ6Y6p5i-thsH37ThNAA4ewYRMsYMi6SAhkfDVKutKdo2YCQZGRm0mL80cHJrKqRIu6Q85kbpu_9sH71lse9wAJPfLP07eYynCdTvpV37KaphictOirRQvQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782609,"updated":1638782609,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '760'
+      - '761'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:04 GMT
+      - Mon, 06 Dec 2021 09:23:29 GMT
       expires:
       - '-1'
       pragma:
@@ -290,11 +290,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -310,22 +310,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l3Wj5pwhyIAygXqH4rZz0iVs3V7Lki8TLcfCJACo6xRd1s7DncI9TEdjR1a1lOLeT9yEvDysKrcYQhm5jiTCcUe-FbgeeF6SML12Fn9LBuB80cWeOmRV50OugHq3OiewxWK4f9Aan0SPG1DRx4xmVaeQSHY8-v7PC1L_4ouaqGQ-8KhHwLMD5y7e4DlcGinKKxEGcnEJtJhInRN6dJo2ySzsvQljew8wNiFW29EDhE9IyJVNmdHVYmTb90SEUYBHcaWmcmR13RjxOggS0r4cT-Ctblko8siEuud72ZhqX7DmrJ1elFnOOpb-A8qmtkwTH-yIffocFnAuGkZ5BmORvQ","e":"AQAB"},"attributes":{"enabled":true,"created":1618855204,"updated":1618855204,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"7COx99iKvZMyEfgjZyRnT-PRpqilnns0Wce7GlDcw_ZAyA9ua55SAYsx-UhGsmOWcCHCgAZFIGHto7sGMju_hbkS2kJUHCPAbLmIGB8E_UvZuVX4tF2lR4a79flfsCv2DT5qJ2nsZvjpKk5LloVIzVo9okN25RiyU26JraJXn7QGt7Q9i8guClpM860k8E0CdY35D8BmxJ1c8kvcOuVjXce8AXu8gMEPQ6Y6p5i-thsH37ThNAA4ewYRMsYMi6SAhkfDVKutKdo2YCQZGRm0mL80cHJrKqRIu6Q85kbpu_9sH71lse9wAJPfLP07eYynCdTvpV37KaphictOirRQvQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782609,"updated":1638782609,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '760'
+      - '761'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:04 GMT
+      - Mon, 06 Dec 2021 09:23:30 GMT
       expires:
       - '-1'
       pragma:
@@ -335,11 +335,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -360,22 +360,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"l3Wj5pwhyIAygXqH4rZz0iVs3V7Lki8TLcfCJACo6xRd1s7DncI9TEdjR1a1lOLeT9yEvDysKrcYQhm5jiTCcUe-FbgeeF6SML12Fn9LBuB80cWeOmRV50OugHq3OiewxWK4f9Aan0SPG1DRx4xmVaeQSHY8-v7PC1L_4ouaqGQ-8KhHwLMD5y7e4DlcGinKKxEGcnEJtJhInRN6dJo2ySzsvQljew8wNiFW29EDhE9IyJVNmdHVYmTb90SEUYBHcaWmcmR13RjxOggS0r4cT-Ctblko8siEuud72ZhqX7DmrJ1elFnOOpb-A8qmtkwTH-yIffocFnAuGkZ5BmORvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855204,"updated":1618855205,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"7COx99iKvZMyEfgjZyRnT-PRpqilnns0Wce7GlDcw_ZAyA9ua55SAYsx-UhGsmOWcCHCgAZFIGHto7sGMju_hbkS2kJUHCPAbLmIGB8E_UvZuVX4tF2lR4a79flfsCv2DT5qJ2nsZvjpKk5LloVIzVo9okN25RiyU26JraJXn7QGt7Q9i8guClpM860k8E0CdY35D8BmxJ1c8kvcOuVjXce8AXu8gMEPQ6Y6p5i-thsH37ThNAA4ewYRMsYMi6SAhkfDVKutKdo2YCQZGRm0mL80cHJrKqRIu6Q85kbpu_9sH71lse9wAJPfLP07eYynCdTvpV37KaphictOirRQvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782609,"updated":1638782614,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '705'
+      - '706'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:05 GMT
+      - Mon, 06 Dec 2021 09:23:33 GMT
       expires:
       - '-1'
       pragma:
@@ -385,11 +385,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -407,22 +407,22 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e?api-version=7.1
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e","deletedDate":1618855206,"scheduledPurgeDate":1626631206,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"l3Wj5pwhyIAygXqH4rZz0iVs3V7Lki8TLcfCJACo6xRd1s7DncI9TEdjR1a1lOLeT9yEvDysKrcYQhm5jiTCcUe-FbgeeF6SML12Fn9LBuB80cWeOmRV50OugHq3OiewxWK4f9Aan0SPG1DRx4xmVaeQSHY8-v7PC1L_4ouaqGQ-8KhHwLMD5y7e4DlcGinKKxEGcnEJtJhInRN6dJo2ySzsvQljew8wNiFW29EDhE9IyJVNmdHVYmTb90SEUYBHcaWmcmR13RjxOggS0r4cT-Ctblko8siEuud72ZhqX7DmrJ1elFnOOpb-A8qmtkwTH-yIffocFnAuGkZ5BmORvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855204,"updated":1618855205,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e","deletedDate":1638782614,"scheduledPurgeDate":1646558614,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"7COx99iKvZMyEfgjZyRnT-PRpqilnns0Wce7GlDcw_ZAyA9ua55SAYsx-UhGsmOWcCHCgAZFIGHto7sGMju_hbkS2kJUHCPAbLmIGB8E_UvZuVX4tF2lR4a79flfsCv2DT5qJ2nsZvjpKk5LloVIzVo9okN25RiyU26JraJXn7QGt7Q9i8guClpM860k8E0CdY35D8BmxJ1c8kvcOuVjXce8AXu8gMEPQ6Y6p5i-thsH37ThNAA4ewYRMsYMi6SAhkfDVKutKdo2YCQZGRm0mL80cHJrKqRIu6Q85kbpu_9sH71lse9wAJPfLP07eYynCdTvpV37KaphictOirRQvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782609,"updated":1638782614,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '856'
+      - '858'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:06 GMT
+      - Mon, 06 Dec 2021 09:23:34 GMT
       expires:
       - '-1'
       pragma:
@@ -432,11 +432,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -452,7 +452,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
   response:
@@ -466,7 +466,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:06 GMT
+      - Mon, 06 Dec 2021 09:23:34 GMT
       expires:
       - '-1'
       pragma:
@@ -476,11 +476,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -496,7 +496,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
   response:
@@ -510,7 +510,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:08 GMT
+      - Mon, 06 Dec 2021 09:23:36 GMT
       expires:
       - '-1'
       pragma:
@@ -520,11 +520,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -540,7 +540,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
   response:
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:10 GMT
+      - Mon, 06 Dec 2021 09:23:39 GMT
       expires:
       - '-1'
       pragma:
@@ -564,11 +564,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -584,7 +584,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
   response:
@@ -598,7 +598,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:12 GMT
+      - Mon, 06 Dec 2021 09:23:41 GMT
       expires:
       - '-1'
       pragma:
@@ -608,11 +608,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -628,330 +628,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
   response:
     body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya00143e"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:00:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya00143e"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:00:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya00143e"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:00:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya00143e"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:00:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya00143e"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:00:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya00143e"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:00:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya00143e"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 19 Apr 2021 18:00:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus2
-      x-ms-keyvault-service-version:
-      - 1.2.236.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
-  response:
-    body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e","deletedDate":1618855206,"scheduledPurgeDate":1626631206,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"l3Wj5pwhyIAygXqH4rZz0iVs3V7Lki8TLcfCJACo6xRd1s7DncI9TEdjR1a1lOLeT9yEvDysKrcYQhm5jiTCcUe-FbgeeF6SML12Fn9LBuB80cWeOmRV50OugHq3OiewxWK4f9Aan0SPG1DRx4xmVaeQSHY8-v7PC1L_4ouaqGQ-8KhHwLMD5y7e4DlcGinKKxEGcnEJtJhInRN6dJo2ySzsvQljew8wNiFW29EDhE9IyJVNmdHVYmTb90SEUYBHcaWmcmR13RjxOggS0r4cT-Ctblko8siEuud72ZhqX7DmrJ1elFnOOpb-A8qmtkwTH-yIffocFnAuGkZ5BmORvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855204,"updated":1618855205,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e","deletedDate":1638782614,"scheduledPurgeDate":1646558614,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"7COx99iKvZMyEfgjZyRnT-PRpqilnns0Wce7GlDcw_ZAyA9ua55SAYsx-UhGsmOWcCHCgAZFIGHto7sGMju_hbkS2kJUHCPAbLmIGB8E_UvZuVX4tF2lR4a79flfsCv2DT5qJ2nsZvjpKk5LloVIzVo9okN25RiyU26JraJXn7QGt7Q9i8guClpM860k8E0CdY35D8BmxJ1c8kvcOuVjXce8AXu8gMEPQ6Y6p5i-thsH37ThNAA4ewYRMsYMi6SAhkfDVKutKdo2YCQZGRm0mL80cHJrKqRIu6Q85kbpu_9sH71lse9wAJPfLP07eYynCdTvpV37KaphictOirRQvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782609,"updated":1638782614,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '856'
+      - '858'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:29 GMT
+      - Mon, 06 Dec 2021 09:23:43 GMT
       expires:
       - '-1'
       pragma:
@@ -961,11 +653,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -981,22 +673,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e?api-version=7.1
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e","deletedDate":1618855206,"scheduledPurgeDate":1626631206,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/66e3221b6cb440fd98b92d0c9413138d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"l3Wj5pwhyIAygXqH4rZz0iVs3V7Lki8TLcfCJACo6xRd1s7DncI9TEdjR1a1lOLeT9yEvDysKrcYQhm5jiTCcUe-FbgeeF6SML12Fn9LBuB80cWeOmRV50OugHq3OiewxWK4f9Aan0SPG1DRx4xmVaeQSHY8-v7PC1L_4ouaqGQ-8KhHwLMD5y7e4DlcGinKKxEGcnEJtJhInRN6dJo2ySzsvQljew8wNiFW29EDhE9IyJVNmdHVYmTb90SEUYBHcaWmcmR13RjxOggS0r4cT-Ctblko8siEuud72ZhqX7DmrJ1elFnOOpb-A8qmtkwTH-yIffocFnAuGkZ5BmORvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1618855204,"updated":1618855205,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya00143e","deletedDate":1638782614,"scheduledPurgeDate":1646558614,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya00143e/d96ea0417b054441af0b7a73380cb8dc","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"7COx99iKvZMyEfgjZyRnT-PRpqilnns0Wce7GlDcw_ZAyA9ua55SAYsx-UhGsmOWcCHCgAZFIGHto7sGMju_hbkS2kJUHCPAbLmIGB8E_UvZuVX4tF2lR4a79flfsCv2DT5qJ2nsZvjpKk5LloVIzVo9okN25RiyU26JraJXn7QGt7Q9i8guClpM860k8E0CdY35D8BmxJ1c8kvcOuVjXce8AXu8gMEPQ6Y6p5i-thsH37ThNAA4ewYRMsYMi6SAhkfDVKutKdo2YCQZGRm0mL80cHJrKqRIu6Q85kbpu_9sH71lse9wAJPfLP07eYynCdTvpV37KaphictOirRQvQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782609,"updated":1638782614,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '856'
+      - '858'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Apr 2021 18:00:29 GMT
+      - Mon, 06 Dec 2021 09:23:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1006,11 +698,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - eastus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.236.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_2_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_2_vault.yaml
@@ -13,22 +13,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya07143f/create?api-version=7.2
   response:
     body:
-      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
-        or PoP token."}}'
+      string: '{"error":{"code":"Unauthorized","message":"AKV10000: Request is missing
+        a Bearer or PoP token."}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '97'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:07 GMT
+      - Mon, 06 Dec 2021 09:24:23 GMT
       expires:
       - '-1'
       pragma:
@@ -41,19 +41,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"kty": "EC-HSM", "tags": {"purpose": "unit test", "test name": "CreateECKeyTest"},
-      "attributes": {"enabled": true}}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -62,26 +62,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya07143f/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya07143f/22ef6d7a544d449fa8110b3bd5765975","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"alTRupbV0RT2-bW0K74nJxJaX78dsFVfJCvA-qRgFis","y":"wpKn1v0odCokIks_q6iVhedFNEPs4gUeANZk1W7EQwg"},"attributes":{"enabled":true,"created":1620408488,"updated":1620408488,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keya07143f/3afd129f29b24847ba9b1095dc0d1444","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"LOlfE1qGk7WR6eZuwrydKVXsd3WX8mCXOz4ySQ7c5B8","y":"FAPKJizZzfXVTvYO7jyltVxypsqMeKQMeBFf7YzU1Mw"},"attributes":{"enabled":true,"created":1638782665,"updated":1638782665,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '472'
+      - '469'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:09 GMT
+      - Mon, 06 Dec 2021 09:24:25 GMT
       expires:
       - '-1'
       pragma:
@@ -91,11 +91,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -115,21 +115,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keya07143f/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keya07143f/af1b10a3aea649a1bd6c14249a5611dc","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"oL74C9HUA01YdGpR0B4VNvT2G4xnwSfdzEBxzYia7qc","y":"IPhaRaFRMMtIcmbJ09FUA4-6YXMFDVFdcT93iSyIynM"},"attributes":{"enabled":true,"created":1620408492,"updated":1620408492,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keya07143f/6aa7f737195849b38f156e321479b773","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"2t-UCYCNaYJlltKb48Th_Fd61Zu-5byVvpRTo18K6Kg","y":"kuJNHwnYVdh1KTvzeLQHmiZuern9PNrmSPES3dEBAz4"},"attributes":{"enabled":true,"created":1638782668,"updated":1638782668,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '413'
+      - '414'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:11 GMT
+      - Mon, 06 Dec 2021 09:24:28 GMT
       expires:
       - '-1'
       pragma:
@@ -139,25 +139,25 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key": {"dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp",
-      "kty": "RSA", "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
-      "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
-      "e": "AQAB", "key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey",
-      "unwrapKey"], "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+    body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
+      "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "e": "AQAB", "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
+      "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp",
+      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
       "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
-      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
-      "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU"}}'
+      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3"}}'
     headers:
       Accept:
       - application/json
@@ -170,12 +170,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keya07143f?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keya07143f/37331578c7494674b92373c84ad3dd43","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1620408492,"updated":1620408492,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keya07143f/d0d7e33c16ec40849b89bd97887421aa","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782668,"updated":1638782668,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
@@ -184,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:11 GMT
+      - Mon, 06 Dec 2021 09:24:28 GMT
       expires:
       - '-1'
       pragma:
@@ -194,20 +194,20 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
-      "kty": "RSA", "key_size": 2048, "tags": {"test name ": "CreateRSAKeyTest", "purpose":
-      "unit test"}}'
+    body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
+      "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
+      ": "CreateRSAKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -220,22 +220,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0S-LoN4W6DriHnI7-OVq0RPbN-2OhWTGwX59UZ_UI8JW0yGbGl3T6TzwRfDBr_hzt_ccqJh9ChG7buGVZxiVVOg8bx-9ow1NlO1g7Jq3-KDBxK3fC-rJjSqNpBrmGU_ceRkgMuWMVaZ2sEE74jIiDaWFBc3HgIYf4ZkO5hl_OE7gEgrZEp7fuzRw5xlv98ScPL3_Rg4GPpcMBHKCIbshKPtpWqZXC0lKkKUKVQD0Gt-9CnlbtcdjZD0rZApTfl7MjSPf6H4DlxT-3Emn5FLT4jkze-q_WQh2LgqAwcZ9tsnnEUkR-e9ZFnKsHoNj3_WM97UbNrdsIuz3UuVnn92HgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1620408494,"updated":1620408494,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"02gJt3vMzMjm0ZdRUqQ_Klr1kLY-OtXVKw0NlIylOc7fd_pvfwLuUrhopUMsusQBAkg1rfosEQKtzy2CFt7f2v3hfWHTBIcndRHyvgLAbLMh2BOalR21rjsLHgWLIhti2EA3BsHMDkcYVVPEs_8_mH8DaRG0fzVOxaOhEM8eFEP9l4QsHVpP7rTqrkDyEgfx53wNYwGGlbK5BFVwvIZaAYvEAv-rGdmgFrUS7FuYHUTSjIUKuByU-0vTltwSOLwOx-IV_PZEf7SGdg-AluoRdjFgKW-9qgDKvFAmc5IgqI6Hd4ONGoanyDS8GhLW7Q1FdQKgqg6s5yNCBodF_BqDiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782671,"updated":1638782671,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '760'
+      - '761'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:14 GMT
+      - Mon, 06 Dec 2021 09:24:30 GMT
       expires:
       - '-1'
       pragma:
@@ -245,11 +245,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -265,22 +265,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0S-LoN4W6DriHnI7-OVq0RPbN-2OhWTGwX59UZ_UI8JW0yGbGl3T6TzwRfDBr_hzt_ccqJh9ChG7buGVZxiVVOg8bx-9ow1NlO1g7Jq3-KDBxK3fC-rJjSqNpBrmGU_ceRkgMuWMVaZ2sEE74jIiDaWFBc3HgIYf4ZkO5hl_OE7gEgrZEp7fuzRw5xlv98ScPL3_Rg4GPpcMBHKCIbshKPtpWqZXC0lKkKUKVQD0Gt-9CnlbtcdjZD0rZApTfl7MjSPf6H4DlxT-3Emn5FLT4jkze-q_WQh2LgqAwcZ9tsnnEUkR-e9ZFnKsHoNj3_WM97UbNrdsIuz3UuVnn92HgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1620408494,"updated":1620408494,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"02gJt3vMzMjm0ZdRUqQ_Klr1kLY-OtXVKw0NlIylOc7fd_pvfwLuUrhopUMsusQBAkg1rfosEQKtzy2CFt7f2v3hfWHTBIcndRHyvgLAbLMh2BOalR21rjsLHgWLIhti2EA3BsHMDkcYVVPEs_8_mH8DaRG0fzVOxaOhEM8eFEP9l4QsHVpP7rTqrkDyEgfx53wNYwGGlbK5BFVwvIZaAYvEAv-rGdmgFrUS7FuYHUTSjIUKuByU-0vTltwSOLwOx-IV_PZEf7SGdg-AluoRdjFgKW-9qgDKvFAmc5IgqI6Hd4ONGoanyDS8GhLW7Q1FdQKgqg6s5yNCBodF_BqDiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782671,"updated":1638782671,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '760'
+      - '761'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:14 GMT
+      - Mon, 06 Dec 2021 09:24:30 GMT
       expires:
       - '-1'
       pragma:
@@ -290,11 +290,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -310,22 +310,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0S-LoN4W6DriHnI7-OVq0RPbN-2OhWTGwX59UZ_UI8JW0yGbGl3T6TzwRfDBr_hzt_ccqJh9ChG7buGVZxiVVOg8bx-9ow1NlO1g7Jq3-KDBxK3fC-rJjSqNpBrmGU_ceRkgMuWMVaZ2sEE74jIiDaWFBc3HgIYf4ZkO5hl_OE7gEgrZEp7fuzRw5xlv98ScPL3_Rg4GPpcMBHKCIbshKPtpWqZXC0lKkKUKVQD0Gt-9CnlbtcdjZD0rZApTfl7MjSPf6H4DlxT-3Emn5FLT4jkze-q_WQh2LgqAwcZ9tsnnEUkR-e9ZFnKsHoNj3_WM97UbNrdsIuz3UuVnn92HgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1620408494,"updated":1620408494,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"test
-        name ":"CreateRSAKeyTest","purpose":"unit test"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"02gJt3vMzMjm0ZdRUqQ_Klr1kLY-OtXVKw0NlIylOc7fd_pvfwLuUrhopUMsusQBAkg1rfosEQKtzy2CFt7f2v3hfWHTBIcndRHyvgLAbLMh2BOalR21rjsLHgWLIhti2EA3BsHMDkcYVVPEs_8_mH8DaRG0fzVOxaOhEM8eFEP9l4QsHVpP7rTqrkDyEgfx53wNYwGGlbK5BFVwvIZaAYvEAv-rGdmgFrUS7FuYHUTSjIUKuByU-0vTltwSOLwOx-IV_PZEf7SGdg-AluoRdjFgKW-9qgDKvFAmc5IgqI6Hd4ONGoanyDS8GhLW7Q1FdQKgqg6s5yNCBodF_BqDiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782671,"updated":1638782671,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+        test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '760'
+      - '761'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:14 GMT
+      - Mon, 06 Dec 2021 09:24:31 GMT
       expires:
       - '-1'
       pragma:
@@ -335,19 +335,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"key_ops": ["decrypt", "encrypt"], "tags": {"foo": "updated tag"}, "attributes":
-      {"exp": 2524723200}}'
+    body: '{"key_ops": ["decrypt", "encrypt"], "attributes": {"exp": 2524723200},
+      "tags": {"foo": "updated tag"}}'
     headers:
       Accept:
       - application/json
@@ -360,22 +360,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0S-LoN4W6DriHnI7-OVq0RPbN-2OhWTGwX59UZ_UI8JW0yGbGl3T6TzwRfDBr_hzt_ccqJh9ChG7buGVZxiVVOg8bx-9ow1NlO1g7Jq3-KDBxK3fC-rJjSqNpBrmGU_ceRkgMuWMVaZ2sEE74jIiDaWFBc3HgIYf4ZkO5hl_OE7gEgrZEp7fuzRw5xlv98ScPL3_Rg4GPpcMBHKCIbshKPtpWqZXC0lKkKUKVQD0Gt-9CnlbtcdjZD0rZApTfl7MjSPf6H4DlxT-3Emn5FLT4jkze-q_WQh2LgqAwcZ9tsnnEUkR-e9ZFnKsHoNj3_WM97UbNrdsIuz3UuVnn92HgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1620408494,"updated":1620408496,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"02gJt3vMzMjm0ZdRUqQ_Klr1kLY-OtXVKw0NlIylOc7fd_pvfwLuUrhopUMsusQBAkg1rfosEQKtzy2CFt7f2v3hfWHTBIcndRHyvgLAbLMh2BOalR21rjsLHgWLIhti2EA3BsHMDkcYVVPEs_8_mH8DaRG0fzVOxaOhEM8eFEP9l4QsHVpP7rTqrkDyEgfx53wNYwGGlbK5BFVwvIZaAYvEAv-rGdmgFrUS7FuYHUTSjIUKuByU-0vTltwSOLwOx-IV_PZEf7SGdg-AluoRdjFgKW-9qgDKvFAmc5IgqI6Hd4ONGoanyDS8GhLW7Q1FdQKgqg6s5yNCBodF_BqDiQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782671,"updated":1638782675,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '705'
+      - '706'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:15 GMT
+      - Mon, 06 Dec 2021 09:24:35 GMT
       expires:
       - '-1'
       pragma:
@@ -385,11 +385,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -407,22 +407,22 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f?api-version=7.2
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f","deletedDate":1620408496,"scheduledPurgeDate":1628184496,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0S-LoN4W6DriHnI7-OVq0RPbN-2OhWTGwX59UZ_UI8JW0yGbGl3T6TzwRfDBr_hzt_ccqJh9ChG7buGVZxiVVOg8bx-9ow1NlO1g7Jq3-KDBxK3fC-rJjSqNpBrmGU_ceRkgMuWMVaZ2sEE74jIiDaWFBc3HgIYf4ZkO5hl_OE7gEgrZEp7fuzRw5xlv98ScPL3_Rg4GPpcMBHKCIbshKPtpWqZXC0lKkKUKVQD0Gt-9CnlbtcdjZD0rZApTfl7MjSPf6H4DlxT-3Emn5FLT4jkze-q_WQh2LgqAwcZ9tsnnEUkR-e9ZFnKsHoNj3_WM97UbNrdsIuz3UuVnn92HgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1620408494,"updated":1620408496,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f","deletedDate":1638782675,"scheduledPurgeDate":1646558675,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"02gJt3vMzMjm0ZdRUqQ_Klr1kLY-OtXVKw0NlIylOc7fd_pvfwLuUrhopUMsusQBAkg1rfosEQKtzy2CFt7f2v3hfWHTBIcndRHyvgLAbLMh2BOalR21rjsLHgWLIhti2EA3BsHMDkcYVVPEs_8_mH8DaRG0fzVOxaOhEM8eFEP9l4QsHVpP7rTqrkDyEgfx53wNYwGGlbK5BFVwvIZaAYvEAv-rGdmgFrUS7FuYHUTSjIUKuByU-0vTltwSOLwOx-IV_PZEf7SGdg-AluoRdjFgKW-9qgDKvFAmc5IgqI6Hd4ONGoanyDS8GhLW7Q1FdQKgqg6s5yNCBodF_BqDiQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782671,"updated":1638782675,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '856'
+      - '858'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:16 GMT
+      - Mon, 06 Dec 2021 09:24:35 GMT
       expires:
       - '-1'
       pragma:
@@ -432,11 +432,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -452,7 +452,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
   response:
@@ -466,7 +466,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:16 GMT
+      - Mon, 06 Dec 2021 09:24:36 GMT
       expires:
       - '-1'
       pragma:
@@ -476,11 +476,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -496,7 +496,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
   response:
@@ -510,7 +510,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:18 GMT
+      - Mon, 06 Dec 2021 09:24:38 GMT
       expires:
       - '-1'
       pragma:
@@ -520,11 +520,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -540,7 +540,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
   response:
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:20 GMT
+      - Mon, 06 Dec 2021 09:24:40 GMT
       expires:
       - '-1'
       pragma:
@@ -564,11 +564,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -584,7 +584,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
   response:
@@ -598,7 +598,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:28:21 GMT
+      - Mon, 06 Dec 2021 09:24:42 GMT
       expires:
       - '-1'
       pragma:
@@ -608,11 +608,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -628,946 +628,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
   response:
     body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:28:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:29:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:29:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:29:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keya07143f"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '97'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 07 May 2021 17:29:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - centralus
-      x-ms-keyvault-service-version:
-      - 1.2.265.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
-  response:
-    body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f","deletedDate":1620408496,"scheduledPurgeDate":1628184496,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0S-LoN4W6DriHnI7-OVq0RPbN-2OhWTGwX59UZ_UI8JW0yGbGl3T6TzwRfDBr_hzt_ccqJh9ChG7buGVZxiVVOg8bx-9ow1NlO1g7Jq3-KDBxK3fC-rJjSqNpBrmGU_ceRkgMuWMVaZ2sEE74jIiDaWFBc3HgIYf4ZkO5hl_OE7gEgrZEp7fuzRw5xlv98ScPL3_Rg4GPpcMBHKCIbshKPtpWqZXC0lKkKUKVQD0Gt-9CnlbtcdjZD0rZApTfl7MjSPf6H4DlxT-3Emn5FLT4jkze-q_WQh2LgqAwcZ9tsnnEUkR-e9ZFnKsHoNj3_WM97UbNrdsIuz3UuVnn92HgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1620408494,"updated":1620408496,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f","deletedDate":1638782675,"scheduledPurgeDate":1646558675,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"02gJt3vMzMjm0ZdRUqQ_Klr1kLY-OtXVKw0NlIylOc7fd_pvfwLuUrhopUMsusQBAkg1rfosEQKtzy2CFt7f2v3hfWHTBIcndRHyvgLAbLMh2BOalR21rjsLHgWLIhti2EA3BsHMDkcYVVPEs_8_mH8DaRG0fzVOxaOhEM8eFEP9l4QsHVpP7rTqrkDyEgfx53wNYwGGlbK5BFVwvIZaAYvEAv-rGdmgFrUS7FuYHUTSjIUKuByU-0vTltwSOLwOx-IV_PZEf7SGdg-AluoRdjFgKW-9qgDKvFAmc5IgqI6Hd4ONGoanyDS8GhLW7Q1FdQKgqg6s5yNCBodF_BqDiQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782671,"updated":1638782675,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '856'
+      - '858'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:29:09 GMT
+      - Mon, 06 Dec 2021 09:24:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1577,11 +653,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -1597,22 +673,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f?api-version=7.2
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f","deletedDate":1620408496,"scheduledPurgeDate":1628184496,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/359170d867cb4542b952ed2e83bb337a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0S-LoN4W6DriHnI7-OVq0RPbN-2OhWTGwX59UZ_UI8JW0yGbGl3T6TzwRfDBr_hzt_ccqJh9ChG7buGVZxiVVOg8bx-9ow1NlO1g7Jq3-KDBxK3fC-rJjSqNpBrmGU_ceRkgMuWMVaZ2sEE74jIiDaWFBc3HgIYf4ZkO5hl_OE7gEgrZEp7fuzRw5xlv98ScPL3_Rg4GPpcMBHKCIbshKPtpWqZXC0lKkKUKVQD0Gt-9CnlbtcdjZD0rZApTfl7MjSPf6H4DlxT-3Emn5FLT4jkze-q_WQh2LgqAwcZ9tsnnEUkR-e9ZFnKsHoNj3_WM97UbNrdsIuz3UuVnn92HgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1620408494,"updated":1620408496,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keya07143f","deletedDate":1638782675,"scheduledPurgeDate":1646558675,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keya07143f/8ba33b9d44554f9ab7a948da260e13a8","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"02gJt3vMzMjm0ZdRUqQ_Klr1kLY-OtXVKw0NlIylOc7fd_pvfwLuUrhopUMsusQBAkg1rfosEQKtzy2CFt7f2v3hfWHTBIcndRHyvgLAbLMh2BOalR21rjsLHgWLIhti2EA3BsHMDkcYVVPEs_8_mH8DaRG0fzVOxaOhEM8eFEP9l4QsHVpP7rTqrkDyEgfx53wNYwGGlbK5BFVwvIZaAYvEAv-rGdmgFrUS7FuYHUTSjIUKuByU-0vTltwSOLwOx-IV_PZEf7SGdg-AluoRdjFgKW-9qgDKvFAmc5IgqI6Hd4ONGoanyDS8GhLW7Q1FdQKgqg6s5yNCBodF_BqDiQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782671,"updated":1638782675,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '856'
+      - '858'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 May 2021 17:29:09 GMT
+      - Mon, 06 Dec 2021 09:24:46 GMT
       expires:
       - '-1'
       pragma:
@@ -1622,11 +698,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - centralus
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.2.265.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_crud_operations_7_3_preview_vault.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybafd17a1/create?api-version=7.3-preview
   response:
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:19 GMT
+      - Mon, 06 Dec 2021 09:25:03 GMT
       expires:
       - '-1'
       pragma:
@@ -41,19 +41,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"kty": "EC-HSM", "attributes": {"enabled": true}, "tags": {"purpose":
-      "unit test", "test name": "CreateECKeyTest"}}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
@@ -62,26 +62,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybafd17a1/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybafd17a1/11fe2189022947008417c6c8bf5b2ab9","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"pc5MThywnfZDA91WCRaT1qylxrMLnb44O9di-XM6MAk","y":"9rmlnrm3SXXGiSx23EKAqakhMnYAj8qBufX2GpuVaGQ"},"attributes":{"enabled":true,"created":1628296220,"updated":1628296220,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybafd17a1/1291bf9c0ca54327b2e17fb31e0bc3b7","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"8IcIrwhcg6Wg_EdqeJkwP-ZvoFSEttsce1lPOgm-ZZs","y":"Ro8_AZDacvU6hMDOGXsGyuazhTzQc2bD0ta6LXlhxeE"},"attributes":{"enabled":true,"created":1638782706,"updated":1638782706,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '471'
+      - '470'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:21 GMT
+      - Mon, 06 Dec 2021 09:25:05 GMT
       expires:
       - '-1'
       pragma:
@@ -91,11 +91,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -115,21 +115,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybafd17a1/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybafd17a1/3325caa1af3b4ec5964cb7f7e93c517b","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"JKEEaNhBclLVSMGbkBZOvU0zHgULXUHnwJe24scam0M","y":"5Mn7Pvf0h9hWAf0BbiDYNmj4kf7cewwHMz8SLBT0NfU"},"attributes":{"enabled":true,"created":1628296224,"updated":1628296224,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybafd17a1/dd25a1f739d14204898215c04498f971","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"n2p-aOOCWuAZ8bCvhOWsgObjRJd5vE_0Zi--dRyUK_Q","y":"KAZATnbFfbs0MPWflIHOj2iLBGVDZePQmQsMBek7BA4"},"attributes":{"enabled":true,"created":1638782708,"updated":1638782708,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '412'
+      - '415'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:24 GMT
+      - Mon, 06 Dec 2021 09:25:08 GMT
       expires:
       - '-1'
       pragma:
@@ -139,11 +139,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -170,21 +170,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keybafd17a1?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keybafd17a1/35809865eee14bc7be457fa5220aa41f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1628296224,"updated":1628296224,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keybafd17a1/cacf6d0568d3492e9b71dcd64248a079","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782709,"updated":1638782709,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '699'
+      - '702'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:24 GMT
+      - Mon, 06 Dec 2021 09:25:08 GMT
       expires:
       - '-1'
       pragma:
@@ -194,11 +194,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -220,22 +220,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ujVKB64ua5WAoIeY-bAVsp8-CphR80oW_OvdIV_n1yq-DZbp28n1vSDex5LSBD8GmsYBXA9fM4AWBbJzJy7q9Rpy06wj2QrbTrMWmWCYO6KyxXFsdMVqnsYrygOBugdDdGaih70M30MsxS9uggo0JZZcqazBjbvon8XB260VtYD9e-D-rPIkd8r5JCK2q4uKchOeeXUhP6rOwGa6TmjzangAc9ItAJOiBovTh2lxrInxFOC0venCNWDZdw81yAm3E3KUsOtJmMC8HFWhQ2q_wwaY2zzeSk-c2ypsMsuMsdg-knb1WkLkydTFUK-iCOkZE3HC7q5gCxVQom3W5lQO1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1628296226,"updated":1628296226,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mqPx2uCY46kbv-Ht27H_mLOInFmflpDGsQsy8ByAQdRNJpnCS3HPj3C1L9oexg5LkMM-LdExep4KvH9uOpjf2HV4m0avTth1kq5FYiKMJuKI9BCwh2Bp8cuHD6hM4dJck868dwgRX6aGHYw9A_J2yeOHDvfj5z2Dv4J3hkUlf14sUEna5vcEhsYiZvp1jfudSrIpo8v3KQSuK2USOkrMcVHn31Fnl7UObRAHCYJlS0m_eoLfFRq9kzZjB7AhCP-JRmU7gh5MGW1I7lYg7EEJswiyt_a4m8ZDCTY5i8Buy2mJbjZt_pk8agziltbKmNk8V6M-tnktHgYIpHrQdkNCwQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782711,"updated":1638782711,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '759'
+      - '762'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:27 GMT
+      - Mon, 06 Dec 2021 09:25:11 GMT
       expires:
       - '-1'
       pragma:
@@ -245,11 +245,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -265,22 +265,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ujVKB64ua5WAoIeY-bAVsp8-CphR80oW_OvdIV_n1yq-DZbp28n1vSDex5LSBD8GmsYBXA9fM4AWBbJzJy7q9Rpy06wj2QrbTrMWmWCYO6KyxXFsdMVqnsYrygOBugdDdGaih70M30MsxS9uggo0JZZcqazBjbvon8XB260VtYD9e-D-rPIkd8r5JCK2q4uKchOeeXUhP6rOwGa6TmjzangAc9ItAJOiBovTh2lxrInxFOC0venCNWDZdw81yAm3E3KUsOtJmMC8HFWhQ2q_wwaY2zzeSk-c2ypsMsuMsdg-knb1WkLkydTFUK-iCOkZE3HC7q5gCxVQom3W5lQO1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1628296226,"updated":1628296226,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mqPx2uCY46kbv-Ht27H_mLOInFmflpDGsQsy8ByAQdRNJpnCS3HPj3C1L9oexg5LkMM-LdExep4KvH9uOpjf2HV4m0avTth1kq5FYiKMJuKI9BCwh2Bp8cuHD6hM4dJck868dwgRX6aGHYw9A_J2yeOHDvfj5z2Dv4J3hkUlf14sUEna5vcEhsYiZvp1jfudSrIpo8v3KQSuK2USOkrMcVHn31Fnl7UObRAHCYJlS0m_eoLfFRq9kzZjB7AhCP-JRmU7gh5MGW1I7lYg7EEJswiyt_a4m8ZDCTY5i8Buy2mJbjZt_pk8agziltbKmNk8V6M-tnktHgYIpHrQdkNCwQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782711,"updated":1638782711,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '759'
+      - '762'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:27 GMT
+      - Mon, 06 Dec 2021 09:25:12 GMT
       expires:
       - '-1'
       pragma:
@@ -290,11 +290,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -310,22 +310,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ujVKB64ua5WAoIeY-bAVsp8-CphR80oW_OvdIV_n1yq-DZbp28n1vSDex5LSBD8GmsYBXA9fM4AWBbJzJy7q9Rpy06wj2QrbTrMWmWCYO6KyxXFsdMVqnsYrygOBugdDdGaih70M30MsxS9uggo0JZZcqazBjbvon8XB260VtYD9e-D-rPIkd8r5JCK2q4uKchOeeXUhP6rOwGa6TmjzangAc9ItAJOiBovTh2lxrInxFOC0venCNWDZdw81yAm3E3KUsOtJmMC8HFWhQ2q_wwaY2zzeSk-c2ypsMsuMsdg-knb1WkLkydTFUK-iCOkZE3HC7q5gCxVQom3W5lQO1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1628296226,"updated":1628296226,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mqPx2uCY46kbv-Ht27H_mLOInFmflpDGsQsy8ByAQdRNJpnCS3HPj3C1L9oexg5LkMM-LdExep4KvH9uOpjf2HV4m0avTth1kq5FYiKMJuKI9BCwh2Bp8cuHD6hM4dJck868dwgRX6aGHYw9A_J2yeOHDvfj5z2Dv4J3hkUlf14sUEna5vcEhsYiZvp1jfudSrIpo8v3KQSuK2USOkrMcVHn31Fnl7UObRAHCYJlS0m_eoLfFRq9kzZjB7AhCP-JRmU7gh5MGW1I7lYg7EEJswiyt_a4m8ZDCTY5i8Buy2mJbjZt_pk8agziltbKmNk8V6M-tnktHgYIpHrQdkNCwQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638782711,"updated":1638782711,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '759'
+      - '762'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:27 GMT
+      - Mon, 06 Dec 2021 09:25:12 GMT
       expires:
       - '-1'
       pragma:
@@ -335,11 +335,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -360,22 +360,22 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ujVKB64ua5WAoIeY-bAVsp8-CphR80oW_OvdIV_n1yq-DZbp28n1vSDex5LSBD8GmsYBXA9fM4AWBbJzJy7q9Rpy06wj2QrbTrMWmWCYO6KyxXFsdMVqnsYrygOBugdDdGaih70M30MsxS9uggo0JZZcqazBjbvon8XB260VtYD9e-D-rPIkd8r5JCK2q4uKchOeeXUhP6rOwGa6TmjzangAc9ItAJOiBovTh2lxrInxFOC0venCNWDZdw81yAm3E3KUsOtJmMC8HFWhQ2q_wwaY2zzeSk-c2ypsMsuMsdg-knb1WkLkydTFUK-iCOkZE3HC7q5gCxVQom3W5lQO1Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1628296226,"updated":1628296228,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mqPx2uCY46kbv-Ht27H_mLOInFmflpDGsQsy8ByAQdRNJpnCS3HPj3C1L9oexg5LkMM-LdExep4KvH9uOpjf2HV4m0avTth1kq5FYiKMJuKI9BCwh2Bp8cuHD6hM4dJck868dwgRX6aGHYw9A_J2yeOHDvfj5z2Dv4J3hkUlf14sUEna5vcEhsYiZvp1jfudSrIpo8v3KQSuK2USOkrMcVHn31Fnl7UObRAHCYJlS0m_eoLfFRq9kzZjB7AhCP-JRmU7gh5MGW1I7lYg7EEJswiyt_a4m8ZDCTY5i8Buy2mJbjZt_pk8agziltbKmNk8V6M-tnktHgYIpHrQdkNCwQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782711,"updated":1638782716,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '704'
+      - '707'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:28 GMT
+      - Mon, 06 Dec 2021 09:25:15 GMT
       expires:
       - '-1'
       pragma:
@@ -385,11 +385,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -407,22 +407,22 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1","deletedDate":1628296228,"scheduledPurgeDate":1636072228,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ujVKB64ua5WAoIeY-bAVsp8-CphR80oW_OvdIV_n1yq-DZbp28n1vSDex5LSBD8GmsYBXA9fM4AWBbJzJy7q9Rpy06wj2QrbTrMWmWCYO6KyxXFsdMVqnsYrygOBugdDdGaih70M30MsxS9uggo0JZZcqazBjbvon8XB260VtYD9e-D-rPIkd8r5JCK2q4uKchOeeXUhP6rOwGa6TmjzangAc9ItAJOiBovTh2lxrInxFOC0venCNWDZdw81yAm3E3KUsOtJmMC8HFWhQ2q_wwaY2zzeSk-c2ypsMsuMsdg-knb1WkLkydTFUK-iCOkZE3HC7q5gCxVQom3W5lQO1Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1628296226,"updated":1628296228,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1","deletedDate":1638782716,"scheduledPurgeDate":1646558716,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mqPx2uCY46kbv-Ht27H_mLOInFmflpDGsQsy8ByAQdRNJpnCS3HPj3C1L9oexg5LkMM-LdExep4KvH9uOpjf2HV4m0avTth1kq5FYiKMJuKI9BCwh2Bp8cuHD6hM4dJck868dwgRX6aGHYw9A_J2yeOHDvfj5z2Dv4J3hkUlf14sUEna5vcEhsYiZvp1jfudSrIpo8v3KQSuK2USOkrMcVHn31Fnl7UObRAHCYJlS0m_eoLfFRq9kzZjB7AhCP-JRmU7gh5MGW1I7lYg7EEJswiyt_a4m8ZDCTY5i8Buy2mJbjZt_pk8agziltbKmNk8V6M-tnktHgYIpHrQdkNCwQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782711,"updated":1638782716,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '854'
+      - '860'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:28 GMT
+      - Mon, 06 Dec 2021 09:25:16 GMT
       expires:
       - '-1'
       pragma:
@@ -432,11 +432,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -452,7 +452,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
   response:
@@ -466,7 +466,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:28 GMT
+      - Mon, 06 Dec 2021 09:25:16 GMT
       expires:
       - '-1'
       pragma:
@@ -476,11 +476,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -496,7 +496,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
   response:
@@ -510,7 +510,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:30 GMT
+      - Mon, 06 Dec 2021 09:25:18 GMT
       expires:
       - '-1'
       pragma:
@@ -520,11 +520,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -540,7 +540,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
   response:
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:32 GMT
+      - Mon, 06 Dec 2021 09:25:20 GMT
       expires:
       - '-1'
       pragma:
@@ -564,11 +564,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -584,7 +584,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
   response:
@@ -598,7 +598,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:34 GMT
+      - Mon, 06 Dec 2021 09:25:24 GMT
       expires:
       - '-1'
       pragma:
@@ -608,11 +608,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -628,242 +628,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
   response:
     body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybafd17a1"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 07 Aug 2021 00:30:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus2
-      x-ms-keyvault-service-version:
-      - 1.9.48.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybafd17a1"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 07 Aug 2021 00:30:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus2
-      x-ms-keyvault-service-version:
-      - 1.9.48.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybafd17a1"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 07 Aug 2021 00:30:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus2
-      x-ms-keyvault-service-version:
-      - 1.9.48.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybafd17a1"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 07 Aug 2021 00:30:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus2
-      x-ms-keyvault-service-version:
-      - 1.9.48.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
-  response:
-    body:
-      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybafd17a1"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '98'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 07 Aug 2021 00:30:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus2
-      x-ms-keyvault-service-version:
-      - 1.9.48.0
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
-  response:
-    body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1","deletedDate":1628296228,"scheduledPurgeDate":1636072228,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ujVKB64ua5WAoIeY-bAVsp8-CphR80oW_OvdIV_n1yq-DZbp28n1vSDex5LSBD8GmsYBXA9fM4AWBbJzJy7q9Rpy06wj2QrbTrMWmWCYO6KyxXFsdMVqnsYrygOBugdDdGaih70M30MsxS9uggo0JZZcqazBjbvon8XB260VtYD9e-D-rPIkd8r5JCK2q4uKchOeeXUhP6rOwGa6TmjzangAc9ItAJOiBovTh2lxrInxFOC0venCNWDZdw81yAm3E3KUsOtJmMC8HFWhQ2q_wwaY2zzeSk-c2ypsMsuMsdg-knb1WkLkydTFUK-iCOkZE3HC7q5gCxVQom3W5lQO1Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1628296226,"updated":1628296228,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1","deletedDate":1638782716,"scheduledPurgeDate":1646558716,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mqPx2uCY46kbv-Ht27H_mLOInFmflpDGsQsy8ByAQdRNJpnCS3HPj3C1L9oexg5LkMM-LdExep4KvH9uOpjf2HV4m0avTth1kq5FYiKMJuKI9BCwh2Bp8cuHD6hM4dJck868dwgRX6aGHYw9A_J2yeOHDvfj5z2Dv4J3hkUlf14sUEna5vcEhsYiZvp1jfudSrIpo8v3KQSuK2USOkrMcVHn31Fnl7UObRAHCYJlS0m_eoLfFRq9kzZjB7AhCP-JRmU7gh5MGW1I7lYg7EEJswiyt_a4m8ZDCTY5i8Buy2mJbjZt_pk8agziltbKmNk8V6M-tnktHgYIpHrQdkNCwQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782711,"updated":1638782716,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '854'
+      - '860'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:46 GMT
+      - Mon, 06 Dec 2021 09:25:26 GMT
       expires:
       - '-1'
       pragma:
@@ -873,11 +653,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:
@@ -893,22 +673,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1?api-version=7.3-preview
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1","deletedDate":1628296228,"scheduledPurgeDate":1636072228,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/59895f7d63f14d2e95b771b7fc773b78","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"ujVKB64ua5WAoIeY-bAVsp8-CphR80oW_OvdIV_n1yq-DZbp28n1vSDex5LSBD8GmsYBXA9fM4AWBbJzJy7q9Rpy06wj2QrbTrMWmWCYO6KyxXFsdMVqnsYrygOBugdDdGaih70M30MsxS9uggo0JZZcqazBjbvon8XB260VtYD9e-D-rPIkd8r5JCK2q4uKchOeeXUhP6rOwGa6TmjzangAc9ItAJOiBovTh2lxrInxFOC0venCNWDZdw81yAm3E3KUsOtJmMC8HFWhQ2q_wwaY2zzeSk-c2ypsMsuMsdg-knb1WkLkydTFUK-iCOkZE3HC7q5gCxVQom3W5lQO1Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1628296226,"updated":1628296228,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybafd17a1","deletedDate":1638782716,"scheduledPurgeDate":1646558716,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybafd17a1/d8c447bfca2944b288acce3e79a9d357","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mqPx2uCY46kbv-Ht27H_mLOInFmflpDGsQsy8ByAQdRNJpnCS3HPj3C1L9oexg5LkMM-LdExep4KvH9uOpjf2HV4m0avTth1kq5FYiKMJuKI9BCwh2Bp8cuHD6hM4dJck868dwgRX6aGHYw9A_J2yeOHDvfj5z2Dv4J3hkUlf14sUEna5vcEhsYiZvp1jfudSrIpo8v3KQSuK2USOkrMcVHn31Fnl7UObRAHCYJlS0m_eoLfFRq9kzZjB7AhCP-JRmU7gh5MGW1I7lYg7EEJswiyt_a4m8ZDCTY5i8Buy2mJbjZt_pk8agziltbKmNk8V6M-tnktHgYIpHrQdkNCwQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638782711,"updated":1638782716,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '854'
+      - '860'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 07 Aug 2021 00:30:46 GMT
+      - Mon, 06 Dec 2021 09:25:26 GMT
       expires:
       - '-1'
       pragma:
@@ -918,11 +698,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - eastus
       x-ms-keyvault-service-version:
-      - 1.9.48.0
+      - 1.9.195.1
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_2016_10_01_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_2016_10_01_vault.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/create?api-version=2016-10-01
   response:
@@ -20,56 +20,56 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:08 GMT
+      date: Fri, 03 Dec 2021 10:16:36 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/create?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/create?api-version=2016-10-01
 - request:
-    body: '{"kty": "EC-HSM", "attributes": {"enabled": true}, "tags": {"purpose":
-      "unit test", "test name": "CreateECKeyTest"}}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/b07ed0b3978243e29fe28f6ffeedd9f2","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"5-Bg_iGkXeWa-O50JSWChHUtuDXhk-hY5GliovFQio4","y":"WFoZ1v8_E_7LaMTZU9Zem_36sAlRc1PvxZ1Mdh_7fVo"},"attributes":{"enabled":true,"created":1633729389,"updated":1633729389,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/d4982a9f97534fcc9f26460797d75814","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"-sj5dygb8WG8pORB3IgzhUCoKbwtV4dR07IZT3BEOXg","y":"WvFUtplyT3QM3jzHjYk-meaRdA-68a9CAwCSvTTLN5Y"},"attributes":{"enabled":true,"created":1638526598,"updated":1638526598,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '452'
+      content-length: '438'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:11 GMT
+      date: Fri, 03 Dec 2021 10:16:38 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/create?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-key97b315d2/create?api-version=2016-10-01
 - request:
     body: '{"kty": "EC", "crv": "P-256"}'
     headers:
@@ -80,29 +80,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key97b315d2/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key97b315d2/d7535a78b3364a809bac84a665f4d011","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"t1jCnCgEBy0UspYENpCjEydPGk8cuyftCYH59nksmOk","y":"ZNQy77suUWqMex-jBXCXWxZC3Sl9GKiG9NjSFMHv5QM"},"attributes":{"enabled":true,"created":1633729393,"updated":1633729393,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key97b315d2/e98ec763fabf4be79457fb9bd7daec66","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"ciP5qrY1NofPeNZKz8_-5bM20WxtzoLsAlafHWt7vWU","y":"G_BVMlN0zJmJfjQCQLRQCM-RZ208XwaYZAXwmju4Zd4"},"attributes":{"enabled":true,"created":1638526600,"updated":1638526600,"recoveryLevel":"Recoverable"}}'
     headers:
       cache-control: no-cache
-      content-length: '393'
+      content-length: '383'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:13 GMT
+      date: Fri, 03 Dec 2021 10:16:40 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-P-256-ec-key97b315d2/create?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-key97b315d2/create?api-version=2016-10-01
 - request:
     body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
       "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
@@ -120,29 +120,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-key97b315d2?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-key97b315d2/f383cb18d5da4b0e9e16e775547fa580","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729393,"updated":1633729393,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-key97b315d2/2dd379f86d0f4a099a8d4ab0e5d863cc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638526601,"updated":1638526601,"recoveryLevel":"Recoverable"}}'
     headers:
       cache-control: no-cache
-      content-length: '680'
+      content-length: '670'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:13 GMT
+      date: Fri, 03 Dec 2021 10:16:40 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestimport-test-key97b315d2?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestimport-test-key97b315d2?api-version=2016-10-01
 - request:
     body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
       "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
@@ -155,90 +155,90 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/create?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wCOfYZfiewtypnbt7a43iFyCpIS2Cz9IH_qJA59nglR03I5UNXCqp8GB_YLqByv25pxx-1wEKv8YYGnt2yo1S5VfcWIJBEkJA8HTK7HlPq1uAubdplww6hQ8Ozn6GvnqF7mP2skYbvoK4RBphas-5JNFGcdPvJVJSEWznKD3MFo4Lkd7bUb14-cZwRYQPirGUh4cfMrm_fIT5jKfQJcpjWduiYAHwXY2J9UVUvB9CQEZ8M0GRZJaZMFXHwAwBcnXMFUU9Ngi1bBYlZX3FvvRCApBdjyTy7GT6woXkxXPpzKCW-Asazxl2m1WNm1N2abu_0m-rAR7gkrT92vccCqOEQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729395,"updated":1633729395,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"5w2ynukXJsBZ9VMminyOYQ3xCCiUMjwY10iO7oATIk3whhC-pWwa7uTba8v992cSdRUoPjCVzPpaNmQ5GehmmAVjLsg16NuirOQZoaiyj6Ouwm8e971a4Xfw7bX_LOgWCoSXMGJYDBkXWEgWkJAlI_aF_FDWJTGYw6HsQHkizrzkGRyBgIvi8IJ9ZUDQSpmyBA1_LCEMR-cY1yK0T7sAyK5FoKCV2uqqhtbg3mfEWG1UECbi39veTr1qpNH1boPB9pg-IV6d6iHJtnQVbtHHIQrAm7vRG-rk-28Mfytj6Fmk9b3kMMKFQ7ebkbIZ9nBydJqz0Yn3K72gilqiWTKH5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1638526603,"updated":1638526603,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '740'
+      content-length: '730'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:15 GMT
+      date: Fri, 03 Dec 2021 10:16:43 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/create?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/create?api-version=2016-10-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f?api-version=2016-10-01
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wCOfYZfiewtypnbt7a43iFyCpIS2Cz9IH_qJA59nglR03I5UNXCqp8GB_YLqByv25pxx-1wEKv8YYGnt2yo1S5VfcWIJBEkJA8HTK7HlPq1uAubdplww6hQ8Ozn6GvnqF7mP2skYbvoK4RBphas-5JNFGcdPvJVJSEWznKD3MFo4Lkd7bUb14-cZwRYQPirGUh4cfMrm_fIT5jKfQJcpjWduiYAHwXY2J9UVUvB9CQEZ8M0GRZJaZMFXHwAwBcnXMFUU9Ngi1bBYlZX3FvvRCApBdjyTy7GT6woXkxXPpzKCW-Asazxl2m1WNm1N2abu_0m-rAR7gkrT92vccCqOEQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729395,"updated":1633729395,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"5w2ynukXJsBZ9VMminyOYQ3xCCiUMjwY10iO7oATIk3whhC-pWwa7uTba8v992cSdRUoPjCVzPpaNmQ5GehmmAVjLsg16NuirOQZoaiyj6Ouwm8e971a4Xfw7bX_LOgWCoSXMGJYDBkXWEgWkJAlI_aF_FDWJTGYw6HsQHkizrzkGRyBgIvi8IJ9ZUDQSpmyBA1_LCEMR-cY1yK0T7sAyK5FoKCV2uqqhtbg3mfEWG1UECbi39veTr1qpNH1boPB9pg-IV6d6iHJtnQVbtHHIQrAm7vRG-rk-28Mfytj6Fmk9b3kMMKFQ7ebkbIZ9nBydJqz0Yn3K72gilqiWTKH5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1638526603,"updated":1638526603,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '740'
+      content-length: '730'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:15 GMT
+      date: Fri, 03 Dec 2021 10:16:43 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125?api-version=2016-10-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wCOfYZfiewtypnbt7a43iFyCpIS2Cz9IH_qJA59nglR03I5UNXCqp8GB_YLqByv25pxx-1wEKv8YYGnt2yo1S5VfcWIJBEkJA8HTK7HlPq1uAubdplww6hQ8Ozn6GvnqF7mP2skYbvoK4RBphas-5JNFGcdPvJVJSEWznKD3MFo4Lkd7bUb14-cZwRYQPirGUh4cfMrm_fIT5jKfQJcpjWduiYAHwXY2J9UVUvB9CQEZ8M0GRZJaZMFXHwAwBcnXMFUU9Ngi1bBYlZX3FvvRCApBdjyTy7GT6woXkxXPpzKCW-Asazxl2m1WNm1N2abu_0m-rAR7gkrT92vccCqOEQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729395,"updated":1633729395,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"5w2ynukXJsBZ9VMminyOYQ3xCCiUMjwY10iO7oATIk3whhC-pWwa7uTba8v992cSdRUoPjCVzPpaNmQ5GehmmAVjLsg16NuirOQZoaiyj6Ouwm8e971a4Xfw7bX_LOgWCoSXMGJYDBkXWEgWkJAlI_aF_FDWJTGYw6HsQHkizrzkGRyBgIvi8IJ9ZUDQSpmyBA1_LCEMR-cY1yK0T7sAyK5FoKCV2uqqhtbg3mfEWG1UECbi39veTr1qpNH1boPB9pg-IV6d6iHJtnQVbtHHIQrAm7vRG-rk-28Mfytj6Fmk9b3kMMKFQ7ebkbIZ9nBydJqz0Yn3K72gilqiWTKH5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1638526603,"updated":1638526603,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '740'
+      content-length: '730'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:15 GMT
+      date: Fri, 03 Dec 2021 10:16:43 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/?api-version=2016-10-01
 - request:
     body: '{"key_ops": ["decrypt", "encrypt"], "attributes": {"exp": 2524723200},
       "tags": {"foo": "updated tag"}}'
@@ -250,67 +250,67 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/?api-version=2016-10-01
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"wCOfYZfiewtypnbt7a43iFyCpIS2Cz9IH_qJA59nglR03I5UNXCqp8GB_YLqByv25pxx-1wEKv8YYGnt2yo1S5VfcWIJBEkJA8HTK7HlPq1uAubdplww6hQ8Ozn6GvnqF7mP2skYbvoK4RBphas-5JNFGcdPvJVJSEWznKD3MFo4Lkd7bUb14-cZwRYQPirGUh4cfMrm_fIT5jKfQJcpjWduiYAHwXY2J9UVUvB9CQEZ8M0GRZJaZMFXHwAwBcnXMFUU9Ngi1bBYlZX3FvvRCApBdjyTy7GT6woXkxXPpzKCW-Asazxl2m1WNm1N2abu_0m-rAR7gkrT92vccCqOEQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729395,"updated":1633729398,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5w2ynukXJsBZ9VMminyOYQ3xCCiUMjwY10iO7oATIk3whhC-pWwa7uTba8v992cSdRUoPjCVzPpaNmQ5GehmmAVjLsg16NuirOQZoaiyj6Ouwm8e971a4Xfw7bX_LOgWCoSXMGJYDBkXWEgWkJAlI_aF_FDWJTGYw6HsQHkizrzkGRyBgIvi8IJ9ZUDQSpmyBA1_LCEMR-cY1yK0T7sAyK5FoKCV2uqqhtbg3mfEWG1UECbi39veTr1qpNH1boPB9pg-IV6d6iHJtnQVbtHHIQrAm7vRG-rk-28Mfytj6Fmk9b3kMMKFQ7ebkbIZ9nBydJqz0Yn3K72gilqiWTKH5Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526603,"updated":1638526607,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '685'
+      content-length: '675'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:19 GMT
+      date: Fri, 03 Dec 2021 10:16:47 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/?api-version=2016-10-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2","deletedDate":1633729399,"scheduledPurgeDate":1641505399,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"wCOfYZfiewtypnbt7a43iFyCpIS2Cz9IH_qJA59nglR03I5UNXCqp8GB_YLqByv25pxx-1wEKv8YYGnt2yo1S5VfcWIJBEkJA8HTK7HlPq1uAubdplww6hQ8Ozn6GvnqF7mP2skYbvoK4RBphas-5JNFGcdPvJVJSEWznKD3MFo4Lkd7bUb14-cZwRYQPirGUh4cfMrm_fIT5jKfQJcpjWduiYAHwXY2J9UVUvB9CQEZ8M0GRZJaZMFXHwAwBcnXMFUU9Ngi1bBYlZX3FvvRCApBdjyTy7GT6woXkxXPpzKCW-Asazxl2m1WNm1N2abu_0m-rAR7gkrT92vccCqOEQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729395,"updated":1633729398,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2","deletedDate":1638526608,"scheduledPurgeDate":1646302608,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5w2ynukXJsBZ9VMminyOYQ3xCCiUMjwY10iO7oATIk3whhC-pWwa7uTba8v992cSdRUoPjCVzPpaNmQ5GehmmAVjLsg16NuirOQZoaiyj6Ouwm8e971a4Xfw7bX_LOgWCoSXMGJYDBkXWEgWkJAlI_aF_FDWJTGYw6HsQHkizrzkGRyBgIvi8IJ9ZUDQSpmyBA1_LCEMR-cY1yK0T7sAyK5FoKCV2uqqhtbg3mfEWG1UECbi39veTr1qpNH1boPB9pg-IV6d6iHJtnQVbtHHIQrAm7vRG-rk-28Mfytj6Fmk9b3kMMKFQ7ebkbIZ9nBydJqz0Yn3K72gilqiWTKH5Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526603,"updated":1638526607,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '837'
+      content-length: '827'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:19 GMT
+      date: Fri, 03 Dec 2021 10:16:47 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
   response:
@@ -320,77 +320,164 @@ interactions:
       cache-control: no-cache
       content-length: '98'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:19 GMT
+      date: Fri, 03 Dec 2021 10:16:48 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 404
       message: Not Found
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2","deletedDate":1633729399,"scheduledPurgeDate":1641505399,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"wCOfYZfiewtypnbt7a43iFyCpIS2Cz9IH_qJA59nglR03I5UNXCqp8GB_YLqByv25pxx-1wEKv8YYGnt2yo1S5VfcWIJBEkJA8HTK7HlPq1uAubdplww6hQ8Ozn6GvnqF7mP2skYbvoK4RBphas-5JNFGcdPvJVJSEWznKD3MFo4Lkd7bUb14-cZwRYQPirGUh4cfMrm_fIT5jKfQJcpjWduiYAHwXY2J9UVUvB9CQEZ8M0GRZJaZMFXHwAwBcnXMFUU9Ngi1bBYlZX3FvvRCApBdjyTy7GT6woXkxXPpzKCW-Asazxl2m1WNm1N2abu_0m-rAR7gkrT92vccCqOEQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729395,"updated":1633729398,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key97b315d2"}}'
     headers:
       cache-control: no-cache
-      content-length: '837'
+      content-length: '98'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:21 GMT
+      date: Fri, 03 Dec 2021 10:16:50 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
-      code: 200
-      message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2","deletedDate":1633729399,"scheduledPurgeDate":1641505399,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/fc62430edaea4bbd9294b3fb8b42e86f","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"wCOfYZfiewtypnbt7a43iFyCpIS2Cz9IH_qJA59nglR03I5UNXCqp8GB_YLqByv25pxx-1wEKv8YYGnt2yo1S5VfcWIJBEkJA8HTK7HlPq1uAubdplww6hQ8Ozn6GvnqF7mP2skYbvoK4RBphas-5JNFGcdPvJVJSEWznKD3MFo4Lkd7bUb14-cZwRYQPirGUh4cfMrm_fIT5jKfQJcpjWduiYAHwXY2J9UVUvB9CQEZ8M0GRZJaZMFXHwAwBcnXMFUU9Ngi1bBYlZX3FvvRCApBdjyTy7GT6woXkxXPpzKCW-Asazxl2m1WNm1N2abu_0m-rAR7gkrT92vccCqOEQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729395,"updated":1633729398,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key97b315d2"}}'
     headers:
       cache-control: no-cache
-      content-length: '837'
+      content-length: '98'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:21 GMT
+      date: Fri, 03 Dec 2021 10:16:52 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-key97b315d2"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '98'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:16:54 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2","deletedDate":1638526608,"scheduledPurgeDate":1646302608,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5w2ynukXJsBZ9VMminyOYQ3xCCiUMjwY10iO7oATIk3whhC-pWwa7uTba8v992cSdRUoPjCVzPpaNmQ5GehmmAVjLsg16NuirOQZoaiyj6Ouwm8e971a4Xfw7bX_LOgWCoSXMGJYDBkXWEgWkJAlI_aF_FDWJTGYw6HsQHkizrzkGRyBgIvi8IJ9ZUDQSpmyBA1_LCEMR-cY1yK0T7sAyK5FoKCV2uqqhtbg3mfEWG1UECbi39veTr1qpNH1boPB9pg-IV6d6iHJtnQVbtHHIQrAm7vRG-rk-28Mfytj6Fmk9b3kMMKFQ7ebkbIZ9nBydJqz0Yn3K72gilqiWTKH5Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526603,"updated":1638526607,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '827'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:16:58 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2","deletedDate":1638526608,"scheduledPurgeDate":1646302608,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-key97b315d2/168cbe8b0bd1408893b86a4b2735d125","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5w2ynukXJsBZ9VMminyOYQ3xCCiUMjwY10iO7oATIk3whhC-pWwa7uTba8v992cSdRUoPjCVzPpaNmQ5GehmmAVjLsg16NuirOQZoaiyj6Ouwm8e971a4Xfw7bX_LOgWCoSXMGJYDBkXWEgWkJAlI_aF_FDWJTGYw6HsQHkizrzkGRyBgIvi8IJ9ZUDQSpmyBA1_LCEMR-cY1yK0T7sAyK5FoKCV2uqqhtbg3mfEWG1UECbi39veTr1qpNH1boPB9pg-IV6d6iHJtnQVbtHHIQrAm7vRG-rk-28Mfytj6Fmk9b3kMMKFQ7ebkbIZ9nBydJqz0Yn3K72gilqiWTKH5Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526603,"updated":1638526607,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '827'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:16:58 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-key97b315d2?api-version=2016-10-01
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_0_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_0_vault.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/create?api-version=7.0
   response:
@@ -20,56 +20,56 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:23 GMT
+      date: Fri, 03 Dec 2021 10:17:49 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/create?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/create?api-version=7.0
 - request:
-    body: '{"kty": "EC-HSM", "attributes": {"enabled": true}, "tags": {"purpose":
-      "unit test", "test name": "CreateECKeyTest"}}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/87c5dc412fe8439d8a985b58175e7888","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"mZuF09S_JdDdViEGABiIQ6_l37mTa_sqexBvxbaoHBw","y":"xtNAdo4BGOCSVRGcgrxK08rxmyKK0KJXWIGgeBrnWVc"},"attributes":{"enabled":true,"created":1633729403,"updated":1633729403,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/59aeb700eb5c4a438b783ae86b7010b0","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"-WuuQaueqixKgOxridPSTCgeh9QB2VTBDGnaLacmKgA","y":"ncK1IT977Y-J9sY8F_7hV4AlswQ1LdjRUW_FY01ZGXA"},"attributes":{"enabled":true,"created":1638526672,"updated":1638526672,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '451'
+      content-length: '437'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:23 GMT
+      date: Fri, 03 Dec 2021 10:17:52 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/create?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keycff144f/create?api-version=7.0
 - request:
     body: '{"kty": "EC", "crv": "P-256"}'
     headers:
@@ -80,29 +80,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keycff144f/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keycff144f/5a83974ec243483b95a15d1b006a2b46","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"x-o07wODkblkNhaBWr0k_se3BXesVnPz31cn-pReb-8","y":"7UeosarzRPOngCrpdXN7bdvBMWufcvhSaZd02CU47NY"},"attributes":{"enabled":true,"created":1633729406,"updated":1633729406,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keycff144f/185f39c56a72403da0fa72720a97d789","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"91VaylUf-6foRco4fzarVoGu3PZsyMwOX48lWfdoYBY","y":"rr07MvVW7gJu9lE6tPPscnu-LnYFkVn54vKaCvSIsIs"},"attributes":{"enabled":true,"created":1638526674,"updated":1638526674,"recoveryLevel":"Recoverable"}}'
     headers:
       cache-control: no-cache
-      content-length: '392'
+      content-length: '382'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:25 GMT
+      date: Fri, 03 Dec 2021 10:17:54 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-P-256-ec-keycff144f/create?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keycff144f/create?api-version=7.0
 - request:
     body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
       "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
@@ -120,29 +120,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keycff144f?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keycff144f/692f43f1a6034babbfa26f802c188ee9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729406,"updated":1633729406,"recoveryLevel":"Recoverable+Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keycff144f/5eaf9720d61e439d8fa934861ba4ddcb","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638526675,"updated":1638526675,"recoveryLevel":"Recoverable"}}'
     headers:
       cache-control: no-cache
-      content-length: '679'
+      content-length: '669'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:25 GMT
+      date: Fri, 03 Dec 2021 10:17:54 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestimport-test-keycff144f?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keycff144f?api-version=7.0
 - request:
     body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
       "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
@@ -155,90 +155,90 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"05dpRXpqkWIs2VWhtRvSIQf554cPKZTuRqx9ZWEig5BQ3lbKJWQPSogK164Oe25b8yxlqlvKRATYdG8TUa5pUO_yzLhpnvGt7vHIGTYdw8FaX_c6gZBmtQ_9mC7p1Ykrh1aKJjUoXvnGuF9BSqld5IwMVhZv23949lzRZ9RRpfAWNOL4Qx7JeqS5qN86ifPkSRnk6pO_MDso0zmqy5cBG4JcQpk65IKXmFMWPjGNhPgekausb-Tetg8b_x9u_Y8BF4oTVb-m5LdgffMSeF8T2eXFTBZroCwly35Ufw4Kdpe9Fldm6WfiwxKS-867v76UX0r5GPXhbRcnmsmU4R-NdQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729408,"updated":1633729408,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"5mq910ZJBOBlZDTBnKIUBWd9wmYSDRwA6gGRlKu9k-cVkv9NKVx1rd1Tf6w5rNvzKScHT3HQl_FfQsTkZj4uUNewAT8SdqkXzbW3YPoLqnxpyvvUfbCHxs9u5FZmcvaVZ9Q6h04rXl7AagC8fkkezciqC6ngFedsHniq6bQEUWrKGereNznfLDWnW_J9H4laYziZkskPioeOdAnpVjrxxOMRIYru-PS0CXb1s2meJodukiGM-OQ6PBGjMNZOK3y67hn4WWH6wUkvRH3N4GJ7-Ww05ePdZXjtE40z1eNYMHGmk0_olnOhkeTCVtfCHRTeJQtYNCFgfkRgXPa9qu0X2Q","e":"AQAB"},"attributes":{"enabled":true,"created":1638526677,"updated":1638526677,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '739'
+      content-length: '729'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:28 GMT
+      date: Fri, 03 Dec 2021 10:17:57 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/create?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/create?api-version=7.0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"05dpRXpqkWIs2VWhtRvSIQf554cPKZTuRqx9ZWEig5BQ3lbKJWQPSogK164Oe25b8yxlqlvKRATYdG8TUa5pUO_yzLhpnvGt7vHIGTYdw8FaX_c6gZBmtQ_9mC7p1Ykrh1aKJjUoXvnGuF9BSqld5IwMVhZv23949lzRZ9RRpfAWNOL4Qx7JeqS5qN86ifPkSRnk6pO_MDso0zmqy5cBG4JcQpk65IKXmFMWPjGNhPgekausb-Tetg8b_x9u_Y8BF4oTVb-m5LdgffMSeF8T2eXFTBZroCwly35Ufw4Kdpe9Fldm6WfiwxKS-867v76UX0r5GPXhbRcnmsmU4R-NdQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729408,"updated":1633729408,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"5mq910ZJBOBlZDTBnKIUBWd9wmYSDRwA6gGRlKu9k-cVkv9NKVx1rd1Tf6w5rNvzKScHT3HQl_FfQsTkZj4uUNewAT8SdqkXzbW3YPoLqnxpyvvUfbCHxs9u5FZmcvaVZ9Q6h04rXl7AagC8fkkezciqC6ngFedsHniq6bQEUWrKGereNznfLDWnW_J9H4laYziZkskPioeOdAnpVjrxxOMRIYru-PS0CXb1s2meJodukiGM-OQ6PBGjMNZOK3y67hn4WWH6wUkvRH3N4GJ7-Ww05ePdZXjtE40z1eNYMHGmk0_olnOhkeTCVtfCHRTeJQtYNCFgfkRgXPa9qu0X2Q","e":"AQAB"},"attributes":{"enabled":true,"created":1638526677,"updated":1638526677,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '739'
+      content-length: '729'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:28 GMT
+      date: Fri, 03 Dec 2021 10:17:58 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba?api-version=7.0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"05dpRXpqkWIs2VWhtRvSIQf554cPKZTuRqx9ZWEig5BQ3lbKJWQPSogK164Oe25b8yxlqlvKRATYdG8TUa5pUO_yzLhpnvGt7vHIGTYdw8FaX_c6gZBmtQ_9mC7p1Ykrh1aKJjUoXvnGuF9BSqld5IwMVhZv23949lzRZ9RRpfAWNOL4Qx7JeqS5qN86ifPkSRnk6pO_MDso0zmqy5cBG4JcQpk65IKXmFMWPjGNhPgekausb-Tetg8b_x9u_Y8BF4oTVb-m5LdgffMSeF8T2eXFTBZroCwly35Ufw4Kdpe9Fldm6WfiwxKS-867v76UX0r5GPXhbRcnmsmU4R-NdQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729408,"updated":1633729408,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"5mq910ZJBOBlZDTBnKIUBWd9wmYSDRwA6gGRlKu9k-cVkv9NKVx1rd1Tf6w5rNvzKScHT3HQl_FfQsTkZj4uUNewAT8SdqkXzbW3YPoLqnxpyvvUfbCHxs9u5FZmcvaVZ9Q6h04rXl7AagC8fkkezciqC6ngFedsHniq6bQEUWrKGereNznfLDWnW_J9H4laYziZkskPioeOdAnpVjrxxOMRIYru-PS0CXb1s2meJodukiGM-OQ6PBGjMNZOK3y67hn4WWH6wUkvRH3N4GJ7-Ww05ePdZXjtE40z1eNYMHGmk0_olnOhkeTCVtfCHRTeJQtYNCFgfkRgXPa9qu0X2Q","e":"AQAB"},"attributes":{"enabled":true,"created":1638526677,"updated":1638526677,"recoveryLevel":"Recoverable"},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '739'
+      content-length: '729'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:28 GMT
+      date: Fri, 03 Dec 2021 10:17:58 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/?api-version=7.0
 - request:
     body: '{"key_ops": ["decrypt", "encrypt"], "attributes": {"exp": 2524723200},
       "tags": {"foo": "updated tag"}}'
@@ -250,67 +250,67 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"05dpRXpqkWIs2VWhtRvSIQf554cPKZTuRqx9ZWEig5BQ3lbKJWQPSogK164Oe25b8yxlqlvKRATYdG8TUa5pUO_yzLhpnvGt7vHIGTYdw8FaX_c6gZBmtQ_9mC7p1Ykrh1aKJjUoXvnGuF9BSqld5IwMVhZv23949lzRZ9RRpfAWNOL4Qx7JeqS5qN86ifPkSRnk6pO_MDso0zmqy5cBG4JcQpk65IKXmFMWPjGNhPgekausb-Tetg8b_x9u_Y8BF4oTVb-m5LdgffMSeF8T2eXFTBZroCwly35Ufw4Kdpe9Fldm6WfiwxKS-867v76UX0r5GPXhbRcnmsmU4R-NdQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729408,"updated":1633729411,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5mq910ZJBOBlZDTBnKIUBWd9wmYSDRwA6gGRlKu9k-cVkv9NKVx1rd1Tf6w5rNvzKScHT3HQl_FfQsTkZj4uUNewAT8SdqkXzbW3YPoLqnxpyvvUfbCHxs9u5FZmcvaVZ9Q6h04rXl7AagC8fkkezciqC6ngFedsHniq6bQEUWrKGereNznfLDWnW_J9H4laYziZkskPioeOdAnpVjrxxOMRIYru-PS0CXb1s2meJodukiGM-OQ6PBGjMNZOK3y67hn4WWH6wUkvRH3N4GJ7-Ww05ePdZXjtE40z1eNYMHGmk0_olnOhkeTCVtfCHRTeJQtYNCFgfkRgXPa9qu0X2Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526677,"updated":1638526682,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '684'
+      content-length: '674'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:31 GMT
+      date: Fri, 03 Dec 2021 10:18:02 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/?api-version=7.0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f?api-version=7.0
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f","deletedDate":1633729412,"scheduledPurgeDate":1641505412,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"05dpRXpqkWIs2VWhtRvSIQf554cPKZTuRqx9ZWEig5BQ3lbKJWQPSogK164Oe25b8yxlqlvKRATYdG8TUa5pUO_yzLhpnvGt7vHIGTYdw8FaX_c6gZBmtQ_9mC7p1Ykrh1aKJjUoXvnGuF9BSqld5IwMVhZv23949lzRZ9RRpfAWNOL4Qx7JeqS5qN86ifPkSRnk6pO_MDso0zmqy5cBG4JcQpk65IKXmFMWPjGNhPgekausb-Tetg8b_x9u_Y8BF4oTVb-m5LdgffMSeF8T2eXFTBZroCwly35Ufw4Kdpe9Fldm6WfiwxKS-867v76UX0r5GPXhbRcnmsmU4R-NdQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729408,"updated":1633729411,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f","deletedDate":1638526682,"scheduledPurgeDate":1646302682,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5mq910ZJBOBlZDTBnKIUBWd9wmYSDRwA6gGRlKu9k-cVkv9NKVx1rd1Tf6w5rNvzKScHT3HQl_FfQsTkZj4uUNewAT8SdqkXzbW3YPoLqnxpyvvUfbCHxs9u5FZmcvaVZ9Q6h04rXl7AagC8fkkezciqC6ngFedsHniq6bQEUWrKGereNznfLDWnW_J9H4laYziZkskPioeOdAnpVjrxxOMRIYru-PS0CXb1s2meJodukiGM-OQ6PBGjMNZOK3y67hn4WWH6wUkvRH3N4GJ7-Ww05ePdZXjtE40z1eNYMHGmk0_olnOhkeTCVtfCHRTeJQtYNCFgfkRgXPa9qu0X2Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526677,"updated":1638526682,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '835'
+      content-length: '825'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:31 GMT
+      date: Fri, 03 Dec 2021 10:18:02 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f?api-version=7.0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
   response:
@@ -320,77 +320,251 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:31 GMT
+      date: Fri, 03 Dec 2021 10:18:02 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 404
       message: Not Found
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f","deletedDate":1633729412,"scheduledPurgeDate":1641505412,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"05dpRXpqkWIs2VWhtRvSIQf554cPKZTuRqx9ZWEig5BQ3lbKJWQPSogK164Oe25b8yxlqlvKRATYdG8TUa5pUO_yzLhpnvGt7vHIGTYdw8FaX_c6gZBmtQ_9mC7p1Ykrh1aKJjUoXvnGuF9BSqld5IwMVhZv23949lzRZ9RRpfAWNOL4Qx7JeqS5qN86ifPkSRnk6pO_MDso0zmqy5cBG4JcQpk65IKXmFMWPjGNhPgekausb-Tetg8b_x9u_Y8BF4oTVb-m5LdgffMSeF8T2eXFTBZroCwly35Ufw4Kdpe9Fldm6WfiwxKS-867v76UX0r5GPXhbRcnmsmU4R-NdQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729408,"updated":1633729411,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keycff144f"}}'
     headers:
       cache-control: no-cache
-      content-length: '835'
+      content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:34 GMT
+      date: Fri, 03 Dec 2021 10:18:05 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
-      code: 200
-      message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f","deletedDate":1633729412,"scheduledPurgeDate":1641505412,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/55a3d78a6fea46f297897cd8080afd3a","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"05dpRXpqkWIs2VWhtRvSIQf554cPKZTuRqx9ZWEig5BQ3lbKJWQPSogK164Oe25b8yxlqlvKRATYdG8TUa5pUO_yzLhpnvGt7vHIGTYdw8FaX_c6gZBmtQ_9mC7p1Ykrh1aKJjUoXvnGuF9BSqld5IwMVhZv23949lzRZ9RRpfAWNOL4Qx7JeqS5qN86ifPkSRnk6pO_MDso0zmqy5cBG4JcQpk65IKXmFMWPjGNhPgekausb-Tetg8b_x9u_Y8BF4oTVb-m5LdgffMSeF8T2eXFTBZroCwly35Ufw4Kdpe9Fldm6WfiwxKS-867v76UX0r5GPXhbRcnmsmU4R-NdQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729408,"updated":1633729411,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keycff144f"}}'
     headers:
       cache-control: no-cache
-      content-length: '835'
+      content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:34 GMT
+      date: Fri, 03 Dec 2021 10:18:07 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keycff144f"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:18:09 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keycff144f"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:18:12 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keycff144f"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:18:14 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keycff144f"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:18:16 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f","deletedDate":1638526682,"scheduledPurgeDate":1646302682,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5mq910ZJBOBlZDTBnKIUBWd9wmYSDRwA6gGRlKu9k-cVkv9NKVx1rd1Tf6w5rNvzKScHT3HQl_FfQsTkZj4uUNewAT8SdqkXzbW3YPoLqnxpyvvUfbCHxs9u5FZmcvaVZ9Q6h04rXl7AagC8fkkezciqC6ngFedsHniq6bQEUWrKGereNznfLDWnW_J9H4laYziZkskPioeOdAnpVjrxxOMRIYru-PS0CXb1s2meJodukiGM-OQ6PBGjMNZOK3y67hn4WWH6wUkvRH3N4GJ7-Ww05ePdZXjtE40z1eNYMHGmk0_olnOhkeTCVtfCHRTeJQtYNCFgfkRgXPa9qu0X2Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526677,"updated":1638526682,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '825'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:18:19 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f","deletedDate":1638526682,"scheduledPurgeDate":1646302682,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keycff144f/05ce77f8fa7a4a6ebfddfe482ecff7ba","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"5mq910ZJBOBlZDTBnKIUBWd9wmYSDRwA6gGRlKu9k-cVkv9NKVx1rd1Tf6w5rNvzKScHT3HQl_FfQsTkZj4uUNewAT8SdqkXzbW3YPoLqnxpyvvUfbCHxs9u5FZmcvaVZ9Q6h04rXl7AagC8fkkezciqC6ngFedsHniq6bQEUWrKGereNznfLDWnW_J9H4laYziZkskPioeOdAnpVjrxxOMRIYru-PS0CXb1s2meJodukiGM-OQ6PBGjMNZOK3y67hn4WWH6wUkvRH3N4GJ7-Ww05ePdZXjtE40z1eNYMHGmk0_olnOhkeTCVtfCHRTeJQtYNCFgfkRgXPa9qu0X2Q","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526677,"updated":1638526682,"recoveryLevel":"Recoverable"},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '825'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:18:19 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keycff144f?api-version=7.0
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_1_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_1_vault.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/create?api-version=7.1
   response:
@@ -20,56 +20,56 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:35 GMT
+      date: Fri, 03 Dec 2021 10:18:59 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/create?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/create?api-version=7.1
 - request:
-    body: '{"kty": "EC-HSM", "attributes": {"enabled": true}, "tags": {"purpose":
-      "unit test", "test name": "CreateECKeyTest"}}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/1847e5518a4644109848eeba7c353fee","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"yBYRaS42-COHuONSDL0a5crkTk-dPNoTrOCCaN7xRJU","y":"v8bD2hlQ23KAQ4OQqItbNj2jAuiSGHh5HV0PvjSB3pQ"},"attributes":{"enabled":true,"created":1633729416,"updated":1633729416,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/84227bfee68643998d6eb1b603a4b53a","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"CFiUpabjzhs0Kgzt8xLxvSOmqu1W0mighjbJFhtisck","y":"HxJlmeDw9WYUHmfVOX2u-Sd-yPraut5nv04bMquYegg"},"attributes":{"enabled":true,"created":1638526741,"updated":1638526741,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '472'
+      content-length: '458'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:38 GMT
+      date: Fri, 03 Dec 2021 10:19:01 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/create?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd061450/create?api-version=7.1
 - request:
     body: '{"kty": "EC", "crv": "P-256"}'
     headers:
@@ -80,29 +80,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd061450/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd061450/f0ebb220ee7942a28572e5a4cdb9fae1","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"JJrHwJ7hN47gHYVdF7qelL81wOcQToZ6eJOUFOwz5wA","y":"zSQKS-eJj7qjpXvVaLWaQILpZDqxExyU-1JnX6IsYAE"},"attributes":{"enabled":true,"created":1633729420,"updated":1633729420,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd061450/6b898a5532ff4651b10c7e18e9cb326d","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"PtiL2uOnd_d6ru9YgrlNdjBowOLX9O8SzI_F7O-l6uc","y":"plugKjB3Gax_iR3dFlRHW0oan6rG1-eFSwtcmJtRkjI"},"attributes":{"enabled":true,"created":1638526744,"updated":1638526744,"recoveryLevel":"Recoverable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
-      content-length: '413'
+      content-length: '403'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:40 GMT
+      date: Fri, 03 Dec 2021 10:19:03 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd061450/create?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd061450/create?api-version=7.1
 - request:
     body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
       "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
@@ -120,29 +120,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd061450?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd061450/301e505c1a864e7b9365b543ab0003f5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729420,"updated":1633729420,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd061450/19d9fe61f77a41ff81e33712343162e9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638526744,"updated":1638526744,"recoveryLevel":"Recoverable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
-      content-length: '700'
+      content-length: '690'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:40 GMT
+      date: Fri, 03 Dec 2021 10:19:04 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestimport-test-keyd061450?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd061450?api-version=7.1
 - request:
     body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
       "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
@@ -155,90 +155,90 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/create?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1Nl26S4CgSOxkhmEDa44891Jd74ujMNNz2HQoW8h7Sx9dDyYGohzyKMcAxdvevEOtBFHPlabr3jI5lGCaoF-utHuRp2hoiGpON_EAvD25CsXi-wTXA75ADSLbpCGb6zbq5C5Xz3q9Fy3i6BjXY2ZLO2By_iZUnoEhvv3knbW9el72lXRUs3TA16b-l_GzclKcK5FUl7oH1oHgHOA3MwPSowncuA4_zu8QsoMDkUFLoh0L6uoVzh-WMKQHiS9E9RD6FWQ-lIXLeZUxBQ1wLao1I3N3Aw-gA0-OVi2Cw9-KT__Tpgx2To84wyA8Axpr1yyp1JRohVJnNrr8nZz8iWlHQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729423,"updated":1633729423,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zmgm6hwzHv7DbnpQjmUKr8tsT2Qos93pQ4cggtdYnrCN3VGVSIhupjXwk5O3lITfccDioyLxzNW1K_NwifZYKUV46kBVPaK3t1GyzB0ULML9ngLx8V4UUArIrLz6_pA-sfEHMO_LNF13X4f0jGm_9ZrA24OfN4embOtkCsr4DgULkOlsfZByqDNUZ7MnTX4g2Pa0sckN6trnbyDKxjQYLANdpHuGLP0VzzQhCBqHLDrICL4d_8Iafkoc7rAH_4mjP_XOOcGQhuvayPQJ3tCtWdyspQ0hMAa9Ng334r6Dr1lK7Y3BINOmXd1HDTRBWlwCwX_a59DmCLJaRFz7PpYBSQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638526746,"updated":1638526746,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '760'
+      content-length: '750'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:42 GMT
+      date: Fri, 03 Dec 2021 10:19:06 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/create?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/create?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d?api-version=7.1
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1Nl26S4CgSOxkhmEDa44891Jd74ujMNNz2HQoW8h7Sx9dDyYGohzyKMcAxdvevEOtBFHPlabr3jI5lGCaoF-utHuRp2hoiGpON_EAvD25CsXi-wTXA75ADSLbpCGb6zbq5C5Xz3q9Fy3i6BjXY2ZLO2By_iZUnoEhvv3knbW9el72lXRUs3TA16b-l_GzclKcK5FUl7oH1oHgHOA3MwPSowncuA4_zu8QsoMDkUFLoh0L6uoVzh-WMKQHiS9E9RD6FWQ-lIXLeZUxBQ1wLao1I3N3Aw-gA0-OVi2Cw9-KT__Tpgx2To84wyA8Axpr1yyp1JRohVJnNrr8nZz8iWlHQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729423,"updated":1633729423,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zmgm6hwzHv7DbnpQjmUKr8tsT2Qos93pQ4cggtdYnrCN3VGVSIhupjXwk5O3lITfccDioyLxzNW1K_NwifZYKUV46kBVPaK3t1GyzB0ULML9ngLx8V4UUArIrLz6_pA-sfEHMO_LNF13X4f0jGm_9ZrA24OfN4embOtkCsr4DgULkOlsfZByqDNUZ7MnTX4g2Pa0sckN6trnbyDKxjQYLANdpHuGLP0VzzQhCBqHLDrICL4d_8Iafkoc7rAH_4mjP_XOOcGQhuvayPQJ3tCtWdyspQ0hMAa9Ng334r6Dr1lK7Y3BINOmXd1HDTRBWlwCwX_a59DmCLJaRFz7PpYBSQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638526746,"updated":1638526746,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '760'
+      content-length: '750'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:43 GMT
+      date: Fri, 03 Dec 2021 10:19:06 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1Nl26S4CgSOxkhmEDa44891Jd74ujMNNz2HQoW8h7Sx9dDyYGohzyKMcAxdvevEOtBFHPlabr3jI5lGCaoF-utHuRp2hoiGpON_EAvD25CsXi-wTXA75ADSLbpCGb6zbq5C5Xz3q9Fy3i6BjXY2ZLO2By_iZUnoEhvv3knbW9el72lXRUs3TA16b-l_GzclKcK5FUl7oH1oHgHOA3MwPSowncuA4_zu8QsoMDkUFLoh0L6uoVzh-WMKQHiS9E9RD6FWQ-lIXLeZUxBQ1wLao1I3N3Aw-gA0-OVi2Cw9-KT__Tpgx2To84wyA8Axpr1yyp1JRohVJnNrr8nZz8iWlHQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729423,"updated":1633729423,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zmgm6hwzHv7DbnpQjmUKr8tsT2Qos93pQ4cggtdYnrCN3VGVSIhupjXwk5O3lITfccDioyLxzNW1K_NwifZYKUV46kBVPaK3t1GyzB0ULML9ngLx8V4UUArIrLz6_pA-sfEHMO_LNF13X4f0jGm_9ZrA24OfN4embOtkCsr4DgULkOlsfZByqDNUZ7MnTX4g2Pa0sckN6trnbyDKxjQYLANdpHuGLP0VzzQhCBqHLDrICL4d_8Iafkoc7rAH_4mjP_XOOcGQhuvayPQJ3tCtWdyspQ0hMAa9Ng334r6Dr1lK7Y3BINOmXd1HDTRBWlwCwX_a59DmCLJaRFz7PpYBSQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638526746,"updated":1638526746,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '760'
+      content-length: '750'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:43 GMT
+      date: Fri, 03 Dec 2021 10:19:07 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/?api-version=7.1
 - request:
     body: '{"key_ops": ["decrypt", "encrypt"], "attributes": {"exp": 2524723200},
       "tags": {"foo": "updated tag"}}'
@@ -250,67 +250,67 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/?api-version=7.1
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"1Nl26S4CgSOxkhmEDa44891Jd74ujMNNz2HQoW8h7Sx9dDyYGohzyKMcAxdvevEOtBFHPlabr3jI5lGCaoF-utHuRp2hoiGpON_EAvD25CsXi-wTXA75ADSLbpCGb6zbq5C5Xz3q9Fy3i6BjXY2ZLO2By_iZUnoEhvv3knbW9el72lXRUs3TA16b-l_GzclKcK5FUl7oH1oHgHOA3MwPSowncuA4_zu8QsoMDkUFLoh0L6uoVzh-WMKQHiS9E9RD6FWQ-lIXLeZUxBQ1wLao1I3N3Aw-gA0-OVi2Cw9-KT__Tpgx2To84wyA8Axpr1yyp1JRohVJnNrr8nZz8iWlHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729423,"updated":1633729426,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"zmgm6hwzHv7DbnpQjmUKr8tsT2Qos93pQ4cggtdYnrCN3VGVSIhupjXwk5O3lITfccDioyLxzNW1K_NwifZYKUV46kBVPaK3t1GyzB0ULML9ngLx8V4UUArIrLz6_pA-sfEHMO_LNF13X4f0jGm_9ZrA24OfN4embOtkCsr4DgULkOlsfZByqDNUZ7MnTX4g2Pa0sckN6trnbyDKxjQYLANdpHuGLP0VzzQhCBqHLDrICL4d_8Iafkoc7rAH_4mjP_XOOcGQhuvayPQJ3tCtWdyspQ0hMAa9Ng334r6Dr1lK7Y3BINOmXd1HDTRBWlwCwX_a59DmCLJaRFz7PpYBSQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526746,"updated":1638526751,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '705'
+      content-length: '695'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:45 GMT
+      date: Fri, 03 Dec 2021 10:19:11 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450?api-version=7.1
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450","deletedDate":1633729426,"scheduledPurgeDate":1641505426,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"1Nl26S4CgSOxkhmEDa44891Jd74ujMNNz2HQoW8h7Sx9dDyYGohzyKMcAxdvevEOtBFHPlabr3jI5lGCaoF-utHuRp2hoiGpON_EAvD25CsXi-wTXA75ADSLbpCGb6zbq5C5Xz3q9Fy3i6BjXY2ZLO2By_iZUnoEhvv3knbW9el72lXRUs3TA16b-l_GzclKcK5FUl7oH1oHgHOA3MwPSowncuA4_zu8QsoMDkUFLoh0L6uoVzh-WMKQHiS9E9RD6FWQ-lIXLeZUxBQ1wLao1I3N3Aw-gA0-OVi2Cw9-KT__Tpgx2To84wyA8Axpr1yyp1JRohVJnNrr8nZz8iWlHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729423,"updated":1633729426,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450","deletedDate":1638526751,"scheduledPurgeDate":1646302751,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"zmgm6hwzHv7DbnpQjmUKr8tsT2Qos93pQ4cggtdYnrCN3VGVSIhupjXwk5O3lITfccDioyLxzNW1K_NwifZYKUV46kBVPaK3t1GyzB0ULML9ngLx8V4UUArIrLz6_pA-sfEHMO_LNF13X4f0jGm_9ZrA24OfN4embOtkCsr4DgULkOlsfZByqDNUZ7MnTX4g2Pa0sckN6trnbyDKxjQYLANdpHuGLP0VzzQhCBqHLDrICL4d_8Iafkoc7rAH_4mjP_XOOcGQhuvayPQJ3tCtWdyspQ0hMAa9Ng334r6Dr1lK7Y3BINOmXd1HDTRBWlwCwX_a59DmCLJaRFz7PpYBSQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526746,"updated":1638526751,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '856'
+      content-length: '846'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:45 GMT
+      date: Fri, 03 Dec 2021 10:19:11 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
   response:
@@ -320,26 +320,26 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:46 GMT
+      date: Fri, 03 Dec 2021 10:19:12 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 404
       message: Not Found
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
   response:
@@ -349,77 +349,164 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:48 GMT
+      date: Fri, 03 Dec 2021 10:19:14 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 404
       message: Not Found
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450","deletedDate":1633729426,"scheduledPurgeDate":1641505426,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"1Nl26S4CgSOxkhmEDa44891Jd74ujMNNz2HQoW8h7Sx9dDyYGohzyKMcAxdvevEOtBFHPlabr3jI5lGCaoF-utHuRp2hoiGpON_EAvD25CsXi-wTXA75ADSLbpCGb6zbq5C5Xz3q9Fy3i6BjXY2ZLO2By_iZUnoEhvv3knbW9el72lXRUs3TA16b-l_GzclKcK5FUl7oH1oHgHOA3MwPSowncuA4_zu8QsoMDkUFLoh0L6uoVzh-WMKQHiS9E9RD6FWQ-lIXLeZUxBQ1wLao1I3N3Aw-gA0-OVi2Cw9-KT__Tpgx2To84wyA8Axpr1yyp1JRohVJnNrr8nZz8iWlHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729423,"updated":1633729426,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keyd061450"}}'
     headers:
       cache-control: no-cache
-      content-length: '856'
+      content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:50 GMT
+      date: Fri, 03 Dec 2021 10:19:16 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
-      code: 200
-      message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450","deletedDate":1633729426,"scheduledPurgeDate":1641505426,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/185d4b5d38ea48ac96a60307c47a106d","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"1Nl26S4CgSOxkhmEDa44891Jd74ujMNNz2HQoW8h7Sx9dDyYGohzyKMcAxdvevEOtBFHPlabr3jI5lGCaoF-utHuRp2hoiGpON_EAvD25CsXi-wTXA75ADSLbpCGb6zbq5C5Xz3q9Fy3i6BjXY2ZLO2By_iZUnoEhvv3knbW9el72lXRUs3TA16b-l_GzclKcK5FUl7oH1oHgHOA3MwPSowncuA4_zu8QsoMDkUFLoh0L6uoVzh-WMKQHiS9E9RD6FWQ-lIXLeZUxBQ1wLao1I3N3Aw-gA0-OVi2Cw9-KT__Tpgx2To84wyA8Axpr1yyp1JRohVJnNrr8nZz8iWlHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729423,"updated":1633729426,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keyd061450"}}'
     headers:
       cache-control: no-cache
-      content-length: '856'
+      content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:43:50 GMT
+      date: Fri, 03 Dec 2021 10:19:18 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keyd061450"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:19:21 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450","deletedDate":1638526751,"scheduledPurgeDate":1646302751,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"zmgm6hwzHv7DbnpQjmUKr8tsT2Qos93pQ4cggtdYnrCN3VGVSIhupjXwk5O3lITfccDioyLxzNW1K_NwifZYKUV46kBVPaK3t1GyzB0ULML9ngLx8V4UUArIrLz6_pA-sfEHMO_LNF13X4f0jGm_9ZrA24OfN4embOtkCsr4DgULkOlsfZByqDNUZ7MnTX4g2Pa0sckN6trnbyDKxjQYLANdpHuGLP0VzzQhCBqHLDrICL4d_8Iafkoc7rAH_4mjP_XOOcGQhuvayPQJ3tCtWdyspQ0hMAa9Ng334r6Dr1lK7Y3BINOmXd1HDTRBWlwCwX_a59DmCLJaRFz7PpYBSQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526746,"updated":1638526751,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '846'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:19:23 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450","deletedDate":1638526751,"scheduledPurgeDate":1646302751,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd061450/09a6f1a869e14467bede89b258f68126","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"zmgm6hwzHv7DbnpQjmUKr8tsT2Qos93pQ4cggtdYnrCN3VGVSIhupjXwk5O3lITfccDioyLxzNW1K_NwifZYKUV46kBVPaK3t1GyzB0ULML9ngLx8V4UUArIrLz6_pA-sfEHMO_LNF13X4f0jGm_9ZrA24OfN4embOtkCsr4DgULkOlsfZByqDNUZ7MnTX4g2Pa0sckN6trnbyDKxjQYLANdpHuGLP0VzzQhCBqHLDrICL4d_8Iafkoc7rAH_4mjP_XOOcGQhuvayPQJ3tCtWdyspQ0hMAa9Ng334r6Dr1lK7Y3BINOmXd1HDTRBWlwCwX_a59DmCLJaRFz7PpYBSQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638526746,"updated":1638526751,"recoveryLevel":"Recoverable","recoverableDays":90},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '846'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 10:19:24 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd061450?api-version=7.1
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_2_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_2_vault.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/create?api-version=7.2
   response:
@@ -20,56 +20,56 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:04 GMT
+      date: Fri, 03 Dec 2021 06:27:56 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/create?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/create?api-version=7.2
 - request:
-    body: '{"kty": "EC-HSM", "attributes": {"enabled": true}, "tags": {"purpose":
-      "unit test", "test name": "CreateECKeyTest"}}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/d56c9099c7644410ad5eb24cd0d25eb0","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"ZBCIgws3elGwYb6co-6qGgUSOsRiy-KwqcAC9licoYU","y":"lEJ3os6ajdvggnQSYV0pPso0AWDdXVdwLzVWOsI1wG0"},"attributes":{"enabled":true,"created":1633729444,"updated":1633729444,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/5d3ce5c0e71f4eb19a80d6fb729e1fb4","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"U8sN1orKgS3ZMz54PmJsFSCtY6jnQdnIXkFZSVdzgBI","y":"4mjuWtbWTHdCvcFaGa6wi3DII1Bc-Yu-t-6y5Wja8Dg"},"attributes":{"enabled":true,"created":1638512878,"updated":1638512878,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '472'
+      content-length: '470'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:04 GMT
+      date: Fri, 03 Dec 2021 06:27:57 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/create?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keyd0d1451/create?api-version=7.2
 - request:
     body: '{"kty": "EC", "crv": "P-256"}'
     headers:
@@ -80,29 +80,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd0d1451/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd0d1451/619220a483cb4d049320296b3432f7dd","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"vgOyPXQf3mIBKV6nGbSfHMcWYpMxEPCL7mQTprMxcb8","y":"lZxUDAUn98Xh4kUSf_IO6JdON0ZV1fTYYdwx3zC7b0w"},"attributes":{"enabled":true,"created":1633729447,"updated":1633729447,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd0d1451/c99f027ee2f24e5b90775d9df2d4333d","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"h_96UyOw_QmCIietZN2i9jVAnoFj0-xLU6i_3Sp7XyY","y":"fbwQfOuQDCAoVrIKHTpaKGX7WxTO3Gc09lswSzkW4V8"},"attributes":{"enabled":true,"created":1638512880,"updated":1638512880,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
-      content-length: '413'
+      content-length: '415'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:06 GMT
+      date: Fri, 03 Dec 2021 06:28:00 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd0d1451/create?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keyd0d1451/create?api-version=7.2
 - request:
     body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
       "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
@@ -120,29 +120,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd0d1451?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd0d1451/289e131ee76d4672921f46b348c6b5fc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729447,"updated":1633729447,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd0d1451/874191e38d7645df83038175acc270f7","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512881,"updated":1638512881,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
-      content-length: '700'
+      content-length: '702'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:06 GMT
+      date: Fri, 03 Dec 2021 06:28:00 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestimport-test-keyd0d1451?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keyd0d1451?api-version=7.2
 - request:
     body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
       "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
@@ -155,90 +155,90 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/create?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"qxxIyHWfgVi9D4o2wcxVTK-LJmWQDzD6ILTNXEhArMJS67d9bt7_FZ4yHE2LuoW7pn4zw67u-h5kxHBNxWpsQvFSRrfETubpG92--79UCJB4VU5tChvhYfwN65BeoHeHv5aoeV7QZLDionpGEm7Iw2_Dy_It_L_Jnb6c800L7OwwLMc5rpWMlFaYlNIIruWBN6j7OgUUuxcGYTfuWwEbvizb1WyirBnA8at3sdj3rl_2P0fEZKqs6miVQ2PpANMqHjw30DcaFj3n1a7fPuE-lWd2HUivWFRQQNE8xNNjYji79EYzmCVH200q1ygdE7bV14JvaybpT6M4CqMjsfNQaQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729449,"updated":1633729449,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6SZTXcdqMfor1yAcmtDM-FBKNYRqj2LR9PM_0IYmaXqYrWj37BvXJfBV6gbXNYCiZrkY1WH56sYUTferbB3oNNIxVXL0W2IlqOvb1p3PU91BvU9PshSsldnSrQVv9U-6zyLuWCgySe6Lc9n_TQLbfnv6Hm2dgTpSlGvoKQl7_D_FS9qfVbpS2ebKyegb8nnxzfSYc5ucCnTgI9YhxPWZZq5YNci0v0CsmNOPjaSqiyk673cymO9ZdBZb9UWhkUqqnzBbFiRhqPdYdwq2Fq5ILjQwnKa2D65JYnuYq04-o_awqlF5gFmwyHyQ3ilfXGGsPNNtclvlVMdV9ealmxXhgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512883,"updated":1638512883,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '760'
+      content-length: '762'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:09 GMT
+      date: Fri, 03 Dec 2021 06:28:03 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/create?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/create?api-version=7.2
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515?api-version=7.2
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"qxxIyHWfgVi9D4o2wcxVTK-LJmWQDzD6ILTNXEhArMJS67d9bt7_FZ4yHE2LuoW7pn4zw67u-h5kxHBNxWpsQvFSRrfETubpG92--79UCJB4VU5tChvhYfwN65BeoHeHv5aoeV7QZLDionpGEm7Iw2_Dy_It_L_Jnb6c800L7OwwLMc5rpWMlFaYlNIIruWBN6j7OgUUuxcGYTfuWwEbvizb1WyirBnA8at3sdj3rl_2P0fEZKqs6miVQ2PpANMqHjw30DcaFj3n1a7fPuE-lWd2HUivWFRQQNE8xNNjYji79EYzmCVH200q1ygdE7bV14JvaybpT6M4CqMjsfNQaQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729449,"updated":1633729449,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6SZTXcdqMfor1yAcmtDM-FBKNYRqj2LR9PM_0IYmaXqYrWj37BvXJfBV6gbXNYCiZrkY1WH56sYUTferbB3oNNIxVXL0W2IlqOvb1p3PU91BvU9PshSsldnSrQVv9U-6zyLuWCgySe6Lc9n_TQLbfnv6Hm2dgTpSlGvoKQl7_D_FS9qfVbpS2ebKyegb8nnxzfSYc5ucCnTgI9YhxPWZZq5YNci0v0CsmNOPjaSqiyk673cymO9ZdBZb9UWhkUqqnzBbFiRhqPdYdwq2Fq5ILjQwnKa2D65JYnuYq04-o_awqlF5gFmwyHyQ3ilfXGGsPNNtclvlVMdV9ealmxXhgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512883,"updated":1638512883,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '760'
+      content-length: '762'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:09 GMT
+      date: Fri, 03 Dec 2021 06:28:04 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161?api-version=7.2
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"qxxIyHWfgVi9D4o2wcxVTK-LJmWQDzD6ILTNXEhArMJS67d9bt7_FZ4yHE2LuoW7pn4zw67u-h5kxHBNxWpsQvFSRrfETubpG92--79UCJB4VU5tChvhYfwN65BeoHeHv5aoeV7QZLDionpGEm7Iw2_Dy_It_L_Jnb6c800L7OwwLMc5rpWMlFaYlNIIruWBN6j7OgUUuxcGYTfuWwEbvizb1WyirBnA8at3sdj3rl_2P0fEZKqs6miVQ2PpANMqHjw30DcaFj3n1a7fPuE-lWd2HUivWFRQQNE8xNNjYji79EYzmCVH200q1ygdE7bV14JvaybpT6M4CqMjsfNQaQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729449,"updated":1633729449,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6SZTXcdqMfor1yAcmtDM-FBKNYRqj2LR9PM_0IYmaXqYrWj37BvXJfBV6gbXNYCiZrkY1WH56sYUTferbB3oNNIxVXL0W2IlqOvb1p3PU91BvU9PshSsldnSrQVv9U-6zyLuWCgySe6Lc9n_TQLbfnv6Hm2dgTpSlGvoKQl7_D_FS9qfVbpS2ebKyegb8nnxzfSYc5ucCnTgI9YhxPWZZq5YNci0v0CsmNOPjaSqiyk673cymO9ZdBZb9UWhkUqqnzBbFiRhqPdYdwq2Fq5ILjQwnKa2D65JYnuYq04-o_awqlF5gFmwyHyQ3ilfXGGsPNNtclvlVMdV9ealmxXhgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512883,"updated":1638512883,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '760'
+      content-length: '762'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:09 GMT
+      date: Fri, 03 Dec 2021 06:28:04 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/?api-version=7.2
 - request:
     body: '{"key_ops": ["decrypt", "encrypt"], "attributes": {"exp": 2524723200},
       "tags": {"foo": "updated tag"}}'
@@ -250,67 +250,67 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/?api-version=7.2
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"qxxIyHWfgVi9D4o2wcxVTK-LJmWQDzD6ILTNXEhArMJS67d9bt7_FZ4yHE2LuoW7pn4zw67u-h5kxHBNxWpsQvFSRrfETubpG92--79UCJB4VU5tChvhYfwN65BeoHeHv5aoeV7QZLDionpGEm7Iw2_Dy_It_L_Jnb6c800L7OwwLMc5rpWMlFaYlNIIruWBN6j7OgUUuxcGYTfuWwEbvizb1WyirBnA8at3sdj3rl_2P0fEZKqs6miVQ2PpANMqHjw30DcaFj3n1a7fPuE-lWd2HUivWFRQQNE8xNNjYji79EYzmCVH200q1ygdE7bV14JvaybpT6M4CqMjsfNQaQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729449,"updated":1633729453,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6SZTXcdqMfor1yAcmtDM-FBKNYRqj2LR9PM_0IYmaXqYrWj37BvXJfBV6gbXNYCiZrkY1WH56sYUTferbB3oNNIxVXL0W2IlqOvb1p3PU91BvU9PshSsldnSrQVv9U-6zyLuWCgySe6Lc9n_TQLbfnv6Hm2dgTpSlGvoKQl7_D_FS9qfVbpS2ebKyegb8nnxzfSYc5ucCnTgI9YhxPWZZq5YNci0v0CsmNOPjaSqiyk673cymO9ZdBZb9UWhkUqqnzBbFiRhqPdYdwq2Fq5ILjQwnKa2D65JYnuYq04-o_awqlF5gFmwyHyQ3ilfXGGsPNNtclvlVMdV9ealmxXhgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512883,"updated":1638512888,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '705'
+      content-length: '707'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:12 GMT
+      date: Fri, 03 Dec 2021 06:28:07 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/?api-version=7.2
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451","deletedDate":1633729453,"scheduledPurgeDate":1641505453,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"qxxIyHWfgVi9D4o2wcxVTK-LJmWQDzD6ILTNXEhArMJS67d9bt7_FZ4yHE2LuoW7pn4zw67u-h5kxHBNxWpsQvFSRrfETubpG92--79UCJB4VU5tChvhYfwN65BeoHeHv5aoeV7QZLDionpGEm7Iw2_Dy_It_L_Jnb6c800L7OwwLMc5rpWMlFaYlNIIruWBN6j7OgUUuxcGYTfuWwEbvizb1WyirBnA8at3sdj3rl_2P0fEZKqs6miVQ2PpANMqHjw30DcaFj3n1a7fPuE-lWd2HUivWFRQQNE8xNNjYji79EYzmCVH200q1ygdE7bV14JvaybpT6M4CqMjsfNQaQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729449,"updated":1633729453,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451","deletedDate":1638512888,"scheduledPurgeDate":1646288888,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6SZTXcdqMfor1yAcmtDM-FBKNYRqj2LR9PM_0IYmaXqYrWj37BvXJfBV6gbXNYCiZrkY1WH56sYUTferbB3oNNIxVXL0W2IlqOvb1p3PU91BvU9PshSsldnSrQVv9U-6zyLuWCgySe6Lc9n_TQLbfnv6Hm2dgTpSlGvoKQl7_D_FS9qfVbpS2ebKyegb8nnxzfSYc5ucCnTgI9YhxPWZZq5YNci0v0CsmNOPjaSqiyk673cymO9ZdBZb9UWhkUqqnzBbFiRhqPdYdwq2Fq5ILjQwnKa2D65JYnuYq04-o_awqlF5gFmwyHyQ3ilfXGGsPNNtclvlVMdV9ealmxXhgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512883,"updated":1638512888,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '856'
+      content-length: '860'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:12 GMT
+      date: Fri, 03 Dec 2021 06:28:08 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
   response:
@@ -320,26 +320,26 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:12 GMT
+      date: Fri, 03 Dec 2021 06:28:08 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 404
       message: Not Found
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
   response:
@@ -349,77 +349,193 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:14 GMT
+      date: Fri, 03 Dec 2021 06:28:10 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 404
       message: Not Found
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451","deletedDate":1633729453,"scheduledPurgeDate":1641505453,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"qxxIyHWfgVi9D4o2wcxVTK-LJmWQDzD6ILTNXEhArMJS67d9bt7_FZ4yHE2LuoW7pn4zw67u-h5kxHBNxWpsQvFSRrfETubpG92--79UCJB4VU5tChvhYfwN65BeoHeHv5aoeV7QZLDionpGEm7Iw2_Dy_It_L_Jnb6c800L7OwwLMc5rpWMlFaYlNIIruWBN6j7OgUUuxcGYTfuWwEbvizb1WyirBnA8at3sdj3rl_2P0fEZKqs6miVQ2PpANMqHjw30DcaFj3n1a7fPuE-lWd2HUivWFRQQNE8xNNjYji79EYzmCVH200q1ygdE7bV14JvaybpT6M4CqMjsfNQaQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729449,"updated":1633729453,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keyd0d1451"}}'
     headers:
       cache-control: no-cache
-      content-length: '856'
+      content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:17 GMT
+      date: Fri, 03 Dec 2021 06:28:13 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
-      code: 200
-      message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451","deletedDate":1633729453,"scheduledPurgeDate":1641505453,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/9ba0ac6c14ed4422b3214b50405df515","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"qxxIyHWfgVi9D4o2wcxVTK-LJmWQDzD6ILTNXEhArMJS67d9bt7_FZ4yHE2LuoW7pn4zw67u-h5kxHBNxWpsQvFSRrfETubpG92--79UCJB4VU5tChvhYfwN65BeoHeHv5aoeV7QZLDionpGEm7Iw2_Dy_It_L_Jnb6c800L7OwwLMc5rpWMlFaYlNIIruWBN6j7OgUUuxcGYTfuWwEbvizb1WyirBnA8at3sdj3rl_2P0fEZKqs6miVQ2PpANMqHjw30DcaFj3n1a7fPuE-lWd2HUivWFRQQNE8xNNjYji79EYzmCVH200q1ygdE7bV14JvaybpT6M4CqMjsfNQaQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729449,"updated":1633729453,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keyd0d1451"}}'
     headers:
       cache-control: no-cache
-      content-length: '856'
+      content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:17 GMT
+      date: Fri, 03 Dec 2021 06:28:15 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keyd0d1451"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:28:17 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keyd0d1451"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '97'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:28:20 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451","deletedDate":1638512888,"scheduledPurgeDate":1646288888,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6SZTXcdqMfor1yAcmtDM-FBKNYRqj2LR9PM_0IYmaXqYrWj37BvXJfBV6gbXNYCiZrkY1WH56sYUTferbB3oNNIxVXL0W2IlqOvb1p3PU91BvU9PshSsldnSrQVv9U-6zyLuWCgySe6Lc9n_TQLbfnv6Hm2dgTpSlGvoKQl7_D_FS9qfVbpS2ebKyegb8nnxzfSYc5ucCnTgI9YhxPWZZq5YNci0v0CsmNOPjaSqiyk673cymO9ZdBZb9UWhkUqqnzBbFiRhqPdYdwq2Fq5ILjQwnKa2D65JYnuYq04-o_awqlF5gFmwyHyQ3ilfXGGsPNNtclvlVMdV9ealmxXhgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512883,"updated":1638512888,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '860'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:28:23 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451","deletedDate":1638512888,"scheduledPurgeDate":1646288888,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keyd0d1451/8ae6076d780842d3a91cee4d116d5161","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"6SZTXcdqMfor1yAcmtDM-FBKNYRqj2LR9PM_0IYmaXqYrWj37BvXJfBV6gbXNYCiZrkY1WH56sYUTferbB3oNNIxVXL0W2IlqOvb1p3PU91BvU9PshSsldnSrQVv9U-6zyLuWCgySe6Lc9n_TQLbfnv6Hm2dgTpSlGvoKQl7_D_FS9qfVbpS2ebKyegb8nnxzfSYc5ucCnTgI9YhxPWZZq5YNci0v0CsmNOPjaSqiyk673cymO9ZdBZb9UWhkUqqnzBbFiRhqPdYdwq2Fq5ILjQwnKa2D65JYnuYq04-o_awqlF5gFmwyHyQ3ilfXGGsPNNtclvlVMdV9ealmxXhgQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512883,"updated":1638512888,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '860'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:28:23 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keyd0d1451?api-version=7.2
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_3_preview_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_crud_operations_7_3_preview_vault.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/create?api-version=7.3-preview
   response:
@@ -20,56 +20,56 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:31 GMT
+      date: Fri, 03 Dec 2021 06:29:43 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/create?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/create?api-version=7.3-preview
 - request:
-    body: '{"kty": "EC-HSM", "attributes": {"enabled": true}, "tags": {"purpose":
-      "unit test", "test name": "CreateECKeyTest"}}'
+    body: '{"kty": "EC", "attributes": {"enabled": true}, "tags": {"purpose": "unit
+      test", "test name": "CreateECKeyTest"}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '116'
+      - '112'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/902df1caa45c468da42e5ac9d647c9c4","kty":"EC-HSM","key_ops":["sign","verify"],"crv":"P-256","x":"q51W2t6BtFDQ4OadI_RanAH-Y4eHb6tQLOOk8vBfT6c","y":"LDO35oyLMP8kYd5XCePEKiim4RUZwm37i1CVHB7x4M4"},"attributes":{"enabled":true,"created":1633729471,"updated":1633729471,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/8eb4f2db9ca143ee80ac6c9a4a37aa7e","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"jPBdlr6yf_CsMgaHOO3QVRSFn2W8xbSCSdRlTr9aKaU","y":"ZyEfdr82FUpmeKahDhg92BUi3jL2C88zyTOZ7CIqPuA"},"attributes":{"enabled":true,"created":1638512985,"updated":1638512985,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name":"CreateECKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '473'
+      content-length: '471'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:32 GMT
+      date: Fri, 03 Dec 2021 06:29:45 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/create?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-ec-keybe9317b3/create?api-version=7.3-preview
 - request:
     body: '{"kty": "EC", "crv": "P-256"}'
     headers:
@@ -80,29 +80,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybe9317b3/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybe9317b3/0853de7f1a4e46a1adc2c898e2f0e203","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"jVGHATCe693bhg4Icvyfr6QdmFMB5Yhe56DIHB4Olq0","y":"wuUCkVD6cN1Dlz_ogVJImmDX9Rj_5gB6edhmcCQ1eHg"},"attributes":{"enabled":true,"created":1633729475,"updated":1633729475,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybe9317b3/1b72ff5abc7c4a0fa0de1213e71e19da","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"UmA_IAMLg-9rFaLhjbQ0nGaI6x6AtTSmFUfU4lyxQWc","y":"EHjEn0wnPK_5Yme32XXERcBchcOuyiRkmi3Q3GsPLOQ"},"attributes":{"enabled":true,"created":1638512988,"updated":1638512988,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
-      content-length: '414'
+      content-length: '416'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:35 GMT
+      date: Fri, 03 Dec 2021 06:29:47 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybe9317b3/create?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-P-256-ec-keybe9317b3/create?api-version=7.3-preview
 - request:
     body: '{"key": {"kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify",
       "wrapKey", "unwrapKey"], "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
@@ -120,29 +120,29 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keybe9317b3?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keybe9317b3/2509c986c16346acbca29f1536404549","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729475,"updated":1633729475,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestimport-test-keybe9317b3/48c726b0a4a64afb9749fc7def278661","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oJFNACNKxoOyG0wV1b7Yh73JWcLlevVK5zTo8Acg13XSdeRVIH43hM7rYKUKRlXdcqepTScejuj3lZpmnKbndb8OI7ra6ZG0Up2XhSi0vZBSHTLdJlZ5a6gra7_HZoyPXutQU3R_0ZkxnSmoRA0I9EEtUn_5MR7acYJZILR7HEaxGrPpHXMWQH6Jx_NA97haNAQs5RdDsn1HGEA9NMe0OK9hgb4F5NEeuYXTglPX_pv1P8LxsALSLS15P6eaUEtqtC0EkoBNcHHXJ6Bs86iJOqVCsVA_gyspY3G2cH1NxuNy-P5n2N7RyQj95FzgO8CGpxSH-nXkOqDgZ5qg0g7-NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512988,"updated":1638512988,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control: no-cache
-      content-length: '701'
+      content-length: '703'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:35 GMT
+      date: Fri, 03 Dec 2021 06:29:48 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestimport-test-keybe9317b3?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestimport-test-keybe9317b3?api-version=7.3-preview
 - request:
     body: '{"kty": "RSA", "key_size": 2048, "key_ops": ["encrypt", "decrypt", "sign",
       "verify", "wrapKey", "unwrapKey"], "tags": {"purpose": "unit test", "test name
@@ -155,90 +155,90 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/create?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mcGlxUEHgOtU66D8llJmjJbblPIRyLDWb1Co5qHH_RcfaTCN3BlWFhGBVk4SKDeLWmJBJhSHp-QV3pEJj_C_us2ElxTL8KMxnJmH0GzL1Y4gRI-lxsC2bkdZKjtLVZze5zGeFJXbKuCxPNicivqhNq_3BVAtdPSe2madAUqh2CQ6AAmvt2YQjzo6jC6meGFhJesA9_aFu3lDIO-_2I5c7b976vJUPVppQyXzvtCTnrKZ474tGmDoBCIEaHZw5eK5IqrttX4_eo0pT8aNgb092kz73o7TGYC8t7D7v0Sxcjn8mwxUctDI0IJpy6LqZdVcpEe3pgvl468NnL_BCKtrlQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729477,"updated":1633729477,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0WIx2ncAUhOUS5EjMZHRrQReOquveOt4DxgUVSt-JOHzH3R3Yjfs8cUCLnkIznxUL6e_tQAA9t4RpuaHN5kQX0-stYu0P_97_z0ICnwdzVAyjY8aM3klhFFKBPKDgAXvhJt3qDOwxLPs6yddR92J4rxPNKxXkyvAnHNbm9c0I2f6gfEPwBwCmrcx-yq-9RrJdfUS5F_Ra1k0hhqqJ2dYa8PY0WaEQdprclWHEATl0Y46AiR-icpKxOMKabqdoL6MqveuOYr6maGIXmb8PQEQOvMZLbPoV1tatJ0ImNhtyOdwqAJC6a5lmZfka60hGQT5m0AFs5otMmDkZZCPSlmnHQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512991,"updated":1638512991,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '761'
+      content-length: '763'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:37 GMT
+      date: Fri, 03 Dec 2021 06:29:50 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/create?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/create?api-version=7.3-preview
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73?api-version=7.3-preview
+    uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mcGlxUEHgOtU66D8llJmjJbblPIRyLDWb1Co5qHH_RcfaTCN3BlWFhGBVk4SKDeLWmJBJhSHp-QV3pEJj_C_us2ElxTL8KMxnJmH0GzL1Y4gRI-lxsC2bkdZKjtLVZze5zGeFJXbKuCxPNicivqhNq_3BVAtdPSe2madAUqh2CQ6AAmvt2YQjzo6jC6meGFhJesA9_aFu3lDIO-_2I5c7b976vJUPVppQyXzvtCTnrKZ474tGmDoBCIEaHZw5eK5IqrttX4_eo0pT8aNgb092kz73o7TGYC8t7D7v0Sxcjn8mwxUctDI0IJpy6LqZdVcpEe3pgvl468NnL_BCKtrlQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729477,"updated":1633729477,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0WIx2ncAUhOUS5EjMZHRrQReOquveOt4DxgUVSt-JOHzH3R3Yjfs8cUCLnkIznxUL6e_tQAA9t4RpuaHN5kQX0-stYu0P_97_z0ICnwdzVAyjY8aM3klhFFKBPKDgAXvhJt3qDOwxLPs6yddR92J4rxPNKxXkyvAnHNbm9c0I2f6gfEPwBwCmrcx-yq-9RrJdfUS5F_Ra1k0hhqqJ2dYa8PY0WaEQdprclWHEATl0Y46AiR-icpKxOMKabqdoL6MqveuOYr6maGIXmb8PQEQOvMZLbPoV1tatJ0ImNhtyOdwqAJC6a5lmZfka60hGQT5m0AFs5otMmDkZZCPSlmnHQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512991,"updated":1638512991,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '761'
+      content-length: '763'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:37 GMT
+      date: Fri, 03 Dec 2021 06:29:51 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c?api-version=7.3-preview
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"mcGlxUEHgOtU66D8llJmjJbblPIRyLDWb1Co5qHH_RcfaTCN3BlWFhGBVk4SKDeLWmJBJhSHp-QV3pEJj_C_us2ElxTL8KMxnJmH0GzL1Y4gRI-lxsC2bkdZKjtLVZze5zGeFJXbKuCxPNicivqhNq_3BVAtdPSe2madAUqh2CQ6AAmvt2YQjzo6jC6meGFhJesA9_aFu3lDIO-_2I5c7b976vJUPVppQyXzvtCTnrKZ474tGmDoBCIEaHZw5eK5IqrttX4_eo0pT8aNgb092kz73o7TGYC8t7D7v0Sxcjn8mwxUctDI0IJpy6LqZdVcpEe3pgvl468NnL_BCKtrlQ","e":"AQAB"},"attributes":{"enabled":true,"created":1633729477,"updated":1633729477,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0WIx2ncAUhOUS5EjMZHRrQReOquveOt4DxgUVSt-JOHzH3R3Yjfs8cUCLnkIznxUL6e_tQAA9t4RpuaHN5kQX0-stYu0P_97_z0ICnwdzVAyjY8aM3klhFFKBPKDgAXvhJt3qDOwxLPs6yddR92J4rxPNKxXkyvAnHNbm9c0I2f6gfEPwBwCmrcx-yq-9RrJdfUS5F_Ra1k0hhqqJ2dYa8PY0WaEQdprclWHEATl0Y46AiR-icpKxOMKabqdoL6MqveuOYr6maGIXmb8PQEQOvMZLbPoV1tatJ0ImNhtyOdwqAJC6a5lmZfka60hGQT5m0AFs5otMmDkZZCPSlmnHQ","e":"AQAB"},"attributes":{"enabled":true,"created":1638512991,"updated":1638512991,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"purpose":"unit
         test","test name ":"CreateRSAKeyTest"}}'
     headers:
       cache-control: no-cache
-      content-length: '761'
+      content-length: '763'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:37 GMT
+      date: Fri, 03 Dec 2021 06:29:51 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/?api-version=7.3-preview
 - request:
     body: '{"key_ops": ["decrypt", "encrypt"], "attributes": {"exp": 2524723200},
       "tags": {"foo": "updated tag"}}'
@@ -250,67 +250,67 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: PATCH
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/?api-version=7.3-preview
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mcGlxUEHgOtU66D8llJmjJbblPIRyLDWb1Co5qHH_RcfaTCN3BlWFhGBVk4SKDeLWmJBJhSHp-QV3pEJj_C_us2ElxTL8KMxnJmH0GzL1Y4gRI-lxsC2bkdZKjtLVZze5zGeFJXbKuCxPNicivqhNq_3BVAtdPSe2madAUqh2CQ6AAmvt2YQjzo6jC6meGFhJesA9_aFu3lDIO-_2I5c7b976vJUPVppQyXzvtCTnrKZ474tGmDoBCIEaHZw5eK5IqrttX4_eo0pT8aNgb092kz73o7TGYC8t7D7v0Sxcjn8mwxUctDI0IJpy6LqZdVcpEe3pgvl468NnL_BCKtrlQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729477,"updated":1633729481,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0WIx2ncAUhOUS5EjMZHRrQReOquveOt4DxgUVSt-JOHzH3R3Yjfs8cUCLnkIznxUL6e_tQAA9t4RpuaHN5kQX0-stYu0P_97_z0ICnwdzVAyjY8aM3klhFFKBPKDgAXvhJt3qDOwxLPs6yddR92J4rxPNKxXkyvAnHNbm9c0I2f6gfEPwBwCmrcx-yq-9RrJdfUS5F_Ra1k0hhqqJ2dYa8PY0WaEQdprclWHEATl0Y46AiR-icpKxOMKabqdoL6MqveuOYr6maGIXmb8PQEQOvMZLbPoV1tatJ0ImNhtyOdwqAJC6a5lmZfka60hGQT5m0AFs5otMmDkZZCPSlmnHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512991,"updated":1638512995,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '706'
+      content-length: '708'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:41 GMT
+      date: Fri, 03 Dec 2021 06:29:54 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/?api-version=7.3-preview
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3","deletedDate":1633729481,"scheduledPurgeDate":1641505481,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mcGlxUEHgOtU66D8llJmjJbblPIRyLDWb1Co5qHH_RcfaTCN3BlWFhGBVk4SKDeLWmJBJhSHp-QV3pEJj_C_us2ElxTL8KMxnJmH0GzL1Y4gRI-lxsC2bkdZKjtLVZze5zGeFJXbKuCxPNicivqhNq_3BVAtdPSe2madAUqh2CQ6AAmvt2YQjzo6jC6meGFhJesA9_aFu3lDIO-_2I5c7b976vJUPVppQyXzvtCTnrKZ474tGmDoBCIEaHZw5eK5IqrttX4_eo0pT8aNgb092kz73o7TGYC8t7D7v0Sxcjn8mwxUctDI0IJpy6LqZdVcpEe3pgvl468NnL_BCKtrlQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729477,"updated":1633729481,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3","deletedDate":1638512995,"scheduledPurgeDate":1646288995,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0WIx2ncAUhOUS5EjMZHRrQReOquveOt4DxgUVSt-JOHzH3R3Yjfs8cUCLnkIznxUL6e_tQAA9t4RpuaHN5kQX0-stYu0P_97_z0ICnwdzVAyjY8aM3klhFFKBPKDgAXvhJt3qDOwxLPs6yddR92J4rxPNKxXkyvAnHNbm9c0I2f6gfEPwBwCmrcx-yq-9RrJdfUS5F_Ra1k0hhqqJ2dYa8PY0WaEQdprclWHEATl0Y46AiR-icpKxOMKabqdoL6MqveuOYr6maGIXmb8PQEQOvMZLbPoV1tatJ0ImNhtyOdwqAJC6a5lmZfka60hGQT5m0AFs5otMmDkZZCPSlmnHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512991,"updated":1638512995,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
         tag"}}'
     headers:
       cache-control: no-cache
-      content-length: '858'
+      content-length: '862'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:41 GMT
+      date: Fri, 03 Dec 2021 06:29:55 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
   response:
@@ -320,77 +320,193 @@ interactions:
       cache-control: no-cache
       content-length: '98'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:41 GMT
+      date: Fri, 03 Dec 2021 06:29:55 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 404
       message: Not Found
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3","deletedDate":1633729481,"scheduledPurgeDate":1641505481,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mcGlxUEHgOtU66D8llJmjJbblPIRyLDWb1Co5qHH_RcfaTCN3BlWFhGBVk4SKDeLWmJBJhSHp-QV3pEJj_C_us2ElxTL8KMxnJmH0GzL1Y4gRI-lxsC2bkdZKjtLVZze5zGeFJXbKuCxPNicivqhNq_3BVAtdPSe2madAUqh2CQ6AAmvt2YQjzo6jC6meGFhJesA9_aFu3lDIO-_2I5c7b976vJUPVppQyXzvtCTnrKZ474tGmDoBCIEaHZw5eK5IqrttX4_eo0pT8aNgb092kz73o7TGYC8t7D7v0Sxcjn8mwxUctDI0IJpy6LqZdVcpEe3pgvl468NnL_BCKtrlQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729477,"updated":1633729481,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybe9317b3"}}'
     headers:
       cache-control: no-cache
-      content-length: '858'
+      content-length: '98'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:43 GMT
+      date: Fri, 03 Dec 2021 06:29:58 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
-      code: 200
-      message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.9.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3","deletedDate":1633729481,"scheduledPurgeDate":1641505481,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/b1851060a1cd4b5eb9bb9838e984ab73","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"mcGlxUEHgOtU66D8llJmjJbblPIRyLDWb1Co5qHH_RcfaTCN3BlWFhGBVk4SKDeLWmJBJhSHp-QV3pEJj_C_us2ElxTL8KMxnJmH0GzL1Y4gRI-lxsC2bkdZKjtLVZze5zGeFJXbKuCxPNicivqhNq_3BVAtdPSe2madAUqh2CQ6AAmvt2YQjzo6jC6meGFhJesA9_aFu3lDIO-_2I5c7b976vJUPVppQyXzvtCTnrKZ474tGmDoBCIEaHZw5eK5IqrttX4_eo0pT8aNgb092kz73o7TGYC8t7D7v0Sxcjn8mwxUctDI0IJpy6LqZdVcpEe3pgvl468NnL_BCKtrlQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1633729477,"updated":1633729481,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
-        tag"}}'
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybe9317b3"}}'
     headers:
       cache-control: no-cache
-      content-length: '858'
+      content-length: '98'
       content-type: application/json; charset=utf-8
-      date: Fri, 08 Oct 2021 21:44:43 GMT
+      date: Fri, 03 Dec 2021 06:30:00 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.9.132.3
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybe9317b3"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '98'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:30:02 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: livekvtestcrud-rsa-keybe9317b3"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '98'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:30:04 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 404
+      message: Not Found
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3","deletedDate":1638512995,"scheduledPurgeDate":1646288995,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0WIx2ncAUhOUS5EjMZHRrQReOquveOt4DxgUVSt-JOHzH3R3Yjfs8cUCLnkIznxUL6e_tQAA9t4RpuaHN5kQX0-stYu0P_97_z0ICnwdzVAyjY8aM3klhFFKBPKDgAXvhJt3qDOwxLPs6yddR92J4rxPNKxXkyvAnHNbm9c0I2f6gfEPwBwCmrcx-yq-9RrJdfUS5F_Ra1k0hhqqJ2dYa8PY0WaEQdprclWHEATl0Y46AiR-icpKxOMKabqdoL6MqveuOYr6maGIXmb8PQEQOvMZLbPoV1tatJ0ImNhtyOdwqAJC6a5lmZfka60hGQT5m0AFs5otMmDkZZCPSlmnHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512991,"updated":1638512995,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '862'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:30:07 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://mcpatinotest.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0b5 Python/3.7.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3","deletedDate":1638512995,"scheduledPurgeDate":1646288995,"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestcrud-rsa-keybe9317b3/c905ec0f75f64e58aa4381927e5b866c","kty":"RSA","key_ops":["decrypt","encrypt"],"n":"0WIx2ncAUhOUS5EjMZHRrQReOquveOt4DxgUVSt-JOHzH3R3Yjfs8cUCLnkIznxUL6e_tQAA9t4RpuaHN5kQX0-stYu0P_97_z0ICnwdzVAyjY8aM3klhFFKBPKDgAXvhJt3qDOwxLPs6yddR92J4rxPNKxXkyvAnHNbm9c0I2f6gfEPwBwCmrcx-yq-9RrJdfUS5F_Ra1k0hhqqJ2dYa8PY0WaEQdprclWHEATl0Y46AiR-icpKxOMKabqdoL6MqveuOYr6maGIXmb8PQEQOvMZLbPoV1tatJ0ImNhtyOdwqAJC6a5lmZfka60hGQT5m0AFs5otMmDkZZCPSlmnHQ","e":"AQAB"},"attributes":{"enabled":true,"exp":2524723200,"created":1638512991,"updated":1638512995,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"foo":"updated
+        tag"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '862'
+      content-type: application/json; charset=utf-8
+      date: Fri, 03 Dec 2021 06:30:07 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=167.220.255.60;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: eastus
+      x-ms-keyvault-service-version: 1.9.195.1
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://vaultname.vault.azure.net/deletedkeys/livekvtestcrud-rsa-keybe9317b3?api-version=7.3-preview
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -8,6 +8,7 @@ import functools
 import json
 import logging
 import time
+import os
 
 from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
@@ -23,7 +24,7 @@ import pytest
 from six import byte2int
 
 from _shared.test_case import KeyVaultTestCase
-from _test_case import client_setup, get_attestation_token, get_decorator, get_release_policy, KeysTestCase
+from _test_case import client_setup, get_attestation_token, get_decorator, get_release_policy, is_public_cloud, KeysTestCase
 
 
 all_api_versions = get_decorator()
@@ -188,7 +189,7 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
         # create ec key
         ec_key_name = self.get_resource_name("crud-ec-key")
         tags = {"purpose": "unit test", "test name": "CreateECKeyTest"}
-        ec_key = self._create_ec_key(client, enabled=True, key_name=ec_key_name, hardware_protected=True, tags=tags)
+        ec_key = self._create_ec_key(client, enabled=True, key_name=ec_key_name, hardware_protected=is_hsm, tags=tags)
         assert ec_key.properties.enabled
         assert tags == ec_key.properties.tags
         # create ec with curve
@@ -557,6 +558,9 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
     @only_vault_7_3_preview()
     @client_setup
     def test_key_rotation(self, client, **kwargs):
+        if (not is_public_cloud() and self.is_live):
+            pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
+
         key_name = self.get_resource_name("rotation-key")
         key = self._create_rsa_key(client, key_name)
         rotated_key = client.rotate_key(key_name)
@@ -569,6 +573,9 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
     @only_vault_7_3_preview()
     @client_setup
     def test_key_rotation_policy(self, client, **kwargs):
+        if (not is_public_cloud() and self.is_live):
+            pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
+
         key_name = self.get_resource_name("rotation-key")
         self._create_rsa_key(client, key_name)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -4,6 +4,8 @@
 # ------------------------------------
 from __future__ import print_function
 import time
+import os
+import pytest
 
 from azure.keyvault.keys import KeyType
 
@@ -36,6 +38,9 @@ class TestExamplesKeyVault(KeysTestCase, KeyVaultTestCase):
     @all_api_versions()
     @client_setup
     def test_example_key_crud_operations(self, key_client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test not supprot in usgov/china region. Follow up with service team")
+
         key_name = self.get_resource_name("key-name")
 
         # [START create_key]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import asyncio
+import os
 
 from azure.keyvault.keys import KeyType
 import pytest
@@ -42,6 +43,9 @@ class TestExamplesKeyVault(KeysTestCase, KeyVaultTestCase):
     @all_api_versions()
     @client_setup
     async def test_example_key_crud_operations(self, key_client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test not supprot in usgov/china region. Follow up with service team")
+
         key_name = self.get_resource_name("key-name")
 
         # [START create_key]

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -17,6 +17,18 @@ stages:
         BuildTargetingString: ${{ service }}
         JobName: ${{ replace(service, '-', '_') }}
         TestTimeoutInMinutes: 240
+        SupportedClouds: 'Public,UsGov,China'
+        CloudConfig:
+          Public:
+            SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          UsGov:
+            SubscriptionConfiguration: $(sub-config-gov-test-resources)
+            MatrixFilters:
+              - ArmTemplateParameters=^(?!.*enableHsm.*true)
+          China:
+            SubscriptionConfiguration: $(sub-config-cn-test-resources)
+            MatrixFilters:
+              - ArmTemplateParameters=^(?!.*enableHsm.*true)
         ${{ if or(eq(service, 'azure-keyvault-keys'), eq(service, 'azure-keyvault-administration')) }}:
           AdditionalMatrixConfigs:
             - Name: keyvault_test_matrix_addons


### PR DESCRIPTION
These changes enable keyvault to run live tests against Public, UsGov and China.
1. According to JS issue https://github.com/Azure/azure-sdk-for-js/issues/18267, there is the same error here . 
So skip the following tests:
- `test_key_client.py::KeyClientTests::test_key_crud_operations`, 
- `test_keys_async.py::KeyVaultKeyTest::test_key_crud_operations`,
- `test_samples_keys.py::TestExamplesKeyVault::test_example_key_crud_operations`,
- `test_samples_keys_async.py::TestExamplesKeyVault::test_example_key_crud_operations`
2. According to JS issue https://github.com/Azure/azure-sdk-for-js/issues/18142, there is the same error here. 
So skip the following tests:

- `test_key_client.py::KeyClientTests::test_key_rotation`,
- `test_key_client.py::KeyClientTests::test_key_rotation_policy`,
- `test_keys_async.py::KeyVaultKeyTest::test_key_rotation`,
- `test_keys_async.py::KeyVaultKeyTest::test_key_rotation_policy`

3. According to JS issue https://github.com/Azure/azure-sdk-for-js/issues/18414, there is the same error here. 
So add code `MatrixFilters:ArmTemplateParameters=^(?!.*enableHsm.*true)` in UsGov and China cloudconfig in tests.yml.

Pipeline results:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1194909&view=results

@benbp , @jameszliao-msft , @lmazuel , @AlexGhiondea , @chlowell for notification.