### PR TITLE
[pipeline] upgrade autorest version(autorest.core : `3.4.5` => `3.7.2`, autorest.python: `5.8.4` => `5.12.0`)

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "autorest_options": {
-      "version": "3.4.5",
-      "use": ["@autorest/python@5.8.4", "@autorest/modelerfour@4.19.2"],
+      "version": "3.7.2",
+      "use": ["@autorest/python@5.12.0", "@autorest/modelerfour@4.19.3"],
       "python": "",
       "python-mode": "update",
       "sdkrel:python-sdks-folder": "./sdk/.",


### PR DESCRIPTION
test link: https://github.com/openapi-env-test/azure-rest-api-specs/pull/3007(network)