### PR TITLE
skip eng/ and scripts/ paths for cspell

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -10,6 +10,8 @@
     "en-gb"
   ],
   "ignorePaths": [
+    "eng/**",
+    "scripts/**",
     "**/tests/recordings/**",
     ".vscode/cspell.json",
     "*.parquet",


### PR DESCRIPTION
We decided in scrum that we want to skip running cspell on these paths