### PR TITLE
add error message when no recording file exists

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -90,7 +90,10 @@ def start_record_or_playback(test_id):
             PLAYBACK_START_URL,
             headers={"x-recording-file": test_id, "x-recording-sha": current_sha},
         )
-        recording_id = result.headers["x-recording-id"]
+        try:
+            recording_id = result.headers["x-recording-id"]
+        except KeyError:
+            raise ValueError("No recording file found for {}".format(test_id))
         if result.text:
             try:
                 variables = result.json()


### PR DESCRIPTION
just a suggestion, feel free to reject the PR.

A `KeyError` is raised when the `x-recording-id` cannot be found. My understanding is that this happens when trying to run playback without a recording file present for the specific test (I've accidentally done this a few times myself). Suggestion to raise an error message that helps explains the problem.