### PR TITLE
Update package exclusions list in language settings script

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -284,7 +284,6 @@ $PackageExclusions = @{
   'azure-mgmt-reservations' = 'Unsupported doc directives https://github.com/Azure/azure-sdk-for-python/issues/18077';
   'azure-mgmt-signalr' = 'Unsupported doc directives https://github.com/Azure/azure-sdk-for-python/issues/18085';
   'azure-mgmt-mixedreality' = 'Missing version info https://github.com/Azure/azure-sdk-for-python/issues/18457';
-  'azure-monitor-query' = 'Unsupported doc directives https://github.com/Azure/azure-sdk-for-python/issues/19417';
   'azure-mgmt-network' = 'Manual process used to build';
 }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-python/issues/19417

Remove the Azure Monitor Query data plane package from the package exclusions list, per the recommendation at https://github.com/Azure/azure-sdk-for-python/issues/19417#issuecomment-981734331. This change will allow us to onboard the API ref docs for the Python client library.