### PR TITLE
[translation] Update async samples to use asyncio.run instead of loop

### DIFF
--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_authentication_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_authentication_async.py
@@ -77,5 +77,4 @@ async def main():
     await sample_authentication_with_azure_active_directory_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_begin_translation_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_begin_translation_async.py
@@ -71,5 +71,4 @@ async def main():
     await sample_translation_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_check_document_statuses_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_check_document_statuses_async.py
@@ -75,5 +75,4 @@ async def main():
     await sample_document_status_checks_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_list_document_statuses_with_filters_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_list_document_statuses_with_filters_async.py
@@ -87,5 +87,4 @@ async def main():
     await sample_list_document_statuses_with_filters_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_list_translations_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_list_translations_async.py
@@ -56,5 +56,4 @@ async def main():
     await sample_list_translations_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_list_translations_with_filters_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_list_translations_with_filters_async.py
@@ -88,5 +88,4 @@ async def main():
     await sample_list_translations_with_filters_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translate_multiple_inputs_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translate_multiple_inputs_async.py
@@ -106,5 +106,4 @@ async def main():
     await sample_multiple_translation_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translation_with_azure_blob_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translation_with_azure_blob_async.py
@@ -147,5 +147,4 @@ async def main():
     await sample.sample_translation_with_azure_blob()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translation_with_custom_model_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translation_with_custom_model_async.py
@@ -78,5 +78,4 @@ async def main():
     await sample_translation_with_custom_model_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translation_with_glossaries_async.py
+++ b/sdk/translation/azure-ai-translation-document/samples/async_samples/sample_translation_with_glossaries_async.py
@@ -79,5 +79,4 @@ async def main():
     await sample_translation_with_glossaries_async()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
Related to #21210

I have updated `translation` async samples from `asyncio.get_event_loop()` to `asyncio.run()`.

Thanks !
