### PR TITLE
[EventHubs] Update async samples

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/async_samples/authenticate_with_sas_token_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/authenticate_with_sas_token_async.py
@@ -83,7 +83,6 @@ async def create_with_sas_token():
         await producer_client.send_batch(event_data_batch)
 
 
-loop = asyncio.get_event_loop()
 start_time = time.time()
-loop.run_until_complete(create_with_sas_token())
+asyncio.run(create_with_sas_token())
 print("Send messages in {} seconds.".format(time.time() - start_time))

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/client_identity_authentication_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/client_identity_authentication_async.py
@@ -61,6 +61,6 @@ async def run():
                     break
             await producer.send_batch(event_data_batch)
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(run())
+
+asyncio.run(run())
 print('Finished sending.')

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/connection_string_authentication_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/connection_string_authentication_async.py
@@ -15,6 +15,7 @@ from azure.eventhub.aio import EventHubConsumerClient
 CONNECTION_STR = os.environ["EVENT_HUB_CONN_STR"]
 EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
 
+
 async def main():
     consumer_client = EventHubConsumerClient.from_connection_string(
         conn_str=CONNECTION_STR,
@@ -24,6 +25,6 @@ async def main():
     async with consumer_client:
         pass # consumer_client is now ready to be used.
 
+
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -123,5 +123,4 @@ async def receive_events_from_iothub(iothub_conn_str):
 
 if __name__ == '__main__':
     iothub_conn_str = os.environ["IOTHUB_CONN_STR"]
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(receive_events_from_iothub(iothub_conn_str))
+    asyncio.run(receive_events_from_iothub(iothub_conn_str))

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/proxy_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/proxy_async.py
@@ -61,6 +61,4 @@ async def main():
         print('Finished receiving.')
 
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
-
+asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/receive_batch_with_checkpoint_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/receive_batch_with_checkpoint_async.py
@@ -55,5 +55,4 @@ async def receive_batch():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(receive_batch())
+    asyncio.run(receive_batch())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/recv_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/recv_async.py
@@ -63,6 +63,6 @@ async def main():
             starting_position="-1",  # "-1" is from the beginning of the partition.
         )
 
+
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/recv_for_period_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/recv_for_period_async.py
@@ -73,6 +73,6 @@ async def main():
 
     print('Consumer has stopped receiving, end time is {}.'.format(time.time()))
 
+
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/recv_track_last_enqueued_event_prop_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/recv_track_last_enqueued_event_prop_async.py
@@ -46,5 +46,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_checkpoint_by_event_count_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_checkpoint_by_event_count_async.py
@@ -65,5 +65,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_checkpoint_by_time_interval_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_checkpoint_by_time_interval_async.py
@@ -68,5 +68,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_checkpoint_store_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_checkpoint_store_async.py
@@ -56,5 +56,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_custom_starting_position_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/recv_with_custom_starting_position_async.py
@@ -87,5 +87,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
@@ -114,5 +114,4 @@ async def main():
     await receive_and_parse_message(consumer)
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/send_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/send_async.py
@@ -102,7 +102,6 @@ async def run():
         await send_event_data_list(producer)
 
 
-loop = asyncio.get_event_loop()
 start_time = time.time()
-loop.run_until_complete(run())
+asyncio.run(run())
 print("Send messages in {} seconds.".format(time.time() - start_time))

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/send_stream_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/send_stream_async.py
@@ -45,7 +45,7 @@ async def run():
         if len(event_data_batch) > 0:
             await producer.send_batch(event_data_batch)
 
-loop = asyncio.get_event_loop()
+
 start_time = time.time()
-loop.run_until_complete(run())
+asyncio.run(run())
 print("Send messages in {} seconds.".format(time.time() - start_time))


### PR DESCRIPTION
Related to #21101

I've updated EventHubs samples to drop `loop.run_until_complete(...)`(updated to `asyncio.run(...)`)

I did not modified those files.

- [`client_creation_async.py`](https://github.com/Azure/azure-sdk-for-python/blob/fe37155dcb6bf66491cf59a4d3cd65763b2aa01c/sdk/eventhub/azure-eventhub/samples/async_samples/client_creation_async.py#L100)
- [`connection_to_custom_endpoint_address_async.py`](https://github.com/Azure/azure-sdk-for-python/blob/fe37155dcb6bf66491cf59a4d3cd65763b2aa01c/sdk/eventhub/azure-eventhub/samples/async_samples/connection_to_custom_endpoint_address_async.py#L73)
- [`sample_code_eventhub_async.py`](https://github.com/Azure/azure-sdk-for-python/blob/fe37155dcb6bf66491cf59a4d3cd65763b2aa01c/sdk/eventhub/azure-eventhub/samples/async_samples/sample_code_eventhub_async.py#L210)

Because I'm not sure if the behavior will be changed or not once I modified the code.

For examples, 

**from**
``` python
loop = asyncio.get_event_loop()
loop.run_until_complete(create_producer_client())
loop.run_until_complete(create_consumer_client())
```
**to**
``` python
async def main():
    await create_producer_client()
    await create_consumer_client()

asyncio.run(main())
```