### PR TITLE
[ServiceBus&EventHubs] api fixes

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -64,6 +64,7 @@ PrimitiveTypes = Optional[Union[
     int,
     float,
     bytes,
+    bool,
     str,
     Dict,
     List,
@@ -339,7 +340,7 @@ class EventData(object):
         For :class:`azure.eventhub.amqp.AmqpMessageBodyType.VALUE<azure.eventhub.amqp.AmqpMessageBodyType.VALUE>`,
         the body could be any type.
 
-        :rtype: int or float or bytes or str or Dict or List or uuid.UUID
+        :rtype: int or bool or float or bytes or str or Dict or List or uuid.UUID
         """
         try:
             return self._raw_amqp_message.body

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -340,7 +340,7 @@ class EventData(object):
         For :class:`azure.eventhub.amqp.AmqpMessageBodyType.VALUE<azure.eventhub.amqp.AmqpMessageBodyType.VALUE>`,
         the body could be any type.
 
-        :rtype: int or bool or float or bytes or str or Dict or List or uuid.UUID
+        :rtype: int or bool or float or bytes or str or dict or list or uuid.UUID
         """
         try:
             return self._raw_amqp_message.body

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import json
 import logging
+import uuid
 from typing import (
     Union,
     Dict,
@@ -58,6 +59,17 @@ from .amqp import (
 
 if TYPE_CHECKING:
     import datetime
+
+PrimitiveTypes = Union[
+    None,
+    int,
+    float,
+    bytes,
+    str,
+    Dict,
+    List,
+    uuid.UUID,
+]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -319,7 +331,7 @@ class EventData(object):
 
     @property
     def body(self):
-        # type: () -> Any
+        # type: () -> PrimitiveTypes
         """The body of the Message. The format may vary depending on the body type:
         For :class:`azure.eventhub.amqp.AmqpMessageBodyType.DATA<azure.eventhub.amqp.AmqpMessageBodyType.DATA>`,
         the body could be bytes or Iterable[bytes].
@@ -328,7 +340,7 @@ class EventData(object):
         For :class:`azure.eventhub.amqp.AmqpMessageBodyType.VALUE<azure.eventhub.amqp.AmqpMessageBodyType.VALUE>`,
         the body could be any type.
 
-        :rtype: Any
+        :rtype: Union[None, int, float, bytes, str, Dict, List, uuid.UUID]
         """
         try:
             return self._raw_amqp_message.body

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -60,8 +60,7 @@ from .amqp import (
 if TYPE_CHECKING:
     import datetime
 
-PrimitiveTypes = Union[
-    None,
+PrimitiveTypes = Optional[Union[
     int,
     float,
     bytes,
@@ -69,7 +68,7 @@ PrimitiveTypes = Union[
     Dict,
     List,
     uuid.UUID,
-]
+]]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -339,7 +339,7 @@ class EventData(object):
         For :class:`azure.eventhub.amqp.AmqpMessageBodyType.VALUE<azure.eventhub.amqp.AmqpMessageBodyType.VALUE>`,
         the body could be any type.
 
-        :rtype: Union[None, int, float, bytes, str, Dict, List, uuid.UUID]
+        :rtype: int or float or bytes or str or Dict or List or uuid.UUID
         """
         try:
             return self._raw_amqp_message.body

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,6 +8,7 @@ This version and all future versions will require Python 3.7+. Python 2.7 and 3.
 
 - Added support for fixed (linear) retry backoff:
   - Sync/async `ServiceBusClient` constructors and `from_connection_string` take `retry_mode` as a keyword argument.
+- Added new enum class `ServiceBusSessionFilter`, which is the type of existing `NEXT_AVAILABLE_SESSION` value.
 
 ### Breaking Changes
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/__init__.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/__init__.py
@@ -21,6 +21,7 @@ from ._common.message import (
 from ._common.constants import (
     ServiceBusReceiveMode,
     ServiceBusSubQueue,
+    ServiceBusSessionFilter,
     NEXT_AVAILABLE_SESSION,
 )
 from ._common.auto_lock_renewer import AutoLockRenewer
@@ -37,6 +38,7 @@ __all__ = [
     "ServiceBusReceivedMessage",
     "NEXT_AVAILABLE_SESSION",
     "ServiceBusSubQueue",
+    "ServiceBusSessionFilter",
     "ServiceBusReceiveMode",
     "ServiceBusClient",
     "ServiceBusReceiver",

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -5,7 +5,6 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
-from typing_extensions import Literal
 
 import uamqp
 
@@ -26,7 +25,6 @@ from ._common.utils import (
 from ._common.constants import (
     ServiceBusSubQueue,
     ServiceBusReceiveMode,
-    ServiceBusSessionFilter,
 )
 
 if TYPE_CHECKING:
@@ -35,8 +33,6 @@ if TYPE_CHECKING:
         AzureSasCredential,
         AzureNamedKeyCredential,
     )
-
-NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -273,7 +269,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
+        session_id = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -426,7 +422,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
+        session_id = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -292,7 +292,7 @@ class ServiceBusClient(object):
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
-        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
+        :paramtype sub_queue: str or ~azure.servicebus.ServiceBusSubQueue
         :keyword receive_mode: The receive_mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the queue. Messages received with RECEIVE_AND_DELETE
@@ -447,7 +447,7 @@ class ServiceBusClient(object):
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
-        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
+        :paramtype sub_queue: str or ~azure.servicebus.ServiceBusSubQueue
         :keyword receive_mode: The receive_mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the subscription. Messages received with RECEIVE_AND_DELETE

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -3,10 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from typing import Any, Union, Optional, TYPE_CHECKING
-from typing_extensions import Literal
-
 import logging
 from weakref import WeakSet
+from typing_extensions import Literal
 
 import uamqp
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -2,7 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from typing import Any, Union, Optional, TYPE_CHECKING, Literal
+from typing import Any, Union, Optional, TYPE_CHECKING
+from typing_extensions import Literal
+
 import logging
 from weakref import WeakSet
 
@@ -35,7 +37,7 @@ if TYPE_CHECKING:
         AzureNamedKeyCredential,
     )
 
-NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]
+NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]  # type: ignore
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -5,7 +5,10 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
-from typing_extensions import Literal
+try:
+    from typing import Literal  # pylint: disable=ungrouped-imports
+except ImportError:
+    from typing_extensions import Literal
 
 import uamqp
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -290,7 +290,7 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful queue, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :paramtype session_id: str or ~azure.servicebus.NEXT_AVAILABLE_SESSION
         :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any
@@ -445,7 +445,7 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful subscription, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :paramtype session_id: str or ~azure.servicebus.NEXT_AVAILABLE_SESSION
         :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -5,6 +5,7 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
+from typing_extensions import Literal
 
 import uamqp
 
@@ -25,6 +26,7 @@ from ._common.utils import (
 from ._common.constants import (
     ServiceBusSubQueue,
     ServiceBusReceiveMode,
+    ServiceBusSessionFilter,
 )
 
 if TYPE_CHECKING:
@@ -33,6 +35,8 @@ if TYPE_CHECKING:
         AzureSasCredential,
         AzureNamedKeyCredential,
     )
+
+NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -269,7 +273,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id=None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -422,7 +426,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id=None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -269,7 +269,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id = None,
+        session_id=None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -422,7 +422,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id = None,
+        session_id=None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -27,7 +27,7 @@ from ._common.utils import (
 from ._common.constants import (
     ServiceBusSubQueue,
     ServiceBusReceiveMode,
-    NEXT_AVAILABLE_SESSION,
+    ServiceBusSessionFilter,
 )
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
         AzureNamedKeyCredential,
     )
 
-NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]  # type: ignore
+NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -5,10 +5,7 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
-try:
-    from typing import Literal  # pylint: disable=ungrouped-imports
-except ImportError:
-    from typing_extensions import Literal
+from typing_extensions import Literal
 
 import uamqp
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from typing import Any, Union, Optional, TYPE_CHECKING
+from typing import Any, Union, Optional, TYPE_CHECKING, Literal
 import logging
 from weakref import WeakSet
 
@@ -25,6 +25,7 @@ from ._common.utils import (
 from ._common.constants import (
     ServiceBusSubQueue,
     ServiceBusReceiveMode,
+    NEXT_AVAILABLE_SESSION,
 )
 
 if TYPE_CHECKING:
@@ -33,6 +34,8 @@ if TYPE_CHECKING:
         AzureSasCredential,
         AzureNamedKeyCredential,
     )
+
+NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -269,7 +272,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id: Optional[str] = None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -285,13 +288,14 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful queue, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, ~azure.servicebus.NEXT_AVAILABLE_SESSION]
-        :keyword Optional[Union[ServiceBusSubQueue, str]] sub_queue: If specified, the subqueue this receiver will
+        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
+        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
         :keyword receive_mode: The receive_mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the queue. Messages received with RECEIVE_AND_DELETE
@@ -421,7 +425,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id: Optional[str] = None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -439,13 +443,14 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful subscription, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, ~azure.servicebus.NEXT_AVAILABLE_SESSION]
-        :keyword Optional[Union[ServiceBusSubQueue, str]] sub_queue: If specified, the subqueue this receiver will
+        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
+        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
         :keyword receive_mode: The receive_mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the subscription. Messages received with RECEIVE_AND_DELETE

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -7,6 +7,7 @@ import logging
 import functools
 import uuid
 import datetime
+import warnings
 from typing import Any, List, Optional, Dict, Iterator, Union, TYPE_CHECKING
 
 import six
@@ -660,7 +661,8 @@ class ServiceBusReceiver(
         self,
         sequence_numbers: Union[int, List[int]],
         *,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        **kwargs: Any
     ) -> List[ServiceBusReceivedMessage]:
         """Receive messages that have previously been deferred.
 
@@ -683,6 +685,8 @@ class ServiceBusReceiver(
                 :caption: Receive deferred messages from ServiceBus.
 
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -734,7 +738,8 @@ class ServiceBusReceiver(
         max_message_count: int = 1,
         *,
         sequence_number: int = 0,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        **kwargs: Any
     ) -> List[ServiceBusReceivedMessage]:
         """Browse messages currently pending in the queue.
 
@@ -759,6 +764,8 @@ class ServiceBusReceiver(
                 :caption: Look at pending messages in the queue.
 
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -899,7 +906,8 @@ class ServiceBusReceiver(
         self,
         message: ServiceBusReceivedMessage,
         *,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        **kwargs: Any
     ) -> datetime.datetime:
         # pylint: disable=protected-access,no-member
         """Renew the message lock.
@@ -933,6 +941,8 @@ class ServiceBusReceiver(
                 :caption: Renew the lock on a received message.
 
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         # type: ignore
         try:
             if self.session:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
@@ -6,6 +6,7 @@ import logging
 import time
 import uuid
 import datetime
+import warnings
 from typing import Any, TYPE_CHECKING, Union, List, Optional, Mapping, cast
 
 import uamqp
@@ -278,7 +279,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         messages: "MessageTypes",
         schedule_time_utc: datetime.datetime,
         *,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        **kwargs: Any
     ) -> List[int]:
         """Send Message or multiple Messages to be enqueued at a specific time.
         Returns a list of the sequence numbers of the enqueued messages.
@@ -301,6 +303,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
                 :dedent: 4
                 :caption: Schedule a message to be sent in future
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         # pylint: disable=protected-access
 
         self._check_live()
@@ -332,7 +336,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         self,
         sequence_numbers: Union[int, List[int]],
         *,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        **kwargs: Any
     ) -> None:
         """
         Cancel one or more messages that have previously been scheduled and are still pending.
@@ -354,6 +359,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
                 :dedent: 4
                 :caption: Cancelling messages scheduled to be sent in future
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -375,7 +382,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         self,
         message: Union["MessageTypes", ServiceBusMessageBatch],
         *,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        **kwargs: Any
     ) -> None:
         """Sends message and blocks until acknowledgement is received or operation times out.
 
@@ -407,6 +415,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
                 :caption: Send message.
 
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_session.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_session.py
@@ -4,7 +4,8 @@
 # --------------------------------------------------------------------------------------------
 import logging
 import datetime
-from typing import TYPE_CHECKING, Union, Optional
+import warnings
+from typing import TYPE_CHECKING, Any, Union, Optional
 import six
 
 from ._common.utils import utc_from_timestamp, utc_now
@@ -88,7 +89,7 @@ class ServiceBusSession(BaseSession):
             :caption: Get session from a receiver
     """
 
-    def get_state(self, *, timeout: Optional[float] = None) -> bytes:
+    def get_state(self, *, timeout: Optional[float] = None, **kwargs: Any) -> bytes:
         # pylint: disable=protected-access
         """Get the session state.
 
@@ -107,6 +108,8 @@ class ServiceBusSession(BaseSession):
                 :dedent: 4
                 :caption: Get the session state
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._receiver._check_live()  # pylint: disable=protected-access
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -119,7 +122,7 @@ class ServiceBusSession(BaseSession):
         session_state = response.get(MGMT_RESPONSE_SESSION_STATE)  # type: ignore
         return session_state
 
-    def set_state(self, state: Union[str, bytes, bytearray], *, timeout: Optional[float] = None) -> None:
+    def set_state(self, state: Union[str, bytes, bytearray], *, timeout: Optional[float] = None, **kwargs: Any) -> None:
         # pylint: disable=protected-access
         """Set the session state.
 
@@ -137,6 +140,8 @@ class ServiceBusSession(BaseSession):
                 :dedent: 4
                 :caption: Set the session state
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._receiver._check_live()  # pylint: disable=protected-access
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -153,7 +158,7 @@ class ServiceBusSession(BaseSession):
             timeout=timeout,
         )
 
-    def renew_lock(self, *, timeout: Optional[float] = None) -> datetime.datetime:
+    def renew_lock(self, *, timeout: Optional[float] = None, **kwargs: Any) -> datetime.datetime:
         # pylint: disable=protected-access
         """Renew the session lock.
 
@@ -179,6 +184,8 @@ class ServiceBusSession(BaseSession):
                 :dedent: 4
                 :caption: Renew the session lock before it expires
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._receiver._check_live()  # pylint: disable=protected-access
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_session.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_session.py
@@ -96,7 +96,7 @@ class ServiceBusSession(BaseSession):
 
         :keyword float timeout: The total operation timeout in seconds including all the retries. The value must be
          greater than 0 if specified. The default value is None, meaning no timeout.
-        :rtype: str
+        :rtype: bytes
 
         .. admonition:: Example:
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -278,7 +278,7 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful queue, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :paramtype session_id: str or ~azure.servicebus.NEXT_AVAILABLE_SESSION
         :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any
@@ -431,7 +431,7 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful subscription, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :paramtype session_id: str or ~azure.servicebus.NEXT_AVAILABLE_SESSION
         :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from typing import Any, Union, Optional, TYPE_CHECKING
-from typing_extensions import Literal
 import logging
 from weakref import WeakSet
+from typing_extensions import Literal
 
 import uamqp
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -5,7 +5,10 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
-from typing_extensions import Literal
+try:
+    from typing import Literal  # pylint: disable=ungrouped-imports
+except ImportError:
+    from typing_extensions import Literal
 
 import uamqp
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -2,7 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from typing import Any, Union, Optional, TYPE_CHECKING, Literal
+from typing import Any, Union, Optional, TYPE_CHECKING
+from typing_extensions import Literal
 import logging
 from weakref import WeakSet
 
@@ -29,7 +30,7 @@ from ._async_utils import create_authentication
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
 
-NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]
+NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]  # type: ignore
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -282,7 +282,7 @@ class ServiceBusClient(object):
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
-        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
+        :paramtype sub_queue: str or ~azure.servicebus.ServiceBusSubQueue
         :keyword receive_mode: The mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the queue. Messages received with RECEIVE_AND_DELETE
@@ -435,7 +435,7 @@ class ServiceBusClient(object):
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
-        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
+        :paramtype sub_queue: str or ~azure.servicebus.ServiceBusSubQueue
         :keyword receive_mode: The mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the subscription. Messages received with RECEIVE_AND_DELETE

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -5,10 +5,7 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
-try:
-    from typing import Literal  # pylint: disable=ungrouped-imports
-except ImportError:
-    from typing_extensions import Literal
+from typing_extensions import Literal
 
 import uamqp
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -23,14 +23,14 @@ from .._common.utils import generate_dead_letter_entity_name, strip_protocol_fro
 from .._common.constants import (
     ServiceBusSubQueue,
     ServiceBusReceiveMode,
-    NEXT_AVAILABLE_SESSION,
+    ServiceBusSessionFilter,
 )
 from ._async_utils import create_authentication
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
 
-NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]  # type: ignore
+NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -259,7 +259,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id = None,
+        session_id=None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -410,7 +410,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id = None,
+        session_id=None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -5,6 +5,7 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
+from typing_extensions import Literal
 
 import uamqp
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
@@ -22,12 +23,14 @@ from .._common.utils import generate_dead_letter_entity_name, strip_protocol_fro
 from .._common.constants import (
     ServiceBusSubQueue,
     ServiceBusReceiveMode,
+    ServiceBusSessionFilter,
 )
 from ._async_utils import create_authentication
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
 
+NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -259,7 +262,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id=None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -410,7 +413,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id=None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -5,7 +5,6 @@
 from typing import Any, Union, Optional, TYPE_CHECKING
 import logging
 from weakref import WeakSet
-from typing_extensions import Literal
 
 import uamqp
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
@@ -23,14 +22,12 @@ from .._common.utils import generate_dead_letter_entity_name, strip_protocol_fro
 from .._common.constants import (
     ServiceBusSubQueue,
     ServiceBusReceiveMode,
-    ServiceBusSessionFilter,
 )
 from ._async_utils import create_authentication
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
 
-NextAvailableSessionType = Literal[ServiceBusSessionFilter.NEXT_AVAILABLE]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -262,7 +259,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
+        session_id = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -413,7 +410,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
+        session_id = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from typing import Any, Union, Optional, TYPE_CHECKING
+from typing import Any, Union, Optional, TYPE_CHECKING, Literal
 import logging
 from weakref import WeakSet
 
@@ -21,12 +21,15 @@ from .._common.auto_lock_renewer import AutoLockRenewer
 from .._common.utils import generate_dead_letter_entity_name, strip_protocol_from_uri
 from .._common.constants import (
     ServiceBusSubQueue,
-    ServiceBusReceiveMode
+    ServiceBusReceiveMode,
+    NEXT_AVAILABLE_SESSION,
 )
 from ._async_utils import create_authentication
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
+
+NextAvailableSessionType = Literal[NEXT_AVAILABLE_SESSION]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -258,7 +261,7 @@ class ServiceBusClient(object):
         self,
         queue_name: str,
         *,
-        session_id: Optional[str] = None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -274,13 +277,14 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful queue, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, ~azure.servicebus.NEXT_AVAILABLE_SESSION]
-        :keyword Optional[Union[ServiceBusSubQueue, str]] sub_queue: If specified, the subqueue this receiver will
+        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
+        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
         :keyword receive_mode: The mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the queue. Messages received with RECEIVE_AND_DELETE
@@ -408,7 +412,7 @@ class ServiceBusClient(object):
         topic_name: str,
         subscription_name: str,
         *,
-        session_id: Optional[str] = None,
+        session_id: Optional[Union[str, NextAvailableSessionType]] = None,
         sub_queue: Optional[Union[ServiceBusSubQueue, str]] = None,
         receive_mode: Union[
             ServiceBusReceiveMode, str
@@ -426,13 +430,14 @@ class ServiceBusClient(object):
         :keyword session_id: A specific session from which to receive. This must be specified for a
          sessionful subscription, otherwise it must be None. In order to receive messages from the next available
          session, set this to ~azure.servicebus.NEXT_AVAILABLE_SESSION.
-        :paramtype session_id: Union[str, ~azure.servicebus.NEXT_AVAILABLE_SESSION]
-        :keyword Optional[Union[ServiceBusSubQueue, str]] sub_queue: If specified, the subqueue this receiver will
+        :paramtype session_id: Union[str, Literal[~azure.servicebus.NEXT_AVAILABLE_SESSION]]
+        :keyword sub_queue: If specified, the subqueue this receiver will
          connect to.
          This includes the DEAD_LETTER and TRANSFER_DEAD_LETTER queues, holds messages that can't be delivered to any
          receiver or messages that can't be processed.
          The default is None, meaning connect to the primary queue.  Can be assigned values from `ServiceBusSubQueue`
          enum or equivalent string values "deadletter" and "transferdeadletter".
+        :paramtype sub_queue: Optional[Union[~azure.servicebus.ServiceBusSubQueue, str]]
         :keyword receive_mode: The mode with which messages will be retrieved from the entity. The two options
          are PEEK_LOCK and RECEIVE_AND_DELETE. Messages received with PEEK_LOCK must be settled within a given
          lock period before they will be removed from the subscription. Messages received with RECEIVE_AND_DELETE

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -7,6 +7,7 @@ import collections
 import datetime
 import functools
 import logging
+import warnings
 from typing import Any, List, Optional, AsyncIterator, Union, Callable, TYPE_CHECKING
 
 import six
@@ -647,7 +648,7 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
             return messages
 
     async def receive_deferred_messages(
-        self, sequence_numbers: Union[int, List[int]], *, timeout: Optional[float] = None
+        self, sequence_numbers: Union[int, List[int]], *, timeout: Optional[float] = None, **kwargs: Any
     ) -> List[ServiceBusReceivedMessage]:
         """Receive messages that have previously been deferred.
 
@@ -670,6 +671,8 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
                 :caption: Receive deferred messages from ServiceBus.
 
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -718,7 +721,7 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
             return messages
 
     async def peek_messages(
-        self, max_message_count: int = 1, *, sequence_number: int = 0, timeout: Optional[float] = None
+        self, max_message_count: int = 1, *, sequence_number: int = 0, timeout: Optional[float] = None, **kwargs: Any
     ) -> List[ServiceBusReceivedMessage]:
         """Browse messages currently pending in the queue.
 
@@ -741,6 +744,8 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
                 :dedent: 4
                 :caption: Peek messages in the queue.
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -879,7 +884,7 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
         )
 
     async def renew_message_lock(
-        self, message: ServiceBusReceivedMessage, *, timeout: Optional[float] = None
+        self, message: ServiceBusReceivedMessage, *, timeout: Optional[float] = None, **kwargs: Any
     ) -> datetime.datetime:
         # pylint: disable=protected-access,no-member
         """Renew the message lock.
@@ -913,6 +918,8 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
                 :caption: Renew the lock on a received message.
 
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         try:
             if self.session:
                 raise TypeError(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -5,6 +5,7 @@
 import logging
 import asyncio
 import datetime
+import warnings
 from typing import Any, TYPE_CHECKING, Union, List, Optional, Mapping, cast
 
 import uamqp
@@ -207,7 +208,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         messages: MessageTypes,
         schedule_time_utc: datetime.datetime,
         *,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        **kwargs: Any
     ) -> List[int]:
         """Send Message or multiple Messages to be enqueued at a specific time by the service.
         Returns a list of the sequence numbers of the enqueued messages.
@@ -230,6 +232,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
                 :dedent: 4
                 :caption: Schedule a message to be sent in future
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         # pylint: disable=protected-access
 
         self._check_live()
@@ -257,7 +261,7 @@ class ServiceBusSender(BaseHandler, SenderMixin):
             )
 
     async def cancel_scheduled_messages(
-        self, sequence_numbers: Union[int, List[int]], *, timeout: Optional[float] = None
+        self, sequence_numbers: Union[int, List[int]], *, timeout: Optional[float] = None, **kwargs:Any
     ) -> None:
         """
         Cancel one or more messages that have previously been scheduled and are still pending.
@@ -279,6 +283,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
                 :dedent: 4
                 :caption: Cancelling messages scheduled to be sent in future
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -297,7 +303,7 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         )
 
     async def send_messages(
-        self, message: Union[MessageTypes, ServiceBusMessageBatch], *, timeout: Optional[float] = None
+        self, message: Union[MessageTypes, ServiceBusMessageBatch], *, timeout: Optional[float] = None, **kwargs: Any
     ) -> None:
         """Sends message and blocks until acknowledgement is received or operation times out.
 
@@ -330,6 +336,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
 
         """
 
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._check_live()
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -261,7 +261,7 @@ class ServiceBusSender(BaseHandler, SenderMixin):
             )
 
     async def cancel_scheduled_messages(
-        self, sequence_numbers: Union[int, List[int]], *, timeout: Optional[float] = None, **kwargs:Any
+        self, sequence_numbers: Union[int, List[int]], *, timeout: Optional[float] = None, **kwargs: Any
     ) -> None:
         """
         Cancel one or more messages that have previously been scheduled and are still pending.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_session_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_session_async.py
@@ -47,7 +47,7 @@ class ServiceBusSession(BaseSession):
 
         :keyword Optional[float] timeout: The total operation timeout in seconds including all the retries.
          The value must be greater than 0 if specified. The default value is None, meaning no timeout.
-        :rtype: str
+        :rtype: bytes
 
         .. admonition:: Example:
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_session_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_session_async.py
@@ -4,7 +4,8 @@
 # --------------------------------------------------------------------------------------------
 import logging
 import datetime
-from typing import Union, Optional
+import warnings
+from typing import Any, Union, Optional
 import six
 
 from .._servicebus_session import BaseSession
@@ -40,7 +41,7 @@ class ServiceBusSession(BaseSession):
             :caption: Get session from a receiver
     """
 
-    async def get_state(self, *, timeout: Optional[float] = None) -> bytes:
+    async def get_state(self, *, timeout: Optional[float] = None, **kwargs: Any) -> bytes:
         """Get the session state.
 
         Returns None if no state has been set.
@@ -58,6 +59,8 @@ class ServiceBusSession(BaseSession):
                 :dedent: 4
                 :caption: Get the session state
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._receiver._check_live()  # pylint: disable=protected-access
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -71,7 +74,7 @@ class ServiceBusSession(BaseSession):
         return session_state
 
     async def set_state(
-        self, state: Union[str, bytes, bytearray], *, timeout: Optional[float] = None
+        self, state: Union[str, bytes, bytearray], *, timeout: Optional[float] = None, **kwargs: Any
     ) -> None:
         """Set the session state.
 
@@ -90,6 +93,8 @@ class ServiceBusSession(BaseSession):
                 :dedent: 4
                 :caption: Set the session state
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._receiver._check_live()  # pylint: disable=protected-access
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")
@@ -106,7 +111,7 @@ class ServiceBusSession(BaseSession):
             timeout=timeout,
         )
 
-    async def renew_lock(self, *, timeout: Optional[float] = None) -> datetime.datetime:
+    async def renew_lock(self, *, timeout: Optional[float] = None, **kwargs: Any) -> datetime.datetime:
         """Renew the session lock.
 
         This operation must be performed periodically in order to retain a lock on the
@@ -131,6 +136,8 @@ class ServiceBusSession(BaseSession):
                 :dedent: 4
                 :caption: Renew the session lock before it expires
         """
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self._receiver._check_live()  # pylint: disable=protected-access
         if timeout is not None and timeout <= 0:
             raise ValueError("The timeout must be greater than 0.")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_amqp_message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_amqp_message.py
@@ -7,6 +7,7 @@
 import time
 import uuid
 from datetime import datetime
+import warnings
 from typing import Optional, Any, cast, Mapping, Union, Dict
 
 from msrest.serialization import TZ_UTC
@@ -500,8 +501,11 @@ class AmqpMessageHeader(DictMixin):
         time_to_live: Optional[int] = None,
         durable: Optional[bool] = None,
         first_acquirer: Optional[bool] = None,
-        priority: Optional[int] = None
+        priority: Optional[int] = None,
+        **kwargs: Any
     ):
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self.delivery_count = delivery_count
         self.time_to_live = time_to_live
         self.first_acquirer = first_acquirer
@@ -601,8 +605,11 @@ class AmqpMessageProperties(DictMixin):
         absolute_expiry_time: Optional[int] = None,
         group_id: Optional[Union[str, bytes]] = None,
         group_sequence: Optional[int] = None,
-        reply_to_group_id: Optional[Union[str, bytes]] = None
+        reply_to_group_id: Optional[Union[str, bytes]] = None,
+        **kwargs: Any
     ):
+        if kwargs:
+            warnings.warn(f"Unsupported keyword args: {kwargs}")
         self.message_id = message_id
         self.user_id = user_id
         self.to = to

--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -69,6 +69,6 @@ setup(
         'azure-core<2.0.0,>=1.14.0',
         "isodate>=0.6.0",
         "six>=1.11.0",
-        "typing-extensions>=3.7.4.3",
+        "typing-extensions>=3.7.4.3; python_version < '3.8'",
     ]
 )

--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -69,5 +69,6 @@ setup(
         'azure-core<2.0.0,>=1.14.0',
         "isodate>=0.6.0",
         "six>=1.11.0",
+        "typing-extensions>=3.7.2",
     ]
 )

--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -69,8 +69,6 @@ setup(
         'azure-core<2.0.0,>=1.14.0',
         "isodate>=0.6.0",
         "six>=1.11.0",
-    ],
-    extras_require={
-        ":python_version<'3.8'": ['typing-extensions']
-    }    
+        "typing-extensions>=3.7.4.3",
+    ]
 )

--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -69,6 +69,6 @@ setup(
         'azure-core<2.0.0,>=1.14.0',
         "isodate>=0.6.0",
         "six>=1.11.0",
-        "typing-extensions>=3.7.2",
+        "typing-extensions>=3.7.4.3",
     ]
 )

--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -69,6 +69,8 @@ setup(
         'azure-core<2.0.0,>=1.14.0',
         "isodate>=0.6.0",
         "six>=1.11.0",
-        "typing-extensions>=3.7.4.3; python_version < '3.8'",
-    ]
+    ],
+    extras_require={
+        ":python_version<'3.8'": ['typing-extensions']
+    }    
 )

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -179,6 +179,7 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-servicebus uamqp>=1.5.0,<2.0.0
 #override azure-servicebus msrest>=0.6.17,<2.0.0
 #override azure-servicebus azure-core<2.0.0,>=1.14.0
+#override azure-servicebus typing-extensions>=3.7.4.3
 #override azure-synapse-accesscontrol azure-core>=1.20.0,<2.0.0
 #override azure-synapse-spark azure-core>=1.20.0,<2.0.0
 #override azure-synapse-artifacts azure-core>=1.20.0,<2.0.0

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -179,7 +179,7 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-servicebus uamqp>=1.5.0,<2.0.0
 #override azure-servicebus msrest>=0.6.17,<2.0.0
 #override azure-servicebus azure-core<2.0.0,>=1.14.0
-#override azure-servicebus typing-extensions>=3.7.4.3
+#override azure-servicebus typing-extensions>=3.7.4.3; python_version < '3.8'
 #override azure-synapse-accesscontrol azure-core>=1.20.0,<2.0.0
 #override azure-synapse-spark azure-core>=1.20.0,<2.0.0
 #override azure-synapse-artifacts azure-core>=1.20.0,<2.0.0

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -179,7 +179,6 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-servicebus uamqp>=1.5.0,<2.0.0
 #override azure-servicebus msrest>=0.6.17,<2.0.0
 #override azure-servicebus azure-core<2.0.0,>=1.14.0
-#override azure-servicebus typing-extensions>=3.7.4.3; python_version < '3.8'
 #override azure-synapse-accesscontrol azure-core>=1.20.0,<2.0.0
 #override azure-synapse-spark azure-core>=1.20.0,<2.0.0
 #override azure-synapse-artifacts azure-core>=1.20.0,<2.0.0


### PR DESCRIPTION
updated the following, after API review:
EH:
1) update `EventData.body` to type primitives (not Any): None/bool/int/float/bytes/str/dict/list/uuid.UUID

SB:
2) update type of kwarg `session_id` in sync/async `ServiceBusClient.get_queue_receiver/get_subscription_receiver` to `Union[str, Literal[NEXT_AVAILABLE_SESSION]]`
3) update return type of async/sync `ServiceBusSession.get_state()` to `bytes`
4) move docstring type of kwarg `sub_queue`  to `:paramtype` line in async/sync `ServiceBusClient.get_queue_receiver`