### PR TITLE
[Key Vault] Create SAS token env var during test resource deployment

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
@@ -84,23 +84,8 @@ class AdministrationTestCase(AzureTestCase):
             self.container_uri = "https://{}.blob.{}/{}".format(storage_name, storage_endpoint_suffix, container_name)
             self._scrub_url(real_url=self.container_uri, playback_url=container_playback_uri)
 
-            storage_account_key = os.environ.get("BLOB_PRIMARY_STORAGE_ACCOUNT_KEY")
-            if storage_account_key:
-                self.sas_token = generate_account_sas(
-                    account_name=storage_name,
-                    account_key=storage_account_key,
-                    resource_types=ResourceTypes(container=True, object=True),
-                    permission=AccountSasPermissions(
-                        create=True,
-                        list=True,
-                        write=True,
-                        read=True,
-                        add=True,
-                        delete=True,
-                        delete_previous_version=True,
-                    ),
-                    expiry=datetime.utcnow() + timedelta(minutes=500),
-                )
+            self.sas_token = os.environ.get("BLOB_STORAGE_SAS_TOKEN")
+            if self.sas_token:
                 self.scrubber.register_name_pair(self.sas_token, playback_sas_token)
         else:
             self.managed_hsm_url = hsm_playback_url

--- a/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
@@ -99,7 +99,7 @@ class AdministrationTestCase(AzureTestCase):
                         delete=True,
                         delete_previous_version=True,
                     ),
-                    expiry=datetime.utcnow() + timedelta(minutes=30),
+                    expiry=datetime.utcnow() + timedelta(minutes=500),
                 )
                 self.scrubber.register_name_pair(self.sas_token, playback_sas_token)
         else:

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -81,7 +81,7 @@
             "type": "string",
             "defaultValue": "[utcNow('u')]",
             "metadata": {
-                "description": "The base time to add 2 hours to for SAS token expiration. The default is the current time."
+                "description": "The base time to add 500 minutes to for SAS token expiration. The default is the current time."
             }
         },
         "attestationImage": {
@@ -123,7 +123,7 @@
             "signedServices": "b",
             "signedPermission": "rwdlacu",
             "signedProtocol": "https",
-            "signedExpiry": "[dateTimeAdd(parameters('baseTime'), 'PT2H')]",
+            "signedExpiry": "[dateTimeAdd(parameters('baseTime'), 'PT500M')]",
             "signedResourceTypes": "sco",
             "keyToSign": "key1"
         }

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -77,6 +77,13 @@
                 "description": "Key Vault SKU to deploy. The default is 'premium'"
             }
         },
+        "baseTime": {
+            "type": "string",
+            "defaultValue": "[utcNow('u')]",
+            "metadata": {
+                "description": "The base time to add 2 hours to for SAS token expiration. The default is the current time."
+            }
+        },
         "attestationImage": {
             "type": "string",
             "defaultValue": "keyvault-mock-attestation:latest",
@@ -111,6 +118,14 @@
             "virtualNetworkRules": [],
             "ipRules": [],
             "defaultAction": "Allow"
+        },
+        "accountSasProperties": {
+            "signedServices": "b",
+            "signedPermission": "rwdlacu",
+            "signedProtocol": "https",
+            "signedExpiry": "[dateTimeAdd(parameters('baseTime'), 'PT2H')]",
+            "signedResourceTypes": "sco",
+            "keyToSign": "key1"
         }
     },
     "resources": [
@@ -279,6 +294,10 @@
         "BLOB_PRIMARY_STORAGE_ACCOUNT_KEY": {
             "type": "string",
             "value": "[listKeys(variables('primaryAccountName'), variables('mgmtApiVersion')).keys[0].value]"
+        },
+        "BLOB_STORAGE_SAS_TOKEN": {
+            "type": "string",
+            "value": "[listAccountSas(variables('primaryAccountName'), '2019-06-01', variables('accountSasProperties')).accountSasToken]"
         },
         "BLOB_CONTAINER_NAME" : {
             "type": "string",


### PR DESCRIPTION
# Description

Context: some `azure-keyvault-administration` tests, such as [test_full_backup_and_restore](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1255078&view=ms.vss-test-web.build-test-results-tab&runId=26904760&resultId=100012&paneView=debug), have been failing in live tests because of InternalServerErrors relating to SAS tokens. The last time this happened, it was because the lifetime of our test SAS tokens was too short.

Extending the lifetime of our tokens didn't fix things this time around, so I followed [JS's approach](https://github.com/Azure/azure-sdk-for-js/blob/2d1b829dc779647a09c08e1f195652830591eb6f/sdk/keyvault/test-resources.json#L275) of outputting a SAS token during test resource creation instead of creating one manually. Our prior methodology for creating tokens has apparently become invalid, presumably because of service-side changes.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.