### PR TITLE
[Cosmos] hotfix: replace sproc/trigger/udf request body invalid

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -10,6 +10,7 @@
   consistency level of the user's cosmos account setting on initialization if not passed during client initialization. 
   This change will impact client application in terms of RUs and latency. Users relying on default `Session` consistency will need to pass it explicitly if their account consistency is different than `Session`.
   Please see [Consistency Levels in Azure Cosmos DB](https://docs.microsoft.com/azure/cosmos-db/consistency-levels) for more details.
+- Fixed invalid request body being sent when passing in `serverScript` body parameter to replace operations for trigger, sproc and udf resources.
 
 ### 4.3.0b2 (2022-01-25)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -1764,7 +1764,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         CosmosClientConnection.__ValidateResource(trigger)
         trigger = trigger.copy()
         if trigger.get("serverScript"):
-            trigger["body"] = str(trigger["serverScript"])
+            trigger["body"] = str(trigger.pop("serverScript", ""))
         elif trigger.get("body"):
             trigger["body"] = str(trigger["body"])
 
@@ -1814,7 +1814,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         CosmosClientConnection.__ValidateResource(udf)
         udf = udf.copy()
         if udf.get("serverScript"):
-            udf["body"] = str(udf["serverScript"])
+            udf["body"] = str(udf.pop("serverScript", ""))
         elif udf.get("body"):
             udf["body"] = str(udf["body"])
 
@@ -1898,7 +1898,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         CosmosClientConnection.__ValidateResource(sproc)
         sproc = sproc.copy()
         if sproc.get("serverScript"):
-            sproc["body"] = str(sproc["serverScript"])
+            sproc["body"] = str(sproc.pop("serverScript", ""))
         elif sproc.get("body"):
             sproc["body"] = str(sproc["body"])
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -1076,7 +1076,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         CosmosClientConnection.__ValidateResource(udf)
         udf = udf.copy()
         if udf.get("serverScript"):
-            udf["body"] = str(udf["serverScript"])
+            udf["body"] = str(udf.pop("serverScript", ""))
         elif udf.get("body"):
             udf["body"] = str(udf["body"])
 
@@ -1105,7 +1105,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         CosmosClientConnection.__ValidateResource(trigger)
         trigger = trigger.copy()
         if trigger.get("serverScript"):
-            trigger["body"] = str(trigger["serverScript"])
+            trigger["body"] = str(trigger.pop("serverScript", ""))
         elif trigger.get("body"):
             trigger["body"] = str(trigger["body"])
 
@@ -1187,7 +1187,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         CosmosClientConnection.__ValidateResource(sproc)
         sproc = sproc.copy()
         if sproc.get("serverScript"):
-            sproc["body"] = str(sproc["serverScript"])
+            sproc["body"] = str(sproc.pop("serverScript", ""))
         elif sproc.get("body"):
             sproc["body"] = str(sproc["body"])
 


### PR DESCRIPTION
Based on this user-reported issue: https://github.com/Azure/azure-sdk-for-python/issues/23006

Basically, we were still passing in the "serverScript" body parameter to the backend as part of the request body when attempting to replace any of the listed resources. Due to this, the backend would return errors stating that the body was invalid.

This PR makes the changes to ensure the backend receives a proper body the same way it does when doing create operations for any of the above resources.