### PR TITLE
fix legacy params in tests.yml 

### DIFF
--- a/sdk/remoterendering/tests.yml
+++ b/sdk/remoterendering/tests.yml
@@ -3,9 +3,7 @@ trigger: none
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      AllocateResourceGroup: false
       ServiceDirectory: remoterendering
-      DeployArmTemplate: true
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)


### PR DESCRIPTION
Initial commit was missing changes performed to tests.yml

Cleanup of this was performed in https://github.com/Azure/azure-sdk-for-python/pull/21458 

This now leads to remote rendering tests failing see pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=2439 