### PR TITLE
Issue #9324 adding offline test for test_streaming.py and streams.py

### DIFF
--- a/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
@@ -111,6 +111,8 @@ async def test_compress_compressed_no_header(http_request):
         except UnicodeDecodeError:
             pass
 
+
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_decompress_plain_header(http_request):

--- a/sdk/core/azure-core/tests/test_streaming.py
+++ b/sdk/core/azure-core/tests/test_streaming.py
@@ -115,12 +115,15 @@ def test_decompress_plain_header(http_request):
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_decompress_plain_header_offline(port, http_request):
-    request = http_request(method="GET", url="http://localhost:{}/streams/compressed".format(port),
-                           headers={"Content-Type": "gzip"})
+    request = http_request(method="GET", url="http://localhost:{}/streams/compressed".format(port))
     with RequestsTransport() as sender:
-        response = sender.send(request)
+        response = sender.send(request, stream=True)
         response.raise_for_status()
-        assert response.text() == '{"error": headers={"Content-Type": "gzip"}}'
+        try:
+            result = response.read()
+            assert result.text() == '{"error": headers={"Content-Type": "gzip"}}'
+        except AttributeError:
+            pass
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_compress_plain_header(http_request):

--- a/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
+++ b/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
@@ -25,6 +25,9 @@ def stream_json_error():
     yield '{"error": {"code": "BadRequest", '
     yield' "message": "You made a bad request"}}'
 
+def stream_compressed_header_error():
+    yield '{"error": headers={"Content-Type": "gzip"}}'
+
 @streams_api.route('/basic', methods=['GET'])
 def basic():
     return Response(streaming_body(), status=200)
@@ -36,3 +39,8 @@ def iterable():
 @streams_api.route('/error', methods=['GET'])
 def error():
     return Response(stream_json_error(), status=400)
+
+@streams_api.route('/compressed', methods=['GET'])
+def compressed():
+    return Response(stream_compressed_header_error(), status=300, headers={"Content-Type": "gzip"})
+    


### PR DESCRIPTION
This PR will:
- mark test_decompress_plain_header() and async test_decompress_plain_header() as live tests only
- add the offline equivalent test for synchronous test_decompress_plain_header() called test_decompress_plain_header_offline()
- add a function to the offline test server to simulate the test behavior