### PR TITLE
Resolve Installation Ordering Issues Preventing PR Checks of dependent packages

### DIFF
--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -250,6 +250,7 @@ if __name__ == "__main__":
                             installation_additions.append(req)
 
                     if installation_additions:
+                        download_command.extend(installation_additions)
                         download_command.extend(commands_options)
 
                         check_call(download_command, env=dict(os.environ, PIP_EXTRA_INDEX_URL=""))

--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -17,8 +17,6 @@ import sys
 import glob
 import shutil
 from pkg_resources import parse_version
-import pdb
-
 
 from tox_helper_tasks import find_whl, find_sdist, get_package_details, get_pip_list_output, parse_req
 
@@ -27,6 +25,7 @@ logging.getLogger().setLevel(logging.INFO)
 setup_parser_path = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "versioning"))
 sys.path.append(setup_parser_path)
 from setup_parser import get_install_requires
+
 
 def cleanup_build_artifacts(build_folder):
     # clean up egginfo
@@ -111,6 +110,7 @@ def build_and_discover_package(setuppy_path, dist_dir, target_setup, package_typ
         logging.info("Cleaning up build directories and files")
         cleanup_build_artifacts(target_setup)
     return prebuilt_packages
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -237,15 +237,15 @@ if __name__ == "__main__":
                         # get all installed packages
                         installed_pkgs = get_pip_list_output()
 
-                        # parse the specifier 
+                        # parse the specifier
                         req_name, req_specifier = parse_req(req)
 
                         # if we have the package already present...
                         if req_name in installed_pkgs:
                             # ...do we need to install the new version? if the existing specifier matches, we're fine
                             if installed_pkgs[req_name] in req_specifier:
-                               addition_necessary = False 
-                        
+                                addition_necessary = False
+
                         if addition_necessary:
                             installation_additions.append(req)
 
@@ -257,13 +257,7 @@ if __name__ == "__main__":
                             os.path.abspath(os.path.join(tmp_dl_folder, pth)) for pth in os.listdir(tmp_dl_folder)
                         ]
 
-            commands = [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                built_pkg_path
-            ]
+            commands = [sys.executable, "-m", "pip", "install", built_pkg_path]
 
             commands.extend(additional_downloaded_reqs)
             commands.extend(commands_options)

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -9,12 +9,11 @@
 import argparse
 import os
 import sys
-from subprocess import check_call
 import logging
-from pkg_resources import parse_version
 import re
-
-from .tox_helper_tasks import parse_req
+from subprocess import check_call
+from pkg_resources import parse_version
+from tox_helper_tasks import parse_req
 
 from pypi_tools.pypi import PyPIClient
 

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -78,6 +78,7 @@ def find_released_packages(setup_py_path, dependency_type):
     avlble_packages = [x for x in map(lambda x: process_requirement(x, dependency_type), requires) if x]
     return avlble_packages
 
+
 def process_requirement(req, dependency_type):
     # this method finds either latest or minimum version of a package that is available on PyPI
 
@@ -126,10 +127,10 @@ def process_requirement(req, dependency_type):
 
 def check_req_against_exclusion(req, req_to_exclude):
     """
-    This function evaluates a requirement from a dev_requirements file against a file name. Returns True 
+    This function evaluates a requirement from a dev_requirements file against a file name. Returns True
     if the requirement is for the same package listed in "req_to_exclude". False otherwise.
 
-    :param req: An incoming "req" looks like a requirement that appears in a dev_requirements file. EG: [ "../../../tools/azure-devtools", 
+    :param req: An incoming "req" looks like a requirement that appears in a dev_requirements file. EG: [ "../../../tools/azure-devtools",
         "https://docsupport.blob.core.windows.net/repackaged/cffi-1.14.6-cp310-cp310-win_amd64.whl; sys_platform=='win32' and python_version >= '3.10'",
         "msrestazure>=0.4.11", "pytest" ]
 

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -11,9 +11,10 @@ import os
 import sys
 from subprocess import check_call
 import logging
-from packaging.specifiers import SpecifierSet
-from pkg_resources import Requirement, parse_version
+from pkg_resources import parse_version
 import re
+
+from .tox_helper_tasks import parse_req
 
 from pypi_tools.pypi import PyPIClient
 
@@ -76,14 +77,6 @@ def find_released_packages(setup_py_path, dependency_type):
     # Get available version on PyPI for each required package
     avlble_packages = [x for x in map(lambda x: process_requirement(x, dependency_type), requires) if x]
     return avlble_packages
-
-
-def parse_req(req):
-    req_object = Requirement.parse(req.split(";")[0])
-    pkg_name = req_object.key
-    spec = SpecifierSet(str(req_object).replace(pkg_name, ""))
-    return pkg_name, spec
-
 
 def process_requirement(req, dependency_type):
     # this method finds either latest or minimum version of a package that is available on PyPI

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -190,6 +190,7 @@ skipsdist = true
 skip_install = true
 changedir = {toxinidir}
 deps =
+    {[packaging]pkgs}
 commands =
     {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py -d {envtmpdir} -p {toxinidir} --skip-install True
     {envbindir}/python {toxinidir}/../../../eng/tox/verify_whl.py -d {envtmpdir} -t {toxinidir}
@@ -200,6 +201,7 @@ skipsdist = true
 skip_install = true
 changedir = {toxinidir}
 deps =
+    {[packaging]pkgs}
 commands =
     {envbindir}/python {toxinidir}/setup.py --q sdist --format zip -d {envtmpdir}
     {envbindir}/python {toxinidir}/../../../eng/tox/verify_sdist.py -d {envtmpdir} -t {toxinidir}

--- a/eng/tox/tox_helper_tasks.py
+++ b/eng/tox/tox_helper_tasks.py
@@ -18,12 +18,12 @@ import zipfile
 import fnmatch
 import subprocess
 import re
-import pdb
 
 from packaging.specifiers import SpecifierSet
 from pkg_resources import Requirement, parse_version
 
 logging.getLogger().setLevel(logging.INFO)
+
 
 def get_package_details(setup_filename):
     mock_setup = textwrap.dedent(
@@ -59,7 +59,7 @@ def get_package_details(setup_filename):
 
     package_name = kwargs["name"]
     # default namespace for the package
-    name_space = package_name.replace('-', '.')
+    name_space = package_name.replace("-", ".")
     if "packages" in kwargs.keys():
         packages = kwargs["packages"]
         if packages:
@@ -67,6 +67,7 @@ def get_package_details(setup_filename):
             logging.info("Namespaces found for package {0}: {1}".format(package_name, packages))
 
     return package_name, name_space, kwargs["version"]
+
 
 def parse_req(req):
     """
@@ -77,22 +78,18 @@ def parse_req(req):
     spec = SpecifierSet(str(req_object).replace(pkg_name, ""))
     return pkg_name, spec
 
+
 def get_pip_list_output():
-    """Uses the invoking python executable to get the output from pip list.
-    """
-    out = subprocess.Popen([
-            sys.executable,
-            "-m",
-            "pip",
-            "list",
-            "--disable-pip-version-check"
-        ],
+    """Uses the invoking python executable to get the output from pip list."""
+    out = subprocess.Popen(
+        [sys.executable, "-m", "pip", "list", "--disable-pip-version-check"],
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
+        stderr=subprocess.STDOUT,
+    )
 
     stdout, stderr = out.communicate()
 
-    collected_output = {};
+    collected_output = {}
 
     if stdout and (stderr is None):
         # this should be compatible with py27 https://docs.python.org/2.7/library/stdtypes.html#str.decode
@@ -105,10 +102,12 @@ def get_pip_list_output():
 
     return collected_output
 
+
 def unzip_sdist_to_directory(containing_folder):
     # grab the first one
     path_to_zip_file = glob.glob(os.path.join(containing_folder, "*.zip"))[0]
     return unzip_file_to_directory(path_to_zip_file, containing_folder)
+
 
 def unzip_file_to_directory(path_to_zip_file, extract_location):
     # unzip file in given path
@@ -118,10 +117,12 @@ def unzip_file_to_directory(path_to_zip_file, extract_location):
         extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
         return os.path.join(extract_location, extracted_dir)
 
+
 def move_and_rename(source_location):
     new_location = os.path.join(os.path.dirname(source_location), "unzipped")
     os.rename(source_location, new_location)
     return new_location
+
 
 def find_sdist(dist_dir, pkg_name, pkg_version):
     # This function will find a sdist for given package name
@@ -157,7 +158,6 @@ def find_whl(whl_dir, pkg_name, pkg_version):
         logging.error("Package name cannot be empty to find whl")
         return
 
-
     pkg_name_format = "{0}-{1}*.whl".format(pkg_name.replace("-", "_"), pkg_version)
     whls = []
     for root, dirnames, filenames in os.walk(whl_dir):
@@ -165,7 +165,7 @@ def find_whl(whl_dir, pkg_name, pkg_version):
             whls.append(os.path.join(root, filename))
 
     whls = [os.path.relpath(w, whl_dir) for w in whls]
-    
+
     if not whls:
         logging.error("No whl is found in directory %s with package name format %s", whl_dir, pkg_name_format)
         logging.info("List of whls in directory: %s", glob.glob(os.path.join(whl_dir, "*.whl")))
@@ -181,9 +181,13 @@ def find_whl(whl_dir, pkg_name, pkg_version):
         if len(whls) > 1:
             # if we have reached here, that means we have whl specific to platform as well.
             # for now we are failing the test if platform specific wheels are found. Todo: enhance to find platform specific whl
-            logging.error("More than one whl is found in wheel directory for package {}. Platform specific whl discovery is not supported now".format(pkg_name))
+            logging.error(
+                "More than one whl is found in wheel directory for package {}. Platform specific whl discovery is not supported now".format(
+                    pkg_name
+                )
+            )
             sys.exit(1)
-    
+
     # Additional filtering based on arch type willbe required in future if that need arises.
     # for now assumption is that no arch specific whl is generated
     if len(whls) == 1:

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -9,7 +9,7 @@
 # package targeting during release.
 
 import glob
-from subprocess import check_call, CalledProcessError
+from subprocess import check_call, CalledProcessError, Popen
 import os
 import errno
 import shutil
@@ -331,7 +331,6 @@ def run_check_call(
             else:
                 return err
 
-
 # This function generates code coverage parameters
 def create_code_coverage_params(parsed_args, package_name):
     coverage_args = []
@@ -368,8 +367,12 @@ def is_error_code_5_allowed(target_pkg, pkg_name):
         return False
 
 
-# This function parses requirement and return package name and specifier
 def parse_require(req):
+    """
+    Parses the incoming version specification and returns a tuple of the requirement name and specifier.
+
+    "azure-core<2.0.0,>=1.11.0" -> [azure-core, <2.0.0,>=1.11.0]
+    """
     req_object = Requirement.parse(req.split(";")[0])
     pkg_name = req_object.key
     spec = SpecifierSet(str(req_object).replace(pkg_name, ""))

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -44,7 +44,7 @@ OMITTED_CI_PACKAGES = [
     "azure-mgmt",
     "azure-storage",
     "azure-monitor",
-    "azure-mgmt-regionmove"
+    "azure-mgmt-regionmove",
 ]
 MANAGEMENT_PACKAGE_IDENTIFIERS = [
     "mgmt",
@@ -64,9 +64,7 @@ MANAGEMENT_PACKAGES_FILTER_EXCLUSIONS = [
     "azure-mgmt-core",
 ]
 
-TEST_COMPATIBILITY_MAP = {
-    "azure-core-tracing-opentelemetry": "<3.10"
-}
+TEST_COMPATIBILITY_MAP = {"azure-core-tracing-opentelemetry": "<3.10"}
 
 omit_regression = (
     lambda x: "nspkg" not in x
@@ -76,7 +74,7 @@ omit_regression = (
     and os.path.basename(x) not in REGRESSION_EXCLUDED_PACKAGES
 )
 omit_docs = lambda x: "nspkg" not in x and os.path.basename(x) not in META_PACKAGES
-omit_build = lambda x: x # Dummy lambda to match omit type
+omit_build = lambda x: x  # Dummy lambda to match omit type
 lambda_filter_azure_pkg = lambda x: x.startswith("azure") and "-nspkg" not in x
 omit_mgmt = lambda x: "mgmt" not in x or os.path.basename(x) in MANAGEMENT_PACKAGES_FILTER_EXCLUSIONS
 
@@ -88,6 +86,7 @@ omit_funct_dict = {
     "Regression": omit_regression,
     "Omit_management": omit_mgmt,
 }
+
 
 def log_file(file_location, is_error=False):
     with open(file_location, "r") as file:
@@ -126,6 +125,7 @@ def clean_coverage(coverage_dir):
         else:
             raise
 
+
 def str_to_bool(input_string):
     if isinstance(input_string, bool):
         return input_string
@@ -135,6 +135,7 @@ def str_to_bool(input_string):
         return False
     else:
         return False
+
 
 def parse_setup(setup_path):
     setup_filename = os.path.join(setup_path, "setup.py")
@@ -199,7 +200,7 @@ def parse_setup_requires(setup_path):
 
 
 def get_name_from_specifier(version):
-    return re.split(r'[><=]', version)[0]
+    return re.split(r"[><=]", version)[0]
 
 
 def filter_for_compatibility(package_set):
@@ -227,12 +228,9 @@ def filter_packages_by_compatibility_override(package_set, resolve_basename=True
     return [
         p
         for p in package_set
-        if compare_python_version(
-            TEST_COMPATIBILITY_MAP.get(
-                os.path.basename(p) if resolve_basename else p, ">=2.7"
-            )
-        )
+        if compare_python_version(TEST_COMPATIBILITY_MAP.get(os.path.basename(p) if resolve_basename else p, ">=2.7"))
     ]
+
 
 # this function is where a glob string gets translated to a list of packages
 # It is called by both BUILD (package) and TEST. In the future, this function will be the central location
@@ -250,21 +248,13 @@ def process_glob_string(
     collected_top_level_directories = []
 
     for glob_string in individual_globs:
-        globbed = glob.glob(
-            os.path.join(target_root_dir, glob_string, "setup.py")
-        ) + glob.glob(os.path.join(target_root_dir, "sdk/*/", glob_string, "setup.py"))
+        globbed = glob.glob(os.path.join(target_root_dir, glob_string, "setup.py")) + glob.glob(
+            os.path.join(target_root_dir, "sdk/*/", glob_string, "setup.py")
+        )
         collected_top_level_directories.extend([os.path.dirname(p) for p in globbed])
 
     # dedup, in case we have double coverage from the glob strings. Example: "azure-mgmt-keyvault,azure-mgmt-*"
-    collected_directories = list(
-        set(
-            [
-                p
-                for p in collected_top_level_directories
-                if additional_contains_filter in p
-            ]
-        )
-    )
+    collected_directories = list(set([p for p in collected_top_level_directories if additional_contains_filter in p]))
 
     # if we have individually queued this specific package, it's obvious that we want to build it specifically
     # in this case, do not honor the omission list
@@ -278,24 +268,16 @@ def process_glob_string(
 
     # Apply filter based on filter type. for e.g. Docs, Regression, Management
     pkg_set_ci_filtered = list(filter(omit_funct_dict.get(filter_type, omit_build), pkg_set_ci_filtered))
+    logging.info("Target packages after filtering by CI: {}".format(pkg_set_ci_filtered))
     logging.info(
-        "Target packages after filtering by CI: {}".format(
-            pkg_set_ci_filtered
-        )
-    )
-    logging.info(
-        "Package(s) omitted by CI filter: {}".format(
-            list(set(collected_directories) - set(pkg_set_ci_filtered))
-        )
+        "Package(s) omitted by CI filter: {}".format(list(set(collected_directories) - set(pkg_set_ci_filtered)))
     )
     return sorted(pkg_set_ci_filtered)
 
 
 def remove_omitted_packages(collected_directories):
     packages = [
-        package_dir
-        for package_dir in collected_directories
-        if os.path.basename(package_dir) not in OMITTED_CI_PACKAGES
+        package_dir for package_dir in collected_directories if os.path.basename(package_dir) not in OMITTED_CI_PACKAGES
     ]
 
     return packages
@@ -311,17 +293,11 @@ def run_check_call(
     try:
         if run_as_shell:
             logging.info(
-                "Command Array: {0}, Target Working Directory: {1}".format(
-                    " ".join(command_array), working_directory
-                )
+                "Command Array: {0}, Target Working Directory: {1}".format(" ".join(command_array), working_directory)
             )
             check_call(" ".join(command_array), cwd=working_directory, shell=True)
         else:
-            logging.info(
-                "Command Array: {0}, Target Working Directory: {1}".format(
-                    command_array, working_directory
-                )
-            )
+            logging.info("Command Array: {0}, Target Working Directory: {1}".format(command_array, working_directory))
             check_call(command_array, cwd=working_directory)
     except CalledProcessError as err:
         if err.returncode not in acceptable_return_codes:
@@ -330,6 +306,7 @@ def run_check_call(
                 exit(1)
             else:
                 return err
+
 
 # This function generates code coverage parameters
 def create_code_coverage_params(parsed_args, package_name):
@@ -354,9 +331,7 @@ def is_error_code_5_allowed(target_pkg, pkg_name):
     if (
         all(
             map(
-                lambda x: any(
-                    [pkg_id in x for pkg_id in MANAGEMENT_PACKAGE_IDENTIFIERS]
-                ),
+                lambda x: any([pkg_id in x for pkg_id in MANAGEMENT_PACKAGE_IDENTIFIERS]),
                 [target_pkg],
             )
         )
@@ -377,6 +352,7 @@ def parse_require(req):
     pkg_name = req_object.key
     spec = SpecifierSet(str(req_object).replace(pkg_name, ""))
     return [pkg_name, spec]
+
 
 def find_whl(package_name, version, whl_directory):
     if not os.path.exists(whl_directory):
@@ -404,11 +380,18 @@ def find_whl(package_name, version, whl_directory):
 
     return whls[0]
 
+
 # This method installs package from a pre-built whl
-def install_package_from_whl(
-    package_whl_path, working_dir, python_sym_link=sys.executable
-):
-    commands = [python_sym_link, "-m", "pip", "install", package_whl_path, "--extra-index-url", "https://pypi.python.org/simple"]
+def install_package_from_whl(package_whl_path, working_dir, python_sym_link=sys.executable):
+    commands = [
+        python_sym_link,
+        "-m",
+        "pip",
+        "install",
+        package_whl_path,
+        "--extra-index-url",
+        "https://pypi.python.org/simple",
+    ]
     run_check_call(commands, working_dir)
     logging.info("Installed package from {}".format(package_whl_path))
 
@@ -425,11 +408,7 @@ def filter_dev_requirements(pkg_root_path, packages_to_exclude, dest_dir):
         requirements = dev_req_file.readlines()
 
     # filter any package given in excluded list
-    requirements = [
-        req
-        for req in requirements
-        if os.path.basename(req.replace("\n", "")) not in packages_to_exclude
-    ]
+    requirements = [req for req in requirements if os.path.basename(req.replace("\n", "")) not in packages_to_exclude]
 
     logging.info("Filtered dev requirements: {}".format(requirements))
     # create new dev requirements file with different name for filtered requirements
@@ -439,6 +418,7 @@ def filter_dev_requirements(pkg_root_path, packages_to_exclude, dest_dir):
 
     return new_dev_req_path
 
+
 def extend_dev_requirements(dev_req_path, packages_to_include):
     requirements = []
     with open(dev_req_path, "r") as dev_req_file:
@@ -447,15 +427,17 @@ def extend_dev_requirements(dev_req_path, packages_to_include):
     # include any package given in included list. omit duplicate
     for requirement in packages_to_include:
         if requirement not in requirements:
-            requirements.insert(0, requirement.rstrip() + '\n')
+            requirements.insert(0, requirement.rstrip() + "\n")
 
     logging.info("Extending dev requirements. New result:: {}".format(requirements))
     # create new dev requirements file with different name for filtered requirements
     with open(dev_req_path, "w") as dev_req_file:
         dev_req_file.writelines(requirements)
 
+
 def is_required_version_on_pypi(package_name, spec):
     from pypi_tools.pypi import PyPIClient
+
     client = PyPIClient()
     versions = []
     try:
@@ -464,8 +446,10 @@ def is_required_version_on_pypi(package_name, spec):
         logging.error("Package {} is not found on PyPI", package_name)
     return versions
 
+
 def find_packages_missing_on_pypi(path):
     import pkginfo
+
     requires = []
     if path.endswith(".whl"):
         requires = list(filter(lambda_filter_azure_pkg, pkginfo.get_metadata(path).requires_dist))
@@ -476,33 +460,35 @@ def find_packages_missing_on_pypi(path):
     pkg_spec_dict = dict(parse_require(req) for req in requires)
     logging.info("Package requirement: {}".format(pkg_spec_dict))
     # find if version is available on pypi
-    missing_packages = ["{0}{1}".format(pkg, pkg_spec_dict[pkg]) for pkg in pkg_spec_dict.keys() if not is_required_version_on_pypi(pkg, pkg_spec_dict[pkg])]
+    missing_packages = [
+        "{0}{1}".format(pkg, pkg_spec_dict[pkg])
+        for pkg in pkg_spec_dict.keys()
+        if not is_required_version_on_pypi(pkg, pkg_spec_dict[pkg])
+    ]
     if missing_packages:
         logging.error("Packages not found on PyPI: {}".format(missing_packages))
     return missing_packages
 
 
 def find_tools_packages(root_path):
-    """Find packages in tools directory. For e.g. azure-sdk-tools, azure-devtools
-    """
+    """Find packages in tools directory. For e.g. azure-sdk-tools, azure-devtools"""
     glob_string = os.path.join(root_path, "tools", "*", "setup.py")
     pkgs = [os.path.basename(os.path.dirname(p)) for p in glob.glob(glob_string)]
     logging.info("Packages in tools: {}".format(pkgs))
     return pkgs
 
 
-def get_installed_packages(paths = None):
-    """Find packages in default or given lib paths
-    """
+def get_installed_packages(paths=None):
+    """Find packages in default or given lib paths"""
     # WorkingSet returns installed packages in given path
     # working_set returns installed packages in default path
     # if paths is set then find installed packages from given paths
     ws = WorkingSet(paths) if paths else working_set
     return ["{0}=={1}".format(p.project_name, p.version) for p in ws]
 
+
 def get_package_properties(setup_py_path):
-    """Parse setup.py and return package details like package name, version, whether it's new SDK
-    """
+    """Parse setup.py and return package details like package name, version, whether it's new SDK"""
     pkgName, version, _, requires = parse_setup(setup_py_path)
     is_new_sdk = pkgName in NEW_REQ_PACKAGES or any(map(lambda x: (parse_require(x)[0] in NEW_REQ_PACKAGES), requires))
     return pkgName, version, is_new_sdk, setup_py_path


### PR DESCRIPTION
@xiangyan99 @iscai-msft 

The issue was introduced when I implemented the addition of some additional restrictions when pulling from PyPI.

Nightly builds would still be pulling the latest version of azure-core, but PR builds wouldn't be getting the checks properly as @xiangyan99 and @iscai-msft identified to me this morning.

I believe this should be the only fix, but I'm running some additional verification jobs to be certain of that.

The cause of this bug is that when we are installing a target package, we evaluate it's dependencies for `azure` specific packages. We go and grab those from a our single dev feed. The problem is that we _always_ do this, meaning that we **replace** the relative dependency version already installed with `dev_requirements.txt`.

The bugfix checks the already installed packages and takes no action if an already installed version matches a version spec from `install_requires`.
