### PR TITLE
Dump alpha version for schedule build

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -73,7 +73,7 @@ steps:
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with dev version
-    condition: and(succeeded(),eq(variables['SetDevVersion'],'true'))
+    condition: and(succeeded(), or(eq(variables['SetDevVersion'],'true'), eq(variables['Build.Reason'],'Schedule')))
   - task: PythonScript@0
     displayName: 'Generate Packages'
     inputs:

--- a/eng/pipelines/templates/steps/set-dev-build.yml
+++ b/eng/pipelines/templates/steps/set-dev-build.yml
@@ -13,7 +13,7 @@ steps:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - task: PythonScript@0
-    condition: and(succeededOrFailed(), eq(variables['SetDevVersion'],'true'))
+    condition: and(succeeded(), or(eq(variables['SetDevVersion'],'true'), eq(variables['Build.Reason'],'Schedule')))
     displayName: "Update package versions for dev build"
     inputs:
       scriptPath: 'eng/versioning/version_set_dev.py'


### PR DESCRIPTION
# Description
Scheduled pipeline failed because of alpha version does not dump correctly into the file. PR is to add dev version on schedule build.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1290455&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=f8123f9a-9210-546c-dd5c-fd8e614fd0e3

![MicrosoftTeams-image](https://user-images.githubusercontent.com/48036328/149199808-f59eb0d1-1082-43a7-85a9-4a916eeb3068.png)

**Testing**
Make temp changes on schedule build time:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1290790&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76


Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.