### PR TITLE
Always return dictionary from tests

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
+++ b/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
@@ -69,14 +69,15 @@ def recorded_by_proxy_async(test_func):
         test_output = None
         try:
             try:
-                test_output = await test_func(*args, variables=variables, **trimmed_kwargs)
+                # tests don't record successfully unless test_output is a dictionary
+                test_output = await test_func(*args, variables=variables, **trimmed_kwargs) or {}
             except TypeError:
                 logger = logging.getLogger()
                 logger.info(
                     "This test can't accept variables as input. The test method should accept `**kwargs` and/or a "
                     "`variables` parameter to make use of recorded test variables."
                 )
-                test_output = await test_func(*args, **trimmed_kwargs)
+                test_output = await test_func(*args, **trimmed_kwargs) or {}
         except ResourceNotFoundError as error:
             error_body = ContentDecodePolicy.deserialize_from_http_generics(error.response)
             message = error_body.get("message") or error_body.get("Message")

--- a/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
+++ b/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
@@ -69,15 +69,14 @@ def recorded_by_proxy_async(test_func):
         test_output = None
         try:
             try:
-                # tests don't record successfully unless test_output is a dictionary
-                test_output = await test_func(*args, variables=variables, **trimmed_kwargs) or {}
+                test_output = await test_func(*args, variables=variables, **trimmed_kwargs)
             except TypeError:
                 logger = logging.getLogger()
                 logger.info(
                     "This test can't accept variables as input. The test method should accept `**kwargs` and/or a "
                     "`variables` parameter to make use of recorded test variables."
                 )
-                test_output = await test_func(*args, **trimmed_kwargs) or {}
+                test_output = await test_func(*args, **trimmed_kwargs)
         except ResourceNotFoundError as error:
             error_body = ContentDecodePolicy.deserialize_from_http_generics(error.response)
             message = error_body.get("message") or error_body.get("Message")

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -138,7 +138,7 @@ def stop_record_or_playback(test_id, recording_id, test_output):
                 "x-recording-save": "true",
                 "Content-Type": "application/json"
             },
-            json=test_output
+            json=test_output or {}  # tests don't record successfully unless test_output is a dictionary
         )
     else:
         requests.post(
@@ -216,15 +216,14 @@ def recorded_by_proxy(test_func):
         test_output = None
         try:
             try:
-                # tests don't record successfully unless test_output is a dictionary
-                test_output = test_func(*args, variables=variables, **trimmed_kwargs) or {}
+                test_output = test_func(*args, variables=variables, **trimmed_kwargs)
             except TypeError:
                 logger = logging.getLogger()
                 logger.info(
                     "This test can't accept variables as input. The test method should accept `**kwargs` and/or a "
                     "`variables` parameter to make use of recorded test variables."
                 )
-                test_output = test_func(*args, **trimmed_kwargs) or {}
+                test_output = test_func(*args, **trimmed_kwargs)
         except ResourceNotFoundError as error:
             error_body = ContentDecodePolicy.deserialize_from_http_generics(error.response)
             message = error_body.get("message") or error_body.get("Message")

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -216,14 +216,15 @@ def recorded_by_proxy(test_func):
         test_output = None
         try:
             try:
-                test_output = test_func(*args, variables=variables, **trimmed_kwargs)
+                # tests don't record successfully unless test_output is a dictionary
+                test_output = test_func(*args, variables=variables, **trimmed_kwargs) or {}
             except TypeError:
                 logger = logging.getLogger()
                 logger.info(
                     "This test can't accept variables as input. The test method should accept `**kwargs` and/or a "
                     "`variables` parameter to make use of recorded test variables."
                 )
-                test_output = test_func(*args, **trimmed_kwargs)
+                test_output = test_func(*args, **trimmed_kwargs) or {}
         except ResourceNotFoundError as error:
             error_body = ContentDecodePolicy.deserialize_from_http_generics(error.response)
             message = error_body.get("message") or error_body.get("Message")


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/22787. This is a patch-up for a bug discovered by @tjprescott. After the recent change to put `"x-recording-file"` in the body of recording start requests, tests have stopped producing recordings whenever they don't return a dictionary. Returning anything in a test should only be necessary for tests using the `variables` API.

While I work on a second, more user-friendly iteration of the `variables` API (and track down the code that produced this bug in the test proxy tool), this change will make it unnecessary for every test to return a dictionary in order to record.

Tagging those affected by the bug and @scbedd for notifs.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
  - Tested manually with already-migrated tests
