### PR TITLE
add dependency to azure-mixedreality-authentication library

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/setup.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/setup.py
@@ -65,6 +65,7 @@ setup(
     ]),
     install_requires=[
         'azure-core<2.0.0,>=1.6.0',
+        'azure-mixedreality-authentication>=1.0.0b1',
         'msrest>=0.5.0'
     ],
     extras_require={

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -90,6 +90,7 @@ azure-mgmt-trafficmanager~=0.50.0
 azure-mgmt-web~=0.35.0
 azure-messaging-nspkg
 azure-mixedreality-nspkg
+azure-mixedreality-authentication
 azure-nspkg
 azure-keyvault-nspkg
 azure-media-nspkg
@@ -350,6 +351,7 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-mgmt-containerinstance msrest>=0.6.21
 #override azure-mgmt-recoveryservicessiterecovery msrest>=0.6.21
 #override azure-mixedreality-remoterendering azure-core<2.0.0,>=1.6.0
+#override azure-mixedreality-remoterendering azure-mixedreality-authentication>=1.0.0b1
 #override azure-mgmt-batch msrest>=0.6.21
 #override azure-batch msrest>=0.6.21
 #override azure-mgmt-servicebus msrest>=0.6.21


### PR DESCRIPTION
Azure Remote Rendering uses the mixed reality STS service for authentication and uses the azure-mixedreality-authentication client for authentication.

This PR adds the missed dependency to the auth package which was now released in a preview 

See:
Released preview package: https://pypi.org/project/azure-mixedreality-authentication/
Auth library in python sdk repo: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/mixedreality/azure-mixedreality-authentication