### PR TITLE
Prevent BoM upload failure on failed builds

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -114,6 +114,7 @@ steps:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generate BOM'
+    condition: succeededOrFailed()
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 

--- a/eng/pipelines/templates/steps/build-conda-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-conda-artifacts.yml
@@ -86,6 +86,7 @@ steps:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Upload Conda Package SBOM'
+    condition: succeededOrFailed()
     inputs:
       BuildDropPath: '$(Agent.BuildDirectory)/conda/manifest'
 


### PR DESCRIPTION
This is the same condition fix (with the same logic) that is applied in this PR Azure/azure-sdk-for-cpp#3256