### PR TITLE
[translation] remove sample tests dependency on static storage acc

### DIFF
--- a/sdk/translation/azure-ai-translation-document/samples/assets/translate.txt
+++ b/sdk/translation/azure-ai-translation-document/samples/assets/translate.txt
@@ -1,0 +1,1 @@
+hello world

--- a/sdk/translation/test-resources-post.ps1
+++ b/sdk/translation/test-resources-post.ps1
@@ -1,20 +1,3 @@
-[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
-param (
-    [Parameter(Mandatory = $true)]
-    [string] $ResourceGroupName,
-
-    [Parameter()]
-    [string] $TestApplicationOid,
-
-    # The DeploymentOutputs parameter is only valid in the test-resources-post.ps1 script.
-    [Parameter()]
-    [hashtable] $DeploymentOutputs,
-
-    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
-    [Parameter(ValueFromRemainingArguments = $true)]
-    $RemainingArguments
-)
-
 $StorageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -Name $DeploymentOutputs["TRANSLATION_DOCUMENT_STORAGE_NAME"]
 $ctx = $StorageAccount.Context
 Set-AzStorageBlobContent -File "./sdk/translation/azure-ai-translation-document/samples/assets/glossary_sample.tsv" -Container "sourcecontainer" -Blob "glosario.tsv" -Context $ctx

--- a/sdk/translation/test-resources-post.ps1
+++ b/sdk/translation/test-resources-post.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $ResourceGroupName,
+
+    [Parameter()]
+    [string] $TestApplicationOid,
+
+    # The DeploymentOutputs parameter is only valid in the test-resources-post.ps1 script.
+    [Parameter()]
+    [hashtable] $DeploymentOutputs,
+
+    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArguments
+)
+
+$StorageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -Name $DeploymentOutputs["TRANSLATION_DOCUMENT_STORAGE_NAME"]
+$ctx = $StorageAccount.Context
+Set-AzStorageBlobContent -File "./sdk/translation/azure-ai-translation-document/samples/assets/glossary_sample.tsv" -Container "sourcecontainer" -Blob "glosario.tsv" -Context $ctx
+Set-AzStorageBlobContent -File "./sdk/translation/azure-ai-translation-document/samples/assets/translate.txt" -Container "sourcecontainer" -Blob "translate.txt" -Context $ctx

--- a/sdk/translation/test-resources.json
+++ b/sdk/translation/test-resources.json
@@ -50,32 +50,7 @@
             "type": "string",
             "defaultValue": "[concat(parameters('baseName'), 'prim')]"
         },
-        "sourceStorageAccount": {
-            "type": "string",
-            "defaultValue": "krpraticstorageacc"
-        },
-        "sourceResourceId": {
-            "type": "string",
-            "defaultValue": "[resourceId('faa080af-c1d8-40ad-9cce-e1a450ca5b57', 'krpratic-rg', 'Microsoft.Storage/storageAccounts', parameters('sourceStorageAccount'))]"
-        },
-        "sourceContainerName": {
-            "type": "string",
-            "defaultValue": "testingtranslation"
-        },
-        "glossaryFileName": {
-            "type": "string",
-            "defaultValue": "glosario.tsv"
-        },
-        "sourceContainerSasProperties": {
-            "type": "object",
-            "defaultValue": {
-                "canonicalizedResource": "[concat('/blob/', parameters('sourceStorageAccount'), '/', parameters('sourceContainerName'))]",
-                "signedExpiry": "[dateTimeAdd(utcNow('u'), 'PT3H')]",
-                "signedPermission": "rl",
-                "signedResource": "c"
-            }
-        },
-        "targetResourceId": {
+        "storageAccResourceId": {
             "type": "string",
             "defaultValue": "[resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccount'))]"
         },
@@ -130,6 +105,23 @@
                 "signedPermission": "wl",
                 "signedResource": "c"
             }
+        },
+        "sourceContainerName": {
+            "type": "string",
+            "defaultValue": "sourcecontainer"
+        },
+        "sourceContainerSasProperties": {
+            "type": "object",
+            "defaultValue": {
+                "canonicalizedResource": "[concat('/blob/', parameters('blobStorageAccount'), '/', parameters('sourceContainerName'))]",
+                "signedExpiry": "[dateTimeAdd(utcNow('u'), 'PT3H')]",
+                "signedPermission": "wl",
+                "signedResource": "c"
+            }
+        },
+        "glossaryFileName": {
+            "type": "string",
+            "defaultValue": "glosario.tsv"
         }
     },
     "variables": {
@@ -231,6 +223,14 @@
                   "dependsOn": [
                     "[parameters('blobStorageAccount')]"
                   ]
+                }, 
+                {
+                  "type": "blobServices/containers",
+                  "apiVersion": "[variables('storageMgmtApiVersion')]",
+                  "name": "[concat('default/', parameters('sourceContainerName'))]",
+                  "dependsOn": [
+                    "[parameters('blobStorageAccount')]"
+                  ]
                 }
             ]
         }
@@ -290,35 +290,35 @@
         },
         "AZURE_SOURCE_CONTAINER_URL": {
             "type": "string",
-            "value": "[concat(reference(parameters('sourceResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '?', listServiceSas(parameters('sourceResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
         },
         "AZURE_SOURCE_CONTAINER_URL_1": {
             "type": "string",
-            "value": "[concat(reference(parameters('sourceResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '?', listServiceSas(parameters('sourceResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
         },
         "AZURE_SOURCE_CONTAINER_URL_2": {
             "type": "string",
-            "value": "[concat(reference(parameters('sourceResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '?', listServiceSas(parameters('sourceResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
         },
         "AZURE_TRANSLATION_GLOSSARY_URL": {
             "type": "string",
-            "value": "[concat(reference(parameters('sourceResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '/', parameters('glossaryFileName'), '?', listServiceSas(parameters('sourceResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('sourceContainerName'), '/', parameters('glossaryFileName'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('sourceContainerSasProperties')).serviceSasToken)]"
         },
         "AZURE_TARGET_CONTAINER_URL": {
             "type": "string",
-            "value": "[concat(reference(parameters('targetResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_1'), '?', listServiceSas(parameters('targetResourceId'), '2019-06-01', parameters('targetContainerSasProperties_1')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_1'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('targetContainerSasProperties_1')).serviceSasToken)]"
         },
         "AZURE_TARGET_CONTAINER_URL_FR": {
             "type": "string",
-            "value": "[concat(reference(parameters('targetResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_2'), '?', listServiceSas(parameters('targetResourceId'), '2019-06-01', parameters('targetContainerSasProperties_2')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_2'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('targetContainerSasProperties_2')).serviceSasToken)]"
         },
         "AZURE_TARGET_CONTAINER_URL_AR": {
             "type": "string",
-            "value": "[concat(reference(parameters('targetResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_3'), '?', listServiceSas(parameters('targetResourceId'), '2019-06-01', parameters('targetContainerSasProperties_3')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_3'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('targetContainerSasProperties_3')).serviceSasToken)]"
         },
         "AZURE_TARGET_CONTAINER_URL_ES": {
             "type": "string",
-            "value": "[concat(reference(parameters('targetResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_4'), '?', listServiceSas(parameters('targetResourceId'), '2019-06-01', parameters('targetContainerSasProperties_4')).serviceSasToken)]"
+            "value": "[concat(reference(parameters('storageAccResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('targetContainerName_4'), '?', listServiceSas(parameters('storageAccResourceId'), '2019-06-01', parameters('targetContainerSasProperties_4')).serviceSasToken)]"
         }
     }
 }

--- a/sdk/translation/test-resources.json
+++ b/sdk/translation/test-resources.json
@@ -115,7 +115,7 @@
             "defaultValue": {
                 "canonicalizedResource": "[concat('/blob/', parameters('blobStorageAccount'), '/', parameters('sourceContainerName'))]",
                 "signedExpiry": "[dateTimeAdd(utcNow('u'), 'PT3H')]",
-                "signedPermission": "wl",
+                "signedPermission": "rl",
                 "signedResource": "c"
             }
         },


### PR DESCRIPTION
The sample tests for Document Translation depend on a persistent storage account which needs a container with two small files to test the scenarios in the live CI. We originally were using a static storage account for this in the test-resources.json, but I want to fix this because...

1) This isn't the right way to use static resources in our live tests
2) This complicates adding additional cloud configs, e.g. Dogfood. However, I don't think it makes sense to have a static storage account across clouds for just two small files.

The rest of the resources and containers needed for tests/samples can be be dynamically created and torn down as expected.

Live test run pass: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1226274&view=results



 