### PR TITLE
pin markupsafe

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -180,6 +180,7 @@ deps =
   recommonmark==0.6.0
   mistune<2.0.0
   m2r==0.2.1
+  markupsafe==2.0.1
 commands =
   {envbindir}/python {toxinidir}/../../../eng/tox/prep_sphinx_env.py -d {distdir} -t {toxinidir}
   {envbindir}/python {toxinidir}/../../../eng/tox/run_sphinx_apidoc.py \


### PR DESCRIPTION
Seeing this in the CI: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1377829&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=651a14cc-88df-515d-1311-e0e8b23b578a&l=1078

We take a dependency on jinja2 which takes a dep on markupsafe. It seems markupsafe released yesterday and introduced breaking changes. Trying to pin to the older version to see if it resolves CI.