### PR TITLE
[Key Vault] Remove metapackage from ci.yml

### DIFF
--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -46,5 +46,3 @@ extends:
       safeName: azurekeyvaultsecrets
     - name: azure-mgmt-keyvault
       safeName: azuremgmtkeyvault
-    - name: azure-keyvault
-      safeName: azurekeyvault


### PR DESCRIPTION
# Description

Context: the [Apply Documentation Updates](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1280853&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=95157bd4-d7ec-5ed7-b303-68e386ec5302) job in nightly pipelines has been failing because the `azure-keyvault` metapackage isn't applicable to the docs check. This should be resolved by removing the package from `ci.yml`, and after looking into it, removing the reference shouldn't cause an issue. The reference was added to `ci.yml` in [this PR](https://github.com/Azure/azure-sdk-for-python/pull/8347) in order to release the initial version of the metapackage, but now that the package is stably deprecated, this reference isn't necessary.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.