### PR TITLE
Ensure Py36 can autostart/stop test-proxy on windows2019

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -73,6 +73,7 @@ def get_container_info():
         shlex.split("docker container ls -a --format '{{json .}}' --filter name=" + CONTAINER_NAME),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL
     )
 
     output, stderr = proc.communicate()


### PR DESCRIPTION
Uncertain why this failure did not crop up on [the tables](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1369831&view=results) run of the prospective test-proxy changes.

(And scheduled run is actually totally fine)

@kristapratico this should address the error you're seeing.