### PR TITLE
Use docker validation on unified pipeline and release

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -77,7 +77,7 @@ jobs:
         inputs:
           pwsh: true
           filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation) -PackageSourceOverride "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/" -ImageId '$(DocValidationImageId)'
+          arguments: -DocRepoLocation $(DocRepoLocation) -PackageSourceOverride "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
         displayName: Update Docs Onboarding for Daily branch
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -8,6 +8,8 @@ parameters:
   DevFeedName: 'public/azure-sdk-for-python'
   TargetDocRepoOwner: ''
   TargetDocRepoName: ''
+  PackageSourceOverride: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+  DocValidationImageId: "azuresdkimages.azurecr.io/pyrefautocr:latest"
 
 stages:
   - ${{if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
@@ -175,7 +177,8 @@ stages:
                               SparseCheckoutPaths:
                                 - docs-ref-services/
                                 - metadata/
-
+                              PackageSourceOverride: ${{parameters.PackageSourceOverride}}
+                              DocValidationImageId: ${{parameters.DocValidationImageId}}
           - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
             - deployment: UpdatePackageVersion
               displayName: "Update Package Version"
@@ -291,3 +294,5 @@ stages:
             SparseCheckoutPaths:
               - docs-ref-services/
               - metadata/
+            PackageSourceOverride: ${{parameters.PackageSourceOverride}}
+            DocValidationImageId: ${{parameters.DocValidationImageId}}

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -161,29 +161,59 @@ function Get-python-GithubIoDocIndex()
   GenerateDocfxTocContent -tocContent $tocContent -lang "Python" -campaignId "UA-62780441-36"
 }
 
-function ValidatePackage($packageName, $packageVersion, $workingDirectory) {
+function ValidatePackage
+{
+  Param(
+    [Parameter(Mandatory=$true)]
+    [string]$packageName, 
+    [Parameter(Mandatory=$true)]
+    [string]$packageVersion,
+    [Parameter(Mandatory=$false)]
+    [string]$PackageSourceOverride,
+    [Parameter(Mandatory=$false)]
+    [string]$DocValidationImageId
+  ) 
+  $installValidationFolder = Join-Path ([System.IO.Path]::GetTempPath()) "validation"
+  if (!(Test-Path $installValidationFolder)) {
+    New-Item -ItemType Directory -Force -Path $installValidationFolder | Out-Null
+  }
   # Add more validation by replicating as much of the docs CI process as
   # possible
   # https://github.com/Azure/azure-sdk-for-python/issues/20109
-  if (!$ImageId) {
+  if (!$DocValidationImageId) {
     Write-Host "Validating using pip command directly on $packageName."
-    FallbackValidation -packageName "$packageName" -packageVersion "$packageVersion" -workingDirectory $workingDirectory
+    FallbackValidation -packageName "$packageName" -packageVersion "$packageVersion" -workingDirectory $installValidationFolder- PackageSourceOverride $PackageSourceOverride
   } 
   else {
-    Write-Host "Validating using $ImageId on $packageName."
-    DockerValidation -packageName "$packageName" -packageVersion "$packageVersion"
+    Write-Host "Validating using $DocValidationImageId on $packageName."
+    DockerValidation -packageName "$packageName" -packageVersion "$packageVersion" `
+        -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId
   }
 }
-function DockerValidation($packageName, $packageVersion) {
-  $packageExpression = "$packageName==$packageVersion"
-  docker run -e TARGET_PACKAGE=$packageExpression -t $ImageId
+function DockerValidation{
+  Param(
+    [Parameter(Mandatory=$true)]
+    [string]$packageName, 
+    [Parameter(Mandatory=$true)]
+    [string]$packageVersion,
+    [Parameter(Mandatory=$false)]
+    [string]$PackageSourceOverride,
+    [Parameter(Mandatory=$false)]
+    [string]$DocValidationImageId
+  ) 
+  if ($PackageSourceOverride) {
+    docker run -e TARGET_PACKAGE=$packageName -e TARGET_VERSION=$packageVersion -e EXTRA_INDEX_URL=$PackageSourceOverride -t $DocValidationImageId
+  }
+  else {
+    docker run -e TARGET_PACKAGE=$packageName -e TARGET_VERSION=$packageVersion -t $DocValidationImageId
+  }
   # The docker exit codes: https://docs.docker.com/engine/reference/run/#exit-status
   # If the docker failed because of docker itself instead of the application, 
   # we should skip the validation and keep the packages. 
   if ($LASTEXITCODE -eq 125 -Or $LASTEXITCODE -eq 126 -Or $LASTEXITCODE -eq 127) { 
     Write-Host $commandLine
     LogWarning "The `docker` command does not work with exit code $LASTEXITCODE. Fall back to npm install $packageName directly."
-    FallbackValidation -packageName "$packageName" -packageVersion "$packageVersion"
+    FallbackValidation -packageName "$packageName" -packageVersion "$packageVersion" -workingDirectory $installValidationFolder -PackageSourceOverride $PackageSourceOverride
   }
   elseif ($LASTEXITCODE -ne 0) { 
     Write-Host $commandLine
@@ -193,7 +223,18 @@ function DockerValidation($packageName, $packageVersion) {
   return $true
 }
 
-function FallbackValidation($packageName, $packageVersion, $workingDirectory) {
+function FallbackValidation
+{
+  Param(
+    [Parameter(Mandatory=$true)]
+    [string]$packageName, 
+    [Parameter(Mandatory=$true)]
+    [string]$packageVersion,
+    [Parameter(Mandatory=$true)]
+    [string]$workingDirectory,
+    [Parameter(Mandatory=$false)]
+    [string]$PackageSourceOverride
+  ) 
   $installTargetFolder = Join-Path $workingDirectory $packageName
   New-Item -ItemType Directory -Force -Path $installTargetFolder | Out-Null
   $packageExpression = "$packageName$packageVersion"
@@ -266,10 +307,6 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
   Write-Host "Updating configuration: $DocConfigFile with mode: $Mode"
   $packageConfig = Get-Content $DocConfigFile -Raw | ConvertFrom-Json
 
-  $installValidationFolder = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-  New-Item -ItemType Directory -Force -Path $installValidationFolder | Out-Null
-
-
   $outputPackages = @()
   foreach ($package in $packageConfig.packages) {
     $packageName = $package.package_info.name
@@ -329,7 +366,7 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
     # If upgrading the package, run basic sanity checks against the package
     if ($package.package_info.version -ne $packageVersion) {
       Write-Host "New version detected for $packageName ($packageVersion)"
-      if (!(ValidatePackage -packageName $packageName -packageVersion $packageVersion -workingDirectory $installValidationFolder)) {
+      if (!(ValidatePackage -packageName $packageName -packageVersion $packageVersion)) {
         LogWarning "Package is not valid: $packageName. Keeping old version."
         $outputPackages += $package
         continue
@@ -384,7 +421,7 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
     if ($Mode -eq 'preview') {
       $packageVersion = "==$($package.VersionPreview)"
     }
-    if (!(ValidatePackage -packageName $packageName -packageVersion $packageVersion -workingDirectory $installValidationFolder)) {
+    if (!(ValidatePackage -packageName $packageName -packageVersion $packageVersion)) {
       LogWarning "Package is not valid: $packageName. Cannot onboard."
       continue
     }
@@ -514,4 +551,20 @@ function Import-Dev-Cert-python
   $pathToScript = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../scripts/devops_tasks/trust_proxy_cert.py")
 
   python $pathToScript
+}
+
+function Validate-Python-DocMsPackages
+{ 
+  Param(
+    [Parameter(Mandatory=$true)]
+    [PSCustomObject]$PackageInfo,
+    [Parameter(Mandatory=$false)]
+    [string]$PackageSourceOverride,
+    [Parameter(Mandatory=$false)]
+    [string]$DocValidationImageId
+  ) 
+  $packageName = $packageInfo.Name
+  $packageVersion = $packageInfo.Version
+  ValidatePackage -packageName $packageName -packageVersion $packageVersion `
+      -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId
 }


### PR DESCRIPTION
The PR is to remove the all package validation from python docindex. 
Onboard with docker validation on unified pipeline and release pipeline.

Testing unified: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1232729&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=95157bd4-d7ec-5ed7-b303-68e386ec5302
Testing release: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1232944&view=results