### PR TITLE
[Test Proxy] Improve error handling

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
+++ b/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
@@ -79,8 +79,9 @@ def recorded_by_proxy_async(test_func):
                 test_output = await test_func(*args, **trimmed_kwargs)
         except ResourceNotFoundError as error:
             error_body = ContentDecodePolicy.deserialize_from_http_generics(error.response)
-            error_with_message = ResourceNotFoundError(message=error_body["Message"], response=error.response)
-            raise error_with_message
+            message = error_body.get("message") or error_body.get("Message")
+            error_with_message = ResourceNotFoundError(message=message, response=error.response)
+            raise error_with_message from error
         finally:
             AioHttpTransport.send = original_transport_func
             stop_record_or_playback(test_id, recording_id, test_output)


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/22389 and resolves https://github.com/Azure/azure-sdk-for-python/issues/22390. We now throw with a correct message when we receive a non-200 response from the test proxy when starting recording/playback, and `raise from` when encountering exceptions to maintain context for errors.

Example output when a recording file can't be located when beginning a playback test (from VS Code):
```
>               raise HttpResponseError(message=message)
E               azure.core.exceptions.HttpResponseError: System.IO.FileNotFoundException: Could not find file '/srv/testproxy/sdk/tables/azure-data-tables/tests/recordings/test_table_entity.pyTestTableEntitytest_datetime_duplicate_field.json'.
E               File name: '/srv/testproxy/sdk/tables/azure-data-tables/tests/recordings/test_table_entity.pyTestTableEntitytest_datetime_duplicate_field.json'
E                  at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
E                  at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
E                  at System.IO.FileStream.OpenHandle(FileMode mode, FileShare share, FileOptions options)
E                  at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
E                  at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
E                  at System.IO.File.OpenRead(String path)
E                  at Azure.Sdk.Tools.TestProxy.RecordingHandler.StartPlayback(String sessionId, HttpResponse outgoingResponse, RecordingType mode) in /proxyservercode/RecordingHandler.cs:line 272
E                  at Azure.Sdk.Tools.TestProxy.Playback.Start() in /proxyservercode/Playback.cs:line 30
E                  at lambda_method29(Closure , Object )
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.AwaitableResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
E               --- End of stack trace from previous location ---
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
E               --- End of stack trace from previous location ---
E                  at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
E                  at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
E                  at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
E                  at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
E                  at Azure.Sdk.Tools.TestProxy.Common.HttpExceptionMiddleware.Invoke(HttpContext context) in /proxyservercode/Common/HttpExceptionMiddleware.cs:line 24
E                  at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
E
E               HEADERS
E               =======
E               Connection: keep-alive
E               Accept: */*
E               Accept-Encoding: gzip, deflate
E               Host: localhost:5001
E               User-Agent: python-requests/2.26.0
E               Content-Length: 0
E               x-recording-file: sdk/tables/azure-data-tables/tests/recordings/test_table_entity.pyTestTableEntitytest_datetime_duplicate_field
E               x-recording-sha: 842701ad1838fed06791f2ebd909d8a27eb9db34
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
  - Uses already-migrated package to test changes