### PR TITLE
[formrecognizer] add back deprecation notice

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-formrecognizer/README.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-formrecognizer/README.md
@@ -1,3 +1,8 @@
+## NOTE: This package has been deprecated
+
+This version has endpoints that are no longer active. To use the more recent version of the Azure Form Recognizer service,
+please install the azure-ai-formrecognizer package found here: https://pypi.org/project/azure-ai-formrecognizer/
+
 # Microsoft Azure SDK for Python
 
 This is the Microsoft Azure Cognitive Services Form Recognizer Client Library.

--- a/sdk/cognitiveservices/azure-cognitiveservices-formrecognizer/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-formrecognizer/setup.py
@@ -61,7 +61,7 @@ setup(
     author_email='azpysdkhelp@microsoft.com',
     url='https://github.com/Azure/azure-sdk-for-python',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 7 - Inactive',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
We already released this track 1 as deprecated on PyPi, but the note in the README and setup.py got overwritten in another PR so adding them back.

https://pypi.org/project/azure-cognitiveservices-formrecognizer/