### PR TITLE
Pinning azure-mgmt-resource in conda pipelines

### DIFF
--- a/eng/conda_test_requirements.txt
+++ b/eng/conda_test_requirements.txt
@@ -1,4 +1,5 @@
 # install from root of repo
+azure-mgmt-resource==20.0.0
 aiohttp>=3.0; python_version >= '3.5'
 tools/azure-devtools
 tools/azure-sdk-tools


### PR DESCRIPTION
Published conda azure-core does not contain `azure.core.rest`. Newly published `azure-mgmt-resource` requires said module. Pinning to previous.
