### PR TITLE
Set AZURE_TEST_RUN_LIVE in pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -111,6 +111,7 @@ jobs:
           CoverageArg: $(CoverageArg)
           EnvVars:
             AZURE_RUN_MODE: 'Live' #Record, Playback
+            AZURE_TEST_RUN_LIVE: 'true'
             ${{ insert }}: ${{ parameters.EnvVars }}
           PreSteps: ${{ parameters.PreSteps }}
           PostSteps: ${{ parameters.PostSteps }}


### PR DESCRIPTION
# Description

Without setting this variable, test proxy tooling isn't able to detect that we're running tests live. Because of this, if `AZURE_TEST_RUN_LIVE` isn't set in a library's `tests.yml` file, we'll get errors because the test proxy isn't available to agents.

@scbedd for notifs

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
