### PR TITLE
[Test-Proxy] Deferring Session-level settings

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -109,7 +109,7 @@
     "eng/*.txt",
     "eng/tox/tox.ini",
     "eng/common/docgeneration/Generate-DocIndex.ps1",
-    "eng/tox/*.py"
+    "eng/**/*.py"
   ],
   "words": [
     "aad",

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -141,9 +141,9 @@ def stop_record_or_playback(test_id, recording_id, test_output):
                 "x-recording-file": test_id,
                 "x-recording-id": recording_id,
                 "x-recording-save": "true",
-                "Content-Type": "application/json",
+                "Content-Type": "application/json"
             },
-            json=test_output or {},  # tests don't record successfully unless test_output is a dictionary
+            json=test_output or {} # tests don't record successfully unless test_output is a dictionary
         )
     else:
         requests.post(

--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -4,33 +4,42 @@
 # license information.
 # --------------------------------------------------------------------------
 import requests
+import sys
 from typing import TYPE_CHECKING
 
 from .config import PROXY_URL
 from .helpers import is_live_and_not_recording
-from .proxy_testcase import get_recording_id
 
 if TYPE_CHECKING:
     from typing import Any, Dict
 
+# We store session-level sanitizers and matchers in a module variable. Any settings at the "session" level (read, not at the recording Id) are not added until
+# a recording has been started. When that occurs, any session level sanitizers/matchers are then applied to the recording id returned from the test-proxy Start operation.
+this = sys.modules[__name__]
+this.global_sanitizers = []
+this.global_matchers = []
 
-def set_bodiless_matcher():
-    # type: () -> None
+
+def set_bodiless_matcher(recording_id=None):
+    # type: (str) -> None
     """Adjusts the "match" operation to EXCLUDE the body when matching a request to a recording's entries.
 
-    This method must be called during test case execution, rather than at a session, module, or class level.
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     """
 
-    x_recording_id = get_recording_id()
-    _send_matcher_request("BodilessMatcher", {"x-recording-id": x_recording_id})
+    if recording_id:
+        _send_matcher_request("BodilessMatcher", {"x-recording-id": recording_id})
+    else:
+        this.global_matchers.append(("BodilessMatcher", {}))
 
 
-def add_body_key_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_body_key_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer that offers regex update of a specific JTokenPath within a returned body.
 
     For example, "TableName" within a json response body having its value replaced by whatever substitution is offered.
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str json_path: The SelectToken path (which could possibly match multiple entries) that will be used to
         select JTokens for value replacement.
     :keyword str value: The substitution value.
@@ -41,16 +50,21 @@ def add_body_key_sanitizer(**kwargs):
     """
 
     request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("BodyKeySanitizer", request_args)
+
+    if recording_id:
+        _send_sanitizer_request("BodyKeySanitizer", recording_id, request_args)
+    else:
+        this.global_sanitizers.append(("BodyKeySanitizer", request_args))
 
 
-def add_body_regex_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_body_regex_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer that offers regex replace within a returned body.
-    
+
     Specifically, this means regex applying to the raw JSON. If you are attempting to simply replace a specific key, the
     BodyKeySanitizer is probably the way to go.
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str value: The substitution value.
     :keyword str regex: A regex. Can be defined as a simple regex, or if a ``group_for_replace`` is provided, a
         substitution operation.
@@ -59,17 +73,22 @@ def add_body_regex_sanitizer(**kwargs):
     """
 
     request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("BodyRegexSanitizer", request_args)
+
+    if recording_id:
+        _send_sanitizer_request("BodyRegexSanitizer", recording_id, request_args)
+    else:
+        this.global_sanitizers.append(("BodyRegexSanitizer", request_args))
 
 
-def add_continuation_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_continuation_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer that's used to anonymize private keys in response/request pairs.
 
     For instance, a request hands back a "sessionId" that needs to be present in the next request. Supports "all further
     requests get this key" as well as "single response/request pair". Defaults to maintaining same key for rest of
     recording.
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str key: The name of the header whos value will be replaced from response -> next request.
     :keyword str method: The method by which the value of the targeted key will be replaced. Defaults to guid
         replacement.
@@ -78,15 +97,20 @@ def add_continuation_sanitizer(**kwargs):
     """
 
     request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("ContinuationSanitizer", request_args)
+
+    if recording_id:
+        _send_sanitizer_request("ContinuationSanitizer", recording_id, request_args)
+    else:
+        this.global_sanitizers.append(("ContinuationSanitizer", request_args))
 
 
-def add_general_regex_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_general_regex_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer that offers a general regex replace across request/response Body, Headers, and URI.
 
     For the body, this means regex applying to the raw JSON.
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str value: The substitution value.
     :keyword str regex: A regex. Can be defined as a simple regex, or if a ``group_for_replace`` is provided, a
         substitution operation.
@@ -95,17 +119,22 @@ def add_general_regex_sanitizer(**kwargs):
     """
 
     request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("GeneralRegexSanitizer", request_args)
+
+    if recording_id:
+        _send_sanitizer_request("GeneralRegexSanitizer", recording_id, request_args)
+    else:
+        this.global_sanitizers.append(("GeneralRegexSanitizer", request_args))
 
 
-def add_header_regex_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_header_regex_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer that offers regex replace on returned headers.
 
     Can be used for multiple purposes: 1) To replace a key with a specific value, do not set "regex" value. 2) To do a
     simple regex replace operation, define arguments "key", "value", and "regex". 3) To do a targeted substitution of a
     specific group, define all arguments "key", "value", and "regex".
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str key: The name of the header we're operating against.
     :keyword str value: The substitution or whole new header value, depending on "regex" setting.
     :keyword str regex: A regex. Can be defined as a simple regex, or if a ``group_for_replace`` is provided, a
@@ -114,46 +143,66 @@ def add_header_regex_sanitizer(**kwargs):
         a simple replacement operation.
     """
 
-    request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("HeaderRegexSanitizer", request_args)
+    request_args = _get_request_args(recording_id=None, **kwargs)
+
+    if recording_id:
+        _send_sanitizer_request("HeaderRegexSanitizer", recording_id, request_args)
+    else:
+        this.global_sanitizers.append(("HeaderRegexSanitizer", request_args))
 
 
-def add_oauth_response_sanitizer():
-    # type: () -> None
-    """Registers a sanitizer that cleans out all request/response pairs that match an oauth regex in their URI."""
+def add_oauth_response_sanitizer(recording_id=None):
+    # type: (str) -> None
+    """Registers a sanitizer that cleans out all request/response pairs that match an oauth regex in their URI.
 
-    _send_sanitizer_request("OAuthResponseSanitizer", {})
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
+    """
+    if recording_id:
+        _send_sanitizer_request("OAuthResponseSanitizer", recording_id, {})
+    else:
+        this.global_sanitizers.append(("OAuthResponseSanitizer", recording_id, {}))
 
 
-def add_remove_header_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_remove_header_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer that removes specified headers before saving a recording.
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str headers: A comma separated list. Should look like "Location, Transfer-Encoding" or something along
         those lines. Don't worry about whitespace between the commas separating each key. They will be ignored.
     """
 
-    request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("RemoveHeaderSanitizer", request_args)
+    request_args = _get_request_args(recording_id=None, **kwargs)
+
+    if recording_id:
+        _send_sanitizer_request("RemoveHeaderSanitizer", request_args)
+    else:
+        this.global_sanitizers.append(("RemoveHeaderSanitizer", request_args))
 
 
-def add_request_subscription_id_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_request_subscription_id_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer that replaces subscription IDs in requests.
 
     Subscription IDs are replaced with "00000000-0000-0000-0000-000000000000" by default.
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str value: The fake subscriptionId that will be placed where the real one is in the real request.
     """
 
     request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("ReplaceRequestSubscriptionId", request_args)
+
+    if recording_id:
+        _send_sanitizer_request("ReplaceRequestSubscriptionId", recording_id, request_args)
+    else:
+        this.global_sanitizers.append(("ReplaceRequestSubscriptionId", request_args))
 
 
-def add_uri_regex_sanitizer(**kwargs):
-    # type: (**Any) -> None
+def add_uri_regex_sanitizer(recording_id=None, **kwargs):
+    # type: (str, **Any) -> None
     """Registers a sanitizer for cleaning URIs via regex.
 
+    :param str recording_id: The targeted recording id this sanitizer will be added to. Absence of this param results in a deferred session-level sanitizer.
     :keyword str value: The substitution value.
     :keyword str regex: A regex. Can be defined as a simple regex, or if a ``group_for_replace`` is provided, a
         substitution operation.
@@ -162,7 +211,41 @@ def add_uri_regex_sanitizer(**kwargs):
     """
 
     request_args = _get_request_args(**kwargs)
-    _send_sanitizer_request("UriRegexSanitizer", request_args)
+    if recording_id:
+        _send_sanitizer_request("UriRegexSanitizer", recording_id, request_args)
+    else:
+        this.global_sanitizers.append(("UriRegexSanitizer", request_args))
+
+
+def set_recording_settings(recording_id):
+    # type: (str) -> None
+    """Applies all globally set sanitizers and matchers to an individual recording id.
+
+    :param str recording_id: The targeted recording that these settings will be applied to. Retrieved from proxy_testcase.start_record_or_playback.
+    """
+    _send_deferred_sanitizers(recording_id)
+    _send_deferred_matchers(recording_id)
+
+
+def _send_deferred_sanitizers(recording_id):
+    # type: (str) -> None
+    """Sets session-set sanitizers to a specific recording.
+
+    :param str recording_id: The targeted recording that these sanitizers will be applied to. Retrieved from proxy_testcase.start_record_or_playback.
+    """
+    for deferred_sanitizer_tuple in this.global_sanitizers:
+        _send_sanitizer_request(deferred_sanitizer_tuple[0], recording_id, deferred_sanitizer_tuple[1])
+
+
+def _send_deferred_matchers(recording_id):
+    # type: (str) -> None
+    """Sets session-set matchers to a specific recording. Given the nature of how the test-proxy handles a matcher. The last one sent will be the "winner"
+    on test-proxy side.
+
+    :param str recording_id: The targeted recording that these matchers will be applied to. Retrieved from proxy_testcase.start_record_or_playback.
+    """
+    for deferred_matcher_tuple in this.global_matchers:
+        _send_matcher_request(deferred_matcher_tuple[0], recording_id, deferred_matcher_tuple[1])
 
 
 def _get_request_args(**kwargs):
@@ -189,14 +272,15 @@ def _get_request_args(**kwargs):
     return request_args
 
 
-def _send_matcher_request(matcher, headers):
-    # type: (str, Dict) -> None
+def _send_matcher_request(matcher, recording_id, headers):
+    # type: (str, str, Dict) -> None
     """Sends a POST request to the test proxy endpoint to register the specified matcher.
 
     If live tests are being run with recording turned off via the AZURE_SKIP_LIVE_RECORDING environment variable, no
     request will be sent.
 
     :param str matcher: The name of the matcher to set.
+    :param str recording_id: An individual recording id that this matcher is being set for.
     :param dict headers: Any matcher headers, as a dictionary.
     """
 
@@ -205,28 +289,33 @@ def _send_matcher_request(matcher, headers):
 
     headers_to_send = {"x-abstraction-identifier": matcher}
     headers_to_send.update(headers)
+
+    if recording_id:
+        headers_to_send["x-recording-id"] = recording_id
+
     requests.post(
         "{}/Admin/SetMatcher".format(PROXY_URL),
         headers=headers_to_send,
     )
 
 
-def _send_sanitizer_request(sanitizer, parameters):
-    # type: (str, Dict) -> None
+def _send_sanitizer_request(sanitizer, recording_id, parameters):
+    # type: (str, str, Dict) -> None
     """Sends a POST request to the test proxy endpoint to register the specified sanitizer.
 
     If live tests are being run with recording turned off via the AZURE_SKIP_LIVE_RECORDING environment variable, no
     request will be sent.
 
     :param str sanitizer: The name of the sanitizer to add.
+    :param str recording_id: An individual recording id that this matcher is being set for.
     :param dict parameters: The sanitizer constructor parameters, as a dictionary.
     """
 
     if is_live_and_not_recording():
         return
 
-    requests.post(
-        "{}/Admin/AddSanitizer".format(PROXY_URL),
-        headers={"x-abstraction-identifier": sanitizer, "Content-Type": "application/json"},
-        json=parameters
-    )
+    headers_to_send = {"x-abstraction-identifier": sanitizer, "Content-Type": "application/json"}
+    if recording_id:
+        headers_to_send["x-recording-id"] = recording_id
+
+    requests.post("{}/Admin/AddSanitizer".format(PROXY_URL), headers=headers_to_send, json=parameters)


### PR DESCRIPTION
This PR addresses the root cause of Azure/azure-sdk-tools#2451. 

Context:

1. We use a single test-proxy instance for the test run
2. We run at least two `tox` test runs at the same time. For CI, we run `sdist`,`whl`, and `mindependency`.  This means that one environment will start significantly after the first two, and will most likely occur while one of the original two is still running.
3. An exception "collection can not be enumerated" is blocking PR #21764 

Each environment follows a pattern of:

`tests start -> set proxy settings -> invoke tests`

If one of these resets the sanitizers while a match operation is running,  we see the `collection can not be enumerated` exception.

This PR addresses this by deferring all `session` level sanitizers to apply per recording. @mccoyp can you take a look? 

UPDATE: going to extend the `auto-start` code to also handle booting the proxy in a test. We'll just run a separate test proxy. The current methodology is ok.

- [ ] In each tox.ini environment, set a different set of `ASPNETCORE_URLS="https://localhost:5003;http://localhost:5002"` 
- [ ] Extend auto-starter to start the test proxy via dotnet command as well as docker

