### PR TITLE
[Storage] Drop support for Python 2.7 and 3.6

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob-changefeed/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 12.0.0b4 (Unreleased)
 
+This version and all future versions will require Python 3.7+. Python 2.7 and 3.6 are no longer supported.
+
 #### Features Added
 
 #### Breaking Changes

--- a/sdk/storage/azure-storage-blob-changefeed/README.md
+++ b/sdk/storage/azure-storage-blob-changefeed/README.md
@@ -1,3 +1,6 @@
+## _Disclaimer_
+_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+
 # Azure Storage Blob ChangeFeed client library for Python
 
 This preview package for Python enables users to get blob change feed events. These events can be lazily generated, iterated by page, retrieved for a specific time interval, or iterated from a specific continuation token.
@@ -9,7 +12,7 @@ This preview package for Python enables users to get blob change feed events. Th
 ## Getting started
 
 ### Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package.
+* Python 3.7 or later is required to use this package.
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/blobs/data-lake-storage-quickstart-create-account) to use this package.
 

--- a/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
@@ -3,4 +3,4 @@
 -e ../../../tools/azure-sdk-tools
 ../azure-storage-blob
 -e ../../identity/azure-identity
-aiohttp>=3.0; python_version >= '3.5'
+aiohttp>=3.0

--- a/sdk/storage/azure-storage-blob-changefeed/mypy.ini
+++ b/sdk/storage/azure-storage-blob-changefeed/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/sdk/storage/azure-storage-blob-changefeed/samples/README.md
+++ b/sdk/storage/azure-storage-blob-changefeed/samples/README.md
@@ -11,8 +11,7 @@ urlFragment: storage-blobchangefeed-samples
 # Azure Storage Blob client library for Python Samples
 
 These are code samples that show common scenario operations with the Azure Storage Blob ChangeFeed client library.
-The async versions of the samples (the python sample files appended with `_async`) show asynchronous operations,
-and require Python 3.5 or later.
+The async versions of the samples (the python sample files appended with `_async`) show asynchronous operations.
 
 Several Storage Blobs Python SDK samples are available to you in the SDK's GitHub repository. These samples provide example code for additional scenarios commonly encountered while working with Storage Blobs:
 
@@ -23,7 +22,7 @@ Several Storage Blobs Python SDK samples are available to you in the SDK's GitHu
     * list events starting from a continuation token
 
 ## Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (3.5 or later if using asyncio)
+* Python 3.7 or later is required to use this package
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) to run these samples.
 

--- a/sdk/storage/azure-storage-blob-changefeed/setup.cfg
+++ b/sdk/storage/azure-storage-blob-changefeed/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/sdk/storage/azure-storage-blob-changefeed/setup.py
+++ b/sdk/storage/azure-storage-blob-changefeed/setup.py
@@ -21,23 +21,6 @@ PACKAGE_PPRINT_NAME = "Azure Storage Blob ChangeFeed"
 # a-b-c => a/b/c
 package_folder_path = NAMESPACE_NAME.replace('.', '/')
 
-
-# azure v0.x is not compatible with this package
-# azure v0.x used to have a __version__ attribute (newer versions don't)
-try:
-    import azure
-
-    try:
-        ver = azure.__version__
-        raise Exception(
-            'This package is incompatible with azure=={}. '.format(ver) +
-            'Uninstall it with "pip uninstall azure".'
-        )
-    except AttributeError:
-        pass
-except ImportError:
-    pass
-
 # azure-storage v0.36.0 and prior are not compatible with this package
 try:
     import azure.storage
@@ -74,25 +57,19 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: MIT License',
     ],
     zip_safe=False,
     packages=[
         'azure.storage.blob.changefeed',
     ],
+    python_requires=">=3.7",
     install_requires=[
         "azure-storage-blob>=12.5.0,<13.0.0"
     ],
-    extras_require={
-        ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],
-        ":python_version<'3.4'": ['enum34>=1.0.4'],
-        ":python_version<'3.5'": ["typing"]
-    },
 )

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 12.10.0b3 (Unreleased)
+
+This version and all future versions will require Python 3.7+. Python 2.7 and 3.6 are no longer supported.
+
+### Features Added
+
+### Bugs Fixed
+
 ## 12.10.0b2 (2021-12-13)
 
 ### Features Added

--- a/sdk/storage/azure-storage-blob/README.md
+++ b/sdk/storage/azure-storage-blob/README.md
@@ -1,5 +1,5 @@
 ## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 is ending 01 January 2022. This change will be effective azure-storage-blob>12.10.0b2 For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
 
 # Azure Storage Blobs client library for Python
 Azure Blob storage is Microsoft's object storage solution for the cloud. Blob storage is optimized for storing massive amounts of unstructured data, such as text or binary data.
@@ -18,7 +18,7 @@ Blob storage is ideal for:
 ## Getting started
 
 ### Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (ending Python 2.7 support starting 01 January 2022).
+* Python 3.7 or later is required to use this package.
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) to use this package.
 

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -4,4 +4,4 @@
 ../../core/azure-core
 azure-identity
 -e ../../storage/azure-mgmt-storage
-aiohttp>=3.0; python_version >= '3.5'
+aiohttp>=3.0

--- a/sdk/storage/azure-storage-blob/mypy.ini
+++ b/sdk/storage/azure-storage-blob/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/sdk/storage/azure-storage-blob/samples/README.md
+++ b/sdk/storage/azure-storage-blob/samples/README.md
@@ -11,8 +11,7 @@ urlFragment: storage-blob-samples
 # Azure Storage Blob client library for Python Samples
 
 These are code samples that show common scenario operations with the Azure Storage Blob client library.
-The async versions of the samples (the python sample files appended with `_async`) show asynchronous operations,
-and require Python 3.5 or later.
+The async versions of the samples (the python sample files appended with `_async`) show asynchronous operations.
 
 Several Storage Blobs Python SDK samples are available to you in the SDK's GitHub repository. These samples provide example code for additional scenarios commonly encountered while working with Storage Blobs:
 
@@ -85,7 +84,7 @@ get and set access policies:
     * Integrate blob with other Azure Services such as App Insights, and utilize it as a tool for data experimentation.
 
 ## Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (3.5 or later if using asyncio)
+* Python 3.7 or later is required to use this package
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) to run these samples.
 

--- a/sdk/storage/azure-storage-blob/setup.cfg
+++ b/sdk/storage/azure-storage-blob/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/sdk/storage/azure-storage-blob/setup.py
+++ b/sdk/storage/azure-storage-blob/setup.py
@@ -20,23 +20,6 @@ PACKAGE_PPRINT_NAME = "Azure Blob Storage"
 # a-b-c => a/b/c
 package_folder_path = PACKAGE_NAME.replace('-', '/')
 
-
-# azure v0.x is not compatible with this package
-# azure v0.x used to have a __version__ attribute (newer versions don't)
-try:
-    import azure
-
-    try:
-        ver = azure.__version__
-        raise Exception(
-            'This package is incompatible with azure=={}. '.format(ver) +
-            'Uninstall it with "pip uninstall azure".'
-        )
-    except AttributeError:
-        pass
-except ImportError:
-    pass
-
 # azure-storage v0.36.0 and prior are not compatible with this package
 try:
     import azure.storage
@@ -74,11 +57,8 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -93,14 +73,10 @@ setup(
         'tests.blob',
         'tests.common'
     ]),
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.10.0",
         "msrest>=0.6.21",
         "cryptography>=2.1.4"
     ],
-    extras_require={
-        ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],
-        ":python_version<'3.4'": ['enum34>=1.0.4'],
-        ":python_version<'3.5'": ["typing"]
-    },
 )

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 12.6.0b3 (Unreleased)
+
+This version and all future versions will require Python 3.7+. Python 2.7 and 3.6 are no longer supported.
+
+### Features Added
+
+### Bugs Fixed
+
 ## 12.6.0b2 (2021-12-13)
 
 ### Features Added

--- a/sdk/storage/azure-storage-file-datalake/README.md
+++ b/sdk/storage/azure-storage-file-datalake/README.md
@@ -1,5 +1,5 @@
 ## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 is ending 01 January 2022. This change will be effective azure-storage-file-datalake>12.6.0b2 For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
 
 # Azure DataLake service client library for Python
 Overview
@@ -15,7 +15,7 @@ This preview package for Python includes ADLS Gen2 specific API support made ava
 ## Getting started
 
 ### Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (ending Python 2.7 support starting 01 January 2022).
+* Python 3.7 or later is required to use this package.
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/blobs/data-lake-storage-quickstart-create-account) to use this package.
 

--- a/sdk/storage/azure-storage-file-datalake/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-datalake/dev_requirements.txt
@@ -4,5 +4,5 @@
 ../../core/azure-core
 ../azure-storage-blob
 -e ../../identity/azure-identity
-aiohttp>=3.0; python_version >= '3.5'
+aiohttp>=3.0
 adal

--- a/sdk/storage/azure-storage-file-datalake/samples/README.md
+++ b/sdk/storage/azure-storage-file-datalake/samples/README.md
@@ -38,7 +38,7 @@ Several DataLake Storage Python SDK samples are available to you in the SDK's Gi
     * Delete file system
 
 ## Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package
+* Python 3.7 later is required to use this package
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/blobs/data-lake-storage-quickstart-create-account) to run these samples.
 

--- a/sdk/storage/azure-storage-file-datalake/setup.cfg
+++ b/sdk/storage/azure-storage-file-datalake/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/sdk/storage/azure-storage-file-datalake/setup.py
+++ b/sdk/storage/azure-storage-file-datalake/setup.py
@@ -21,23 +21,6 @@ PACKAGE_PPRINT_NAME = "Azure File DataLake Storage"
 # a-b-c => a/b/c
 package_folder_path = NAMESPACE_NAME.replace('.', '/')
 
-
-# azure v0.x is not compatible with this package
-# azure v0.x used to have a __version__ attribute (newer versions don't)
-try:
-    import azure
-
-    try:
-        ver = azure.__version__
-        raise Exception(
-            'This package is incompatible with azure=={}. '.format(ver) +
-            'Uninstall it with "pip uninstall azure".'
-        )
-    except AttributeError:
-        pass
-except ImportError:
-    pass
-
 # azure-storage v0.36.0 and prior are not compatible with this package
 try:
     import azure.storage
@@ -75,11 +58,8 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -92,14 +72,10 @@ setup(
         'azure.storage',
         'tests',
     ]),
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.10.0",
         "msrest>=0.6.21",
         "azure-storage-blob<13.0.0,>=12.10.0b2"
     ],
-    extras_require={
-        ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],
-        ":python_version<'3.4'": ['enum34>=1.0.4'],
-        ":python_version<'3.5'": ["typing"]
-    },
 )

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 12.7.0b2 (Unreleased)
+
+This version and all future versions will require Python 3.7+. Python 2.7 and 3.6 are no longer supported.
+
+### Features Added
+
+### Bugs Fixed
+
 ## 12.7.0b1 (2021-12-13)
 
 ### Features Added

--- a/sdk/storage/azure-storage-file-share/README.md
+++ b/sdk/storage/azure-storage-file-share/README.md
@@ -1,5 +1,5 @@
 ## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 is ending 01 January 2022. This change will be effective azure-storage-file-share>12.7.0b1 For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
 
 # Azure Storage File Share client library for Python
 Azure File Share storage offers fully managed file shares in the cloud that are accessible via the industry standard [Server Message Block (SMB) protocol](https://docs.microsoft.com/windows/desktop/FileIO/microsoft-smb-protocol-and-cifs-protocol-overview). Azure file shares can be mounted concurrently by cloud or on-premises deployments of Windows, Linux, and macOS. Additionally, Azure file shares can be cached on Windows Servers with Azure File Sync for fast access near where the data is being used.
@@ -15,7 +15,7 @@ Azure file shares can be used to:
 ## Getting started
 
 ### Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (ending Python 2.7 support starting 01 January 2022).
+* Python 3.7 or later is required to use this package.
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) to use this package.
 

--- a/sdk/storage/azure-storage-file-share/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-share/dev_requirements.txt
@@ -4,4 +4,4 @@
 ../../core/azure-core
 azure-identity
 -e ../azure-storage-blob
-aiohttp>=3.0; python_version >= '3.5'
+aiohttp>=3.0

--- a/sdk/storage/azure-storage-file-share/mypy.ini
+++ b/sdk/storage/azure-storage-file-share/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/sdk/storage/azure-storage-file-share/samples/README.md
+++ b/sdk/storage/azure-storage-file-share/samples/README.md
@@ -12,7 +12,7 @@ urlFragment: storage-file-share-samples
 
 These are code samples that show common scenario operations with the Azure Storage File Share client library.
 The async versions of the samples (the python sample files appended with `_async`) show asynchronous operations
-with file shares and require Python 3.5 or later.
+with file shares.
 
 * [file_samples_hello_world.py](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share/samples/file_samples_hello_world.py) ([async version](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share/samples/file_samples_hello_world_async.py)) - Examples for getting started with file shares:
     * Client creation
@@ -45,7 +45,7 @@ with file shares and require Python 3.5 or later.
     * Copy a file from a URL
 
 ## Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (3.5 or later if using asyncio)
+* Python 3.7 or later is required to use this package
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) to run these samples.
 

--- a/sdk/storage/azure-storage-file-share/setup.cfg
+++ b/sdk/storage/azure-storage-file-share/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/sdk/storage/azure-storage-file-share/setup.py
+++ b/sdk/storage/azure-storage-file-share/setup.py
@@ -19,21 +19,6 @@ PACKAGE_PPRINT_NAME = "Azure File Share Storage"
 # a.b.c => a/b/c
 package_folder_path = NAMESPACE_NAME.replace('.', '/')
 
-# azure v0.x is not compatible with this package
-# azure v0.x used to have a __version__ attribute (newer versions don't)
-try:
-    import azure
-    try:
-        ver = azure.__version__
-        raise Exception(
-            'This package is incompatible with azure=={}. '.format(ver) +
-            'Uninstall it with "pip uninstall azure".'
-        )
-    except AttributeError:
-        pass
-except ImportError:
-    pass
-
 # Version extraction inspired from 'requests'
 with open(os.path.join(package_folder_path, '_version.py'), 'r') as fd:
     version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]',
@@ -61,11 +46,8 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -78,14 +60,10 @@ setup(
         'azure.storage',
         'tests',
     ]),
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.10.0",
         "msrest>=0.6.21",
         "cryptography>=2.1.4"
     ],
-    extras_require={
-        ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],
-        ":python_version<'3.4'": ['enum34>=1.0.4'],
-        ":python_version<'3.5'": ["typing"]
-    },
 )

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 12.2.0b1 (Unreleased)
 
+This version and all future versions will require Python 3.7+. Python 2.7 and 3.6 are no longer supported.
+
+### Features Added
+
+### Bugs Fixed
+
 ## 12.1.6 (2021-04-20)
 **Fixes**
 - Make `AccountName`, `AccountKey` etc. in conn_str case insensitive

--- a/sdk/storage/azure-storage-queue/README.md
+++ b/sdk/storage/azure-storage-queue/README.md
@@ -1,5 +1,5 @@
 ## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 is ending 01 January 2022. This change will be effective azure-storage-queue>12.1.6 For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
 
 # Azure Storage Queues client library for Python
 
@@ -15,7 +15,7 @@ Common uses of Queue storage include:
 ## Getting started
 
 ### Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (ending Python 2.7 support starting 01 January 2022).
+* Python 3.7 or later is required to use this package.
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) to use this package.
 

--- a/sdk/storage/azure-storage-queue/dev_requirements.txt
+++ b/sdk/storage/azure-storage-queue/dev_requirements.txt
@@ -3,4 +3,4 @@
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
 azure-identity
-aiohttp>=3.0; python_version >= '3.5'
+aiohttp>=3.0

--- a/sdk/storage/azure-storage-queue/mypy.ini
+++ b/sdk/storage/azure-storage-queue/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/sdk/storage/azure-storage-queue/samples/README.md
+++ b/sdk/storage/azure-storage-queue/samples/README.md
@@ -12,7 +12,7 @@ urlFragment: storage-queue-samples
 
 These are code samples that show common scenario operations with the Azure Storage Queue client library.
 The async versions of the samples (the python sample files appended with `_async`) show asynchronous operations
-with queues and require Python 3.5 or later.
+with queues.
 
 ## Contents
 
@@ -47,7 +47,7 @@ with queues and require Python 3.5 or later.
     * Enabling the logger for the service and printing any logging messages
 
 ## Prerequisites
-* Python 2.7, or 3.5 or later is required to use this package (3.5 or later if using asyncio)
+* Python 3.7 or later is required to use this package
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an
 [Azure storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) to run these samples.
 

--- a/sdk/storage/azure-storage-queue/setup.cfg
+++ b/sdk/storage/azure-storage-queue/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/sdk/storage/azure-storage-queue/setup.py
+++ b/sdk/storage/azure-storage-queue/setup.py
@@ -47,6 +47,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
+        "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/sdk/storage/azure-storage-queue/setup.py
+++ b/sdk/storage/azure-storage-queue/setup.py
@@ -20,21 +20,6 @@ package_folder_path = PACKAGE_NAME.replace('-', '/')
 # a-b-c => a.b.c
 namespace_name = PACKAGE_NAME.replace('-', '.')
 
-# azure v0.x is not compatible with this package
-# azure v0.x used to have a __version__ attribute (newer versions don't)
-try:
-    import azure
-    try:
-        ver = azure.__version__  # type: ignore
-        raise Exception(
-            'This package is incompatible with azure=={}. '.format(ver) +
-            'Uninstall it with "pip uninstall azure".'
-        )
-    except AttributeError:
-        pass
-except ImportError:
-    pass
-
 # Version extraction inspired from 'requests'
 with open(os.path.join(package_folder_path, '_version.py'), 'r') as fd:
     version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]',  # type: ignore
@@ -62,11 +47,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -81,14 +62,10 @@ setup(
         'tests.queue',
         'tests.common'
     ]),
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.10.0",
         "msrest>=0.6.18",
         "cryptography>=2.1.4"
     ],
-    extras_require={
-        ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],
-        ":python_version<'3.4'": ['enum34>=1.0.4'],
-        ":python_version<'3.5'": ["typing"]
-    },
 )


### PR DESCRIPTION
Dropping support for Python 2.7 and 3.6 with the following steps for each package:

- Modifying `setup.py`.
- Modifying `dev_requirements.txt`.
- Modifying `mypy.ini` to use Python 3.7.
- Modifying package `README.md`.
- Modifying `samples/README.md`.
- Removing `setup.cfg`.