### PR TITLE
Pin Crypto Temporarily

### DIFF
--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -2,6 +2,7 @@ pip==20.3
 
 # python 3.10 pinned packages
 cffi==1.15.0rc2; python_version >= '3.10'
+cryptography==35.0.0
 
 # requirements leveraged by ci for testing
 pytest==4.6.9; python_version == '2.7'

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -2,7 +2,8 @@ pip==20.3
 
 # python 3.10 pinned packages
 cffi==1.15.0rc2; python_version >= '3.10'
-cryptography==35.0.0
+cryptography==35.0.0; python_version > '2.7'
+cryptography==3.3; python_version == '2.7'
 
 # requirements leveraged by ci for testing
 pytest==4.6.9; python_version == '2.7'

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -15,6 +15,7 @@ from packaging.specifiers import SpecifierSet
 from pkg_resources import Requirement, parse_version
 import re
 
+import pdb
 from pypi_tools.pypi import PyPIClient
 
 setup_parser_path = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "versioning"))
@@ -39,7 +40,7 @@ MINIMUM_VERSION_SUPPORTED_OVERRIDE = {
     "six": "1.12.0",
 }
 
-MAXIMUM_VERSION_SUPPORTED_OVERRIDE = {"cryptography": "3.4.8"}
+MAXIMUM_VERSION_SUPPORTED_OVERRIDE = {"cryptography": "35.0.0"}
 
 
 def install_dependent_packages(setup_py_file_path, dependency_type, temp_dir):
@@ -101,6 +102,7 @@ def process_requirement(req, dependency_type):
             v for v in versions if parse_version(v) >= parse_version(MINIMUM_VERSION_SUPPORTED_OVERRIDE[pkg_name])
         ]
 
+    pdb.set_trace()
     if pkg_name in MAXIMUM_VERSION_SUPPORTED_OVERRIDE:
         versions = [
             v for v in versions if parse_version(v) <= parse_version(MAXIMUM_VERSION_SUPPORTED_OVERRIDE[pkg_name])

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -15,7 +15,6 @@ from packaging.specifiers import SpecifierSet
 from pkg_resources import Requirement, parse_version
 import re
 
-import pdb
 from pypi_tools.pypi import PyPIClient
 
 setup_parser_path = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "versioning"))
@@ -102,7 +101,6 @@ def process_requirement(req, dependency_type):
             v for v in versions if parse_version(v) >= parse_version(MINIMUM_VERSION_SUPPORTED_OVERRIDE[pkg_name])
         ]
 
-    pdb.set_trace()
     if pkg_name in MAXIMUM_VERSION_SUPPORTED_OVERRIDE:
         versions = [
             v for v in versions if parse_version(v) <= parse_version(MAXIMUM_VERSION_SUPPORTED_OVERRIDE[pkg_name])

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -173,6 +173,7 @@ changedir = {toxinidir}
 deps =
   {[packaging]pkgs}
   requests
+  cryptography==3.1;python_version < 3.7
 commands =
     {envbindir}/python {toxinidir}/../../../eng/tox/sanitize_setup.py -t {toxinidir}
     {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py \

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -173,7 +173,7 @@ changedir = {toxinidir}
 deps =
   {[packaging]pkgs}
   requests
-  cryptography==3.1;python_version < 3.7
+  cryptography==3.1;python_version < '3.7'
 commands =
     {envbindir}/python {toxinidir}/../../../eng/tox/sanitize_setup.py -t {toxinidir}
     {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py \


### PR DESCRIPTION
The true path forward will be one of two options.

1. Stop using `UsePythonVersion` in favor of our own hand-rolled version. It's not too bad, couple hours.
2. Finish [the PR to the task itself](https://github.com/microsoft/azure-pipelines-tasks/pull/15553). I'm not optimistic about engagement there.


For those of you that are lost. The timeline of events:

1. crypto 36 released
2. it started crashing on pypy (even though they ship pypy wheels)

The reason behind this is that the `UsePythonVersion` task is hardcoded to go after `pypy w/2.7` or `pypy w/3.6` ONLY. It legit doesn't even parse the versionspec. 
