### PR TITLE
Update async legacy module to newer async module in authenticate_with_azure_sas_credential_async.py

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/async_samples/authenticate_with_azure_sas_credential_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/authenticate_with_azure_sas_credential_async.py
@@ -66,7 +66,6 @@ async def create_with_sas_token():
         await producer_client.send_batch(event_data_batch)
 
 
-loop = asyncio.get_event_loop()
 start_time = time.time()
-loop.run_until_complete(create_with_sas_token())
+asyncio.run(create_with_sas_token())
 print("Send messages in {} seconds.".format(time.time() - start_time))


### PR DESCRIPTION
I've modified one of the samples that is written as asyncio.get_event_loop() to asyncio.run() since get_running_loop() is deprecated (since version 3.10).

https://docs.python.org/3/library/asyncio-eventloop.html#event-loop

> Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. In future Python releases, this function will be an alias of get_running_loop().