### PR TITLE
Use normal way for parameters

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -560,16 +560,8 @@ function Import-Dev-Cert-python
   python $pathToScript
 }
 
-function Validate-Python-DocMsPackages
+function Validate-Python-DocMsPackages ($PackageInfo, $PackageSourceOverride, $DocValidationImageId)
 {
-  Param(
-    [Parameter(Mandatory=$true)]
-    [PSCustomObject]$PackageInfo,
-    [Parameter(Mandatory=$false)]
-    [string]$PackageSourceOverride,
-    [Parameter(Mandatory=$false)]
-    [string]$DocValidationImageId
-  )
   $packageName = $packageInfo.Name
   $packageVersion = $packageInfo.Version
   ValidatePackage -packageName $packageName -packageVersion $packageVersion `


### PR DESCRIPTION
The pipeline failed because we recently add `DocRepoLocation` in upper layer.

The way we currently use is not able to perform no op for non-exist parameters. 

Failed pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1247165&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76
Testing pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1248350&view=results