### PR TITLE
Generate Manifests alongside build artifacts

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -108,7 +108,7 @@ steps:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Upload Documentation SBOM'
-    condition: and(succeeded(), ${{ parameters.CustomCondition }})
+    condition: and(succeeded(), ${{ parameters.BuildDocs }})
     inputs:
       BuildDropPath: $(Build.SourcesDirectory)/_docs
 

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -101,6 +101,17 @@ steps:
 
   - ${{ parameters.BeforePublishSteps }}
 
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Upload Package SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Upload Documentation SBOM'
+    condition: and(succeeded(), ${{ parameters.CustomCondition }})
+    inputs:
+      BuildDropPath: $(Build.SourcesDirectory)/_docs
+
   - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
     parameters:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)'

--- a/eng/pipelines/templates/steps/build-conda-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-conda-artifacts.yml
@@ -78,6 +78,11 @@ steps:
       displayName: 'Activate Conda Environment and Build ${{ artifact.name }}'
       workingDirectory: $(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}/conda-recipe
   
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Upload Conda Package SBOM'
+    inputs:
+      BuildDropPath: '$(Agent.BuildDirectory)/conda/output'
+
   - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
     parameters:
       ArtifactPath: '$(Agent.BuildDirectory)/conda/output'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -2,3 +2,4 @@ variables:
   PythonVersion: '3.6'
   skipComponentGovernanceDetection: true
   AzureSDKCondaChannel: https://azuresdkconda.blob.core.windows.net/channel1/
+  Package.EnableSBOMSigning: true


### PR DESCRIPTION
This adds two steps to the `build-artifacts` stage of our yaml pipelines.

Related to Azure/azure-sdk-tools#2273