### PR TITLE
[Communication] - phone-numbers - Implement a phone number pool for update capabilities live tests

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
+++ b/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
@@ -1,0 +1,58 @@
+{
+  "displayNames": {
+    "--disablecov": "",
+    "false": "",
+    "true": ""
+  },
+  "matrix": {
+    "Agent": {
+      "ubuntu-20.04": {
+        "OSVmImage": "MMSUbuntu20.04",
+        "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+        "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "true"
+      },
+      "windows-2019": {
+        "OSVmImage": "MMS2019",
+        "Pool": "azsdk-pool-mms-win-2019-general",
+        "AZURE_TEST_AGENT": "windows_2019_python36",
+        "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
+      },
+      "macOS-10.15": {
+        "OSVmImage": "macOS-10.15",
+        "Pool": "Azure Pipelines",
+        "AZURE_TEST_AGENT": "macos_1015_python37",
+        "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
+      }
+    },
+    "PythonVersion": ["pypy3.7", "3.6", "3.7", "3.8"],
+    "CoverageArg": "--disablecov",
+    "TestSamples": "false"
+  },
+  "include": [
+    {
+      "CoverageConfig": {
+        "ubuntu2004_39_coverage": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+          "PythonVersion": "3.9",
+          "CoverageArg": "",
+          "TestSamples": "false",
+          "AZURE_TEST_AGENT": "ubuntu_2004_python39",
+          "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
+        }
+      }
+    },
+    {
+      "Config": {
+        "Ubuntu2004_310": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+          "PythonVersion": "3.10.0",
+          "CoverageArg": "--disablecov",
+          "TestSamples": "false",
+          "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "true"
+        }
+      }
+    }
+  ]
+}

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
@@ -23,7 +23,14 @@ SKIP_INT_PHONE_NUMBER_TESTS = os.getenv("COMMUNICATION_SKIP_INT_PHONENUMBERS_TES
 INT_PHONE_NUMBER_TEST_SKIP_REASON = "Phone numbers setting SMS capability does not support in INT. Skip these tests in INT."
 
 SKIP_UPDATE_CAPABILITIES_TESTS = os.getenv("COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST", "false") == "true"
-SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities update does not currently support parallel execution. Skip these tests from live test pipeline."
+SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities are skipped."
+
+def get_test_phone_number():
+    if SKIP_UPDATE_CAPABILITIES_TESTS:
+        return os.getenv("AZURE_PHONE_NUMBER")
+
+    test_agent = os.getenv("AZURE_TEST_AGENT")
+    return os.getenv("AZURE_PHONE_NUMBER_" + test_agent)
 
 class PhoneNumbersClientTest(CommunicationTestCase):
     def setUp(self):
@@ -32,7 +39,7 @@ class PhoneNumbersClientTest(CommunicationTestCase):
             self.phone_number = "sanitized"
             self.country_code = "US"
         else:
-            self.phone_number = os.getenv("AZURE_PHONE_NUMBER")
+            self.phone_number = get_test_phone_number()
             self.country_code = os.getenv("AZURE_COMMUNICATION_SERVICE_COUNTRY_CODE", "US")
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str, 

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
@@ -24,7 +24,14 @@ SKIP_INT_PHONE_NUMBER_TESTS = os.getenv("COMMUNICATION_SKIP_INT_PHONENUMBERS_TES
 INT_PHONE_NUMBER_TEST_SKIP_REASON = "Phone numbers setting SMS capability does not support in INT. Skip these tests in INT."
 
 SKIP_UPDATE_CAPABILITIES_TESTS = os.getenv("COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST", "false") == "true"
-SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities update does not currently support parallel execution. Skip these tests from live test pipeline."
+SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities are skipped."
+
+def get_test_phone_number():
+    if SKIP_UPDATE_CAPABILITIES_TESTS:
+        return os.getenv("AZURE_PHONE_NUMBER")
+
+    test_agent = os.getenv("AZURE_TEST_AGENT")
+    return os.getenv("AZURE_PHONE_NUMBER_" + test_agent)
 
 class PhoneNumbersClientTestAsync(AsyncCommunicationTestCase):
     def setUp(self):
@@ -33,7 +40,7 @@ class PhoneNumbersClientTestAsync(AsyncCommunicationTestCase):
             self.phone_number = "sanitized"
             self.country_code = "US"
         else:
-            self.phone_number = os.getenv("AZURE_PHONE_NUMBER")
+            self.phone_number = get_test_phone_number()
             self.country_code = os.getenv("AZURE_COMMUNICATION_SERVICE_COUNTRY_CODE", "US")
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str, 

--- a/sdk/communication/azure-communication-phonenumbers/tests.yml
+++ b/sdk/communication/azure-communication-phonenumbers/tests.yml
@@ -19,7 +19,7 @@ stages:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
           MatrixReplace:
-            - SKIP_UPDATE_CAPABILITIES_TESTS=false/true
+            - COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST=false/true
       Clouds: Public,Int
       MatrixConfigs:
         - Name: PhoneNumbers_python_livetest_matrix

--- a/sdk/communication/azure-communication-phonenumbers/tests.yml
+++ b/sdk/communication/azure-communication-phonenumbers/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      BuildTargetingString: 'azure-communication-phonenumbers'
+      BuildTargetingString: "azure-communication-phonenumbers"
       JobName: phonenumbers
       ServiceDirectory: communication
       CloudConfig:
@@ -15,9 +15,14 @@ stages:
           MatrixReplace:
             - TestSamples=.*/true
         Int:
-            SubscriptionConfigurations:
-              - $(sub-config-communication-int-test-resources-common)
-              - $(sub-config-communication-int-test-resources-python)
+          SubscriptionConfigurations:
+            - $(sub-config-communication-int-test-resources-common)
+            - $(sub-config-communication-int-test-resources-python)
+          MatrixReplace:
+            - SKIP_UPDATE_CAPABILITIES_TESTS=false/true
       Clouds: Public,Int
-      EnvVars:
-        COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST: true
+      MatrixConfigs:
+        - Name: PhoneNumbers_python_livetest_matrix
+          Path: sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true


### PR DESCRIPTION
This implements a simple pool of available phone numbers to use in live test pipelines. This solves an issue with the update capabilities live tests caused when multiple tests attempt to modify the state of a phone number simultaneously. 

In order to make use of this, the following environment variables need to be passed:
- `AZURE_TEST_AGENT` specifies the OS and runtime configuration for the job. It should contain the OS, the OS version and the framework/runtime version separated by underscores; e.g. `windows_2019_python36`.
- `AZURE_PHONE_NUMBER_<AZURE_TEST_AGENT>`, where _`<AZURE_TEST_AGENT>`_ corresponds to the value of the variable described prior; e.g. `AZURE_PHONE_NUMBER_windows_2019_python36`.

Additionally, by setting the `COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST` variable to `true`, update capabilities tests can be skipped altoghether. This is useful because the amount of phone numbers available for testing (currently limited to 3) is smaller than the number of test jobs running in parallel.

**NOTE: If either the `AZURE_TEST_AGENT` or `AZURE_PHONE_NUMBER_<AZURE_TEST_AGENT>` are not present when running live tests and `COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST=false`, then the test run will fail. In any other scenario, the `AZURE_PHONE_NUMBER` will be used.**

This PR is a follow-up to #22911.