### PR TITLE
[Core] Document TokenCredential implementation requirements

### DIFF
--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -531,7 +531,7 @@ Clients from the Azure SDK often require a `TokenCredential` instance in their c
 meant to provide OAuth tokens to authenticate service requests and can be implemented in a number of ways.
 
 The `TokenCredential` protocol specifies a class that has a single method -- `get_token` -- which returns an
-`AccessToken`: a `NamedTuple` containing a `token` string and an `expires_on` integer.
+`AccessToken`: a `NamedTuple` containing a `token` string and an `expires_on` integer (in Unix time).
 
 ```python
 AccessToken = NamedTuple("AccessToken", [("token", str), ("expires_on", int)])
@@ -556,6 +556,10 @@ A `TokenCredential` implementation needs to implement the `get_token` method to 
 implement additional methods. The [`azure-identity`][identity_github] package has a number of `TokenCredential`
 implementations that can be used for reference. For example, the [`InteractiveCredential`][interactive_cred] is used as
 a base class for multiple credentials and uses `claims` and `tenant_id` in token requests.
+
+There is also an async protocol -- the `AsyncTokenCredential` protocol -- that specifies a class with an aysnc
+`get_token` method with the same arguments. An `AsyncTokenCredential` implementation additionally needs to be a context
+manager, with `__aenter__`, `__aexit__`, and `close` methods.
 
 #### Known uses of `get_token` keyword-only parameters
 

--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -549,6 +549,9 @@ class TokenCredential(Protocol):
         :keyword str claims: Additional claims required in the token, such as those returned in a resource
             provider's claims challenge following an authorization failure.
         :keyword str tenant_id: Optional tenant to include in the token request.
+
+        :rtype: AccessToken
+        :return: An AccessToken instance containing the token string and its expiration time in Unix time.
         """
 ```
 

--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -540,10 +540,7 @@ class TokenCredential(Protocol):
     """Protocol for classes able to provide OAuth tokens."""
 
     def get_token(
-        *scopes : str,
-        claims : Optional[str] = None,
-        tenant_id : Optional[str] = None,
-        **kwargs : Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -522,3 +522,29 @@ class Pipeline:
         return first_node.send(pipeline_request)  # type: ignore
 
 ```
+
+## Credentials
+
+### TokenCredential protocol
+
+Clients from the Azure SDK often require a `TokenCredential` instance in their constructors. A `TokenCredential` is
+meant to provide OAuth tokens to authenticate service requests and can be implemented in a number of ways.
+
+The [`TokenCredential` protocol][token_cred_definition] specifies a class that has a single method -- `get_token` --
+which accepts `*scopes` and `**kwargs`. Each scope specifies a type of access being requested, and the contents of
+`**kwargs` are arbitrary. For example, `TokenCredential` implementations in [`azure-identity`][identity_pypi] may
+accept [`tenant_id`][default_cred_get_token] as a keyword-only argument.
+
+`get_token` returns an [`AccessToken`][access_token_definition]: a `NamedTuple` containing a `token` string and an
+`expires_on` integer.
+
+A `TokenCredential` implementation needs to implement the `get_token` method to these specifications and can optionally
+implement additional methods. Refer to the [custom_credentials.py][custom_creds_sample] sample in `azure-identity` for
+examples of custom `TokenCredential` implementations.
+
+
+[access_token_definition]: https://github.com/Azure/azure-sdk-for-python/blob/844e16db0abc553ab1adf104128cbf0e223af189/sdk/core/azure-core/azure/core/credentials.py#L14
+[custom_creds_sample]: https://github.com/Azure/azure-sdk-for-python/blob/fc95f8d3d84d076ffea158116ca1bf6912689c70/sdk/identity/azure-identity/samples/custom_credentials.py
+[default_cred_get_token]: https://docs.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python#azure-identity-defaultazurecredential-get-token
+[identity_pypi]: https://pypi.org/project/azure-identity/
+[token_cred_definition]: https://github.com/Azure/azure-sdk-for-python/blob/844e16db0abc553ab1adf104128cbf0e223af189/sdk/core/azure-core/azure/core/credentials.py#L16

--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
             :keyword str claims: Additional claims required in the token, such as those returned in a resource
                 provider's claims challenge following an authorization failure.
             :keyword str tenant_id: Optional tenant to include in the token request.
+
+            :rtype: AccessToken
+            :return: An AccessToken instance containing the token string and its expiration time in Unix time.
             """
 
 

--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
     class TokenCredential(Protocol):
         """Protocol for classes able to provide OAuth tokens."""
 
-        # pylint:disable=too-few-public-methods
+        # pylint:disable=too-few-public-methods, no-method-argument, unnecessary-pass
         def get_token(
-            *scopes : str,
-            claims : Optional[str] = None,
-            tenant_id : Optional[str] = None,
-            **kwargs : Any
+            *scopes: str,
+            claims: Optional[str] = None,
+            tenant_id: Optional[str] = None,
+            **kwargs: Any
         ) -> AccessToken:
             """Request an access token for `scopes`.
 

--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -16,22 +16,17 @@ if TYPE_CHECKING:
     class TokenCredential(Protocol):
         """Protocol for classes able to provide OAuth tokens."""
 
-        # pylint:disable=too-few-public-methods, no-method-argument, unnecessary-pass
         def get_token(
-            *scopes: str,
-            claims: Optional[str] = None,
-            tenant_id: Optional[str] = None,
-            **kwargs: Any
+            self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
         ) -> AccessToken:
             """Request an access token for `scopes`.
 
-            :param str scopes: The type(s) of access needed.
+            :param str scopes: The type of access needed.
 
             :keyword str claims: Additional claims required in the token, such as those returned in a resource
                 provider's claims challenge following an authorization failure.
             :keyword str tenant_id: Optional tenant to include in the token request.
             """
-            pass
 
 
 else:
@@ -131,6 +126,7 @@ class AzureNamedKeyCredential(object):
     :param str key: The key used to authenticate to an Azure service.
     :raises: TypeError
     """
+
     def __init__(self, name, key):
         # type: (str, str) -> None
         if not isinstance(name, six.string_types) or not isinstance(key, six.string_types):

--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -8,20 +8,29 @@ from typing import TYPE_CHECKING
 import six
 
 if TYPE_CHECKING:
-    from typing import Any, NamedTuple
+    from typing import Any, Optional, NamedTuple
     from typing_extensions import Protocol
 
     AccessToken = NamedTuple("AccessToken", [("token", str), ("expires_on", int)])
 
     class TokenCredential(Protocol):
-        """Protocol for classes able to provide OAuth tokens.
-
-        :param str scopes: Lets you specify the type of access needed.
-        """
+        """Protocol for classes able to provide OAuth tokens."""
 
         # pylint:disable=too-few-public-methods
-        def get_token(self, *scopes, **kwargs):
-            # type: (*str, **Any) -> AccessToken
+        def get_token(
+            *scopes : str,
+            claims : Optional[str] = None,
+            tenant_id : Optional[str] = None,
+            **kwargs : Any
+        ) -> AccessToken:
+            """Request an access token for `scopes`.
+
+            :param str scopes: The type(s) of access needed.
+
+            :keyword str claims: Additional claims required in the token, such as those returned in a resource
+                provider's claims challenge following an authorization failure.
+            :keyword str tenant_id: Optional tenant to include in the token request.
+            """
             pass
 
 

--- a/sdk/core/azure-core/azure/core/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/credentials_async.py
@@ -5,13 +5,24 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Optional
     from typing_extensions import Protocol
     from .credentials import AccessToken
 
     class AsyncTokenCredential(Protocol):
-        async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
-            pass
+        """Protocol for classes able to provide OAuth tokens."""
+
+        async def get_token(
+            self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        ) -> AccessToken:
+            """Request an access token for `scopes`.
+
+            :param str scopes: The type of access needed.
+
+            :keyword str claims: Additional claims required in the token, such as those returned in a resource
+                provider's claims challenge following an authorization failure.
+            :keyword str tenant_id: Optional tenant to include in the token request.
+            """
 
         async def close(self) -> None:
             pass

--- a/sdk/core/azure-core/azure/core/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/credentials_async.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
             :keyword str claims: Additional claims required in the token, such as those returned in a resource
                 provider's claims challenge following an authorization failure.
             :keyword str tenant_id: Optional tenant to include in the token request.
+
+            :rtype: AccessToken
+            :return: An AccessToken instance containing the token string and its expiration time in Unix time.
             """
 
         async def close(self) -> None:


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/22853 and resolves https://github.com/Azure/azure-sdk-for-python/issues/22824. This adds a section to the client library developer doc, describing the TokenCredential protocol and the requirements for implementing such a credential. The current plan is to link to the "TokenCredential protocol" section anchor with an `aka.ms` link: https://aka.ms/azsdk/python/identity/tokencredential. I'm open to suggestions for a different URL!

This also updates the TokenCredential protocol in Core to reflect changes in the past year to accept `claims` and `tenant_id`. A section of the TokenCredential documentation covers the current known uses of these parameters for reference and record keeping.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
