### PR TITLE
remove Table name check

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_error.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_error.py
@@ -61,9 +61,9 @@ def _wrap_exception(ex, desired_type):
 
 
 def _validate_table_name(table_name):
-    if match("^[a-zA-Z]{1}[a-zA-Z0-9]{2,62}$", table_name) is None:
+    if table_name is None:
         raise ValueError(
-            "Table names must be alphanumeric, cannot begin with a number, and must be between 3-63 characters long."
+            "Table name should not be None or empty."
         )
 
 


### PR DESCRIPTION
Please assist to review the Table name checking method, because Azure Portal - Cosmos DB Data Explorer allows users to create a table name that disallowed in the regex match.

In the deprecated SDK azure-cosmosdb-table 1.0.6, it’s just simply checked the input shouldn't be empty only.
Ref: https://github.com/Azure/azure-cosmos-table-python/blob/master/azure-cosmosdb-table/azure/cosmosdb/table/common/_error.py#L127
def _validate_not_none(param_name, param):
    if param is None:
        raise ValueError(_ERROR_VALUE_NONE.format(param_name))

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
