### PR TITLE
Remoterendering test pipeline missing environment variable

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0b2 (Unreleased)
+## 1.0.0b3 (2022-01-31)
 
-### Features Added
+### Bug fixes
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Fixing the test pipeline.
 
 ## 1.0.0b1 (2021-11-15)
 

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_version.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_version.py
@@ -5,6 +5,6 @@
 # --------------------------------------------------------------------------
 
 # matches SEMVER
-VERSION = "1.0.0b2"
+VERSION = "1.0.0b3"
 
 SDK_MONIKER = "mixedreality-remoterendering/{}".format(VERSION)  # type: str

--- a/sdk/remoterendering/test-resources.json
+++ b/sdk/remoterendering/test-resources.json
@@ -116,6 +116,10 @@
       "REMOTERENDERING_ARR_SERVICE_ENDPOINT": {
         "type": "string",
         "value": "[concat('https://remoterendering.', parameters('location'), '.mixedreality.azure.com')]"
+      },
+      "REMOTERENDERING_STORAGE_ENDPOINT_SUFFIX": {
+        "type": "string",
+        "value": "core.windows.net"
       }
     }
 }


### PR DESCRIPTION
# Description

The test pipeline for the remoterendering sdk is missing an environment variable, thus all tests run fail in the setup process.
This PR adds this environment variable and should fix the tests or at least will run them, so we can see if something is really broken and not only the environment.
