### PR TITLE
Revert functools.wraps to functools.update_wrapper

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
@@ -172,7 +172,7 @@ You must specify use_cache=True in the preparer decorator""".format(
         # Inform the next step in the chain (our parent) that we're cached.
         if self._use_cache or getattr(fn, "__use_cache", False):
             setattr(_preparer_wrapper, "__use_cache", True)
-        functools.wraps(_preparer_wrapper, fn)
+        functools.update_wrapper(_preparer_wrapper, fn)
         return _preparer_wrapper
 
     @contextlib.contextmanager


### PR DESCRIPTION
# Description

Context: I recently noticed that the majority of tests in `azure-keyvault-certificates` and `azure-keyvault-secrets` haven't been getting collected by `pytest` since the morning of 11/16/21. Specifically, no tests with decorators have been getting collected: compare the [161 collected tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1195662&view=logs&j=69247760-d00b-59ba-802c-4e283c193199&t=f20575ad-23dc-5da2-643e-2edfc62d6048&l=15391) for `azure-keyvault-secrets` on 11/15/21 with the [31 collected tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1197630&view=logs&j=69247760-d00b-59ba-802c-4e283c193199&t=f20575ad-23dc-5da2-643e-2edfc62d6048&l=15046) on 11/16/21 when executing the same command.

It turns out that these tests stopped getting collected by `pytest` after [this change](https://github.com/Azure/azure-sdk-for-python/commit/a96aee38786daddf4fc6fa0e487f243ed8c9fde9#diff-6f5a5cb1eaabd54e2ea0b5879901de7125b90b354304d2f3d3f44f3d0b8adea6L175) to `AbstractPreparer.__call__` was made, replacing `functools.update_wrapper` with `functools.wraps`. This change was made while migrating mgmt-plane tests to the test proxy (https://github.com/Azure/azure-sdk-for-python/pull/21746) because decorated tests weren't being collected when using the former method, but were collected when using the latter. I wasn't able to reproduce the error that necessitated this change today, so it's possible that a secondary error (which had since been fixed) was causing the collection issue.

This reverts the function change. [functools.wraps](https://docs.python.org/3/library/functools.html#functools.wraps) is equivalent to a `partial` call of [functools.update_wrapper](https://docs.python.org/3/library/functools.html#functools.update_wrapper), so this change shouldn't break tests (especially considering that `functools.update_wrapper` had been used up until the 11/15/21 change).

For more context: the reason `azure-keyvault-administration` and `azure-keyvault-keys` were not affected by the use of `functools.wraps`, despite having a similar test structure, is that these packages don't use PowerShellPreparer (`azure-keyvault-certificates` and `azure-keyvault-secrets` do). PowerShellPreparer was affected by the change because it inherits from AzureMgmtPreparer, which inherits from AbstractPreparer.

My theory is that AbstractPreparer's use of `functools.wraps` is incompatible with the `parameterized` package, which is used in KV tests (and _only_ KV tests, as far as I know). Tests get collected correctly, even with `functools.wraps` and using PowerShellPreparer, if `parameterized` code is commented out. If this is the case, then only KV tests should have been affected by the use of `functools.wraps`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](../CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.