### PR TITLE
[Key Vault] Fix managed property in keys and secrets

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,16 +1,13 @@
 # Release History
 
-## 4.1.0b3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 4.1.0b3 (2022-02-08)
 
 ### Other Changes
 - Python 2.7 is no longer supported. Please use Python version 3.6 or later.
 - Updated minimum `azure-core` version to 1.20.0
+- (From 4.1.0b2) To support multi-tenant authentication, `get_token` calls during challenge
+  authentication requests now pass in a `tenant_id` keyword argument
+  ([#20698](https://github.com/Azure/azure-sdk-for-python/issues/20698))
 
 ## 4.1.0b2 (2021-11-11)
 

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Release History
 
-## 4.4.0b3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 4.4.0b3 (2022-02-08)
 
 ### Other Changes
 - Python 2.7 is no longer supported. Please use Python version 3.6 or later.
+- (From 4.4.0b2) To support multi-tenant authentication, `get_token` calls during challenge
+  authentication requests now pass in a `tenant_id` keyword argument
+  ([#20698](https://github.com/Azure/azure-sdk-for-python/issues/20698))
 
 ## 4.4.0b2 (2021-11-11)
 

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.5.0b6 (Unreleased)
+## 4.5.0b6 (2022-02-08)
 
 ### Features Added
 - Added `immutable` keyword-only argument and property to `KeyReleasePolicy` to support immutable
@@ -12,11 +12,14 @@
 - Renamed the required argument `data` in `KeyReleasePolicy`'s constructor to
   `encoded_policy`
 
-### Bugs Fixed
-
 ### Other Changes
 - Python 2.7 is no longer supported. Please use Python version 3.6 or later.
 - Updated minimum `azure-core` version to 1.20.0
+- Updated type hints for `KeyProperties` model's `managed`, `exportable`, and `release_policy`
+  properties ([#22368](https://github.com/Azure/azure-sdk-for-python/pull/22368))
+- (From 4.5.0b5) To support multi-tenant authentication, `get_token` calls during challenge
+  authentication requests now pass in a `tenant_id` keyword argument
+  ([#20698](https://github.com/Azure/azure-sdk-for-python/issues/20698))
 
 ## 4.5.0b5 (2021-11-11)
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -225,10 +225,10 @@ class KeyProperties(object):
 
     @property
     def managed(self):
-        # type: () -> bool
-        """Returns whether the key's lifetime is managed by key vault
+        # type: () -> Optional[bool]
+        """Whether the key's lifetime is managed by Key Vault. If the key backs a certificate, this will be true.
 
-        :rtype: bool
+        :rtype: bool or None
         """
         return self._managed
 
@@ -237,7 +237,7 @@ class KeyProperties(object):
         # type: () -> Optional[bool]
         """Whether the private key can be exported
 
-        :rtype: bool
+        :rtype: bool or None
         """
         # exportable was added in 7.3-preview
         if self._attributes:
@@ -249,7 +249,7 @@ class KeyProperties(object):
         # type: () -> Optional[KeyReleasePolicy]
         """The :class:`~azure.keyvault.keys.KeyReleasePolicy` specifying the rules under which the key can be exported.
 
-        :rtype: ~azure.keyvault.keys.KeyReleasePolicy
+        :rtype: ~azure.keyvault.keys.KeyReleasePolicy or None
         """
         return self._release_policy
 

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Release History
 
-## 4.4.0b3 (Unreleased)
+## 4.4.0b3 (2022-02-08)
 
 ### Features Added
 - Added `managed` property to SecretProperties
 
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 - Python 2.7 is no longer supported. Please use Python version 3.6 or later.
+- (From 4.4.0b2) To support multi-tenant authentication, `get_token` calls during challenge
+  authentication requests now pass in a `tenant_id` keyword argument
+  ([#20698](https://github.com/Azure/azure-sdk-for-python/issues/20698))
 
 ## 4.4.0b2 (2021-11-11)
 

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.4.0b3 (Unreleased)
 
 ### Features Added
+- Added `managed` property to SecretProperties
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
@@ -187,6 +187,15 @@ class SecretProperties(object):
         """
         return self._tags
 
+    @property
+    def managed(self):
+        # type: () -> Optional[bool]
+        """Whether the secret's lifetime is managed by Key Vault. If the secret backs a certificate, this will be true.
+
+        :rtype: bool or None
+        """
+        return self._managed
+
 
 class KeyVaultSecret(object):
     """All of a secret's properties, and its value."""


### PR DESCRIPTION
# Description

The `managed` property is largely meant to indicate whether a key or secret is part of a Key Vault certificate. Without a property for this, some scenarios -- like making sure all non-certificate keys and secrets have been deleted -- can be complicated. This property was missing entirely for secrets, and was misleading for keys (`managed` can be None, but the type hint didn't indicate this).

There are also some small type hint fixes in unrelated `azure-keyvault-keys` models.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.