### PR TITLE
LatestDependency Breaking on pypy3.6

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -39,7 +39,7 @@ MINIMUM_VERSION_SUPPORTED_OVERRIDE = {
     "six": "1.12.0",
 }
 
-MAXIMUM_VERSION_SUPPORTED_OVERRIDE = {"cryptography": "35.0.0"}
+MAXIMUM_VERSION_SUPPORTED_OVERRIDE = {"cryptography": "4.0.0"}
 
 
 def install_dependent_packages(setup_py_file_path, dependency_type, temp_dir):

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -39,7 +39,7 @@ MINIMUM_VERSION_SUPPORTED_OVERRIDE = {
     "six": "1.12.0",
 }
 
-MAXIMUM_VERSION_SUPPORTED_OVERRIDE = {}
+MAXIMUM_VERSION_SUPPORTED_OVERRIDE = {"cryptography": "35.0.0"}
 
 
 def install_dependent_packages(setup_py_file_path, dependency_type, temp_dir):


### PR DESCRIPTION
This hotfix will resolve issues with `latestdependency` and unblock a release.