### PR TITLE
[formrecognizer] Add perf tests for DAC client

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/perfstress_tests/perf_dac_analyze_document_from_url_requests.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/perfstress_tests/perf_dac_analyze_document_from_url_requests.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+import os
+from azure_devtools.perfstress_tests import PerfStressTest
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.formrecognizer import DocumentAnalysisClient
+from azure.ai.formrecognizer.aio import DocumentAnalysisClient as AsyncDocumentAnalysisClient
+
+class AnalyzeDocumentFromUrlRequestPreparation(PerfStressTest):   
+
+    def __init__(self, arguments):
+        super().__init__(arguments)
+
+        self.document_jpg_url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/main/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/forms/Form_1.jpg"
+        
+        # read test related env vars
+        formrecognizer_test_endpoint = os.environ["FORMRECOGNIZER_TEST_ENDPOINT"]
+        form_recognizer_account_key = os.environ["FORMRECOGNIZER_TEST_API_KEY"]
+
+        # assign the clients that will be used in the perf tests
+        self.service_client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(form_recognizer_account_key))
+        self.async_service_client = AsyncDocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(form_recognizer_account_key))
+
+    async def close(self):
+        """This is run after cleanup."""
+        await self.async_service_client.close()
+        self.service_client.close()
+        await super().close()
+
+    def run_sync(self):
+        """The synchronous perf test."""
+        poller = self.service_client.begin_analyze_document_from_url(
+            "prebuilt-document",
+            self.document_jpg_url)
+        assert poller
+
+    async def run_async(self):
+        """The asynchronous perf test."""
+        poller = await self.async_service_client.begin_analyze_document_from_url(
+            "prebuilt-document",
+            self.document_jpg_url)
+        assert poller

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/perfstress_tests/perf_dac_analyze_document_requests.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/perfstress_tests/perf_dac_analyze_document_requests.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+import os
+from azure_devtools.perfstress_tests import PerfStressTest
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.formrecognizer import DocumentAnalysisClient
+from azure.ai.formrecognizer.aio import DocumentAnalysisClient as AsyncDocumentAnalysisClient
+
+class AnalyzeDocumentRequestPreparation(PerfStressTest):   
+
+    def __init__(self, arguments):
+        super().__init__(arguments)
+
+        with open(os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "./../sample_forms/forms/Form_1.jpg")), "rb") as fd:
+            self.document_jpg = fd.read()
+        
+        # read test related env vars
+        formrecognizer_test_endpoint = os.environ["FORMRECOGNIZER_TEST_ENDPOINT"]
+        form_recognizer_account_key = os.environ["FORMRECOGNIZER_TEST_API_KEY"]
+
+        # assign the clients that will be used in the perf tests
+        self.service_client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(form_recognizer_account_key))
+        self.async_service_client = AsyncDocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(form_recognizer_account_key))
+
+    async def close(self):
+        """This is run after cleanup."""
+        await self.async_service_client.close()
+        self.service_client.close()
+        await super().close()
+
+    def run_sync(self):
+        """The synchronous perf test."""
+        poller = self.service_client.begin_analyze_document(
+            "prebuilt-document",
+            self.document_jpg)
+        assert poller
+
+    async def run_async(self):
+        """The asynchronous perf test."""
+        poller = await self.async_service_client.begin_analyze_document(
+            "prebuilt-document",
+            self.document_jpg)
+        assert poller

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/perfstress_tests/perf_dmac_build_model_requests.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/perfstress_tests/perf_dmac_build_model_requests.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+import os
+from azure_devtools.perfstress_tests import PerfStressTest
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.formrecognizer import DocumentModelAdministrationClient
+from azure.ai.formrecognizer.aio import DocumentModelAdministrationClient as AsyncDocumentModelAdministrationClient
+
+class BuildModelRequestPreparation(PerfStressTest):   
+
+    def __init__(self, arguments):
+        super().__init__(arguments)
+
+        # read test related env vars
+        self.formrecognizer_storage_container_sas_url = os.environ["FORMRECOGNIZER_TRAINING_DATA_CONTAINER_SAS_URL"]
+        formrecognizer_test_endpoint = os.environ["FORMRECOGNIZER_TEST_ENDPOINT"]
+        form_recognizer_account_key = os.environ["FORMRECOGNIZER_TEST_API_KEY"]
+
+        # assign the clients that will be used in the perf tests
+        self.admin_client = DocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential(form_recognizer_account_key))
+        self.async_admin_client = AsyncDocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential(form_recognizer_account_key))
+
+    async def close(self):
+        """This is run after cleanup."""
+        await self.async_admin_client.close()
+        self.admin_client.close()
+        await super().close()
+
+    def run_sync(self):
+        """The synchronous perf test."""
+        poller = self.admin_client.begin_build_model(self.formrecognizer_storage_container_sas_url)
+        assert poller
+
+    async def run_async(self):
+        """The asynchronous perf test."""
+        poller = await self.async_admin_client.begin_build_model(self.formrecognizer_storage_container_sas_url)
+        assert poller


### PR DESCRIPTION
Add perf tests that cover request prep and initial service call. 

Fixes #20983

Pending issue to cover investigating and discussing how to perf test response handling: #22149