### PR TITLE
Update TextAnalytics to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -14,7 +14,7 @@ import json
 from unittest import mock
 from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
-from testcase import TextAnalyticsTest, TextAnalyticsPreparer
+from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
 from azure.ai.textanalytics import (
@@ -47,6 +47,17 @@ from azure.ai.textanalytics import (
 # pre-apply the client_cls positional argument so it needn't be explicitly passed below
 TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, TextAnalyticsClient)
 
+TextAnalyticsCustomPreparer = functools.partial(
+    TextAnalyticsPreparer,
+    textanalytics_custom_text_endpoint="https://fakeendpoint.cognitiveservices.azure.com",
+    textanalytics_custom_text_key="fakeZmFrZV9hY29jdW50X2tleQ==",
+    textanalytics_single_category_classify_project_name="single_category_classify_project_name",
+    textanalytics_single_category_classify_deployment_name="single_category_classify_deployment_name",
+    textanalytics_multi_category_classify_project_name="multi_category_classify_project_name",
+    textanalytics_multi_category_classify_deployment_name="multi_category_classify_deployment_name",
+    textanalytics_custom_entities_project_name="custom_entities_project_name",
+    textanalytics_custom_entities_deployment_name="custom_entities_deployment_name",
+)
 
 class TestAnalyze(TextAnalyticsTest):
 
@@ -627,7 +638,8 @@ class TestAnalyze(TextAnalyticsTest):
             )
         assert excinfo.value.status_code == 400
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy
     def test_disable_service_logs(
             self,
@@ -989,7 +1001,8 @@ class TestAnalyze(TextAnalyticsTest):
         assert not document_results[1][0].is_error
         assert isinstance(document_results[1][0], ExtractSummaryResult)
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy
     def test_single_category_classify(
             self,
@@ -1028,7 +1041,8 @@ class TestAnalyze(TextAnalyticsTest):
                 assert result.classification.category
                 assert result.classification.confidence_score
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy
     def test_multi_category_classify(
             self,
@@ -1068,7 +1082,8 @@ class TestAnalyze(TextAnalyticsTest):
                     assert classification.category
                     assert classification.confidence_score
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy
     def test_recognize_custom_entities(
             self,
@@ -1216,7 +1231,8 @@ class TestAnalyze(TextAnalyticsTest):
 
         initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     def test_generic_action_error_no_target(
         self,
         textanalytics_custom_text_endpoint,
@@ -1276,7 +1292,8 @@ class TestAnalyze(TextAnalyticsTest):
             ).result())
         assert e.value.message == "(InternalServerError) 1 out of 3 job tasks failed. Failed job tasks : v3.2-preview.2/custom/entities/general."
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     def test_action_errors_with_targets(
         self,
         textanalytics_custom_text_endpoint,
@@ -1366,7 +1383,8 @@ class TestAnalyze(TextAnalyticsTest):
                 assert result.error.code == "InvalidRequest"
                 assert result.error.message == "Some error" + str(idx)  # confirms correct doc error order
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     def test_action_job_failure(
             self,
             textanalytics_custom_text_endpoint,

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
-from testcase import TextAnalyticsPreparer
+from testcase import TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
@@ -49,6 +49,18 @@ from azure.ai.textanalytics import (
 
 # pre-apply the client_cls positional argument so it needn't be explicitly passed below
 TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, TextAnalyticsClient)
+
+TextAnalyticsCustomPreparer = functools.partial(
+    TextAnalyticsPreparer,
+    textanalytics_custom_text_endpoint="https://fakeendpoint.cognitiveservices.azure.com",
+    textanalytics_custom_text_key="fakeZmFrZV9hY29jdW50X2tleQ==",
+    textanalytics_single_category_classify_project_name="single_category_classify_project_name",
+    textanalytics_single_category_classify_deployment_name="single_category_classify_deployment_name",
+    textanalytics_multi_category_classify_project_name="multi_category_classify_project_name",
+    textanalytics_multi_category_classify_deployment_name="multi_category_classify_deployment_name",
+    textanalytics_custom_entities_project_name="custom_entities_project_name",
+    textanalytics_custom_entities_deployment_name="custom_entities_deployment_name",
+)
 
 def get_completed_future(result=None):
     future = asyncio.Future()
@@ -682,7 +694,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                 )).result()
         assert excinfo.value.status_code == 400
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
     async def test_disable_service_logs(
             self,
@@ -1058,7 +1071,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
             assert not document_results[1][0].is_error
             assert isinstance(document_results[1][0], ExtractSummaryResult)
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
     async def test_single_category_classify(
             self,
@@ -1100,7 +1114,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                 assert result.classification.category
                 assert result.classification.confidence_score
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
     async def test_multi_category_classify(
             self,
@@ -1144,7 +1159,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                     assert classification.category
                     assert classification.confidence_score
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
     async def test_recognize_custom_entities(
             self,
@@ -1303,7 +1319,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
 
             await initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
     async def test_generic_action_error_no_target(
         self,
@@ -1367,7 +1384,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                     results.append(resp)
             assert e.value.message == "(InternalServerError) 1 out of 3 job tasks failed. Failed job tasks : v3.2-preview.2/custom/entities/general."
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
     async def test_action_errors_with_targets(
         self,
@@ -1463,7 +1481,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                 assert result.error.code == "InvalidRequest"
                 assert result.error.message == "Some error" + str(idx)  # confirms correct doc error order
 
-    @TextAnalyticsPreparer()
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
     async def test_action_job_failure(
             self,

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth.py
@@ -7,6 +7,8 @@ import pytest
 from testcase import TextAnalyticsTest, TextAnalyticsPreparer
 from azure.ai.textanalytics import TextAnalyticsClient
 from azure.core.credentials import AzureKeyCredential
+import os
+
 
 class TestAuth(TextAnalyticsTest):
 
@@ -14,7 +16,9 @@ class TestAuth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     def test_active_directory_auth(self, textanalytics_test_endpoint):
         token = self.get_credential(TextAnalyticsClient)
-        text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, token)
+        text_analytics_endpoint_suffix = os.environ.get("TEXTANALYTICS_ENDPOINT_SUFFIX",".cognitiveservices.azure.com")
+        credential_scopes = ["https://{}/.default".format(text_analytics_endpoint_suffix[1:])]
+        text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, token, credential_scopes=credential_scopes)
 
         docs = [{"id": "1", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth_async.py
@@ -8,6 +8,7 @@ from azure.ai.textanalytics.aio import TextAnalyticsClient
 from azure.core.credentials import AzureKeyCredential
 from testcase import TextAnalyticsPreparer
 from testcase import TextAnalyticsTest
+import os
 
 
 class TestAuth(TextAnalyticsTest):
@@ -16,7 +17,9 @@ class TestAuth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     async def test_active_directory_auth(self, textanalytics_test_endpoint):
         token = self.get_credential(TextAnalyticsClient, is_async=True)
-        text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, token)
+        text_analytics_endpoint_suffix = os.environ.get("TEXTANALYTICS_ENDPOINT_SUFFIX",".cognitiveservices.azure.com")
+        credential_scopes = ["https://{}/.default".format(text_analytics_endpoint_suffix[1:])]
+        text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, token, credential_scopes=credential_scopes)
 
         docs = [{"id": "1", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/testcase.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/testcase.py
@@ -22,19 +22,15 @@ from azure.ai.textanalytics import (
 from devtools_testutils import PowerShellPreparer, AzureRecordedTestCase
 
 
+def is_public_cloud():
+    return (".microsoftonline.com" in os.getenv('AZURE_AUTHORITY_HOST', ''))
+
+
 TextAnalyticsPreparer = functools.partial(
     PowerShellPreparer,
     'textanalytics',
     textanalytics_test_endpoint="https://fakeendpoint.cognitiveservices.azure.com",
     textanalytics_test_api_key="fakeZmFrZV9hY29jdW50X2tleQ==",
-    textanalytics_custom_text_endpoint="https://fakeendpoint.cognitiveservices.azure.com",
-    textanalytics_custom_text_key="fakeZmFrZV9hY29jdW50X2tleQ==",
-    textanalytics_single_category_classify_project_name="single_category_classify_project_name",
-    textanalytics_single_category_classify_deployment_name="single_category_classify_deployment_name",
-    textanalytics_multi_category_classify_project_name="multi_category_classify_project_name",
-    textanalytics_multi_category_classify_deployment_name="multi_category_classify_deployment_name",
-    textanalytics_custom_entities_project_name="custom_entities_project_name",
-    textanalytics_custom_entities_deployment_name="custom_entities_deployment_name",
 )
 
 

--- a/sdk/textanalytics/test-resources.json
+++ b/sdk/textanalytics/test-resources.json
@@ -42,16 +42,16 @@
                 "description": "The application client secret used to run tests."
             }
         },
-        "textAnalyticsEndpointSuffix": {
-            "defaultValue": ".cognitiveservices.azure.com/",
+        "cognitiveServicesEndpointSuffix": {
+            "defaultValue": ".cognitiveservices.azure.com",
             "type": "String"
-        },
+        }
     },
     "variables": {
         "authorizationApiVersion": "2018-09-01-preview",
         "textAnalyticsBaseName": "[concat('textanalytics', parameters('baseName'))]",
         "cognitiveApiVersion": "2017-04-18",
-        "azureTextAnalyticsUrl": "[concat('https://', variables('textAnalyticsBaseName'), parameters('textAnalyticsEndpointSuffix'))]",
+        "azureTextAnalyticsUrl": "[concat('https://', variables('textAnalyticsBaseName'), parameters('cognitiveServicesEndpointSuffix'))]",
         "cognitiveServiceUserRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]"
     },
     "resources": [
@@ -101,6 +101,10 @@
         "TEXTANALYTICS_TEST_ENDPOINT": {
             "type": "string",
             "value": "[variables('azureTextAnalyticsUrl')]"
+        },
+        "TEXTANALYTICS_ENDPOINT_SUFFIX": {
+            "type": "string",
+            "value": "[parameters('cognitiveServicesEndpointSuffix')]"
         }
     }
 }

--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -10,12 +10,13 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-text-analytics-azure-cloud-test-resources)
+          MatrixReplace:
+            - TestSamples=.*/true
         UsGov:
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
         China:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
-      MatrixReplace:
-        - TestSamples=.*/true
+      SupportedClouds: 'Public,UsGov,China'
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(TEXTANALYTICS_SUBSCRIPTION_ID)
         AZURE_TENANT_ID: $(TEXTANALYTICS_TENANT_ID)


### PR DESCRIPTION
These changes enable textanalytics to run live tests against Public, UsGov and China.

1. As suggested in the issue https://github.com/Azure/azure-sdk-for-python/issues/21448,
So update `text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, token)` in test_auth.py(async)
to:
    ```
    text_analytics_endpoint_suffix = os.environ.get("TEXTANALYTICS_ENDPOINT_SUFFIX",".cognitiveservices.azure.com")
    credential_scopes = ["https://{}/.default".format(text_analytics_endpoint_suffix[1:])]
    text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, token, credential_scopes=credential_scopes)
    ```
2. As suggested in the issue https://github.com/Azure/azure-sdk-for-python/issues/22281,
move `MatrixReplace: - TestSamples=.*/true` to the PublicCloud config in test.yaml, and skip these tests related to env `textanalytics_custom_text_endpoint` in usgov and china clouds.

Besides, in order to solve the [error](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1283946&view=logs&j=a7bc4bf7-faea-50a8-6676-78ef3b853b40&t=fc991221-8f54-5a2a-9702-94d71b289a0e):`KeyError: 'TEXTANALYTICS_CUSTOM_TEXT_ENDPOINT'` in most tests, 
add code `TextAnalyticsCustomPreparer` in files `test_analyze.py(async)` and update `TextAnalyticsPreparer` in `testcase.py`.

Pipeline results:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1289623&view=results

@benbp, @kristapratico, @jameszliao-msft, @lmazuel, @meeraharidasa , @mayurid, @abhahn for notification.