### PR TITLE
[Search] Update Azure Machine Learning Skill (AML Skill) Support

### DIFF
--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added models: `AmlSkill`
+- Added models: `AzureMachineLearningSkill`
 
 ### Breaking Changes
 

--- a/sdk/search/azure-search-documents/azure/search/documents/_generated/models/_models.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_generated/models/_models.py
@@ -18,7 +18,7 @@ class AnswerResult(msrest.serialization.Model):
     :ivar additional_properties: Unmatched properties from the message are deserialized to this
      collection.
     :vartype additional_properties: dict[str, any]
-    :ivar score: The score value represents how relevant the answer is to the the query relative to
+    :ivar score: The score value represents how relevant the answer is to the query relative to
      other answers returned for the query.
     :vartype score: float
     :ivar key: The key of the document the answer was extracted from.

--- a/sdk/search/azure-search-documents/azure/search/documents/_generated/models/_models_py3.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_generated/models/_models_py3.py
@@ -22,7 +22,7 @@ class AnswerResult(msrest.serialization.Model):
     :ivar additional_properties: Unmatched properties from the message are deserialized to this
      collection.
     :vartype additional_properties: dict[str, any]
-    :ivar score: The score value represents how relevant the answer is to the the query relative to
+    :ivar score: The score value represents how relevant the answer is to the query relative to
      other answers returned for the query.
     :vartype score: float
     :ivar key: The key of the document the answer was extracted from.

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/aio/operations/_indexes_operations.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/aio/operations/_indexes_operations.py
@@ -203,6 +203,7 @@ class IndexesOperations:
         )
     list.metadata = {'url': '/indexes'}  # type: ignore
 
+
     @distributed_trace_async
     async def create_or_update(
         self,

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/__init__.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/__init__.py
@@ -7,12 +7,12 @@
 # --------------------------------------------------------------------------
 
 try:
-    from ._models_py3 import AmlSkill
     from ._models_py3 import AnalyzeRequest
     from ._models_py3 import AnalyzeResult
     from ._models_py3 import AnalyzedTokenInfo
     from ._models_py3 import AsciiFoldingTokenFilter
     from ._models_py3 import AzureActiveDirectoryApplicationCredentials
+    from ._models_py3 import AzureMachineLearningSkill
     from ._models_py3 import BM25Similarity
     from ._models_py3 import CharFilter
     from ._models_py3 import CjkBigramTokenFilter
@@ -158,12 +158,12 @@ try:
     from ._models_py3 import WebApiSkill
     from ._models_py3 import WordDelimiterTokenFilter
 except (SyntaxError, ImportError):
-    from ._models import AmlSkill  # type: ignore
     from ._models import AnalyzeRequest  # type: ignore
     from ._models import AnalyzeResult  # type: ignore
     from ._models import AnalyzedTokenInfo  # type: ignore
     from ._models import AsciiFoldingTokenFilter  # type: ignore
     from ._models import AzureActiveDirectoryApplicationCredentials  # type: ignore
+    from ._models import AzureMachineLearningSkill  # type: ignore
     from ._models import BM25Similarity  # type: ignore
     from ._models import CharFilter  # type: ignore
     from ._models import CjkBigramTokenFilter  # type: ignore
@@ -355,12 +355,12 @@ from ._search_client_enums import (
 )
 
 __all__ = [
-    'AmlSkill',
     'AnalyzeRequest',
     'AnalyzeResult',
     'AnalyzedTokenInfo',
     'AsciiFoldingTokenFilter',
     'AzureActiveDirectoryApplicationCredentials',
+    'AzureMachineLearningSkill',
     'BM25Similarity',
     'CharFilter',
     'CjkBigramTokenFilter',

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/_models.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/_models.py
@@ -10,209 +10,6 @@ from azure.core.exceptions import HttpResponseError
 import msrest.serialization
 
 
-class SearchIndexerSkill(msrest.serialization.Model):
-    """Base type for skills.
-
-    You probably want to use the sub-classes and not this class directly. Known
-    sub-classes are: AmlSkill, WebApiSkill, CustomEntityLookupSkill, EntityRecognitionSkill, KeyPhraseExtractionSkill, LanguageDetectionSkill, MergeSkill, PIIDetectionSkill, SentimentSkill, SplitSkill, TextTranslationSkill, EntityLinkingSkill, EntityRecognitionSkillV3, SentimentSkillV3, ConditionalSkill, DocumentExtractionSkill, ShaperSkill, ImageAnalysisSkill, OcrSkill.
-
-    All required parameters must be populated in order to send to Azure.
-
-    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
-     server.
-    :vartype odata_type: str
-    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
-     with no name defined will be given a default name of its 1-based index in the skills array,
-     prefixed with the character '#'.
-    :vartype name: str
-    :ivar description: The description of the skill which describes the inputs, outputs, and usage
-     of the skill.
-    :vartype description: str
-    :ivar context: Represents the level at which operations take place, such as the document root
-     or document content (for example, /document or /document/content). The default is /document.
-    :vartype context: str
-    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
-     output of an upstream skill.
-    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
-     that can be consumed as an input by another skill.
-    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-    """
-
-    _validation = {
-        'odata_type': {'required': True},
-        'inputs': {'required': True},
-        'outputs': {'required': True},
-    }
-
-    _attribute_map = {
-        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
-        'name': {'key': 'name', 'type': 'str'},
-        'description': {'key': 'description', 'type': 'str'},
-        'context': {'key': 'context', 'type': 'str'},
-        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
-        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
-    }
-
-    _subtype_map = {
-        'odata_type': {'#Microsoft.Skills.Custom.AmlSkill': 'AmlSkill', '#Microsoft.Skills.Custom.WebApiSkill': 'WebApiSkill', '#Microsoft.Skills.Text.CustomEntityLookupSkill': 'CustomEntityLookupSkill', '#Microsoft.Skills.Text.EntityRecognitionSkill': 'EntityRecognitionSkill', '#Microsoft.Skills.Text.KeyPhraseExtractionSkill': 'KeyPhraseExtractionSkill', '#Microsoft.Skills.Text.LanguageDetectionSkill': 'LanguageDetectionSkill', '#Microsoft.Skills.Text.MergeSkill': 'MergeSkill', '#Microsoft.Skills.Text.PIIDetectionSkill': 'PIIDetectionSkill', '#Microsoft.Skills.Text.SentimentSkill': 'SentimentSkill', '#Microsoft.Skills.Text.SplitSkill': 'SplitSkill', '#Microsoft.Skills.Text.TranslationSkill': 'TextTranslationSkill', '#Microsoft.Skills.Text.V3.EntityLinkingSkill': 'EntityLinkingSkill', '#Microsoft.Skills.Text.V3.EntityRecognitionSkill': 'EntityRecognitionSkillV3', '#Microsoft.Skills.Text.V3.SentimentSkill': 'SentimentSkillV3', '#Microsoft.Skills.Util.ConditionalSkill': 'ConditionalSkill', '#Microsoft.Skills.Util.DocumentExtractionSkill': 'DocumentExtractionSkill', '#Microsoft.Skills.Util.ShaperSkill': 'ShaperSkill', '#Microsoft.Skills.Vision.ImageAnalysisSkill': 'ImageAnalysisSkill', '#Microsoft.Skills.Vision.OcrSkill': 'OcrSkill'}
-    }
-
-    def __init__(
-        self,
-        **kwargs
-    ):
-        """
-        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
-         with no name defined will be given a default name of its 1-based index in the skills array,
-         prefixed with the character '#'.
-        :paramtype name: str
-        :keyword description: The description of the skill which describes the inputs, outputs, and
-         usage of the skill.
-        :paramtype description: str
-        :keyword context: Represents the level at which operations take place, such as the document
-         root or document content (for example, /document or /document/content). The default is
-         /document.
-        :paramtype context: str
-        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
-         the output of an upstream skill.
-        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
-         value that can be consumed as an input by another skill.
-        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-        """
-        super(SearchIndexerSkill, self).__init__(**kwargs)
-        self.odata_type = None  # type: Optional[str]
-        self.name = kwargs.get('name', None)
-        self.description = kwargs.get('description', None)
-        self.context = kwargs.get('context', None)
-        self.inputs = kwargs['inputs']
-        self.outputs = kwargs['outputs']
-
-
-class AmlSkill(SearchIndexerSkill):
-    """The AML skill allows you to extend AI enrichment with a custom Azure Machine Learning (AML) model. Once an AML model is trained and deployed, an AML skill integrates it into AI enrichment.
-
-    All required parameters must be populated in order to send to Azure.
-
-    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
-     server.
-    :vartype odata_type: str
-    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
-     with no name defined will be given a default name of its 1-based index in the skills array,
-     prefixed with the character '#'.
-    :vartype name: str
-    :ivar description: The description of the skill which describes the inputs, outputs, and usage
-     of the skill.
-    :vartype description: str
-    :ivar context: Represents the level at which operations take place, such as the document root
-     or document content (for example, /document or /document/content). The default is /document.
-    :vartype context: str
-    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
-     output of an upstream skill.
-    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
-     that can be consumed as an input by another skill.
-    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-    :ivar uri: (Required for no authentication or key authentication) The scoring URI of the AML
-     service to which the JSON payload will be sent. Only the https URI scheme is allowed.
-    :vartype uri: str
-    :ivar key: (Required for key authentication) The key for the AML service.
-    :vartype key: str
-    :ivar resource_id: (Required for token authentication). The Azure Resource Manager resource ID
-     of the AML service. It should be in the format
-     subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
-    :vartype resource_id: str
-    :ivar timeout: (Optional) When specified, indicates the timeout for the http client making the
-     API call.
-    :vartype timeout: ~datetime.timedelta
-    :ivar region: (Optional for token authentication). The region the AML service is deployed in.
-    :vartype region: str
-    :ivar degree_of_parallelism: (Optional) When specified, indicates the number of calls the
-     indexer will make in parallel to the endpoint you have provided. You can decrease this value if
-     your endpoint is failing under too high of a request load, or raise it if your endpoint is able
-     to accept more requests and you would like an increase in the performance of the indexer. If
-     not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
-     and a minimum of 1.
-    :vartype degree_of_parallelism: int
-    """
-
-    _validation = {
-        'odata_type': {'required': True},
-        'inputs': {'required': True},
-        'outputs': {'required': True},
-    }
-
-    _attribute_map = {
-        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
-        'name': {'key': 'name', 'type': 'str'},
-        'description': {'key': 'description', 'type': 'str'},
-        'context': {'key': 'context', 'type': 'str'},
-        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
-        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
-        'uri': {'key': 'uri', 'type': 'str'},
-        'key': {'key': 'key', 'type': 'str'},
-        'resource_id': {'key': 'resourceId', 'type': 'str'},
-        'timeout': {'key': 'timeout', 'type': 'duration'},
-        'region': {'key': 'region', 'type': 'str'},
-        'degree_of_parallelism': {'key': 'degreeOfParallelism', 'type': 'int'},
-    }
-
-    def __init__(
-        self,
-        **kwargs
-    ):
-        """
-        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
-         with no name defined will be given a default name of its 1-based index in the skills array,
-         prefixed with the character '#'.
-        :paramtype name: str
-        :keyword description: The description of the skill which describes the inputs, outputs, and
-         usage of the skill.
-        :paramtype description: str
-        :keyword context: Represents the level at which operations take place, such as the document
-         root or document content (for example, /document or /document/content). The default is
-         /document.
-        :paramtype context: str
-        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
-         the output of an upstream skill.
-        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
-         value that can be consumed as an input by another skill.
-        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-        :keyword uri: (Required for no authentication or key authentication) The scoring URI of the AML
-         service to which the JSON payload will be sent. Only the https URI scheme is allowed.
-        :paramtype uri: str
-        :keyword key: (Required for key authentication) The key for the AML service.
-        :paramtype key: str
-        :keyword resource_id: (Required for token authentication). The Azure Resource Manager resource
-         ID of the AML service. It should be in the format
-         subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
-        :paramtype resource_id: str
-        :keyword timeout: (Optional) When specified, indicates the timeout for the http client making
-         the API call.
-        :paramtype timeout: ~datetime.timedelta
-        :keyword region: (Optional for token authentication). The region the AML service is deployed
-         in.
-        :paramtype region: str
-        :keyword degree_of_parallelism: (Optional) When specified, indicates the number of calls the
-         indexer will make in parallel to the endpoint you have provided. You can decrease this value if
-         your endpoint is failing under too high of a request load, or raise it if your endpoint is able
-         to accept more requests and you would like an increase in the performance of the indexer. If
-         not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
-         and a minimum of 1.
-        :paramtype degree_of_parallelism: int
-        """
-        super(AmlSkill, self).__init__(**kwargs)
-        self.odata_type = '#Microsoft.Skills.Custom.AmlSkill'  # type: str
-        self.uri = kwargs.get('uri', None)
-        self.key = kwargs.get('key', None)
-        self.resource_id = kwargs.get('resource_id', None)
-        self.timeout = kwargs.get('timeout', None)
-        self.region = kwargs.get('region', None)
-        self.degree_of_parallelism = kwargs.get('degree_of_parallelism', None)
-
-
 class AnalyzedTokenInfo(msrest.serialization.Model):
     """Information about a token returned by an analyzer.
 
@@ -521,6 +318,209 @@ class AzureActiveDirectoryApplicationCredentials(msrest.serialization.Model):
         super(AzureActiveDirectoryApplicationCredentials, self).__init__(**kwargs)
         self.application_id = kwargs['application_id']
         self.application_secret = kwargs.get('application_secret', None)
+
+
+class SearchIndexerSkill(msrest.serialization.Model):
+    """Base type for skills.
+
+    You probably want to use the sub-classes and not this class directly. Known
+    sub-classes are: AzureMachineLearningSkill, WebApiSkill, CustomEntityLookupSkill, EntityRecognitionSkill, KeyPhraseExtractionSkill, LanguageDetectionSkill, MergeSkill, PIIDetectionSkill, SentimentSkill, SplitSkill, TextTranslationSkill, EntityLinkingSkill, EntityRecognitionSkillV3, SentimentSkillV3, ConditionalSkill, DocumentExtractionSkill, ShaperSkill, ImageAnalysisSkill, OcrSkill.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
+     server.
+    :vartype odata_type: str
+    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
+     with no name defined will be given a default name of its 1-based index in the skills array,
+     prefixed with the character '#'.
+    :vartype name: str
+    :ivar description: The description of the skill which describes the inputs, outputs, and usage
+     of the skill.
+    :vartype description: str
+    :ivar context: Represents the level at which operations take place, such as the document root
+     or document content (for example, /document or /document/content). The default is /document.
+    :vartype context: str
+    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
+     output of an upstream skill.
+    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
+     that can be consumed as an input by another skill.
+    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+    """
+
+    _validation = {
+        'odata_type': {'required': True},
+        'inputs': {'required': True},
+        'outputs': {'required': True},
+    }
+
+    _attribute_map = {
+        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
+        'name': {'key': 'name', 'type': 'str'},
+        'description': {'key': 'description', 'type': 'str'},
+        'context': {'key': 'context', 'type': 'str'},
+        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
+        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
+    }
+
+    _subtype_map = {
+        'odata_type': {'#Microsoft.Skills.Custom.AmlSkill': 'AzureMachineLearningSkill', '#Microsoft.Skills.Custom.WebApiSkill': 'WebApiSkill', '#Microsoft.Skills.Text.CustomEntityLookupSkill': 'CustomEntityLookupSkill', '#Microsoft.Skills.Text.EntityRecognitionSkill': 'EntityRecognitionSkill', '#Microsoft.Skills.Text.KeyPhraseExtractionSkill': 'KeyPhraseExtractionSkill', '#Microsoft.Skills.Text.LanguageDetectionSkill': 'LanguageDetectionSkill', '#Microsoft.Skills.Text.MergeSkill': 'MergeSkill', '#Microsoft.Skills.Text.PIIDetectionSkill': 'PIIDetectionSkill', '#Microsoft.Skills.Text.SentimentSkill': 'SentimentSkill', '#Microsoft.Skills.Text.SplitSkill': 'SplitSkill', '#Microsoft.Skills.Text.TranslationSkill': 'TextTranslationSkill', '#Microsoft.Skills.Text.V3.EntityLinkingSkill': 'EntityLinkingSkill', '#Microsoft.Skills.Text.V3.EntityRecognitionSkill': 'EntityRecognitionSkillV3', '#Microsoft.Skills.Text.V3.SentimentSkill': 'SentimentSkillV3', '#Microsoft.Skills.Util.ConditionalSkill': 'ConditionalSkill', '#Microsoft.Skills.Util.DocumentExtractionSkill': 'DocumentExtractionSkill', '#Microsoft.Skills.Util.ShaperSkill': 'ShaperSkill', '#Microsoft.Skills.Vision.ImageAnalysisSkill': 'ImageAnalysisSkill', '#Microsoft.Skills.Vision.OcrSkill': 'OcrSkill'}
+    }
+
+    def __init__(
+        self,
+        **kwargs
+    ):
+        """
+        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
+         with no name defined will be given a default name of its 1-based index in the skills array,
+         prefixed with the character '#'.
+        :paramtype name: str
+        :keyword description: The description of the skill which describes the inputs, outputs, and
+         usage of the skill.
+        :paramtype description: str
+        :keyword context: Represents the level at which operations take place, such as the document
+         root or document content (for example, /document or /document/content). The default is
+         /document.
+        :paramtype context: str
+        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
+         the output of an upstream skill.
+        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
+         value that can be consumed as an input by another skill.
+        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+        """
+        super(SearchIndexerSkill, self).__init__(**kwargs)
+        self.odata_type = None  # type: Optional[str]
+        self.name = kwargs.get('name', None)
+        self.description = kwargs.get('description', None)
+        self.context = kwargs.get('context', None)
+        self.inputs = kwargs['inputs']
+        self.outputs = kwargs['outputs']
+
+
+class AzureMachineLearningSkill(SearchIndexerSkill):
+    """The AML skill allows you to extend AI enrichment with a custom Azure Machine Learning (AML) model. Once an AML model is trained and deployed, an AML skill integrates it into AI enrichment.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
+     server.
+    :vartype odata_type: str
+    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
+     with no name defined will be given a default name of its 1-based index in the skills array,
+     prefixed with the character '#'.
+    :vartype name: str
+    :ivar description: The description of the skill which describes the inputs, outputs, and usage
+     of the skill.
+    :vartype description: str
+    :ivar context: Represents the level at which operations take place, such as the document root
+     or document content (for example, /document or /document/content). The default is /document.
+    :vartype context: str
+    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
+     output of an upstream skill.
+    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
+     that can be consumed as an input by another skill.
+    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+    :ivar scoring_uri: (Required for no authentication or key authentication) The scoring URI of
+     the AML service to which the JSON payload will be sent. Only the https URI scheme is allowed.
+    :vartype scoring_uri: str
+    :ivar authentication_key: (Required for key authentication) The key for the AML service.
+    :vartype authentication_key: str
+    :ivar resource_id: (Required for token authentication). The Azure Resource Manager resource ID
+     of the AML service. It should be in the format
+     subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
+    :vartype resource_id: str
+    :ivar timeout: (Optional) When specified, indicates the timeout for the http client making the
+     API call.
+    :vartype timeout: ~datetime.timedelta
+    :ivar region: (Optional for token authentication). The region the AML service is deployed in.
+    :vartype region: str
+    :ivar degree_of_parallelism: (Optional) When specified, indicates the number of calls the
+     indexer will make in parallel to the endpoint you have provided. You can decrease this value if
+     your endpoint is failing under too high of a request load, or raise it if your endpoint is able
+     to accept more requests and you would like an increase in the performance of the indexer. If
+     not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
+     and a minimum of 1.
+    :vartype degree_of_parallelism: int
+    """
+
+    _validation = {
+        'odata_type': {'required': True},
+        'inputs': {'required': True},
+        'outputs': {'required': True},
+    }
+
+    _attribute_map = {
+        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
+        'name': {'key': 'name', 'type': 'str'},
+        'description': {'key': 'description', 'type': 'str'},
+        'context': {'key': 'context', 'type': 'str'},
+        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
+        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
+        'scoring_uri': {'key': 'uri', 'type': 'str'},
+        'authentication_key': {'key': 'key', 'type': 'str'},
+        'resource_id': {'key': 'resourceId', 'type': 'str'},
+        'timeout': {'key': 'timeout', 'type': 'duration'},
+        'region': {'key': 'region', 'type': 'str'},
+        'degree_of_parallelism': {'key': 'degreeOfParallelism', 'type': 'int'},
+    }
+
+    def __init__(
+        self,
+        **kwargs
+    ):
+        """
+        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
+         with no name defined will be given a default name of its 1-based index in the skills array,
+         prefixed with the character '#'.
+        :paramtype name: str
+        :keyword description: The description of the skill which describes the inputs, outputs, and
+         usage of the skill.
+        :paramtype description: str
+        :keyword context: Represents the level at which operations take place, such as the document
+         root or document content (for example, /document or /document/content). The default is
+         /document.
+        :paramtype context: str
+        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
+         the output of an upstream skill.
+        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
+         value that can be consumed as an input by another skill.
+        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+        :keyword scoring_uri: (Required for no authentication or key authentication) The scoring URI of
+         the AML service to which the JSON payload will be sent. Only the https URI scheme is allowed.
+        :paramtype scoring_uri: str
+        :keyword authentication_key: (Required for key authentication) The key for the AML service.
+        :paramtype authentication_key: str
+        :keyword resource_id: (Required for token authentication). The Azure Resource Manager resource
+         ID of the AML service. It should be in the format
+         subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
+        :paramtype resource_id: str
+        :keyword timeout: (Optional) When specified, indicates the timeout for the http client making
+         the API call.
+        :paramtype timeout: ~datetime.timedelta
+        :keyword region: (Optional for token authentication). The region the AML service is deployed
+         in.
+        :paramtype region: str
+        :keyword degree_of_parallelism: (Optional) When specified, indicates the number of calls the
+         indexer will make in parallel to the endpoint you have provided. You can decrease this value if
+         your endpoint is failing under too high of a request load, or raise it if your endpoint is able
+         to accept more requests and you would like an increase in the performance of the indexer. If
+         not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
+         and a minimum of 1.
+        :paramtype degree_of_parallelism: int
+        """
+        super(AzureMachineLearningSkill, self).__init__(**kwargs)
+        self.odata_type = '#Microsoft.Skills.Custom.AmlSkill'  # type: str
+        self.scoring_uri = kwargs.get('scoring_uri', None)
+        self.authentication_key = kwargs.get('authentication_key', None)
+        self.resource_id = kwargs.get('resource_id', None)
+        self.timeout = kwargs.get('timeout', None)
+        self.region = kwargs.get('region', None)
+        self.degree_of_parallelism = kwargs.get('degree_of_parallelism', None)
 
 
 class Similarity(msrest.serialization.Model):

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/_models_py3.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/_models_py3.py
@@ -15,227 +15,6 @@ import msrest.serialization
 from ._search_client_enums import *
 
 
-class SearchIndexerSkill(msrest.serialization.Model):
-    """Base type for skills.
-
-    You probably want to use the sub-classes and not this class directly. Known
-    sub-classes are: AmlSkill, WebApiSkill, CustomEntityLookupSkill, EntityRecognitionSkill, KeyPhraseExtractionSkill, LanguageDetectionSkill, MergeSkill, PIIDetectionSkill, SentimentSkill, SplitSkill, TextTranslationSkill, EntityLinkingSkill, EntityRecognitionSkillV3, SentimentSkillV3, ConditionalSkill, DocumentExtractionSkill, ShaperSkill, ImageAnalysisSkill, OcrSkill.
-
-    All required parameters must be populated in order to send to Azure.
-
-    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
-     server.
-    :vartype odata_type: str
-    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
-     with no name defined will be given a default name of its 1-based index in the skills array,
-     prefixed with the character '#'.
-    :vartype name: str
-    :ivar description: The description of the skill which describes the inputs, outputs, and usage
-     of the skill.
-    :vartype description: str
-    :ivar context: Represents the level at which operations take place, such as the document root
-     or document content (for example, /document or /document/content). The default is /document.
-    :vartype context: str
-    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
-     output of an upstream skill.
-    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
-     that can be consumed as an input by another skill.
-    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-    """
-
-    _validation = {
-        'odata_type': {'required': True},
-        'inputs': {'required': True},
-        'outputs': {'required': True},
-    }
-
-    _attribute_map = {
-        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
-        'name': {'key': 'name', 'type': 'str'},
-        'description': {'key': 'description', 'type': 'str'},
-        'context': {'key': 'context', 'type': 'str'},
-        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
-        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
-    }
-
-    _subtype_map = {
-        'odata_type': {'#Microsoft.Skills.Custom.AmlSkill': 'AmlSkill', '#Microsoft.Skills.Custom.WebApiSkill': 'WebApiSkill', '#Microsoft.Skills.Text.CustomEntityLookupSkill': 'CustomEntityLookupSkill', '#Microsoft.Skills.Text.EntityRecognitionSkill': 'EntityRecognitionSkill', '#Microsoft.Skills.Text.KeyPhraseExtractionSkill': 'KeyPhraseExtractionSkill', '#Microsoft.Skills.Text.LanguageDetectionSkill': 'LanguageDetectionSkill', '#Microsoft.Skills.Text.MergeSkill': 'MergeSkill', '#Microsoft.Skills.Text.PIIDetectionSkill': 'PIIDetectionSkill', '#Microsoft.Skills.Text.SentimentSkill': 'SentimentSkill', '#Microsoft.Skills.Text.SplitSkill': 'SplitSkill', '#Microsoft.Skills.Text.TranslationSkill': 'TextTranslationSkill', '#Microsoft.Skills.Text.V3.EntityLinkingSkill': 'EntityLinkingSkill', '#Microsoft.Skills.Text.V3.EntityRecognitionSkill': 'EntityRecognitionSkillV3', '#Microsoft.Skills.Text.V3.SentimentSkill': 'SentimentSkillV3', '#Microsoft.Skills.Util.ConditionalSkill': 'ConditionalSkill', '#Microsoft.Skills.Util.DocumentExtractionSkill': 'DocumentExtractionSkill', '#Microsoft.Skills.Util.ShaperSkill': 'ShaperSkill', '#Microsoft.Skills.Vision.ImageAnalysisSkill': 'ImageAnalysisSkill', '#Microsoft.Skills.Vision.OcrSkill': 'OcrSkill'}
-    }
-
-    def __init__(
-        self,
-        *,
-        inputs: List["InputFieldMappingEntry"],
-        outputs: List["OutputFieldMappingEntry"],
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        context: Optional[str] = None,
-        **kwargs
-    ):
-        """
-        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
-         with no name defined will be given a default name of its 1-based index in the skills array,
-         prefixed with the character '#'.
-        :paramtype name: str
-        :keyword description: The description of the skill which describes the inputs, outputs, and
-         usage of the skill.
-        :paramtype description: str
-        :keyword context: Represents the level at which operations take place, such as the document
-         root or document content (for example, /document or /document/content). The default is
-         /document.
-        :paramtype context: str
-        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
-         the output of an upstream skill.
-        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
-         value that can be consumed as an input by another skill.
-        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-        """
-        super(SearchIndexerSkill, self).__init__(**kwargs)
-        self.odata_type = None  # type: Optional[str]
-        self.name = name
-        self.description = description
-        self.context = context
-        self.inputs = inputs
-        self.outputs = outputs
-
-
-class AmlSkill(SearchIndexerSkill):
-    """The AML skill allows you to extend AI enrichment with a custom Azure Machine Learning (AML) model. Once an AML model is trained and deployed, an AML skill integrates it into AI enrichment.
-
-    All required parameters must be populated in order to send to Azure.
-
-    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
-     server.
-    :vartype odata_type: str
-    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
-     with no name defined will be given a default name of its 1-based index in the skills array,
-     prefixed with the character '#'.
-    :vartype name: str
-    :ivar description: The description of the skill which describes the inputs, outputs, and usage
-     of the skill.
-    :vartype description: str
-    :ivar context: Represents the level at which operations take place, such as the document root
-     or document content (for example, /document or /document/content). The default is /document.
-    :vartype context: str
-    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
-     output of an upstream skill.
-    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
-     that can be consumed as an input by another skill.
-    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-    :ivar uri: (Required for no authentication or key authentication) The scoring URI of the AML
-     service to which the JSON payload will be sent. Only the https URI scheme is allowed.
-    :vartype uri: str
-    :ivar key: (Required for key authentication) The key for the AML service.
-    :vartype key: str
-    :ivar resource_id: (Required for token authentication). The Azure Resource Manager resource ID
-     of the AML service. It should be in the format
-     subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
-    :vartype resource_id: str
-    :ivar timeout: (Optional) When specified, indicates the timeout for the http client making the
-     API call.
-    :vartype timeout: ~datetime.timedelta
-    :ivar region: (Optional for token authentication). The region the AML service is deployed in.
-    :vartype region: str
-    :ivar degree_of_parallelism: (Optional) When specified, indicates the number of calls the
-     indexer will make in parallel to the endpoint you have provided. You can decrease this value if
-     your endpoint is failing under too high of a request load, or raise it if your endpoint is able
-     to accept more requests and you would like an increase in the performance of the indexer. If
-     not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
-     and a minimum of 1.
-    :vartype degree_of_parallelism: int
-    """
-
-    _validation = {
-        'odata_type': {'required': True},
-        'inputs': {'required': True},
-        'outputs': {'required': True},
-    }
-
-    _attribute_map = {
-        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
-        'name': {'key': 'name', 'type': 'str'},
-        'description': {'key': 'description', 'type': 'str'},
-        'context': {'key': 'context', 'type': 'str'},
-        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
-        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
-        'uri': {'key': 'uri', 'type': 'str'},
-        'key': {'key': 'key', 'type': 'str'},
-        'resource_id': {'key': 'resourceId', 'type': 'str'},
-        'timeout': {'key': 'timeout', 'type': 'duration'},
-        'region': {'key': 'region', 'type': 'str'},
-        'degree_of_parallelism': {'key': 'degreeOfParallelism', 'type': 'int'},
-    }
-
-    def __init__(
-        self,
-        *,
-        inputs: List["InputFieldMappingEntry"],
-        outputs: List["OutputFieldMappingEntry"],
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        context: Optional[str] = None,
-        uri: Optional[str] = None,
-        key: Optional[str] = None,
-        resource_id: Optional[str] = None,
-        timeout: Optional[datetime.timedelta] = None,
-        region: Optional[str] = None,
-        degree_of_parallelism: Optional[int] = None,
-        **kwargs
-    ):
-        """
-        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
-         with no name defined will be given a default name of its 1-based index in the skills array,
-         prefixed with the character '#'.
-        :paramtype name: str
-        :keyword description: The description of the skill which describes the inputs, outputs, and
-         usage of the skill.
-        :paramtype description: str
-        :keyword context: Represents the level at which operations take place, such as the document
-         root or document content (for example, /document or /document/content). The default is
-         /document.
-        :paramtype context: str
-        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
-         the output of an upstream skill.
-        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
-        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
-         value that can be consumed as an input by another skill.
-        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
-        :keyword uri: (Required for no authentication or key authentication) The scoring URI of the AML
-         service to which the JSON payload will be sent. Only the https URI scheme is allowed.
-        :paramtype uri: str
-        :keyword key: (Required for key authentication) The key for the AML service.
-        :paramtype key: str
-        :keyword resource_id: (Required for token authentication). The Azure Resource Manager resource
-         ID of the AML service. It should be in the format
-         subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
-        :paramtype resource_id: str
-        :keyword timeout: (Optional) When specified, indicates the timeout for the http client making
-         the API call.
-        :paramtype timeout: ~datetime.timedelta
-        :keyword region: (Optional for token authentication). The region the AML service is deployed
-         in.
-        :paramtype region: str
-        :keyword degree_of_parallelism: (Optional) When specified, indicates the number of calls the
-         indexer will make in parallel to the endpoint you have provided. You can decrease this value if
-         your endpoint is failing under too high of a request load, or raise it if your endpoint is able
-         to accept more requests and you would like an increase in the performance of the indexer. If
-         not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
-         and a minimum of 1.
-        :paramtype degree_of_parallelism: int
-        """
-        super(AmlSkill, self).__init__(name=name, description=description, context=context, inputs=inputs, outputs=outputs, **kwargs)
-        self.odata_type = '#Microsoft.Skills.Custom.AmlSkill'  # type: str
-        self.uri = uri
-        self.key = key
-        self.resource_id = resource_id
-        self.timeout = timeout
-        self.region = region
-        self.degree_of_parallelism = degree_of_parallelism
-
-
 class AnalyzedTokenInfo(msrest.serialization.Model):
     """Information about a token returned by an analyzer.
 
@@ -561,6 +340,227 @@ class AzureActiveDirectoryApplicationCredentials(msrest.serialization.Model):
         super(AzureActiveDirectoryApplicationCredentials, self).__init__(**kwargs)
         self.application_id = application_id
         self.application_secret = application_secret
+
+
+class SearchIndexerSkill(msrest.serialization.Model):
+    """Base type for skills.
+
+    You probably want to use the sub-classes and not this class directly. Known
+    sub-classes are: AzureMachineLearningSkill, WebApiSkill, CustomEntityLookupSkill, EntityRecognitionSkill, KeyPhraseExtractionSkill, LanguageDetectionSkill, MergeSkill, PIIDetectionSkill, SentimentSkill, SplitSkill, TextTranslationSkill, EntityLinkingSkill, EntityRecognitionSkillV3, SentimentSkillV3, ConditionalSkill, DocumentExtractionSkill, ShaperSkill, ImageAnalysisSkill, OcrSkill.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
+     server.
+    :vartype odata_type: str
+    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
+     with no name defined will be given a default name of its 1-based index in the skills array,
+     prefixed with the character '#'.
+    :vartype name: str
+    :ivar description: The description of the skill which describes the inputs, outputs, and usage
+     of the skill.
+    :vartype description: str
+    :ivar context: Represents the level at which operations take place, such as the document root
+     or document content (for example, /document or /document/content). The default is /document.
+    :vartype context: str
+    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
+     output of an upstream skill.
+    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
+     that can be consumed as an input by another skill.
+    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+    """
+
+    _validation = {
+        'odata_type': {'required': True},
+        'inputs': {'required': True},
+        'outputs': {'required': True},
+    }
+
+    _attribute_map = {
+        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
+        'name': {'key': 'name', 'type': 'str'},
+        'description': {'key': 'description', 'type': 'str'},
+        'context': {'key': 'context', 'type': 'str'},
+        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
+        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
+    }
+
+    _subtype_map = {
+        'odata_type': {'#Microsoft.Skills.Custom.AmlSkill': 'AzureMachineLearningSkill', '#Microsoft.Skills.Custom.WebApiSkill': 'WebApiSkill', '#Microsoft.Skills.Text.CustomEntityLookupSkill': 'CustomEntityLookupSkill', '#Microsoft.Skills.Text.EntityRecognitionSkill': 'EntityRecognitionSkill', '#Microsoft.Skills.Text.KeyPhraseExtractionSkill': 'KeyPhraseExtractionSkill', '#Microsoft.Skills.Text.LanguageDetectionSkill': 'LanguageDetectionSkill', '#Microsoft.Skills.Text.MergeSkill': 'MergeSkill', '#Microsoft.Skills.Text.PIIDetectionSkill': 'PIIDetectionSkill', '#Microsoft.Skills.Text.SentimentSkill': 'SentimentSkill', '#Microsoft.Skills.Text.SplitSkill': 'SplitSkill', '#Microsoft.Skills.Text.TranslationSkill': 'TextTranslationSkill', '#Microsoft.Skills.Text.V3.EntityLinkingSkill': 'EntityLinkingSkill', '#Microsoft.Skills.Text.V3.EntityRecognitionSkill': 'EntityRecognitionSkillV3', '#Microsoft.Skills.Text.V3.SentimentSkill': 'SentimentSkillV3', '#Microsoft.Skills.Util.ConditionalSkill': 'ConditionalSkill', '#Microsoft.Skills.Util.DocumentExtractionSkill': 'DocumentExtractionSkill', '#Microsoft.Skills.Util.ShaperSkill': 'ShaperSkill', '#Microsoft.Skills.Vision.ImageAnalysisSkill': 'ImageAnalysisSkill', '#Microsoft.Skills.Vision.OcrSkill': 'OcrSkill'}
+    }
+
+    def __init__(
+        self,
+        *,
+        inputs: List["InputFieldMappingEntry"],
+        outputs: List["OutputFieldMappingEntry"],
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        context: Optional[str] = None,
+        **kwargs
+    ):
+        """
+        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
+         with no name defined will be given a default name of its 1-based index in the skills array,
+         prefixed with the character '#'.
+        :paramtype name: str
+        :keyword description: The description of the skill which describes the inputs, outputs, and
+         usage of the skill.
+        :paramtype description: str
+        :keyword context: Represents the level at which operations take place, such as the document
+         root or document content (for example, /document or /document/content). The default is
+         /document.
+        :paramtype context: str
+        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
+         the output of an upstream skill.
+        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
+         value that can be consumed as an input by another skill.
+        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+        """
+        super(SearchIndexerSkill, self).__init__(**kwargs)
+        self.odata_type = None  # type: Optional[str]
+        self.name = name
+        self.description = description
+        self.context = context
+        self.inputs = inputs
+        self.outputs = outputs
+
+
+class AzureMachineLearningSkill(SearchIndexerSkill):
+    """The AML skill allows you to extend AI enrichment with a custom Azure Machine Learning (AML) model. Once an AML model is trained and deployed, an AML skill integrates it into AI enrichment.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :ivar odata_type: Required. Identifies the concrete type of the skill.Constant filled by
+     server.
+    :vartype odata_type: str
+    :ivar name: The name of the skill which uniquely identifies it within the skillset. A skill
+     with no name defined will be given a default name of its 1-based index in the skills array,
+     prefixed with the character '#'.
+    :vartype name: str
+    :ivar description: The description of the skill which describes the inputs, outputs, and usage
+     of the skill.
+    :vartype description: str
+    :ivar context: Represents the level at which operations take place, such as the document root
+     or document content (for example, /document or /document/content). The default is /document.
+    :vartype context: str
+    :ivar inputs: Required. Inputs of the skills could be a column in the source data set, or the
+     output of an upstream skill.
+    :vartype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+    :ivar outputs: Required. The output of a skill is either a field in a search index, or a value
+     that can be consumed as an input by another skill.
+    :vartype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+    :ivar scoring_uri: (Required for no authentication or key authentication) The scoring URI of
+     the AML service to which the JSON payload will be sent. Only the https URI scheme is allowed.
+    :vartype scoring_uri: str
+    :ivar authentication_key: (Required for key authentication) The key for the AML service.
+    :vartype authentication_key: str
+    :ivar resource_id: (Required for token authentication). The Azure Resource Manager resource ID
+     of the AML service. It should be in the format
+     subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
+    :vartype resource_id: str
+    :ivar timeout: (Optional) When specified, indicates the timeout for the http client making the
+     API call.
+    :vartype timeout: ~datetime.timedelta
+    :ivar region: (Optional for token authentication). The region the AML service is deployed in.
+    :vartype region: str
+    :ivar degree_of_parallelism: (Optional) When specified, indicates the number of calls the
+     indexer will make in parallel to the endpoint you have provided. You can decrease this value if
+     your endpoint is failing under too high of a request load, or raise it if your endpoint is able
+     to accept more requests and you would like an increase in the performance of the indexer. If
+     not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
+     and a minimum of 1.
+    :vartype degree_of_parallelism: int
+    """
+
+    _validation = {
+        'odata_type': {'required': True},
+        'inputs': {'required': True},
+        'outputs': {'required': True},
+    }
+
+    _attribute_map = {
+        'odata_type': {'key': '@odata\\.type', 'type': 'str'},
+        'name': {'key': 'name', 'type': 'str'},
+        'description': {'key': 'description', 'type': 'str'},
+        'context': {'key': 'context', 'type': 'str'},
+        'inputs': {'key': 'inputs', 'type': '[InputFieldMappingEntry]'},
+        'outputs': {'key': 'outputs', 'type': '[OutputFieldMappingEntry]'},
+        'scoring_uri': {'key': 'uri', 'type': 'str'},
+        'authentication_key': {'key': 'key', 'type': 'str'},
+        'resource_id': {'key': 'resourceId', 'type': 'str'},
+        'timeout': {'key': 'timeout', 'type': 'duration'},
+        'region': {'key': 'region', 'type': 'str'},
+        'degree_of_parallelism': {'key': 'degreeOfParallelism', 'type': 'int'},
+    }
+
+    def __init__(
+        self,
+        *,
+        inputs: List["InputFieldMappingEntry"],
+        outputs: List["OutputFieldMappingEntry"],
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        context: Optional[str] = None,
+        scoring_uri: Optional[str] = None,
+        authentication_key: Optional[str] = None,
+        resource_id: Optional[str] = None,
+        timeout: Optional[datetime.timedelta] = None,
+        region: Optional[str] = None,
+        degree_of_parallelism: Optional[int] = None,
+        **kwargs
+    ):
+        """
+        :keyword name: The name of the skill which uniquely identifies it within the skillset. A skill
+         with no name defined will be given a default name of its 1-based index in the skills array,
+         prefixed with the character '#'.
+        :paramtype name: str
+        :keyword description: The description of the skill which describes the inputs, outputs, and
+         usage of the skill.
+        :paramtype description: str
+        :keyword context: Represents the level at which operations take place, such as the document
+         root or document content (for example, /document or /document/content). The default is
+         /document.
+        :paramtype context: str
+        :keyword inputs: Required. Inputs of the skills could be a column in the source data set, or
+         the output of an upstream skill.
+        :paramtype inputs: list[~azure.search.documents.indexes.models.InputFieldMappingEntry]
+        :keyword outputs: Required. The output of a skill is either a field in a search index, or a
+         value that can be consumed as an input by another skill.
+        :paramtype outputs: list[~azure.search.documents.indexes.models.OutputFieldMappingEntry]
+        :keyword scoring_uri: (Required for no authentication or key authentication) The scoring URI of
+         the AML service to which the JSON payload will be sent. Only the https URI scheme is allowed.
+        :paramtype scoring_uri: str
+        :keyword authentication_key: (Required for key authentication) The key for the AML service.
+        :paramtype authentication_key: str
+        :keyword resource_id: (Required for token authentication). The Azure Resource Manager resource
+         ID of the AML service. It should be in the format
+         subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}.
+        :paramtype resource_id: str
+        :keyword timeout: (Optional) When specified, indicates the timeout for the http client making
+         the API call.
+        :paramtype timeout: ~datetime.timedelta
+        :keyword region: (Optional for token authentication). The region the AML service is deployed
+         in.
+        :paramtype region: str
+        :keyword degree_of_parallelism: (Optional) When specified, indicates the number of calls the
+         indexer will make in parallel to the endpoint you have provided. You can decrease this value if
+         your endpoint is failing under too high of a request load, or raise it if your endpoint is able
+         to accept more requests and you would like an increase in the performance of the indexer. If
+         not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10
+         and a minimum of 1.
+        :paramtype degree_of_parallelism: int
+        """
+        super(AzureMachineLearningSkill, self).__init__(name=name, description=description, context=context, inputs=inputs, outputs=outputs, **kwargs)
+        self.odata_type = '#Microsoft.Skills.Custom.AmlSkill'  # type: str
+        self.scoring_uri = scoring_uri
+        self.authentication_key = authentication_key
+        self.resource_id = resource_id
+        self.timeout = timeout
+        self.region = region
+        self.degree_of_parallelism = degree_of_parallelism
 
 
 class Similarity(msrest.serialization.Model):

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/operations/_indexes_operations.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/operations/_indexes_operations.py
@@ -480,6 +480,7 @@ class IndexesOperations(object):
         )
     list.metadata = {'url': '/indexes'}  # type: ignore
 
+
     @distributed_trace
     def create_or_update(
         self,

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/models/__init__.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/models/__init__.py
@@ -184,7 +184,7 @@ from ._models import (
 
 
 __all__ = (
-    "AmlSkill",
+    "AzureMachineLearningSkill",
     "AnalyzeTextOptions",
     "AnalyzeResult",
     "AnalyzedTokenInfo",

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/models/__init__.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/models/__init__.py
@@ -34,7 +34,7 @@ from ._index import (
 from . import _edm as SearchFieldDataType
 from ..._generated.models import SuggestOptions
 from .._generated.models import (
-    AmlSkill,
+    AzureMachineLearningSkill,
     AnalyzeResult,
     AnalyzedTokenInfo,
     AsciiFoldingTokenFilter,


### PR DESCRIPTION
The following changes were made to the swagger

- AmlSkill renamed to AzureMachineLearningSkill
- Key renamed to AuthenticationKey
- Uri renamed to ScoringUri

Closes: #22842 

[API View Changes](https://apiview.dev/Assemblies/Review/8c4192c326104e7db57b6920a55e6807?diffRevisionId=ee0b2eafee9c483388054cfeaafe6fa1&doc=False&diffOnly=False)