### PR TITLE
Remediate Failing SmokeTests

### DIFF
--- a/common/smoketest/requirements-release.txt
+++ b/common/smoketest/requirements-release.txt
@@ -1,7 +1,7 @@
 azure-core>=0.0.0b1
 azure-identity>=0.0.0b1
 azure-cosmos>=4.0.0b5
-azure-eventhub>=0.0.0b1
+azure-eventhub>=0.0.0b1,!=5.8.0a1
 azure-keyvault-certificates>=0.0.0b1
 azure-keyvault-keys>=0.0.0b1
 azure-keyvault-secrets>=0.0.0b1


### PR DESCRIPTION
Related #22772

New eventhub is re-rolling the UAMQP library to pure python. Given that it is a huge work-in-progress, `azure-eventhub=5.8.0a1` does not have `aio` namespaces.

Temporarily remediating in such a way that we will be forced to update this again if a2 has this same problem. 