### PR TITLE
[Search] Restore Python 3.6 support

### DIFF
--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Python 2.7 and 3.6 are no longer supported. Please use Python version 3.7 or later.
+- Python 2.7 is no longer supported. Please use Python version 3.6 or later.
 
 ## 11.3.0b6 (2021-11-19)
 

--- a/sdk/search/azure-search-documents/README.md
+++ b/sdk/search/azure-search-documents/README.md
@@ -56,7 +56,7 @@ pip install azure-search-documents
 
 ### Prerequisites
 
-* Python 3.7 or later is required to use this package.
+* Python 3.6 or later is required to use this package.
 * You need an [Azure subscription][azure_sub] and a
 [Azure Cognitive Search service][search_resource] to use this package.
 

--- a/sdk/search/azure-search-documents/setup.py
+++ b/sdk/search/azure-search-documents/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -59,7 +60,7 @@ setup(
         'azure',
         'azure.search',
     ]),
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     install_requires=[
         "azure-core<2.0.0,>=1.19.0",
         "msrest>=0.6.21",


### PR DESCRIPTION
# Description

Restore Python 3.6 support. Closes #22558

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.