### PR TITLE
[textanalytics] switch to kwargs where we run nonrecorded tests

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_sentiment.pyTestAnalyzeSentimenttest_opinion_mining_v3.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_sentiment.pyTestAnalyzeSentimenttest_opinion_mining_v3.json
@@ -1,4 +1,0 @@
-{
-  "Entries": [],
-  "Variables": {}
-}

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -1235,15 +1235,16 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsCustomPreparer()
     def test_generic_action_error_no_target(
         self,
-        textanalytics_custom_text_endpoint,
-        textanalytics_custom_text_key,
-        textanalytics_single_category_classify_project_name,
-        textanalytics_single_category_classify_deployment_name,
-        textanalytics_multi_category_classify_project_name,
-        textanalytics_multi_category_classify_deployment_name,
-        textanalytics_custom_entities_project_name,
-        textanalytics_custom_entities_deployment_name
+        **kwargs
     ):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_single_category_classify_project_name = kwargs.pop("textanalytics_single_category_classify_project_name")
+        textanalytics_single_category_classify_deployment_name = kwargs.pop("textanalytics_single_category_classify_deployment_name")
+        textanalytics_multi_category_classify_project_name = kwargs.pop("textanalytics_multi_category_classify_project_name")
+        textanalytics_multi_category_classify_deployment_name = kwargs.pop("textanalytics_multi_category_classify_deployment_name")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
             {"id": "2", "language": "en", "text": ""},
@@ -1296,15 +1297,16 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsCustomPreparer()
     def test_action_errors_with_targets(
         self,
-        textanalytics_custom_text_endpoint,
-        textanalytics_custom_text_key,
-        textanalytics_single_category_classify_project_name,
-        textanalytics_single_category_classify_deployment_name,
-        textanalytics_multi_category_classify_project_name,
-        textanalytics_multi_category_classify_deployment_name,
-        textanalytics_custom_entities_project_name,
-        textanalytics_custom_entities_deployment_name
+        **kwargs
     ):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_single_category_classify_project_name = kwargs.pop("textanalytics_single_category_classify_project_name")
+        textanalytics_single_category_classify_deployment_name = kwargs.pop("textanalytics_single_category_classify_deployment_name")
+        textanalytics_multi_category_classify_project_name = kwargs.pop("textanalytics_multi_category_classify_project_name")
+        textanalytics_multi_category_classify_deployment_name = kwargs.pop("textanalytics_multi_category_classify_deployment_name")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
             {"id": "2", "language": "en", "text": ""},
@@ -1387,11 +1389,12 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsCustomPreparer()
     def test_action_job_failure(
             self,
-            textanalytics_custom_text_endpoint,
-            textanalytics_custom_text_key,
-            textanalytics_custom_entities_project_name,
-            textanalytics_custom_entities_deployment_name
+            **kwargs
     ):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
         docs = [
             {"id": "1", "language": "en",
              "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -1324,15 +1324,16 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @recorded_by_proxy_async
     async def test_generic_action_error_no_target(
         self,
-        textanalytics_custom_text_endpoint,
-        textanalytics_custom_text_key,
-        textanalytics_single_category_classify_project_name,
-        textanalytics_single_category_classify_deployment_name,
-        textanalytics_multi_category_classify_project_name,
-        textanalytics_multi_category_classify_deployment_name,
-        textanalytics_custom_entities_project_name,
-        textanalytics_custom_entities_deployment_name
+        **kwargs
     ):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_single_category_classify_project_name = kwargs.pop("textanalytics_single_category_classify_project_name")
+        textanalytics_single_category_classify_deployment_name = kwargs.pop("textanalytics_single_category_classify_deployment_name")
+        textanalytics_multi_category_classify_project_name = kwargs.pop("textanalytics_multi_category_classify_project_name")
+        textanalytics_multi_category_classify_deployment_name = kwargs.pop("textanalytics_multi_category_classify_deployment_name")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
             {"id": "2", "language": "en", "text": ""},
@@ -1389,15 +1390,16 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @recorded_by_proxy_async
     async def test_action_errors_with_targets(
         self,
-        textanalytics_custom_text_endpoint,
-        textanalytics_custom_text_key,
-        textanalytics_single_category_classify_project_name,
-        textanalytics_single_category_classify_deployment_name,
-        textanalytics_multi_category_classify_project_name,
-        textanalytics_multi_category_classify_deployment_name,
-        textanalytics_custom_entities_project_name,
-        textanalytics_custom_entities_deployment_name
+        **kwargs
     ):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_single_category_classify_project_name = kwargs.pop("textanalytics_single_category_classify_project_name")
+        textanalytics_single_category_classify_deployment_name = kwargs.pop("textanalytics_single_category_classify_deployment_name")
+        textanalytics_multi_category_classify_project_name = kwargs.pop("textanalytics_multi_category_classify_project_name")
+        textanalytics_multi_category_classify_deployment_name = kwargs.pop("textanalytics_multi_category_classify_deployment_name")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
             {"id": "2", "language": "en", "text": ""},
@@ -1486,11 +1488,12 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @recorded_by_proxy_async
     async def test_action_job_failure(
             self,
-            textanalytics_custom_text_endpoint,
-            textanalytics_custom_text_key,
-            textanalytics_custom_entities_project_name,
-            textanalytics_custom_entities_deployment_name
+            **kwargs
     ):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
         docs = [
             {"id": "1", "language": "en",
              "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment.py
@@ -726,8 +726,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_opinion_mining_v3(self, client):
+    def test_opinion_mining_v3(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.analyze_sentiment(["will fail"], show_opinion_mining=True)
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
@@ -729,7 +729,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    async def test_opinion_mining_v3(self, client):
+    async def test_opinion_mining_v3(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             await client.analyze_sentiment(["will fail"], show_opinion_mining=True)
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth.py
@@ -4,7 +4,6 @@
 # ------------------------------------
 
 import pytest
-from devtools_testutils import recorded_by_proxy
 from testcase import TextAnalyticsTest, TextAnalyticsPreparer
 from azure.ai.textanalytics import TextAnalyticsClient
 from azure.core.credentials import AzureKeyCredential

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 
 import pytest
+from devtools_testutils import recorded_by_proxy
 from testcase import TextAnalyticsTest, TextAnalyticsPreparer
 from azure.ai.textanalytics import TextAnalyticsClient
 from azure.core.credentials import AzureKeyCredential
@@ -14,7 +15,8 @@ class TestAuth(TextAnalyticsTest):
 
     @pytest.mark.live_test_only
     @TextAnalyticsPreparer()
-    def test_active_directory_auth(self, textanalytics_test_endpoint):
+    def test_active_directory_auth(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         token = self.get_credential(TextAnalyticsClient)
         text_analytics_endpoint_suffix = os.environ.get("TEXTANALYTICS_ENDPOINT_SUFFIX",".cognitiveservices.azure.com")
         credential_scopes = ["https://{}/.default".format(text_analytics_endpoint_suffix[1:])]
@@ -28,21 +30,25 @@ class TestAuth(TextAnalyticsTest):
         response = text_analytics.detect_language(docs)
 
     @TextAnalyticsPreparer()
-    def test_empty_credentials(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_empty_credentials(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         with pytest.raises(TypeError):
             text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, "")
 
     @TextAnalyticsPreparer()
-    def test_bad_type_for_credentials(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_bad_type_for_credentials(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         with pytest.raises(TypeError):
             text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, [])
 
     @TextAnalyticsPreparer()
-    def test_none_credentials(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_none_credentials(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         with pytest.raises(ValueError):
             text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, None)
 
     @TextAnalyticsPreparer()
-    def test_none_endpoint(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_none_endpoint(self, **kwargs):
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         with pytest.raises(ValueError):
             text_analytics = TextAnalyticsClient(None, AzureKeyCredential(textanalytics_test_api_key))

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth_async.py
@@ -15,7 +15,8 @@ class TestAuth(TextAnalyticsTest):
 
     @pytest.mark.live_test_only
     @TextAnalyticsPreparer()
-    async def test_active_directory_auth(self, textanalytics_test_endpoint):
+    async def test_active_directory_auth(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         token = self.get_credential(TextAnalyticsClient, is_async=True)
         text_analytics_endpoint_suffix = os.environ.get("TEXTANALYTICS_ENDPOINT_SUFFIX",".cognitiveservices.azure.com")
         credential_scopes = ["https://{}/.default".format(text_analytics_endpoint_suffix[1:])]
@@ -29,21 +30,25 @@ class TestAuth(TextAnalyticsTest):
         response = await text_analytics.detect_language(docs)
 
     @TextAnalyticsPreparer()
-    async def test_empty_credentials(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_empty_credentials(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         with pytest.raises(TypeError):
             text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, "")
 
     @TextAnalyticsPreparer()
-    def test_bad_type_for_credentials(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_bad_type_for_credentials(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         with pytest.raises(TypeError):
             text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, [])
 
     @TextAnalyticsPreparer()
-    def test_none_credentials(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_none_credentials(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
         with pytest.raises(ValueError):
             text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, None)
 
     @TextAnalyticsPreparer()
-    def test_none_endpoint(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_none_endpoint(self, **kwargs):
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         with pytest.raises(ValueError):
             text_analytics = TextAnalyticsClient(None, AzureKeyCredential(textanalytics_test_api_key))

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_context_manager.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_context_manager.py
@@ -15,7 +15,9 @@ from azure.ai.textanalytics import TextAnalyticsClient
 class TestContextManager(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
-    def test_close(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_close(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         transport = mock.MagicMock()
         client = TextAnalyticsClient(
             textanalytics_test_endpoint,
@@ -27,7 +29,9 @@ class TestContextManager(TextAnalyticsTest):
         assert transport.__exit__.call_count == 1
 
     @TextAnalyticsPreparer()
-    def test_context_manager(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_context_manager(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         transport = mock.MagicMock()
         client = TextAnalyticsClient(
             textanalytics_test_endpoint,

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_context_manager_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_context_manager_async.py
@@ -34,7 +34,9 @@ class AsyncMockTransport(mock.MagicMock):
 
 class TestContextManager(TextAnalyticsTest):
     @TextAnalyticsPreparer()
-    async def test_close(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_close(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         transport = AsyncMockTransport()
         client = TextAnalyticsClient(
             textanalytics_test_endpoint,
@@ -47,7 +49,9 @@ class TestContextManager(TextAnalyticsTest):
         assert transport.__aexit__.call_count == 1
 
     @TextAnalyticsPreparer()
-    async def test_context_manager(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_context_manager(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         transport = AsyncMockTransport()
         client = TextAnalyticsClient(
             textanalytics_test_endpoint,

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_multiapi.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_multiapi.py
@@ -14,20 +14,24 @@ TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, Te
 class TestMultiApi(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
-    def test_default_api_version(self, client):
+    def test_default_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.2-preview.2" in client._client._client._base_url
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    def test_v3_0_api_version(self, client):
+    def test_v3_0_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.0" in client._client._client._base_url
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
-    def test_v3_1_api_version(self, client):
+    def test_v3_1_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.1" in client._client._client._base_url
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_2_PREVIEW})
-    def test_v3_2_api_version(self, client):
+    def test_v3_2_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.2-preview.2" in client._client._client._base_url

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_multiapi_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_multiapi_async.py
@@ -14,20 +14,24 @@ TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, Te
 class TestMultiApiAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
-    def test_default_api_version(self, client):
+    def test_default_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.2-preview.2" in client._client._client._base_url
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    def test_v3_0_api_version(self, client):
+    def test_v3_0_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.0" in client._client._client._base_url
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
-    def test_v3_1_api_version(self, client):
+    def test_v3_1_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.1" in client._client._client._base_url
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_2_PREVIEW})
-    def test_v3_2_api_version(self, client):
+    def test_v3_2_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v3.2-preview.2" in client._client._client._base_url


### PR DESCRIPTION
If we don't want to record a test, we omit the @recorded_by_proxy decorator. However, this decorator allows the test params be passed as actual params, whereas in its absence, pytest treats any params as fixtures. Moving test params to kwargs for unrecorded tests fixes the issue. Thanks @mccoyp for the help!