### PR TITLE
[formrecognizer] use kwargs where we don't record tests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
@@ -20,13 +20,17 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 class TestDACAnalyzeCustomModel(FormRecognizerTest):
 
     @FormRecognizerPreparer()
-    def test_analyze_document_none_model_id(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_analyze_document_none_model_id(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             client.begin_analyze_document(model=None, document=b"xx")
 
     @FormRecognizerPreparer()
-    def test_analyze_document_empty_model_id(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_analyze_document_empty_model_id(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             client.begin_analyze_document(model="", document=b"xx")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
@@ -24,14 +24,18 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
-    async def test_analyze_document_none_model_id(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_analyze_document_none_model_id(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             async with client:
                 await client.begin_analyze_document(model=None, document=b"xx")
 
     @FormRecognizerPreparer()
-    async def test_analyze_document_empty_model_id(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_analyze_document_empty_model_id(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
@@ -20,13 +20,17 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
-    def test_document_analysis_none_model(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_document_analysis_none_model(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             client.begin_analyze_document_from_url(model=None, document_url="https://badurl.jpg")
 
     @FormRecognizerPreparer()
-    def test_document_analysis_empty_model_id(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_document_analysis_empty_model_id(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             client.begin_analyze_document_from_url(model="", document_url="https://badurl.jpg")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
@@ -22,14 +22,18 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
-    async def test_document_analysis_none_model(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_document_analysis_none_model(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             async with client:
                 await client.begin_analyze_document_from_url(model=None, document_url="https://badurl.jpg")
 
     @FormRecognizerPreparer()
-    async def test_document_analysis_empty_model_id(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_document_analysis_empty_model_id(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         with pytest.raises(ValueError):
             async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts.py
@@ -217,7 +217,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    def test_fail_passing_content_type(self, client):
+    def test_fail_passing_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_png, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(TypeError):
@@ -486,7 +487,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    def test_receipt_continuation_token(self, client):
+    def test_receipt_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_async.py
@@ -66,7 +66,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    async def test_passing_unsupported_url_content_type(self, client, **kwargs):
+    async def test_passing_unsupported_url_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             async with client:
                 poller = await client.begin_analyze_document("prebuilt-receipt", "https://badurl.jpg", content_type="application/json")
@@ -283,7 +284,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    async def test_receipt_continuation_token(self, client):
+    async def test_receipt_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
@@ -355,7 +355,8 @@ class TestDACAnalyzePrebuiltsfromUrl(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    def test_receipt_continuation_token(self, client):
+    def test_receipt_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
 
         initial_poller = client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg)
         cont_token = initial_poller.continuation_token()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
@@ -390,7 +390,8 @@ class TestDACAnalyzePrebuiltsfromUrlAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    async def test_receipt_continuation_token(self, client):
+    async def test_receipt_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
 
         async with client:
             initial_poller = await client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
@@ -84,8 +84,9 @@ class TestTraining(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    def test_compose_continuation_token(self, client, formrecognizer_storage_container_sas_url):
-
+    def test_compose_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model_1 = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
@@ -87,8 +87,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    async def test_compose_continuation_token(self, client, formrecognizer_storage_container_sas_url):
-
+    async def test_compose_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             model_1 = await poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model.py
@@ -178,8 +178,9 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
-    def test_copy_continuation_token(self, client, formrecognizer_storage_container_sas_url):
-
+    def test_copy_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model_async.py
@@ -180,7 +180,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
-    async def test_copy_continuation_token(self, client, formrecognizer_storage_container_sas_url):
+    async def test_copy_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             model = await poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
@@ -44,25 +44,29 @@ class TestManagement(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    def test_get_model_empty_model_id(self, client):
+    def test_get_model_empty_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             result = client.get_model("")
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    def test_get_model_none_model_id(self, client):
+    def test_get_model_none_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             result = client.get_model(None)
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    def test_delete_model_none_model_id(self, client):
+    def test_delete_model_none_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             result = client.delete_model(None)
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    def test_delete_model_empty_model_id(self, client):
+    def test_delete_model_empty_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             result = client.delete_model("")
 
@@ -177,7 +181,8 @@ class TestManagement(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    def test_get_operation_bad_model_id(self, client):
+    def test_get_operation_bad_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             client.get_operation("")
         with pytest.raises(ValueError):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
@@ -47,28 +47,32 @@ class TestManagementAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    async def test_get_model_empty_model_id(self, client):
+    async def test_get_model_empty_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             async with client:
                 result = await client.get_model("")
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    async def test_get_model_none_model_id(self, client):
+    async def test_get_model_none_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             async with client:
                 result = await client.get_model(None)
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    async def test_delete_model_none_model_id(self, client):
+    async def test_delete_model_none_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             async with client:
                 result = await client.delete_model(None)
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    async def test_delete_model_empty_model_id(self, client):
+    async def test_delete_model_empty_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             async with client:
                 result = await client.delete_model("")
@@ -187,7 +191,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    async def test_get_operation_bad_model_id(self, client):
+    async def test_get_operation_bad_model_id(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError):
             await client.get_operation("")
         with pytest.raises(ValueError):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
@@ -214,8 +214,9 @@ class TestDMACTraining(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    def test_build_model_continuation_token(self, client, formrecognizer_storage_container_sas_url):
-
+    def test_build_model_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         initial_poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         cont_token = initial_poller.continuation_token()
         poller = client.begin_build_model(None, continuation_token=cont_token)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
@@ -224,7 +224,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
-    async def test_build_model_continuation_token(self, client, formrecognizer_storage_container_sas_url):
+    async def test_build_model_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             initial_poller = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             cont_token = initial_poller.continuation_token()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
@@ -36,7 +36,8 @@ class TestBusinessCard(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_business_cards(
@@ -45,7 +46,8 @@ class TestBusinessCard(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_damaged_file_bytes_io_fails_autodetect(self, client):
+    def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_business_cards(
@@ -54,7 +56,8 @@ class TestBusinessCard(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_passing_bad_content_type_param_passed(self, client):
+    def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.business_card_jpg, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -181,7 +184,8 @@ class TestBusinessCard(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_business_card_v2(self, client):
+    def test_business_card_v2(self, **kwargs):
+        client = kwargs.pop("client")
         
         with open(self.business_card_jpg, "rb") as fd:
             business_card = fd.read()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
@@ -36,7 +36,8 @@ class TestBusinessCardAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    async def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             async with client:
@@ -46,7 +47,8 @@ class TestBusinessCardAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_damaged_file_bytes_io_fails_autodetect(self, client):
+    async def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             async with client:
@@ -57,7 +59,8 @@ class TestBusinessCardAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_passing_bad_content_type_param_passed(self, client):
+    async def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.business_card_jpg, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -122,7 +125,8 @@ class TestBusinessCardAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_business_card_v2(self, client):
+    async def test_business_card_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.business_card_jpg, "rb") as fd:
             business_card = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
@@ -71,7 +71,8 @@ class TestBusinessCardFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_business_card_v2(self, client):
+    def test_business_card_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             client.begin_recognize_business_cards_from_url(self.business_card_url_jpg)
         assert "Method 'begin_recognize_business_cards_from_url' is only available for API version V2_1 and up" in str(e.value)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
@@ -73,7 +73,8 @@ class TestBusinessCardFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_business_card_v2(self, client):
+    async def test_business_card_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             async with client:
                 await client.begin_recognize_business_cards_from_url(self.business_card_url_jpg)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
@@ -64,7 +64,8 @@ class TestContentFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_passing_bad_content_type_param_passed(self, client):
+    def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -75,7 +76,8 @@ class TestContentFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_auto_detect_unsupported_stream_content(self, client):
+    def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.unsupported_content_py, "rb") as fd:
             myfile = fd.read()
 
@@ -205,7 +207,8 @@ class TestContentFromStream(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_content_continuation_token(self, client):
+    def test_content_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
         initial_poller = client.begin_recognize_content(myfile)
@@ -317,7 +320,8 @@ class TestContentFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_content_language_v2(self, client):
+    def test_content_language_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
@@ -75,7 +75,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_passing_bad_content_type_param_passed(self, client):
+    async def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -88,7 +89,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_auto_detect_unsupported_stream_content(self, client):
+    async def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.unsupported_content_py, "rb") as fd:
             myfile = fd.read()
 
@@ -219,7 +221,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_content_continuation_token(self, client):
+    async def test_content_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
         async with client:
@@ -346,7 +349,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_content_language_v2(self, client):
+    async def test_content_language_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
         async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
@@ -155,7 +155,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_content_continuation_token(self, client):
+    def test_content_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         initial_poller = client.begin_recognize_content_from_url(self.form_url_jpg)
         cont_token = initial_poller.continuation_token()
 
@@ -266,7 +267,8 @@ class TestContentFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_content_language_v2(self, client):
+    def test_content_language_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             client.begin_recognize_content_from_url(self.form_url_jpg, language="en")
         assert "'language' is only available for API version V2_1 and up" in str(e.value)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
@@ -125,7 +125,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_content_continuation_token(self, client):
+    async def test_content_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             initial_poller = await client.begin_recognize_content_from_url(self.form_url_jpg)
             cont_token = initial_poller.continuation_token()
@@ -244,7 +245,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_content_language_v2(self, client):
+    async def test_content_language_v2(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             with pytest.raises(ValueError) as e:
                 await client.begin_recognize_content_from_url(self.form_url_jpg, language="en")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
@@ -214,7 +214,9 @@ class TestCustomForms(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
-    def test_custom_form_continuation_token(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
@@ -145,7 +145,9 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
-    async def test_custom_form_continuation_token(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_custom_form_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         fr_client = client.get_form_recognizer_client()
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
@@ -148,7 +148,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
-    def test_custom_form_continuation_token(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         fr_client = client.get_form_recognizer_client()
 
         training_poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
@@ -158,7 +158,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
-    async def test_custom_form_continuation_token(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_custom_form_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         fr_client = client.get_form_recognizer_client()
 
         async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
@@ -34,7 +34,8 @@ class TestIdDocument(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_identity_documents(
@@ -43,7 +44,8 @@ class TestIdDocument(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_damaged_file_bytes_io_fails_autodetect(self, client):
+    def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_identity_documents(
@@ -52,7 +54,8 @@ class TestIdDocument(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_passing_bad_content_type_param_passed(self, client):
+    def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -63,7 +66,8 @@ class TestIdDocument(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_auto_detect_unsupported_stream_content(self, client):
+    def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.unsupported_content_py, "rb") as fd:
             myfile = fd.read()
 
@@ -137,7 +141,8 @@ class TestIdDocument(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_identity_document_continuation_token(self, client):
+    def test_identity_document_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
 
@@ -150,7 +155,8 @@ class TestIdDocument(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_identity_document_v2(self, client):
+    def test_identity_document_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
@@ -36,7 +36,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    async def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             async with client:
@@ -46,7 +47,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_damaged_file_bytes_io_fails_autodetect(self, client):
+    async def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             async with client:
@@ -56,7 +58,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_passing_bad_content_type_param_passed(self, client):
+    async def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -68,7 +71,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_auto_detect_unsupported_stream_content(self, client):
+    async def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.unsupported_content_py, "rb") as fd:
             myfile = fd.read()
 
@@ -145,7 +149,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_identity_document_continuation_token(self, client):
+    async def test_identity_document_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
         async with client:
@@ -158,7 +163,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_identity_document_v2(self, client):
+    async def test_identity_document_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
@@ -97,7 +97,8 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_identity_document_continuation_token(self, client):
+    def test_identity_document_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         initial_poller = client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg)
         cont_token = initial_poller.continuation_token()
         poller = client.begin_recognize_identity_documents_from_url(None, continuation_token=cont_token)
@@ -107,7 +108,8 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_identity_document_v2(self, client):
+    def test_identity_document_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg)
         assert "Method 'begin_recognize_identity_documents_from_url' is only available for API version V2_1 and up" in str(e.value)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
@@ -101,7 +101,8 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_identity_document_continuation_token(self, client):
+    async def test_identity_document_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             initial_poller = await client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg)
             cont_token = initial_poller.continuation_token()
@@ -112,7 +113,8 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_identity_document_v2(self, client):
+    async def test_identity_document_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             async with client:
                 await client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
@@ -48,7 +48,8 @@ class TestInvoice(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_invoices(
@@ -57,7 +58,8 @@ class TestInvoice(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_damaged_file_bytes_io_fails_autodetect(self, client):
+    def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_invoices(
@@ -66,7 +68,8 @@ class TestInvoice(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_passing_bad_content_type_param_passed(self, client):
+    def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -77,7 +80,8 @@ class TestInvoice(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_auto_detect_unsupported_stream_content(self, client):
+    def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.unsupported_content_py, "rb") as fd:
             myfile = fd.read()
@@ -278,7 +282,8 @@ class TestInvoice(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_invoice_continuation_token(self, client):
+    def test_invoice_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.invoice_tiff, "rb") as fd:
             invoice = fd.read()
@@ -292,7 +297,8 @@ class TestInvoice(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_invoice_v2(self, client):
+    def test_invoice_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             invoice = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
@@ -52,7 +52,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    async def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             async with client:
@@ -62,7 +63,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_damaged_file_bytes_io_fails_autodetect(self, client):
+    async def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             async with client:
@@ -72,7 +74,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_passing_bad_content_type_param_passed(self, client):
+    async def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -84,7 +87,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_auto_detect_unsupported_stream_content(self, client):
+    async def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.unsupported_content_py, "rb") as fd:
             myfile = fd.read()
@@ -293,7 +297,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_invoice_continuation_token(self, client):
+    async def test_invoice_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.invoice_tiff, "rb") as fd:
             invoice = fd.read()
@@ -307,7 +312,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_invoice_v2(self, client):
+    async def test_invoice_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             invoice = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
@@ -88,7 +88,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_invoice_continuation_token(self, client):
+    def test_invoice_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
 
         initial_poller = client.begin_recognize_invoices_from_url(self.invoice_url_tiff)
         cont_token = initial_poller.continuation_token()
@@ -99,7 +100,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_invoice_v2(self, client):
+    def test_invoice_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             client.begin_recognize_invoices_from_url(self.invoice_url_tiff)
         assert "Method 'begin_recognize_invoices_from_url' is only available for API version V2_1 and up" in str(e.value)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
@@ -94,7 +94,8 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_invoice_continuation_token(self, client):
+    async def test_invoice_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             initial_poller = await client.begin_recognize_invoices_from_url(self.invoice_url_tiff)
             cont_token = initial_poller.continuation_token()
@@ -105,7 +106,8 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_invoice_v2(self, client):
+    async def test_invoice_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             async with client:
                 await client.begin_recognize_invoices_from_url(self.invoice_url_tiff)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
@@ -34,7 +34,8 @@ class TestReceiptFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_receipts(
@@ -44,7 +45,8 @@ class TestReceiptFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     # TODO should there be a v3 version of this test?
-    def test_damaged_file_bytes_io_fails_autodetect(self, client):
+    def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             poller = client.begin_recognize_receipts(
@@ -53,7 +55,8 @@ class TestReceiptFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_passing_bad_content_type_param_passed(self, client):
+    def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -64,7 +67,8 @@ class TestReceiptFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_passing_unsupported_url_content_type(self, client):
+    def test_passing_unsupported_url_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             poller = client.begin_recognize_receipts(
                 "https://badurl.jpg",
@@ -107,7 +111,8 @@ class TestReceiptFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_receipt_locale_v2(self, client):
+    def test_receipt_locale_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
@@ -38,7 +38,8 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_damaged_file_bytes_fails_autodetect_content_type(self, client):
+    async def test_damaged_file_bytes_fails_autodetect_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x50\x44\x46\x55\x55\x55"  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
             async with client:
@@ -48,7 +49,9 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
                 result = await poller.result()
 
     @FormRecognizerPreparer()
-    async def test_damaged_file_bytes_io_fails_autodetect(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    async def test_damaged_file_bytes_io_fails_autodetect(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         damaged_pdf = BytesIO(b"\x50\x44\x46\x55\x55\x55")  # doesn't match any magic file numbers
         with pytest.raises(ValueError):
@@ -60,7 +63,8 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    async def test_passing_bad_content_type_param_passed(self, client):
+    async def test_passing_bad_content_type_param_passed(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             myfile = fd.read()
         with pytest.raises(ValueError):
@@ -108,7 +112,8 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_receipt_locale_v2(self, client):
+    async def test_receipt_locale_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         with pytest.raises(ValueError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
@@ -96,7 +96,8 @@ class TestReceiptFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_receipt_locale_v2(self, client):
+    def test_receipt_locale_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             client.begin_recognize_receipts_from_url(self.receipt_url_jpg, locale="en-US")
         assert "'locale' is only available for API version V2_1 and up" in str(e.value)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
@@ -99,7 +99,8 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    async def test_receipt_locale_v2(self, client):
+    async def test_receipt_locale_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as e:
             async with client:
                 await client.begin_recognize_receipts_from_url(self.receipt_url_jpg, locale="en-US")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
@@ -59,7 +59,8 @@ class TestTraining(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
-    def test_compose_model_bad_api_version(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_compose_model_bad_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             poller = client.begin_create_composed_model(["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000"])
             result = poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
@@ -61,7 +61,8 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
-    async def test_compose_model_bad_api_version(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_compose_model_bad_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             with pytest.raises(ValueError) as excinfo:
                 poller = await client.begin_create_composed_model(["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000"])

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
@@ -287,7 +287,8 @@ class TestTraining(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
-    def test_training_with_model_name_bad_api_version(self, client):
+    def test_training_with_model_name_bad_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             poller = client.begin_training(training_files_url="url", use_training_labels=True, model_name="not supported in v2.0")
             result = poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
@@ -290,7 +290,8 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
-    async def test_training_with_model_name_bad_api_version(self, client):
+    async def test_training_with_model_name_bad_api_version(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             async with client:
                 poller = await client.begin_training(training_files_url="url", use_training_labels=True, model_name="not supported in v2.0")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_logging.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_logging.py
@@ -32,7 +32,9 @@ class TestLogging(FormRecognizerTest):
 
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
-    def test_logging_info_dac_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    def test_logging_info_dac_client(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         mock_handler = MockHandler()
 
@@ -53,7 +55,9 @@ class TestLogging(FormRecognizerTest):
 
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
-    def test_logging_info_dmac_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    def test_logging_info_dmac_client(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         mock_handler = MockHandler()
 
@@ -72,7 +76,9 @@ class TestLogging(FormRecognizerTest):
                     assert message.message.find("REDACTED") == -1
 
     @FormRecognizerPreparer()
-    def test_mock_quota_exceeded_403(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    def test_mock_quota_exceeded_403(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
 
         response = mock.Mock(
             status_code=403,
@@ -94,7 +100,9 @@ class TestLogging(FormRecognizerTest):
         assert e.value.error.message == 'Out of call volume quota for FormRecognizer F0 pricing tier. Please retry after 1 day. To increase your call volume switch to a paid tier.'
 
     @FormRecognizerPreparer()
-    def test_mock_quota_exceeded_429(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    def test_mock_quota_exceeded_429(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
 
         response = mock.Mock(
             status_code=429,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_logging_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_logging_async.py
@@ -67,7 +67,9 @@ class TestLogging(AsyncFormRecognizerTest):
 
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
-    async def test_logging_info_dac_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    async def test_logging_info_dac_client(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         mock_handler = MockHandler()
 
@@ -88,7 +90,9 @@ class TestLogging(AsyncFormRecognizerTest):
 
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
-    async def test_logging_info_dmac_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    async def test_logging_info_dmac_client(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key))
         mock_handler = MockHandler()
 
@@ -107,7 +111,9 @@ class TestLogging(AsyncFormRecognizerTest):
                     assert message.message.find("REDACTED") == -1
 
     @FormRecognizerPreparer()
-    async def test_mock_quota_exceeded_403(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    async def test_mock_quota_exceeded_403(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
 
         response = mock.Mock(
             status_code=403,
@@ -129,7 +135,9 @@ class TestLogging(AsyncFormRecognizerTest):
         assert e.value.error.message == 'Out of call volume quota for FormRecognizer F0 pricing tier. Please retry after 1 day. To increase your call volume switch to a paid tier.'
 
     @FormRecognizerPreparer()
-    async def test_mock_quota_exceeded_429(self, formrecognizer_test_endpoint, formrecognizer_test_api_key):
+    async def test_mock_quota_exceeded_429(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         response = mock.Mock(
             status_code=429,
             headers={"Retry-After": 186688, "Content-Type": "application/json"},

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
@@ -27,32 +27,38 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 class TestMultiapi(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_default_api_version_form_recognizer_client(self, client):
+    def test_default_api_version_form_recognizer_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
-    def test_default_api_version_form_training_client(self, client):
+    def test_default_api_version_form_training_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_v2_0_form_recognizer_client(self, client):
+    def test_v2_0_form_recognizer_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.0" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_v2_0_form_training_client(self, client):
+    def test_v2_0_form_training_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.0" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_1})
-    def test_v2_1_form_recognizer_client(self, client):
+    def test_v2_1_form_recognizer_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_1})
-    def test_v2_1_form_training_client(self, client):
+    def test_v2_1_form_training_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
@@ -87,7 +93,8 @@ class TestMultiapi(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    def test_default_api_version_document_analysis_client(self, client):
+    def test_default_api_version_document_analysis_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "2021-09-30-preview" == client._api_version
 
     @FormRecognizerPreparer()
@@ -107,7 +114,8 @@ class TestMultiapi(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    def test_default_api_version_document_model_admin_client(self, client):
+    def test_default_api_version_document_model_admin_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "2021-09-30-preview" == client._api_version
 
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
@@ -26,32 +26,38 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 class TestMultiapi(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
-    def test_default_api_version_form_recognizer_client(self, client):
+    def test_default_api_version_form_recognizer_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
-    def test_default_api_version_form_training_client(self, client):
+    def test_default_api_version_form_training_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_v2_0_form_recognizer_client(self, client):
+    def test_v2_0_form_recognizer_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.0" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
-    def test_v2_0_form_training_client(self, client):
+    def test_v2_0_form_training_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.0" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_1})
-    def test_V2_1_form_recognizer_client(self, client):
+    def test_V2_1_form_recognizer_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_1})
-    def test_V2_1_form_training_client(self, client):
+    def test_V2_1_form_training_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "v2.1" in client._client._client._base_url
 
     @FormRecognizerPreparer()
@@ -86,7 +92,8 @@ class TestMultiapi(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    def test_default_api_version_document_analysis_client(self, client):
+    def test_default_api_version_document_analysis_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "2021-09-30-preview" == client._api_version
 
     @FormRecognizerPreparer()
@@ -106,7 +113,8 @@ class TestMultiapi(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
-    def test_default_api_version_document_model_admin_client(self, client):
+    def test_default_api_version_document_model_admin_client(self, **kwargs):
+        client = kwargs.pop("client")
         assert "2021-09-30-preview" == client._api_version
 
     @FormRecognizerPreparer()


### PR DESCRIPTION
same as https://github.com/Azure/azure-sdk-for-python/pull/22614

@iscai-msft 