### PR TITLE
Added extra index url to python repo

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -4,6 +4,7 @@ jobs:
   - template: /eng/common/pipelines/templates/jobs/docindex.yml
 
   - job: UpdateDocsMsBuildConfig
+    timeoutInMinutes: 90
     pool:
       vmImage: ubuntu-20.04
     variables:

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -78,7 +78,7 @@ jobs:
         inputs:
           pwsh: true
           filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation) -PackageSourceOverride "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/" -ImageId '$(DocValidationImageId)'
+          arguments: -DocRepoLocation $(DocRepoLocation) -PackageSourceOverride "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
         displayName: Update Docs Onboarding for Daily branch
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -264,6 +264,8 @@ stages:
       pool:
         name: azsdk-pool-mms-ubuntu-2004-general
         vmImage: MMSUbuntu20.04
+      variables: 
+        DocValidationImageId: azuresdkimages.azurecr.io/pyrefautocr:latest
       steps:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
@@ -274,7 +276,12 @@ stages:
         - pwsh: |
             Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/
           displayName: Show visible artifacts
-
+        # Pull and build the docker image.
+        - template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
+          parameters:
+            ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
+            ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
+            ImageId: "$(DocValidationImageId)"
         - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
           parameters:
             PackageInfoLocations:

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -176,7 +176,7 @@ function ValidatePackage($packageName, $packageVersion, $workingDirectory) {
 }
 function DockerValidation($packageName, $packageVersion) {
   $packageExpression = "$packageName==$packageVersion"
-  docker run -e TARGET_PACKAGE=$packageExpression -t $ImageId
+  docker run -e TARGET_PACKAGE=$packageExpression -e EXTRA_INDEX_URL=$PackageSourceOverride -t $ImageId
   # The docker exit codes: https://docs.docker.com/engine/reference/run/#exit-status
   # If the docker failed because of docker itself instead of the application, 
   # we should skip the validation and keep the packages. 


### PR DESCRIPTION
Fixed the docker missing extra index url parameter issue.
Added the argument option in python docker validation for daily update branch

Extra_index_url changes in docs repo: 
https://apidrop.visualstudio.com/Content%20CI/_git/ReferenceAutomation?path=/docker/python/scripts/invoke.ps1&version=GBfeature/add-docker&_a=contents

Test pipeline:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1193090&view=logs&j=5e8cddd4-765d-5046-f31f-2d7d6b215293&t=5fc3d5cf-f7ef-5897-f642-6a8fbce4fc7f