### PR TITLE
[Communication] - phone-numbers - Use upper-case values for test agent values

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
+++ b/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
@@ -14,13 +14,13 @@
       "windows-2019": {
         "OSVmImage": "MMS2019",
         "Pool": "azsdk-pool-mms-win-2019-general",
-        "AZURE_TEST_AGENT": "windows_2019_python36",
+        "AZURE_TEST_AGENT": "WINDOWS_2019_PYTHON36",
         "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
       },
       "macOS-10.15": {
         "OSVmImage": "macOS-10.15",
         "Pool": "Azure Pipelines",
-        "AZURE_TEST_AGENT": "macos_1015_python37",
+        "AZURE_TEST_AGENT": "MACOS_1015_PYTHON37",
         "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
       }
     },
@@ -37,7 +37,7 @@
           "PythonVersion": "3.9",
           "CoverageArg": "",
           "TestSamples": "false",
-          "AZURE_TEST_AGENT": "ubuntu_2004_python39",
+          "AZURE_TEST_AGENT": "UBUNTU_2004_PYTHON39",
           "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "false"
         }
       }


### PR DESCRIPTION
When running within the ADO pipeline, the env variable keys are converted to upper-case, which causes issues when running in a case-sensitive OS.

Using uppercase values prevents this issue.