### PR TITLE
[ServiceBus] Fix TTL on messages

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -353,7 +353,7 @@ class ServiceBusMessage(
             if self._raw_amqp_message.properties.absolute_expiry_time:
                 self._raw_amqp_message.properties.absolute_expiry_time = value
         elif isinstance(value, datetime.timedelta):
-            self._raw_amqp_message.header.time_to_live = value.seconds * 1000
+            self._raw_amqp_message.header.time_to_live = int(value.total_seconds()) * 1000
         else:
             self._raw_amqp_message.header.time_to_live = int(value) * 1000
 

--- a/sdk/servicebus/azure-servicebus/tests/test_message.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_message.py
@@ -188,3 +188,11 @@ def test_amqp_message():
     assert amqp_annotated_message.properties.group_id == 'id'
     assert amqp_annotated_message.properties.group_sequence == 1
     assert amqp_annotated_message.properties.reply_to_group_id == 'id'
+
+
+def test_servicebus_message_time_to_live():
+    message = ServiceBusMessage(body="hello")
+    message.time_to_live = timedelta(seconds=30)
+    assert message.time_to_live == timedelta(seconds=30)
+    message.time_to_live = timedelta(days=1)
+    assert message.time_to_live == timedelta(days=1)


### PR DESCRIPTION
Using `seconds` on `timedelta` to set TTL leads to unexpected behaviour with, for example, `timedelta(days=1)`: 

```
azure.servicebus.exceptions.ServiceBusError: Argument TimeToLIve must be a positive timeout value. The provided value was 00:00:00.
Parameter name: TimeToLIve
Actual value was 00:00:00
```

Instead of `seconds`, `total_seconds()` should be used:
```
>>> timedelta(days=1).seconds
0
>>> timedelta(days=1).total_seconds()
86400.0
```