### PR TITLE
Revert "Use working region/subscription for search deployments"

### DIFF
--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -4,9 +4,6 @@ stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       BuildTargetingString: azure-search-documents
-      # TODO: change/remove location back to default westus2 after search RP fixes deletion metadata issue
-      # https://github.com/Azure/azure-sdk-tools/issues/2216
-      Location: 'eastus2'
       ServiceDirectory: search
       EnvVars:
         AZURE_CLIENT_ID: $(SEARCH_CLIENT_ID)


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#21568

The above PR was a temporary workaround fix for an RP deletion metadata issue. Checking to see if it is resolved now.