### PR TITLE
Update pyOpenSSL dependency in pipelines

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci tools
-cryptography==3.1
+cryptography==3.4.8
 setuptools==44.1.0; python_version == '2.7'
 setuptools==46.4.0; python_version >= '3.5'
 virtualenv==20.0.23

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci tools
-cryptography==3.4.8
+cryptography==3.3.2
 setuptools==44.1.0; python_version == '2.7'
 setuptools==46.4.0; python_version >= '3.5'
 virtualenv==20.0.23

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -27,7 +27,7 @@ cffi==1.15.0rc2; python_version >= '3.10'
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21
-pyOpenSSL==19.1.0
+pyOpenSSL==21.0.0
 json-delta==2.0
 ConfigArgParse==1.2.3
 six==1.14.0

--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -14,7 +14,7 @@ bandit==1.6.2
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21
 readme-renderer[md]==25.0
-pyOpenSSL==19.1.0
+pyOpenSSL==21.0.0
 json-delta==2.0
 ConfigArgParse==1.2.3
 six==1.14.0

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci tools
-cryptography==3.1
+cryptography==3.4.8
 setuptools==44.1.0; python_version == '2.7'
 setuptools==46.4.0; python_version >= '3.5'
 virtualenv==20.0.23

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -23,7 +23,7 @@ black==21.6b0; python_version >= '3.6'
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21
-pyOpenSSL==19.1.0
+pyOpenSSL==21.0.0
 json-delta==2.0
 ConfigArgParse==1.2.3
 six==1.14.0

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci tools
-cryptography==3.4.8
+cryptography==3.3.2
 setuptools==44.1.0; python_version == '2.7'
 setuptools==46.4.0; python_version >= '3.5'
 virtualenv==20.0.23

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -22,7 +22,7 @@ chardet>=2.0,<5.0
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21
 readme-renderer[md]==25.0
-pyOpenSSL==19.1.0
+pyOpenSSL==21.0.0
 json-delta==2.0
 ConfigArgParse==1.2.3
 six==1.14.0


### PR DESCRIPTION
# Description

Context: there have been Core regression test failures that are being caused by a failing test in Key Vault. The test failure is caused by a mix of incompatible `pyOpenSSL` and `cryptography` versions that create an [AttributeError](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1283191&view=logs&j=3fadc984-4acf-5cfe-b896-a35ffcc3efec&t=25cc912c-7ca4-5e26-b975-cb95a9900fa8&l=14246). This error happens when using `pyOpenSSL==19.1.0` for `cryptography==3.4.8` and `cryptography==36.0.1`, but doesn't happen when using `pyOpenSSL==21.0.0` for any version of cryptography (I've tried 3.4.8, 35.0.0, and 36.0.1).

After discussing this with @scbedd, there doesn't seem to be any reason to not bump the dependency to the latest stable version. This also updates pinned dependencies of `cryptography` to 3.3.2, from 3.1, to meet `pyOpenSSL`'s dependency requirement while keeping Py2 support.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.