### PR TITLE
Remove canary from default weekly live testing clouds

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -49,7 +49,7 @@ parameters:
     default: 'Public'
   - name: SupportedClouds
     type: string
-    default: 'Public,Canary'
+    default: 'Public'
   - name: CloudConfig
     type: object
     default:
@@ -92,9 +92,6 @@ parameters:
 
 stages:
 - ${{ each cloud in parameters.CloudConfig }}:
-  # TODO: re-enable tests-weekly allow filter once sovereign cloud live tests are stable: https://github.com/Azure/azure-sdk/issues/2074
-  # Run all clouds by default for weekly test pipeline, except for clouds specifically unsupported by the calling pipeline
-  # - ${{ if or(contains(parameters.Clouds, cloud.key), contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
   - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'tests-weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
     - ${{ if not(contains(parameters.UnsupportedClouds, cloud.key)) }}:
       - stage: ${{ cloud.key }}_${{ parameters.JobName }}


### PR DESCRIPTION
Extending https://github.com/Azure/azure-sdk-for-net/pull/25589 to other repos.