### PR TITLE
[translation] add back py3.6

### DIFF
--- a/sdk/translation/azure-ai-translation-document/CHANGELOG.md
+++ b/sdk/translation/azure-ai-translation-document/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
-- Python 2.7 and 3.6 are no longer supported. Please use Python version 3.7 or later.
+- Python 2.7 is no longer supported. Please use Python version 3.6 or later.
 
 ## 1.0.0b5 (2021-09-08)
 

--- a/sdk/translation/azure-ai-translation-document/README.md
+++ b/sdk/translation/azure-ai-translation-document/README.md
@@ -16,7 +16,7 @@ _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For
 ## Getting started
 
 ### Prerequisites
-* Python 3.7 or later is required to use this package.
+* Python 3.6 or later is required to use this package.
 * You must have an [Azure subscription][azure_subscription] and a
 [Translator resource][DT_resource] to use this package.
 

--- a/sdk/translation/azure-ai-translation-document/samples/README.md
+++ b/sdk/translation/azure-ai-translation-document/samples/README.md
@@ -28,7 +28,7 @@ These sample programs show common scenarios for the Document Translation client'
 
 
 ## Prerequisites
-* Python 3.7 or later is required to use this package
+* Python 3.6 or later is required to use this package
 * You must have an [Azure subscription][azure_subscription] and an
 [Azure Translator account][azure_document_translation_account] to run these samples.
 

--- a/sdk/translation/azure-ai-translation-document/setup.py
+++ b/sdk/translation/azure-ai-translation-document/setup.py
@@ -39,6 +39,7 @@ setup(
         'Programming Language :: Python',
         "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -52,7 +53,7 @@ setup(
         'azure.ai',
         'azure.ai.translation'
     ]),
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     install_requires=[
         "azure-core<2.0.0,>=1.14.0",
         "msrest>=0.6.21",


### PR DESCRIPTION
~Since translation depends on storage for tests, I think we're seeing CI errors for 3.6/pypy due to the storage packages recently being updated to >=py3.7. https://github.com/Azure/azure-sdk-for-python/issues/22482~