### PR TITLE
[core] accept 'final-state-via' lro_options in base polling

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Add support for `final-state-via` LRO option in core.  #22713
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -193,7 +193,8 @@ class OperationResourcePolling(LongRunningOperation):
     """Implements a operation resource polling, typically from Operation-Location.
 
     :param str operation_location_header: Name of the header to return operation format (default 'operation-location')
-    :keyword dict[str, any] lro_options: Additional options for LRO
+    :keyword dict[str, any] lro_options: Additional options for LRO. For more information, see
+     https://aka.ms/azsdk/autorest/openapi/lro-options
     """
 
     def __init__(

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -193,6 +193,7 @@ class OperationResourcePolling(LongRunningOperation):
     """Implements a operation resource polling, typically from Operation-Location.
 
     :param str operation_location_header: Name of the header to return operation format (default 'operation-location')
+    :keyword dict[str, any] lro_options: Additional options for LRO
     """
 
     def __init__(

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -225,12 +225,16 @@ class OperationResourcePolling(LongRunningOperation):
         :rtype: str
         """
         if (
+            self._lro_options.get(_LroOption.FINAL_STATE_VIA) == _FinalStateViaOption.LOCATION_FINAL_STATE
+            and self._location_url
+        ):
+            return self._location_url
+        if (
             self._lro_options.get(_LroOption.FINAL_STATE_VIA)
             in [
                 _FinalStateViaOption.AZURE_ASYNC_OPERATION_FINAL_STATE,
                 _FinalStateViaOption.OPERATION_LOCATION_FINAL_STATE
             ]
-            and self._request.method == "POST"
         ):
             return None
         response = pipeline_response.http_response

--- a/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
@@ -748,3 +748,106 @@ async def test_long_running_negative(http_request, http_response):
     LOCATION_BODY = json.dumps({ 'name': TEST_NAME })
     POLLING_STATUS = 200
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(ASYNCIO_REQUESTS_TRANSPORT_RESPONSES))
+async def test_post_final_state_via(async_pipeline_client_builder, deserialization_cb, http_request, http_response):
+    # Test POST LRO with both Location and Operation-Location
+    CLIENT.http_request_type = http_request
+    CLIENT.http_response_type = http_response
+    # The initial response contains both Location and Operation-Location, a 202 and no Body
+    initial_response = TestBasePolling.mock_send(
+        http_request,
+        http_response,
+        'POST',
+        202,
+        {
+            'location': 'http://example.org/location',
+            'operation-location': 'http://example.org/async_monitor',
+        },
+        ''
+    )
+
+    async def send(request, **kwargs):
+        assert request.method == 'GET'
+
+        if request.url == 'http://example.org/location':
+            return TestBasePolling.mock_send(
+                http_request,
+                http_response,
+                'GET',
+                200,
+                body={'location_result': True}
+            ).http_response
+        elif request.url == 'http://example.org/async_monitor':
+            return TestBasePolling.mock_send(
+                http_request,
+                http_response,
+                'GET',
+                200,
+                body={'status': 'Succeeded'}
+            ).http_response
+        else:
+            pytest.fail("No other query allowed")
+
+    client = async_pipeline_client_builder(send)
+
+    # Test 1, LRO options with Location final state
+    poll = async_poller(
+        client,
+        initial_response,
+        deserialization_cb,
+        AsyncLROBasePolling(0, lro_options={"final-state-via": "location"}))
+    result = await poll
+    assert result['location_result'] == True
+
+    # Test 2, LRO options with Operation-Location final state
+    poll = async_poller(
+        client,
+        initial_response,
+        deserialization_cb,
+        AsyncLROBasePolling(0, lro_options={"final-state-via": "operation-location"}))
+    result = await poll
+    assert result['status'] == 'Succeeded'
+
+    # Test 3, "do the right thing" and use Location by default
+    poll = async_poller(
+        client,
+        initial_response,
+        deserialization_cb,
+        AsyncLROBasePolling(0))
+    result = await poll
+    assert result['location_result'] == True
+
+    # Test 4, location has no body
+
+    async def send(request, **kwargs):
+        assert request.method == 'GET'
+
+        if request.url == 'http://example.org/location':
+            return TestBasePolling.mock_send(
+                http_request,
+                http_response,
+                'GET',
+                200,
+                body=None
+            ).http_response
+        elif request.url == 'http://example.org/async_monitor':
+            return TestBasePolling.mock_send(
+                http_request,
+                http_response,
+                'GET',
+                200,
+                body={'status': 'Succeeded'}
+            ).http_response
+        else:
+            pytest.fail("No other query allowed")
+
+    client = async_pipeline_client_builder(send)
+
+    poll = async_poller(
+        client,
+        initial_response,
+        deserialization_cb,
+        AsyncLROBasePolling(0, lro_options={"final-state-via": "location"}))
+    result = await poll
+    assert result is None

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -756,3 +756,106 @@ class TestBasePolling(object):
 
         LOCATION_BODY = json.dumps({ 'name': TEST_NAME })
         POLLING_STATUS = 200
+
+    @pytest.mark.parametrize("http_request,http_response", request_and_responses_product(REQUESTS_TRANSPORT_RESPONSES))
+    def test_post_final_state_via(self, pipeline_client_builder, deserialization_cb, http_request, http_response):
+        # Test POST LRO with both Location and Operation-Location
+        CLIENT.http_request_type = http_request
+        CLIENT.http_response_type = http_response
+        # The initial response contains both Location and Operation-Location, a 202 and no Body
+        initial_response = TestBasePolling.mock_send(
+            http_request,
+            http_response,
+            'POST',
+            202,
+            {
+                'location': 'http://example.org/location',
+                'operation-location': 'http://example.org/async_monitor',
+            },
+            ''
+        )
+
+        def send(request, **kwargs):
+            assert request.method == 'GET'
+
+            if request.url == 'http://example.org/location':
+                return TestBasePolling.mock_send(
+                    http_request,
+                    http_response,
+                    'GET',
+                    200,
+                    body={'location_result': True}
+                ).http_response
+            elif request.url == 'http://example.org/async_monitor':
+                return TestBasePolling.mock_send(
+                    http_request,
+                    http_response,
+                    'GET',
+                    200,
+                    body={'status': 'Succeeded'}
+                ).http_response
+            else:
+                pytest.fail("No other query allowed")
+
+        client = pipeline_client_builder(send)
+
+        # Test 1, LRO options with Location final state
+        poll = LROPoller(
+            client,
+            initial_response,
+            deserialization_cb,
+            LROBasePolling(0, lro_options={"final-state-via": "location"}))
+        result = poll.result()
+        assert result['location_result'] == True
+
+        # Test 2, LRO options with Operation-Location final state
+        poll = LROPoller(
+            client,
+            initial_response,
+            deserialization_cb,
+            LROBasePolling(0, lro_options={"final-state-via": "operation-location"}))
+        result = poll.result()
+        assert result['status'] == 'Succeeded'
+
+        # Test 3, "do the right thing" and use Location by default
+        poll = LROPoller(
+            client,
+            initial_response,
+            deserialization_cb,
+            LROBasePolling(0))
+        result = poll.result()
+        assert result['location_result'] == True
+
+        # Test 4, location has no body
+
+        def send(request, **kwargs):
+            assert request.method == 'GET'
+
+            if request.url == 'http://example.org/location':
+                return TestBasePolling.mock_send(
+                    http_request,
+                    http_response,
+                    'GET',
+                    200,
+                    body=None
+                ).http_response
+            elif request.url == 'http://example.org/async_monitor':
+                return TestBasePolling.mock_send(
+                    http_request,
+                    http_response,
+                    'GET',
+                    200,
+                    body={'status': 'Succeeded'}
+                ).http_response
+            else:
+                pytest.fail("No other query allowed")
+
+        client = pipeline_client_builder(send)
+
+        poll = LROPoller(
+            client,
+            initial_response,
+            deserialization_cb,
+            LROBasePolling(0, lro_options={"final-state-via": "location"}))
+        result = poll.result()
+        assert result is None

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -31,9 +31,7 @@ import types
 import pickle
 import platform
 import six
-from tests.rest_client import TestRestClient
 
-from tests.utils import HTTP_REQUESTS
 try:
     from unittest import mock
 except ImportError:
@@ -47,11 +45,11 @@ from azure.core.polling import LROPoller
 from azure.core.exceptions import DecodeError, HttpResponseError
 from azure.core import PipelineClient
 from azure.core.pipeline import PipelineResponse, Pipeline, PipelineContext
-from azure.core.pipeline.transport import HttpTransport, RequestsTransport
+from azure.core.pipeline.transport import HttpTransport
 
 from azure.core.polling.base_polling import LROBasePolling
 from azure.core.pipeline.policies._utils import _FixedOffset
-from utils import request_and_responses_product, REQUESTS_TRANSPORT_RESPONSES, create_transport_response
+from utils import request_and_responses_product, REQUESTS_TRANSPORT_RESPONSES, create_transport_response, HTTP_REQUESTS
 from azure.core.pipeline._tools import is_rest
 
 class SimpleResource:

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -51,6 +51,7 @@ from azure.core.polling.base_polling import LROBasePolling
 from azure.core.pipeline.policies._utils import _FixedOffset
 from utils import request_and_responses_product, REQUESTS_TRANSPORT_RESPONSES, create_transport_response, HTTP_REQUESTS
 from azure.core.pipeline._tools import is_rest
+from rest_client import TestRestClient
 
 class SimpleResource:
     """An implementation of Python 3 SimpleNamespace.

--- a/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/polling.py
+++ b/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/polling.py
@@ -151,3 +151,22 @@ def request_id_location():
         '{"status": "Succeeded"}',
         status=200
     )
+
+@polling_api.route('/polling-with-options', methods=["PUT"])
+def polling_with_options_first():
+    base_url = get_base_url(request)
+    return Response(
+        '{"properties":{"provisioningState": "InProgress"}}',
+        headers={
+            'location': '{}/polling/final-get-with-location'.format(base_url),
+            'operation-location': '{}/polling/post/resource-location/operation-location-url'.format(base_url),
+        },
+        status=202
+    )
+
+@polling_api.route('/final-get-with-location', methods=["GET"])
+def polling_with_options_final_get_with_location():
+    return Response(
+        '{"returnedFrom": "locationHeaderUrl"}',
+        status=200
+    )


### PR DESCRIPTION
currently, `azure-core` polling doesn't do anything with the `final-state-via` information from open api definitions. This PR adds support for looking into `final-state-via`