### PR TITLE
[pipeline] skip python ci for data-plane

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/auto_codegen.py
+++ b/tools/azure-sdk-tools/packaging_tools/auto_codegen.py
@@ -102,6 +102,9 @@ def main(generate_input, generate_output):
     result = {}
     package_total = set()
     for input_readme in data["relatedReadmeMdFiles"]:
+        # skip codegen for data-plane temporarily since it is useless now and may block PR
+        if 'resource-manager' not in input_readme:
+            continue
         relative_path_readme = str(Path(spec_folder, input_readme))
         _LOGGER.info(f"[CODEGEN]({input_readme})codegen begin")
         config = generate(CONFIG_FILE, sdk_folder, [], relative_path_readme, spec_folder, force_generation=True)


### PR DESCRIPTION
data-plane don't use the package generated by autorest temporarily. To avoid blocking data-plane PR, we skip it temporarily.
test PR : https://github.com/openapi-env-test/azure-rest-api-specs/pull/3005
