### PR TITLE
[Cosmos] further changes to test for internal pipelines

### DIFF
--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -1,3 +1,3 @@
+azure-core
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
 -e ../../../tools/azure-devtools

--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -1,3 +1,3 @@
-azure-core
 -e ../../../tools/azure-sdk-tools
+../../core/azure-core
 -e ../../../tools/azure-devtools

--- a/sdk/cosmos/azure-cosmos/test/test_config.py
+++ b/sdk/cosmos/azure-cosmos/test/test_config.py
@@ -59,6 +59,7 @@ class _test_config(object):
     THROUGHPUT_FOR_1_PARTITION = 400
 
     TEST_DATABASE_ID = os.getenv('COSMOS_TEST_DATABASE_ID', "Python SDK Test Database " + str(uuid.uuid4()))
+    TEST_THROUGHPUT_DATABASE_ID = "Python SDK Test Throughput Database " + str(uuid.uuid4())
     TEST_COLLECTION_SINGLE_PARTITION_ID = "Single Partition Test Collection"
     TEST_COLLECTION_MULTI_PARTITION_ID = "Multi Partition Test Collection"
     TEST_COLLECTION_MULTI_PARTITION_WITH_CUSTOM_PK_ID = "Multi Partition Test Collection With Custom PK"
@@ -88,7 +89,7 @@ class _test_config(object):
         if cls.TEST_DATABASE is not None:
             return cls.TEST_DATABASE
         cls.try_delete_database(client)
-        cls.TEST_DATABASE = client.create_database(id=cls.TEST_DATABASE_ID, offer_throughput=throughput)
+        cls.TEST_DATABASE = client.create_database(id=cls.TEST_THROUGHPUT_DATABASE_ID, offer_throughput=throughput)
         cls.IS_MULTIMASTER_ENABLED = client.get_database_account()._EnableMultipleWritableLocations
         return cls.TEST_DATABASE
 

--- a/sdk/cosmos/azure-cosmos/test/test_config.py
+++ b/sdk/cosmos/azure-cosmos/test/test_config.py
@@ -130,12 +130,12 @@ class _test_config(object):
         return cls.TEST_COLLECTION_MULTI_PARTITION_WITH_CUSTOM_PK
 
     @classmethod
-    def create_collection_no_custom_throughput(cls, client):
+    def create_collection_if_not_exist_no_custom_throughput(cls, client):
         # type: (CosmosClient) -> Container
         database = cls.create_database_if_not_exist(client)
         collection_id = cls.TEST_COLLECTION_SINGLE_PARTITION_ID
 
-        document_collection = database.create_container(
+        document_collection = database.create_container_if_not_exists(
             id=collection_id,
             partition_key=PartitionKey(path="/id"))
         return document_collection

--- a/sdk/cosmos/azure-cosmos/test/test_partition_split_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_partition_split_query.py
@@ -47,7 +47,7 @@ class TestPartitionSplitQuery(unittest.TestCase):
         cls.container = test_config._test_config.create_collection_if_not_exist_no_custom_throughput(cls.client)
 
     def test_partition_split_query(self):
-        for i in range(1000):
+        for i in range(500):
             body = self.get_test_item()
             self.container.create_item(body=body)
 
@@ -58,7 +58,7 @@ class TestPartitionSplitQuery(unittest.TestCase):
         print("--------------------------------")
         print("now starting queries")
 
-        self.run_queries(self.container, 1000)  # initial check for queries before partition split
+        self.run_queries(self.container, 500)  # initial check for queries before partition split
         print("initial check succeeded, now reading offer until replacing is done")
         offer = self.database.read_offer()
         while True:
@@ -67,10 +67,10 @@ class TestPartitionSplitQuery(unittest.TestCase):
                 offer = self.database.read_offer()
             else:
                 print("offer replaced successfully, took around {} seconds".format(time.time() - offer_time))
-                self.run_queries(self.container, 1000)  # check queries work post partition split
+                self.run_queries(self.container, 500)  # check queries work post partition split
                 print("test over")
                 self.assertTrue(offer.offer_throughput > self.throughput)
-                self.client.delete_database(self.configs.TEST_DATABASE_ID)
+                self.client.delete_database(self.configs.TEST_THROUGHPUT_DATABASE_ID)
                 return
 
     def run_queries(self, container, iterations):

--- a/sdk/cosmos/azure-cosmos/test/test_partition_split_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_partition_split_query.py
@@ -44,7 +44,7 @@ class TestPartitionSplitQuery(unittest.TestCase):
     def setUpClass(cls):
         cls.client = cosmos_client.CosmosClient(cls.host, cls.masterKey)
         cls.database = test_config._test_config.create_database_if_not_exist_with_throughput(cls.client, cls.throughput)
-        cls.container = test_config._test_config.create_collection_no_custom_throughput(cls.client)
+        cls.container = test_config._test_config.create_collection_if_not_exist_no_custom_throughput(cls.client)
 
     def test_partition_split_query(self):
         for i in range(1000):


### PR DESCRIPTION
 changed database name to have own resource with explicitly set throughput and reduced the number of iterations, since the splitting alone takes around 10mins