### PR TITLE
Async sample should use asyncio.run

### DIFF
--- a/sdk/communication/azure-communication-chat/samples/chat_client_sample_async.py
+++ b/sdk/communication/azure-communication-chat/samples/chat_client_sample_async.py
@@ -160,5 +160,4 @@ async def main():
     sample.clean_up()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/communication/azure-communication-chat/samples/chat_thread_client_sample_async.py
+++ b/sdk/communication/azure-communication-chat/samples/chat_thread_client_sample_async.py
@@ -398,5 +398,4 @@ async def main():
     sample.clean_up()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/communication/azure-communication-identity/samples/identity_samples_async.py
+++ b/sdk/communication/azure-communication-identity/samples/identity_samples_async.py
@@ -160,5 +160,4 @@ async def main():
     await sample.get_token_for_teams_user()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/communication/azure-communication-networktraversal/samples/network_traversal_samples_async.py
+++ b/sdk/communication/azure-communication-networktraversal/samples/network_traversal_samples_async.py
@@ -62,5 +62,4 @@ async def main():
     await sample.get_relay_config()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/communication/azure-communication-phonenumbers/samples/get_purchased_phone_number_sample_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/get_purchased_phone_number_sample_async.py
@@ -35,5 +35,4 @@ async def get_purchased_phone_number_information():
     print('Country code: ' + purchased_phone_number_information.country_code)
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(get_purchased_phone_number_information())
+    asyncio.run(get_purchased_phone_number_information())

--- a/sdk/communication/azure-communication-phonenumbers/samples/list_purchased_phone_numbers_sample_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/list_purchased_phone_numbers_sample_async.py
@@ -35,5 +35,4 @@ async def list_purchased_phone_numbers():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(list_purchased_phone_numbers())
+    asyncio.run(list_purchased_phone_numbers())

--- a/sdk/communication/azure-communication-phonenumbers/samples/purchase_phone_number_sample_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/purchase_phone_number_sample_async.py
@@ -40,5 +40,4 @@ async def purchase_phone_number():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(purchase_phone_number())
+    asyncio.run(purchase_phone_number())

--- a/sdk/communication/azure-communication-phonenumbers/samples/release_phone_number_sample_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/release_phone_number_sample_async.py
@@ -37,5 +37,4 @@ async def release_phone_number():
         print('Status of the operation: ' + poller.status())
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(release_phone_number())
+    asyncio.run(release_phone_number())

--- a/sdk/communication/azure-communication-phonenumbers/samples/search_available_phone_numbers_sample_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/search_available_phone_numbers_sample_async.py
@@ -52,5 +52,4 @@ async def search_available_phone_numbers():
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(search_available_phone_numbers())
+    asyncio.run(search_available_phone_numbers())

--- a/sdk/communication/azure-communication-phonenumbers/samples/update_phone_number_capabilities_sample_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/update_phone_number_capabilities_sample_async.py
@@ -41,5 +41,4 @@ async def update_phone_number_capabilities():
     print('Status of the operation: ' + poller.status())
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(update_phone_number_capabilities())
+    asyncio.run(update_phone_number_capabilities())

--- a/sdk/communication/azure-communication-sms/samples/send_sms_to_multiple_recipients_sample_async.py
+++ b/sdk/communication/azure-communication-sms/samples/send_sms_to_multiple_recipients_sample_async.py
@@ -56,5 +56,4 @@ class SmsMultipleRecipientsSampleAsync(object):
 
 if __name__ == '__main__':
     sample = SmsMultipleRecipientsSampleAsync()
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(sample.send_sms_to_multiple_recipients_async())
+    asyncio.run(sample.send_sms_to_multiple_recipients_async())

--- a/sdk/communication/azure-communication-sms/samples/send_sms_to_single_recipient_sample_async.py
+++ b/sdk/communication/azure-communication-sms/samples/send_sms_to_single_recipient_sample_async.py
@@ -56,5 +56,4 @@ class SmsSingleRecipientSampleAsync(object):
 
 if __name__ == '__main__':
     sample = SmsSingleRecipientSampleAsync()
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(sample.send_sms_to_single_recipient_async())
+    asyncio.run(sample.send_sms_to_single_recipient_async())

--- a/sdk/communication/azure-communication-sms/samples/sms_token_credential_auth_sample_async.py
+++ b/sdk/communication/azure-communication-sms/samples/sms_token_credential_auth_sample_async.py
@@ -59,5 +59,4 @@ class SmsTokenCredentialAuthSampleAsync(object):
 
 if __name__ == '__main__':
     sample = SmsTokenCredentialAuthSampleAsync()
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(sample.sms_token_credential_auth_async())
+    asyncio.run(sample.sms_token_credential_auth_async())


### PR DESCRIPTION
# Description
Python 3.10 has deprecated asyncio.get_event_loop() which is broadly used in the async samples in communication SDKs. asyncio.get_event_loop() replaced by asyncio.run in the async samples as suggested by Python docs.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
