### PR TITLE
[formrecognizer] Add a default for percent_completed

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Default the `percent_completed` property to 0 when not returned with model operation information.
 
 ### Other Changes
 - Python 2.7 is no longer supported in this release. Please use Python 3.6 or later.

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -3257,7 +3257,7 @@ class ModelOperationInfo(object):
     def __init__(self, **kwargs):
         self.operation_id = kwargs.get("operation_id", None)
         self.status = kwargs.get("status", None)
-        self.percent_completed = kwargs.get("percent_completed", None)
+        self.percent_completed = kwargs.get("percent_completed", 0)
         self.created_on = kwargs.get("created_on", None)
         self.last_updated_on = kwargs.get("last_updated_on", None)
         self.kind = kwargs.get("kind", None)
@@ -3318,7 +3318,7 @@ class ModelOperationInfo(object):
         return cls(
             operation_id=op.operation_id,
             status=op.status,
-            percent_completed=op.percent_completed,
+            percent_completed=op.percent_completed if op.percent_completed else 0,
             created_on=op.created_date_time,
             last_updated_on=op.last_updated_date_time,
             kind=op.kind,
@@ -3425,7 +3425,7 @@ class ModelOperation(ModelOperationInfo):
         return cls(
             operation_id=op.operation_id,
             status=op.status,
-            percent_completed=op.percent_completed,
+            percent_completed=op.percent_completed if op.percent_completed else 0,
             created_on=op.created_date_time,
             last_updated_on=op.last_updated_date_time,
             kind=op.kind,


### PR DESCRIPTION
Default percent_completed to 0. After talking to the service team, this should be defaulted to 0 when not returned. Generally our tests fail with operations that have a `notStarted` status since this is currently not returning a percent_completed value. 