### PR TITLE
[core] fix mypy errors arising from latest mypy version

### DIFF
--- a/sdk/core/azure-core/azure/core/_pipeline_client.py
+++ b/sdk/core/azure-core/azure/core/_pipeline_client.py
@@ -25,10 +25,7 @@
 # --------------------------------------------------------------------------
 
 import logging
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 from .configuration import Configuration
 from .pipeline import Pipeline
 from .pipeline.transport._base import PipelineClientBase

--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -161,6 +161,7 @@ def convert_tracing_impl(value):
         return get_opencensus_span_if_opencensus_is_imported()
 
     if not isinstance(value, six.string_types):
+        value = cast(Type[AbstractSpan], value)
         return value
 
     value = cast(str, value)  # mypy clarity


### PR DESCRIPTION
Output using mypy==0.931 and Python 3.10


azure\core\settings.py:164: error: Incompatible return value type (got "Union[str, Type[AbstractSpan]]", expected "Optional[Type[AbstractSpan]]")
azure\core_pipeline_client.py:31: error: Module "collections" has no attribute "Iterable"
azure\core_pipeline_client.py:31: error: Name "Iterable" already defined (possibly by an import)