### PR TITLE
Disable apistub gen artifact gen for python pipeline

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -95,9 +95,9 @@ steps:
         --service="${{ parameters.ServiceDirectory }}" 
         --toxenv=sphinx
 
-  - template: /eng/pipelines/templates/steps/run_apistub.yml
-    parameters:
-      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+  # - template: /eng/pipelines/templates/steps/run_apistub.yml
+  #   parameters:
+  #     ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - ${{ parameters.BeforePublishSteps }}
 


### PR DESCRIPTION
Python APIStub generator has a new change that seems to have broken apistubgen for azure-core-tracing-opencensus. This PR is to temporarily remove this apistub gen step since we haven't rolled out change to utilize this artifact yet.