### PR TITLE
[Key Vault] Use shared test-resources.json

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -144,9 +144,9 @@ class KeysTestCase(AzureTestCase):
     def _get_attestation_uri(self):
         playback_uri = "https://fakeattestation.azurewebsites.net"
         if self.is_live:
-            real_uri = os.environ.get("AZURE_KEYVAULT_ATTESTATION_URI")
+            real_uri = os.environ.get("AZURE_KEYVAULT_ATTESTATION_URL")
             if real_uri is None:
-                pytest.skip("No AZURE_KEYVAULT_ATTESTATION_URI environment variable")
+                pytest.skip("No AZURE_KEYVAULT_ATTESTATION_URL environment variable")
             self._scrub_url(real_uri, playback_uri)
             return real_uri
         return playback_uri

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -18,7 +18,6 @@
         },
         "testApplicationOid": {
             "type": "string",
-            "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
             "metadata": {
                 "description": "The client OID to grant access to test resources."
             }
@@ -66,13 +65,6 @@
                 "description": "Whether to enable deployment of Managed HSM. The default is false."
             }
         },
-        "keyVaultDomainSuffix": {
-            "type": "string",
-            "defaultValue": ".vault.azure.net",
-            "metadata": {
-                "description": "Domain suffix for sovereign clouds, requies the preceeding '.'. The default uses the public Azure Cloud (.vault.azure.net)"
-            }
-        },
         "keyVaultSku": {
             "type": "string",
             "defaultValue": "premium",
@@ -80,24 +72,22 @@
                 "description": "Key Vault SKU to deploy. The default is 'premium'"
             }
         },
-        "attestationUri": {
+        "attestationImage": {
             "type": "string",
-            "defaultValue": "https://skrattestation.azurewebsites.net/",
+            "defaultValue": "keyvault-mock-attestation:latest",
             "metadata": {
-                "description": "Test attestation service for Secure Key Release."
+                "description": "The container image name and tag to use for the attestation mock service."
             }
-        },
-        "storageEndpointSuffix": {
-          "type": "string",
-          "defaultValue": "core.windows.net",
-          "metadata": {
-              "description": "The url suffix to use when accessing the storage data plane."
-          }
         }
     },
     "variables": {
+        "attestationFarm": "[concat(parameters('baseName'), 'farm')]",
+        "attestationSite": "[concat(parameters('baseName'), 'site')]",
+        "attestationUri": "[concat('DOCKER|azsdkengsys.azurecr.io/', parameters('attestationImage'))]",
         "kvApiVersion": "2019-09-01",
-        "azureKeyVaultUrl": "[format('https://{0}{1}', parameters('baseName'), parameters('keyVaultDomainSuffix'))]",
+        "kvName": "[parameters('baseName')]",
+        "kvAdminDefinitionId": "00482a5a-887f-4fb3-b363-3b7fe8e74483",
+        "kvAdminAssignmentName": "[guid(resourceGroup().id, variables('kvAdminDefinitionId'), parameters('testApplicationOid'))]",
         "hsmApiVersion": "2021-04-01-preview",
         "hsmName": "[concat(parameters('baseName'), 'hsm')]",
         "mgmtApiVersion": "2019-04-01",
@@ -122,7 +112,7 @@
         {
             "type": "Microsoft.KeyVault/vaults",
             "apiVersion": "[variables('kvApiVersion')]",
-            "name": "[parameters('baseName')]",
+            "name": "[variables('kvName')]",
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
@@ -130,66 +120,22 @@
                     "name": "[parameters('keyVaultSku')]"
                 },
                 "tenantId": "[parameters('tenantId')]",
-                "accessPolicies": [
-                    {
-                        "tenantId": "[parameters('tenantId')]",
-                        "objectId": "[parameters('testApplicationOid')]",
-                        "permissions": {
-                            "keys": [
-                                "get",
-                                "list",
-                                "update",
-                                "create",
-                                "import",
-                                "delete",
-                                "recover",
-                                "backup",
-                                "restore",
-                                "decrypt",
-                                "encrypt",
-                                "unwrapKey",
-                                "wrapKey",
-                                "verify",
-                                "sign",
-                                "purge",
-                                "rotate",
-                                "release"
-                            ],
-                            "secrets": [
-                                "get",
-                                "list",
-                                "set",
-                                "delete",
-                                "recover",
-                                "backup",
-                                "restore",
-                                "purge"
-                            ],
-                            "certificates": [
-                                "get",
-                                "list",
-                                "update",
-                                "create",
-                                "import",
-                                "delete",
-                                "recover",
-                                "backup",
-                                "restore",
-                                "managecontacts",
-                                "manageissuers",
-                                "getissuers",
-                                "listissuers",
-                                "setissuers",
-                                "deleteissuers",
-                                "purge"
-                            ]
-                        }
-                    }
-                ],
                 "enabledForDeployment": false,
                 "enabledForDiskEncryption": false,
                 "enabledForTemplateDeployment": false,
-                "enableSoftDelete": true
+                "enableSoftDelete": true,
+                "enableRbacAuthorization": true,
+                "softDeleteRetentionInDays": 7
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[variables('kvAdminAssignmentName')]",
+            "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('kvAdminDefinitionId'))]",
+                "principalId": "[parameters('testApplicationOid')]",
+                "scope": "[resourceGroup().id]"
             }
         },
         {
@@ -207,9 +153,9 @@
                 "initialAdminObjectIds": "[union(array(parameters('testApplicationOid')), array(parameters('provisionerApplicationOid')))]",
                 "enablePurgeProtection": false,
                 "enableSoftDelete": true,
+                "softDeleteRetentionInDays": 7,
                 "publicNetworkAccess": "Enabled",
-                "networkAcls": "[variables('networkAcls')]",
-                "softDeleteRetentionInDays": 7
+                "networkAcls": "[variables('networkAcls')]"
             }
         },
         {
@@ -260,12 +206,53 @@
             "properties": {
                 "publicAccess": "None"
             }
+        },
+        {
+
+            "type": "Microsoft.Web/serverfarms",
+            "apiVersion": "2020-12-01",
+            "name": "[variables('attestationFarm')]",
+            "condition": "[parameters('enableHsm')]",
+            "location": "[parameters('location')]",
+            "kind": "linux",
+            "sku": {
+                "name": "B1"
+            },
+            "properties": {
+                "reserved": true
+            }
+        },
+        {
+
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2020-12-01",
+            "name": "[variables('attestationSite')]",
+            "condition": "[parameters('enableHsm')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('attestationFarm'))]"
+            ],
+            "location": "[parameters('location')]",
+            "properties": {
+                "httpsOnly": true,
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('attestationFarm'))]",
+                "siteConfig": {
+                    "name": "[variables('attestationSite')]",
+                    "alwaysOn": true,
+                    "linuxFxVersion": "[variables('attestationUri')]",
+                    "appSettings": [
+                        {
+                            "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                            "value": "false"
+                        }
+                    ]
+                }
+            }
         }
     ],
     "outputs": {
         "AZURE_KEYVAULT_URL": {
             "type": "string",
-            "value": "[variables('azureKeyVaultUrl')]"
+            "value": "[reference(variables('kvName')).vaultUri]"
         },
         "AZURE_MANAGEDHSM_URL": {
             "type": "string",
@@ -280,10 +267,6 @@
             "type": "string",
             "value": "[parameters('testApplicationOid')]"
         },
-        "KEYVAULT_STORAGE_ENDPOINT_SUFFIX": {
-            "type": "string",
-            "value": "[parameters('storageEndpointSuffix')]"
-        },
         "BLOB_STORAGE_ACCOUNT_NAME": {
             "type": "string",
             "value": "[variables('primaryAccountName')]"
@@ -296,10 +279,10 @@
             "type": "string",
             "value": "[variables('blobContainerName')]"
         },
-        "AZURE_KEYVAULT_ATTESTATION_URI": {
+        "AZURE_KEYVAULT_ATTESTATION_URL": {
             "type": "string",
             "condition": "[parameters('enableHsm')]",
-            "value": "[parameters('attestationUri')]"
+            "value": "[format('https://{0}/', reference(variables('attestationSite')).defaultHostName)]"
         }
     }
 }


### PR DESCRIPTION
This aligns Python's KV `test-resources.json` with [.NET's](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/test-resources.json), which is or will be used by other languages as well.