### PR TITLE
[Cosmos] updating tests for internal pipelines

### DIFF
--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -1,3 +1,3 @@
+azure-core
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
 -e ../../../tools/azure-devtools

--- a/sdk/cosmos/azure-cosmos/test/test_config.py
+++ b/sdk/cosmos/azure-cosmos/test/test_config.py
@@ -130,12 +130,12 @@ class _test_config(object):
         return cls.TEST_COLLECTION_MULTI_PARTITION_WITH_CUSTOM_PK
 
     @classmethod
-    def create_collection_no_custom_throughput(cls, client):
+    def create_collection_if_not_exist_no_custom_throughput(cls, client):
         # type: (CosmosClient) -> Container
         database = cls.create_database_if_not_exist(client)
         collection_id = cls.TEST_COLLECTION_SINGLE_PARTITION_ID
 
-        document_collection = database.create_container(
+        document_collection = database.create_container_if_not_exists(
             id=collection_id,
             partition_key=PartitionKey(path="/id"))
         return document_collection

--- a/sdk/cosmos/azure-cosmos/test/test_partition_split_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_partition_split_query.py
@@ -44,7 +44,7 @@ class TestPartitionSplitQuery(unittest.TestCase):
     def setUpClass(cls):
         cls.client = cosmos_client.CosmosClient(cls.host, cls.masterKey)
         cls.database = test_config._test_config.create_database_if_not_exist_with_throughput(cls.client, cls.throughput)
-        cls.container = test_config._test_config.create_collection_no_custom_throughput(cls.client)
+        cls.container = test_config._test_config.create_collection_if_not_exist_no_custom_throughput(cls.client)
 
     def test_partition_split_query(self):
         for i in range(1000):


### PR DESCRIPTION
Pipelines are running into error when trying to re-create resources because they exist, changed method to use create_if_not_exists()