### PR TITLE
[Key Vault] Skip tests failing with SAS issues

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
@@ -23,6 +23,9 @@ class BackupClientTests(AdministrationTestCase, KeyVaultTestCase):
     @all_api_versions()
     @backup_client_setup
     def test_full_backup_and_restore(self, client):
+        if self.is_live:
+            pytest.skip("SAS token failures are causing sev2 alerts for service team")
+
         # backup the vault
         backup_poller = client.begin_backup(self.container_uri, self.sas_token)
         backup_operation = backup_poller.result()
@@ -67,6 +70,9 @@ class BackupClientTests(AdministrationTestCase, KeyVaultTestCase):
     @all_api_versions()
     @backup_client_setup
     def test_selective_key_restore(self, client):
+        if self.is_live:
+            pytest.skip("SAS token failures are causing sev2 alerts for service team")
+
         # create a key to selectively restore
         key_client = self.create_key_client(self.managed_hsm_url)
         key_name = self.get_resource_name("selective-restore-test-key")
@@ -116,6 +122,7 @@ class BackupClientTests(AdministrationTestCase, KeyVaultTestCase):
         # rehydrate a poller with a continuation token of a completed operation
         late_rehydrated = client.begin_backup(self.container_uri, self.sas_token, continuation_token=token)
         assert late_rehydrated.status() == "Succeeded"
+        late_rehydrated.wait()
 
         # restore the backup
         restore_poller = client.begin_restore(backup_operation.folder_url, self.sas_token)

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration.py
@@ -4,6 +4,8 @@
 # ------------------------------------
 import time
 
+import pytest
+
 from _shared.test_case import KeyVaultTestCase
 from _test_case import AdministrationTestCase, backup_client_setup, get_decorator
 
@@ -18,6 +20,9 @@ class TestExamplesTests(AdministrationTestCase, KeyVaultTestCase):
     @all_api_versions()
     @backup_client_setup
     def test_example_backup_and_restore(self, client):
+        if self.is_live:
+            pytest.skip("SAS token failures are causing sev2 alerts for service team")
+
         backup_client = client
         container_uri = self.container_uri
         sas_token = self.sas_token
@@ -53,6 +58,9 @@ class TestExamplesTests(AdministrationTestCase, KeyVaultTestCase):
     @all_api_versions()
     @backup_client_setup
     def test_example_selective_key_restore(self, client):
+        if self.is_live:
+            pytest.skip("SAS token failures are causing sev2 alerts for service team")
+
         # create a key to selectively restore
         key_client = self.create_key_client(self.managed_hsm_url)
         key_name = self.get_resource_name("selective-restore-test-key")

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration_async.py
@@ -4,6 +4,8 @@
 # ------------------------------------
 import asyncio
 
+import pytest
+
 from _shared.test_case_async import KeyVaultTestCase
 from _test_case import AdministrationTestCase, backup_client_setup, get_decorator
 
@@ -18,6 +20,9 @@ class TestExamplesTests(AdministrationTestCase, KeyVaultTestCase):
     @all_api_versions()
     @backup_client_setup
     async def test_example_backup_and_restore(self, client):
+        if self.is_live:
+            pytest.skip("SAS token failures are causing sev2 alerts for service team")
+
         backup_client = client
         container_uri = self.container_uri
         sas_token = self.sas_token
@@ -53,6 +58,9 @@ class TestExamplesTests(AdministrationTestCase, KeyVaultTestCase):
     @all_api_versions()
     @backup_client_setup
     async def test_example_selective_key_restore(self, client):
+        if self.is_live:
+            pytest.skip("SAS token failures are causing sev2 alerts for service team")
+
         # create a key to selectively restore
         key_client = self.create_key_client(self.managed_hsm_url, is_async=True)
         key_name = self.get_resource_name("selective-restore-test-key")


### PR DESCRIPTION
# Description

**NOTE:** pipeline failures are expected because of Python 2.7/3.6 dropping and known `azure-keyvault-administration` test failures that _don't_ cause sev2 alerts.

**Context:** As https://github.com/Azure/azure-sdk-for-python/pull/22216 has been trying to fix, some tests in `azure-keyvault-administration` are failing because of InternalServerErrors stemming, apparently, from malformed or invalid SAS tokens. There's reason to believe that these failures could be protocol version-related, seeing as SAS failures only come up for 7.3-preview testing and not 7.2 testing ([pipeline test failures here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1276433&view=ms.vss-test-web.build-test-results-tab&runId=27313680&resultId=100010&paneView=debug)), but I digress.

SAS token-related failures raise a sev2 alert for the service, so this skips tests that have this issue for now. I'll try to get the SAS token issue resolved in https://github.com/Azure/azure-sdk-for-python/pull/22216.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.