### PR TITLE
[Test Proxy] Remove unnecessary git SHA fetch

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -87,8 +87,6 @@ def start_record_or_playback(test_id):
     This returns a tuple, (a, b), where a is the recording ID of the test and b is the `variables` dictionary that maps
     test variables to values. If no variable dictionary was stored when the test was recorded, b is an empty dictionary.
     """
-    head_commit = subprocess.check_output(["git", "rev-parse", "HEAD"])
-    current_sha = head_commit.decode("utf-8").strip()
     variables = {}  # this stores a dictionary of test variable values that could have been stored with a recording
 
     if is_live():


### PR DESCRIPTION
# Description

[This pipeline error](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1375908&view=logs&j=4df8a194-0a6a-5270-2ee0-25d33ff802a0&t=02181e79-712c-5b43-58a0-affa6e2e1ca1&l=57842) is coming up when we attempt to run `git rev-parse HEAD` via `subprocess`, but it turns out that we don't use the result anyway. Removing this call. @scbedd 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
  - Using affected pipelines
