### PR TITLE
Revert "Set AZURE_TEST_RUN_LIVE in pipeline"

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -111,7 +111,6 @@ jobs:
           CoverageArg: $(CoverageArg)
           EnvVars:
             AZURE_RUN_MODE: 'Live' #Record, Playback
-            AZURE_TEST_RUN_LIVE: 'true'
             ${{ insert }}: ${{ parameters.EnvVars }}
           PreSteps: ${{ parameters.PreSteps }}
           PostSteps: ${{ parameters.PostSteps }}


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#22902

This breaks many existing pipelines that pre-define AZURE_TEST_RUN_LIVE because it ends up getting defined+injected twice:

https://github.com/Azure/azure-sdk-for-python/blob/main/eng/pipelines/templates/jobs/live.tests.yml#L114-L115

```
            AZURE_TEST_RUN_LIVE: 'true'
            ${{ insert }}: ${{ parameters.EnvVars }}
```

For example:

{"$id":"1","customProperties":**{"ValidationResults":[{"result":"error","message":"/eng/pipelines/templates/jobs/live.tests.yml (Line: 115, Col: 28): 'AZURE_TEST_RUN_LIVE' is already defined"}]}**,"innerException":null,"message":"Could not queue the build because there were validation errors or warnings.","typeName":"Microsoft.TeamFoundation.Build.WebApi.BuildRequestValidationFailedException, Microsoft.TeamFoundation.Build2.WebApi","typeKey":"BuildRequestValidationFailedException","errorCode":0,"eventId":3000}

FYI @mccoyp @scbedd 
