### PR TITLE
Replace TokenCredential reference with AsyncTokenCredential

### DIFF
--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
@@ -29,7 +29,7 @@ class MetricsQueryClient(object):
     """MetricsQueryClient
 
     :param credential: The credential to authenticate the client
-    :type credential: ~azure.core.credentials.TokenCredential
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :keyword endpoint: The endpoint to connect to. Defaults to 'https://management.azure.com'.
     :paramtype endpoint: str
     """


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-python/issues/19417

The async client should reference the async credential type.