### PR TITLE
[storage] update error checks for new azure-core error repr

### DIFF
--- a/sdk/storage/azure-storage-queue/tests/test_queue_encryption.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_encryption.py
@@ -343,7 +343,7 @@ class StorageQueueEncryptionTest(StorageTestCase):
         with self.assertRaises(HttpResponseError) as e:
             queue.peek_messages()
 
-        self.assertEqual(str(e.exception), "Decryption failed.")
+        assert "Decryption failed." in str(e.exception)
 
         invalid_key_2 = lambda: None  # functions are objects, so this effectively creates an empty object
         invalid_key_2.get_kid = valid_key.get_kid
@@ -473,7 +473,7 @@ class StorageQueueEncryptionTest(StorageTestCase):
         with self.assertRaises(HttpResponseError) as e:
             next(queue.receive_messages())
 
-        self.assertEqual(str(e.exception), "Decryption failed.")
+        assert "Decryption failed." in str(e.exception)
 
 
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_encryption_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_encryption_async.py
@@ -383,7 +383,7 @@ class StorageQueueEncryptionTestAsync(AsyncStorageTestCase):
         with self.assertRaises(HttpResponseError) as e:
             await queue.peek_messages()
 
-        self.assertEqual(str(e.exception), "Decryption failed.")
+        assert "Decryption failed." in str(e.exception)
 
         invalid_key_2 = lambda: None  # functions are objects, so this effectively creates an empty object
         invalid_key_2.get_kid = valid_key.get_kid
@@ -522,7 +522,7 @@ class StorageQueueEncryptionTestAsync(AsyncStorageTestCase):
             async for m in queue.receive_messages():
                 messages.append(m)
 
-        self.assertEqual(str(e.exception), "Decryption failed.")
+        assert "Decryption failed." in str(e.exception)
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':


### PR DESCRIPTION
We want to add more information to outputted exceptions, including the error body in cases where error bodies were not included before. This test changes the tests to test that "Decryption failed." is in the error string, instead of validating what the entire exception string looks like.