### PR TITLE
[Storage] Fix account SAS generation for file-share

### DIFF
--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -8,6 +8,8 @@ This version and all future versions will require Python 3.6+. Python 2.7 is no 
 
 ### Bugs Fixed
 - Update `azure-core` dependency to avoid inconsistent dependencies from being installed.
+- Fixed a bug, that was introuced in the previous beta release, where `generate_account_sas()`
+was not generating the proper SAS signature.
 
 ## 12.7.0b1 (2021-12-13)
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
@@ -211,7 +211,9 @@ class _SharedAccessHelper(object):
              get_value_to_append(QueryStringConstants.SIGNED_EXPIRY) +
              get_value_to_append(QueryStringConstants.SIGNED_IP) +
              get_value_to_append(QueryStringConstants.SIGNED_PROTOCOL) +
-             get_value_to_append(QueryStringConstants.SIGNED_VERSION))
+             get_value_to_append(QueryStringConstants.SIGNED_VERSION) +
+             '\n'   # Signed Encryption Scope - always empty for fileshare
+             )
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key, string_to_sign))


### PR DESCRIPTION
In SAS version 2020-12-06 the `stringToSign` for account SAS started to require an additional field for encryption scope. This was added to blob/datalake as part of STG79, but the account SAS generation was not updated for file-share, while the SAS version was, causing the SAS to be invalid when using the latest service version.

Since encryption scope is currently not supported on file-share, the fix was to add an empty line when generating the account SAS from the file-share package since encryption scope will always be empty.