### PR TITLE
[Test Proxy] Normalize paths in test IDs

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -149,26 +149,8 @@ class AzureRecordedTestCase(object):
         return client
 
     def create_random_name(self, name):
-        # pytest sets the current running test in an environment variable
-        # the path to the test can depend on the environment, so we can't assume this is the path from the repo root
-        unique_test_name = os.getenv("PYTEST_CURRENT_TEST")
-        path_to_test = os.path.normpath(unique_test_name.split(" ")[0])
-        full_path_to_test = os.path.abspath(path_to_test)
-
-        # walk up to the repo root by looking for "sdk" directory or root of file system
-        path_components = []
-        head, tail = os.path.split(full_path_to_test)
-        while tail != "sdk" and tail != "":
-            path_components.append(tail)
-            head, tail = os.path.split(head)
-
-        # reverse path_components to construct components of path from repo root: [sdk, ..., tests, {test}]
-        path_components.append("sdk")
-        path_components.reverse()
-        # using the path to the test from the repo root ensures a consistent full_test_name regardless of environment
-        # without consistency, random names might not be consistent across test runs
-        full_test_name = os.sep.join(path_components).encode("utf-8")
-        return get_resource_name(name, full_test_name)
+        unique_test_name = os.getenv("PYTEST_CURRENT_TEST").encode("utf-8")
+        return get_resource_name(name, unique_test_name)
 
     def get_resource_name(self, name):
         """Alias to create_random_name for back compatibility."""

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -57,11 +57,21 @@ def get_recording_id():
 def get_test_id():
     # type: () -> str
     # pytest sets the current running test in an environment variable
+    # the path to the test can depend on the environment, so we can't assume this is the path from the repo root
     setting_value = os.getenv("PYTEST_CURRENT_TEST")
-
     path_to_test = os.path.normpath(setting_value.split(" ")[0])
-    path_components = path_to_test.split(os.sep)
+    full_path_to_test = os.path.abspath(path_to_test)
 
+    # walk up to the repo root by looking for "sdk" directory or root of file system
+    path_components = []
+    head, tail = os.path.split(full_path_to_test)
+    while tail != "sdk" and tail != "":
+        path_components.append(tail)
+        head, tail = os.path.split(head)
+
+    # reverse path_components to construct components of path from repo root: [sdk, ..., tests, {test}]
+    path_components.append("sdk")
+    path_components.reverse()
     for idx, val in enumerate(path_components):
         if val.startswith("test"):
             path_components.insert(idx + 1, "recordings")


### PR DESCRIPTION
# Description

Context: test IDs, which are used by the proxy to determine recording locations, are currently determined based on the value of the `pytest`-controlled `PYTEST_CURRENT_TEST` environment variable. This variable's value isn't consistent across environments though -- the path to the test file is sometimes relative to the repository root, and sometimes not. See https://github.com/Azure/azure-sdk-for-python/issues/22387#issuecomment-1011680482 for more details.

To adjust to this variation in the environment variable, this PR adds logic to determine the repo-root relative path to the current test. This ensures that the test ID is always consistent.

**Note:** AzureRecordedTestCase's `create_random_name` method also relies on the value of `PYTEST_CURRENT_TEST`. The inconsistency of this variable could result in different pseudo-random resource names, which could cause test failures in playback. Fixing this is tracked by https://github.com/Azure/azure-sdk-for-python/issues/22512.

@scbedd for notifs

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
  - An already-migrated test suite is used to verify these changes