### PR TITLE
Exclude _generated files form PoliCheck run.

### DIFF
--- a/eng/guardian-tools/policheck/PolicheckExclusions.xml
+++ b/eng/guardian-tools/policheck/PolicheckExclusions.xml
@@ -1,7 +1,7 @@
 <PoliCheckExclusions>
 <!-- All strings must be UPPER CASE -->
 <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
-<!--<Exclusion Type="FolderPathFull">ABC|XYZ</Exclusion>-->
+<Exclusion Type="FolderPathFull">_GENERATED</Exclusion>
 <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be 
 skipped -->
 <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->


### PR DESCRIPTION
Exclude policheck form files with `_generated` in their path.