### PR TITLE
[textanalytics] update health live tests due to service change

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_healthcare.test_document_errors.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_healthcare.test_document_errors.yaml
@@ -16,7 +16,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-textanalytics/5.2.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-textanalytics/5.2.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=UnicodeCodePoint
   response:
@@ -24,11 +24,11 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - babbcb9d-429e-40ca-9069-8b403b2a7274
+      - 19f8d0af-a534-47b0-b037-07a9b06b0b03
       date:
-      - Wed, 06 Oct 2021 21:00:24 GMT
+      - Tue, 23 Nov 2021 01:09:00 GMT
       operation-location:
-      - https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.1/entities/health/jobs/a26b209e-1f7e-4a27-842a-733780d5f63e
+      - https://westus2.api.cognitive.microsoft.com//text/analytics/v3.2-preview.2/entities/health/jobs/265d2fec-bbbd-4705-ac19-2d406eac189d
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       transfer-encoding:
@@ -36,7 +36,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '266'
+      - '335'
     status:
       code: 202
       message: Accepted
@@ -50,27 +50,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-ai-textanalytics/5.2.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-textanalytics/5.2.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.1/entities/health/jobs/a26b209e-1f7e-4a27-842a-733780d5f63e
+    uri: https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.2/entities/health/jobs/265d2fec-bbbd-4705-ac19-2d406eac189d
   response:
     body:
-      string: '{"jobId":"a26b209e-1f7e-4a27-842a-733780d5f63e","lastUpdateDateTime":"2021-10-06T21:00:25Z","createdDateTime":"2021-10-06T21:00:25Z","expirationDateTime":"2021-10-07T21:00:25Z","status":"succeeded","errors":[],"results":{"documents":[],"errors":[{"id":"1","error":{"code":"InvalidArgument","message":"Invalid
+      string: '{"jobId":"265d2fec-bbbd-4705-ac19-2d406eac189d","lastUpdateDateTime":"2021-11-23T01:09:03Z","createdDateTime":"2021-11-23T01:09:00Z","expirationDateTime":"2021-11-24T01:09:00Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"3","entities":[],"relations":[],"warnings":[{"code":"DocumentTruncated","message":"Document
+        is large and must be split to be processed; relations across splits may not
+        be caught by the model"}]}],"errors":[{"id":"1","error":{"code":"InvalidArgument","message":"Invalid
         document in request.","innererror":{"code":"InvalidDocument","message":"Document
         text is empty."}}},{"id":"2","error":{"code":"InvalidArgument","message":"Invalid
         Language Code.","innererror":{"code":"UnsupportedLanguageCode","message":"Invalid
-        language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support"}}},{"id":"3","error":{"code":"InvalidArgument","message":"Invalid
-        document in request.","innererror":{"code":"InvalidDocument","message":"A
-        document within the request was too large to be processed. Limit document
-        size to: 5120 text elements. For additional details on the data limitations
-        see https://aka.ms/text-analytics-data-limits"}}}],"modelVersion":"2021-05-15"}}'
+        language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support"}}}],"modelVersion":"2021-05-15"}}'
     headers:
       apim-request-id:
-      - d4c1b433-82d4-471c-9d02-58189b8be7ed
+      - de343c73-d70c-4cee-b4dc-bf5bcb783453
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 06 Oct 2021 21:00:29 GMT
+      - Tue, 23 Nov 2021 01:09:05 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       transfer-encoding:
@@ -78,7 +76,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '75'
+      - '332'
     status:
       code: 200
       message: OK

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_healthcare_async.test_document_errors.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_healthcare_async.test_document_errors.yaml
@@ -12,52 +12,50 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-textanalytics/5.2.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-textanalytics/5.2.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=UnicodeCodePoint
   response:
     body:
       string: ''
     headers:
-      apim-request-id: 5aa9d41c-1e0a-440f-abad-62818fc1a2e8
-      date: Wed, 06 Oct 2021 21:02:10 GMT
-      operation-location: https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.1/entities/health/jobs/fc017c6f-ec2c-4d68-be54-fd3b34dfceaf
+      apim-request-id: 9b7a98e2-ce3a-4e2b-8f28-35b8a4960e8e
+      date: Tue, 23 Nov 2021 01:11:00 GMT
+      operation-location: https://westus2.api.cognitive.microsoft.com//text/analytics/v3.2-preview.2/entities/health/jobs/cde5ca0f-d52b-40de-bd83-ca3c304d3a29
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       transfer-encoding: chunked
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '380'
+      x-envoy-upstream-service-time: '227'
     status:
       code: 202
       message: Accepted
-    url: https://javatextanalyticstestresources.cognitiveservices.azure.com//text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=UnicodeCodePoint
+    url: https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=UnicodeCodePoint
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-ai-textanalytics/5.2.0b2 Python/3.9.0 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-textanalytics/5.2.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.1/entities/health/jobs/fc017c6f-ec2c-4d68-be54-fd3b34dfceaf
+    uri: https://westus2.api.cognitive.microsoft.com/text/analytics/v3.2-preview.2/entities/health/jobs/cde5ca0f-d52b-40de-bd83-ca3c304d3a29
   response:
     body:
-      string: '{"jobId":"fc017c6f-ec2c-4d68-be54-fd3b34dfceaf","lastUpdateDateTime":"2021-10-06T21:02:11Z","createdDateTime":"2021-10-06T21:02:10Z","expirationDateTime":"2021-10-07T21:02:10Z","status":"succeeded","errors":[],"results":{"documents":[],"errors":[{"id":"1","error":{"code":"InvalidArgument","message":"Invalid
+      string: '{"jobId":"cde5ca0f-d52b-40de-bd83-ca3c304d3a29","lastUpdateDateTime":"2021-11-23T01:11:04Z","createdDateTime":"2021-11-23T01:11:00Z","expirationDateTime":"2021-11-24T01:11:00Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"3","entities":[],"relations":[],"warnings":[{"code":"DocumentTruncated","message":"Document
+        is large and must be split to be processed; relations across splits may not
+        be caught by the model"}]}],"errors":[{"id":"1","error":{"code":"InvalidArgument","message":"Invalid
         document in request.","innererror":{"code":"InvalidDocument","message":"Document
         text is empty."}}},{"id":"2","error":{"code":"InvalidArgument","message":"Invalid
         Language Code.","innererror":{"code":"UnsupportedLanguageCode","message":"Invalid
-        language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support"}}},{"id":"3","error":{"code":"InvalidArgument","message":"Invalid
-        document in request.","innererror":{"code":"InvalidDocument","message":"A
-        document within the request was too large to be processed. Limit document
-        size to: 5120 text elements. For additional details on the data limitations
-        see https://aka.ms/text-analytics-data-limits"}}}],"modelVersion":"2021-05-15"}}'
+        language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support"}}}],"modelVersion":"2021-05-15"}}'
     headers:
-      apim-request-id: 10d73066-ef26-4e95-98b9-53f1b129eac9
+      apim-request-id: e3a11ff8-78d3-4316-a6b0-4515e8d3497c
       content-type: application/json; charset=utf-8
-      date: Wed, 06 Oct 2021 21:02:15 GMT
+      date: Tue, 23 Nov 2021 01:11:05 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       transfer-encoding: chunked
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '69'
+      x-envoy-upstream-service-time: '183'
     status:
       code: 200
       message: OK
-    url: https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/fc017c6f-ec2c-4d68-be54-fd3b34dfceaf
+    url: https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/cde5ca0f-d52b-40de-bd83-ca3c304d3a29
 version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -249,7 +249,6 @@ class TestHealth(TextAnalyticsTest):
         self.assertIsNotNone(doc_results[0].error.message)
         self.assertEqual(doc_results[1].error.code, "UnsupportedLanguageCode")
         self.assertIsNotNone(doc_results[1].error.message)
-        # Service not returning error b/c of exceeded char limit, returns warning instead
         assert not doc_results[2].is_error
         assert doc_results[2].warnings
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -244,13 +244,14 @@ class TestHealth(TextAnalyticsTest):
                 {"id": "3", "text": text}]
 
         result = client.begin_analyze_healthcare_entities(docs, polling_interval=self._interval()).result()
-        doc_errors = list(result)
-        self.assertEqual(doc_errors[0].error.code, "InvalidDocument")
-        self.assertIsNotNone(doc_errors[0].error.message)
-        self.assertEqual(doc_errors[1].error.code, "UnsupportedLanguageCode")
-        self.assertIsNotNone(doc_errors[1].error.message)
-        self.assertEqual(doc_errors[2].error.code, "InvalidDocument")
-        self.assertIsNotNone(doc_errors[2].error.message)
+        doc_results = list(result)
+        self.assertEqual(doc_results[0].error.code, "InvalidDocument")
+        self.assertIsNotNone(doc_results[0].error.message)
+        self.assertEqual(doc_results[1].error.code, "UnsupportedLanguageCode")
+        self.assertIsNotNone(doc_results[1].error.message)
+        # Service not returning error b/c of exceeded char limit, returns warning instead
+        assert not doc_results[2].is_error
+        assert doc_results[2].warnings
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -273,7 +273,6 @@ class TestHealth(AsyncTextAnalyticsTest):
         self.assertIsNotNone(doc_results[0].error.message)
         self.assertEqual(doc_results[1].error.code, "UnsupportedLanguageCode")
         self.assertIsNotNone(doc_results[1].error.message)
-        # Service not returning error b/c of exceeded char limit, returns warning instead
         assert not doc_results[2].is_error
         assert doc_results[2].warnings
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -266,15 +266,16 @@ class TestHealth(AsyncTextAnalyticsTest):
 
         async with client:
             result = await(await client.begin_analyze_healthcare_entities(docs, polling_interval=self._interval())).result()
-            doc_errors = []
+            doc_results = []
             async for r in result:
-                doc_errors.append(r)
-        self.assertEqual(doc_errors[0].error.code, "InvalidDocument")
-        self.assertIsNotNone(doc_errors[0].error.message)
-        self.assertEqual(doc_errors[1].error.code, "UnsupportedLanguageCode")
-        self.assertIsNotNone(doc_errors[1].error.message)
-        self.assertEqual(doc_errors[2].error.code, "InvalidDocument")
-        self.assertIsNotNone(doc_errors[2].error.message)
+                doc_results.append(r)
+        self.assertEqual(doc_results[0].error.code, "InvalidDocument")
+        self.assertIsNotNone(doc_results[0].error.message)
+        self.assertEqual(doc_results[1].error.code, "UnsupportedLanguageCode")
+        self.assertIsNotNone(doc_results[1].error.message)
+        # Service not returning error b/c of exceeded char limit, returns warning instead
+        assert not doc_results[2].is_error
+        assert doc_results[2].warnings
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()


### PR DESCRIPTION
The service used to return a document error when the text exceeded the character limit in healthcare, but now is returning a result with a warning about the length of the text. Service team confirmed this is the new behavior.

