### PR TITLE
[Key Vault] Add links to ISO 8601 documentation

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -795,7 +795,8 @@ class KeyClient(KeyVaultClientBase):
         :keyword lifetime_actions: Actions that will be performed by Key Vault over the lifetime of a key.
         :paramtype lifetime_actions: Iterable[~azure.keyvault.keys.KeyRotationLifetimeAction]
         :keyword str expires_in: The expiry time of the policy that will be applied on new key versions, defined as an
-            ISO 8601 duration. For example: 90 days is "P90D", 3 months is "P3M", and 48 hours is "PT48H".
+            ISO 8601 duration. For example: 90 days is "P90D", 3 months is "P3M", and 48 hours is "PT48H". See
+            `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_ for more information on ISO 8601 durations.
 
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -286,9 +286,11 @@ class KeyRotationLifetimeAction(object):
     :type action: ~azure.keyvault.keys.KeyRotationPolicyAction or str
 
     :keyword str time_after_create: Time after creation to attempt the specified action, as an ISO 8601 duration.
-        For example, 90 days is "P90D".
+        For example, 90 days is "P90D". See `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_ for more
+        information on ISO 8601 durations.
     :keyword str time_before_expiry: Time before expiry to attempt the specified action, as an ISO 8601 duration.
-        For example, 90 days is "P90D".
+        For example, 90 days is "P90D". See `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_ for more
+        information on ISO 8601 durations.
     """
 
     def __init__(self, action, **kwargs):
@@ -315,7 +317,8 @@ class KeyRotationPolicy(object):
     :ivar lifetime_actions: Actions that will be performed by Key Vault over the lifetime of a key.
     :type lifetime_actions: list[~azure.keyvault.keys.KeyRotationLifetimeAction]
     :ivar str expires_in: The expiry time of the policy that will be applied on new key versions, defined as an ISO
-        8601 duration. For example, 90 days is "P90D".
+        8601 duration. For example, 90 days is "P90D".  See `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_
+        for more information on ISO 8601 durations.
     :ivar created_on: When the policy was created, in UTC
     :type created_on: ~datetime.datetime
     :ivar updated_on: When the policy was last updated, in UTC

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -770,7 +770,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :keyword lifetime_actions: Actions that will be performed by Key Vault over the lifetime of a key.
         :paramtype lifetime_actions: Iterable[~azure.keyvault.keys.KeyRotationLifetimeAction]
         :keyword str expires_in: The expiry time of the policy that will be applied on new key versions, defined as an
-            ISO 8601 duration. For example: 90 days is "P90D", 3 months is "P3M", and 48 hours is "PT48H".
+            ISO 8601 duration. For example: 90 days is "P90D", 3 months is "P3M", and 48 hours is "PT48H". See
+            `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_ for more information on ISO 8601 durations.
 
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/21701. Wikipedia isn't an ideal source, but ultimately the best place that we've agreed to link to across languages.