### PR TITLE
[Key Vault] Add version property to administration

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
@@ -27,3 +27,6 @@ __all__ = [
     "KeyVaultRoleDefinition",
     "KeyVaultRoleScope",
 ]
+
+from ._version import VERSION
+__version__ = VERSION


### PR DESCRIPTION
# Description

Context: `azure-keyvault-administration` is currently the only KV package that doesn't have a `__version__` property that can be used to check the package version. This adds that property.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
