### PR TITLE
Bump sdk_release_scripts `lxml` requirement to `4.6.5`

### DIFF
--- a/scripts/release_sdk_status/requirement.txt
+++ b/scripts/release_sdk_status/requirement.txt
@@ -1,7 +1,7 @@
 certifi==2021.5.30
 chardet==4.0.0
 idna==2.10
-lxml==4.6.3
+lxml==4.6.5
 requests==2.25.1
 urllib3==1.26.6
 azure.storage.blob==12.8.1


### PR DESCRIPTION
Resolving a CG alert.