### PR TITLE
[Storage] Fix some flaky live tests

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption.py
@@ -189,7 +189,7 @@ class StorageBlobEncryptionTest(StorageTestCase):
 
         with self.assertRaises(HttpResponseError) as e:
             blob.download_blob().content_as_bytes()
-        self.assertEqual(str(e.exception), 'Decryption failed.')
+        self.assertTrue('Decryption failed.' in str(e.exception))
 
     @BlobPreparer()
     def test_get_blob_kek(self, storage_account_name, storage_account_key):
@@ -252,7 +252,7 @@ class StorageBlobEncryptionTest(StorageTestCase):
         # Assert
         with self.assertRaises(HttpResponseError) as e:
             blob.download_blob().content_as_bytes()
-        self.assertEqual(str(e.exception), 'Decryption failed.')
+        self.assertTrue('Decryption failed.' in str(e.exception))
 
     @BlobPreparer()
     def test_put_blob_invalid_stream_type(self, storage_account_name, storage_account_key):

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_async.py
@@ -217,7 +217,7 @@ class StorageBlobEncryptionTestAsync(AsyncStorageTestCase):
 
         with self.assertRaises(HttpResponseError) as e:
             await (await blob.download_blob()).content_as_bytes()
-        self.assertEqual(str(e.exception), 'Decryption failed.')
+        self.assertTrue('Decryption failed.' in str(e.exception))
 
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test
@@ -287,7 +287,7 @@ class StorageBlobEncryptionTestAsync(AsyncStorageTestCase):
         # Assert
         with self.assertRaises(HttpResponseError) as e:
             await (await blob.download_blob()).content_as_bytes()
-        self.assertEqual(str(e.exception), 'Decryption failed.')
+        self.assertTrue('Decryption failed.' in str(e.exception))
 
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -148,7 +148,7 @@ class StorageCommonBlobTest(StorageTestCase):
         # wait until the policy has gone into effect
         if self.is_live:
             self.bsc.set_service_properties(delete_retention_policy=delete_retention_policy)
-            time.sleep(30)
+            time.sleep(35)
 
     def _disable_soft_delete(self):
         delete_retention_policy = RetentionPolicy(enabled=False)

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -166,7 +166,7 @@ class StorageCommonBlobAsyncTest(AsyncStorageTestCase):
 
         # wait until the policy has gone into effect
         if self.is_live:
-            time.sleep(30)
+            time.sleep(35)
 
     async def _disable_soft_delete(self):
         delete_retention_policy = RetentionPolicy(enabled=False)


### PR DESCRIPTION
Attempting to fix some flaky tests on our live test nightly pipeline.
- For Decryption Failed exceptions some tests are checking for the exception message to equal "Decryption Failed" but most of the time that exception contains additional content, so changing to contains check.
- A lot of the tests using Soft Delete fail occasionally, and I believe it is caused by us not waiting long enough for Soft Delete to be enabled on the account. We currently wait the exact recommended 30 seconds. Bumping that to 35 to see if that helps with the flakiness.