### PR TITLE
[Test Proxy] Add custom matcher setter and ignore unnecessary headers

### DIFF
--- a/sdk/eventgrid/azure-eventgrid/tests/conftest.py
+++ b/sdk/eventgrid/azure-eventgrid/tests/conftest.py
@@ -27,7 +27,7 @@ import platform
 import sys
 import pytest
 from devtools_testutils import test_proxy
-from devtools_testutils.sanitizers import add_remove_header_sanitizer, add_general_regex_sanitizer, set_bodiless_matcher
+from devtools_testutils.sanitizers import add_remove_header_sanitizer, add_general_regex_sanitizer, set_custom_default_matcher
 
 # Ignore async tests for Python < 3.5
 collect_ignore_glob = []
@@ -37,7 +37,10 @@ if sys.version_info < (3, 5):
 
 @pytest.fixture(scope="session", autouse=True)
 def add_aeg_sanitizer(test_proxy):
-    set_bodiless_matcher()
+    # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+    set_custom_default_matcher(
+        compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+    )
     add_remove_header_sanitizer(headers="aeg-sas-key, aeg-sas-token")
     add_general_regex_sanitizer(
         value="fakeresource",

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer import DocumentAnalysisClient, DocumentModelAdministrationClient, AnalyzeResult
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import AnalyzeResultOperation
@@ -41,7 +41,10 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_custom_document_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url, "template")
@@ -87,7 +90,10 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_custom_document_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         poller = client.begin_build_model(formrecognizer_multipage_storage_container_sas_url, "template")
@@ -133,7 +139,10 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         poller = client.begin_build_model(formrecognizer_selection_mark_storage_container_sas_url, "template")
@@ -179,7 +188,10 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_pages_kwarg_specified(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         with open(self.form_jpg, "rb") as fd:
@@ -197,7 +209,10 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_custom_document_signature_field(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         with open(self.form_jpg, "rb") as fd:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import AnalyzeResultOperation
 from azure.ai.formrecognizer.aio import DocumentAnalysisClient, DocumentModelAdministrationClient
@@ -47,7 +47,10 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_document_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         responses = []
@@ -95,7 +98,10 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_document_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         responses = []
@@ -143,7 +149,10 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
         with open(self.selection_form_pdf, "rb") as fd:
             my_file = fd.read()
@@ -189,7 +198,10 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_pages_kwarg_specified(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         with open(self.form_jpg, "rb") as fd:
@@ -209,7 +221,10 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_document_signature_field(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         with open(self.form_jpg, "rb") as fd:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer import DocumentAnalysisClient, DocumentModelAdministrationClient, AnalyzeResult
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import AnalyzeResultOperation
@@ -41,7 +41,10 @@ class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         poller = client.begin_build_model(formrecognizer_selection_mark_storage_container_sas_url, "template")
@@ -84,7 +87,10 @@ class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_label_tables_variable_rows(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         build_poller = client.begin_build_model(formrecognizer_table_variable_rows_container_sas_url, "template")
@@ -126,7 +132,10 @@ class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_label_tables_fixed_rows(self, client, formrecognizer_table_fixed_rows_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         build_poller = client.begin_build_model(formrecognizer_table_fixed_rows_container_sas_url, "template")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer.aio import DocumentAnalysisClient, DocumentModelAdministrationClient
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import AnalyzeResultOperation
@@ -45,7 +45,10 @@ class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         responses = []
@@ -90,7 +93,10 @@ class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_label_tables_variable_rows(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         responses = []
@@ -135,7 +141,10 @@ class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_label_tables_fixed_rows(self, client, formrecognizer_table_fixed_rows_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         da_client = client.get_document_analysis_client()
 
         responses = []

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from datetime import date, time
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError, ServiceRequestError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer import DocumentAnalysisClient, AnalyzeResult
@@ -29,7 +29,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_business_card_multipage_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_analyze_document_from_url("prebuilt-businessCard", self.business_card_multipage_url_pdf)
         result = poller.result()
 
@@ -89,7 +92,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_identity_document_jpg_passport(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_analyze_document_from_url("prebuilt-idDocument", self.identity_document_url_jpg_passport)
 
         result = poller.result()
@@ -111,7 +117,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_identity_document_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_analyze_document_from_url("prebuilt-idDocument", self.identity_document_url_jpg)
 
         result = poller.result()
@@ -133,7 +142,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_invoice_tiff(self, client, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_analyze_document_from_url(model="prebuilt-invoice", document_url=self.invoice_url_tiff)
 
         result = poller.result()
@@ -155,7 +167,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key), polling_interval=7)
         assert client._client._config.polling_interval ==  7
 
@@ -179,7 +194,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipts_encoded_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         try:
             poller = client.begin_analyze_document_from_url("prebuilt-receipt", "https://fakeuri.com/blank%20space")
         except HttpResponseError as e:
@@ -189,7 +207,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_receipt_url_bad_endpoint(self, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(ServiceRequestError):
             client = DocumentAnalysisClient("http://notreal.azure.com", AzureKeyCredential(formrecognizer_test_api_key))
             poller = client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg)
@@ -197,7 +218,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_receipt_url_auth_bad_key(self, formrecognizer_test_endpoint, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             poller = client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg)
@@ -206,7 +230,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_bad_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError):
             poller = client.begin_analyze_document_from_url("prebuilt-receipt", "https://badurl.jpg")
 
@@ -214,7 +241,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_url_pass_stream(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with open(self.receipt_png, "rb") as receipt:
             with pytest.raises(HttpResponseError):
                 poller = client.begin_analyze_document_from_url("prebuilt-receipt", receipt)
@@ -223,7 +253,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_url_transform_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -261,7 +294,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_url_png(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_png)
 
@@ -283,7 +319,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_multipage_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_analyze_document_from_url("prebuilt-receipt", self.multipage_receipt_url_pdf)
         result = poller.result()
@@ -317,7 +356,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_multipage_transform_url(self, client, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         responses = []
 
@@ -369,7 +411,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_locale_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg, locale="en-IN")
         assert 'en-IN' == poller._polling_method._initial_response.http_response.request.query['locale']
         result = poller.result()
@@ -379,7 +424,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_receipt_locale_error(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg, locale="not a locale")
         assert "InvalidArgument" == e.value.error.code
@@ -388,7 +436,10 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
     def test_pages_kwarg_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg, pages="1")
         assert '1' == poller._polling_method._initial_response.http_response.request.query['pages']
         result = poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
@@ -8,7 +8,7 @@ import pytest
 import functools
 from datetime import date, time
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, ServiceRequestError
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer.aio import DocumentAnalysisClient
@@ -31,7 +31,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_business_card_multipage_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         async with client:
             poller = await client.begin_analyze_document_from_url("prebuilt-businessCard", self.business_card_multipage_url_pdf)
@@ -93,7 +96,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_identity_document_jpg_passport(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_analyze_document_from_url("prebuilt-idDocument", self.identity_document_url_jpg_passport)
 
@@ -116,7 +122,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_identity_document_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_analyze_document_from_url("prebuilt-idDocument", self.identity_document_url_jpg)
 
@@ -139,7 +148,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_invoice_tiff(self, client, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_analyze_document_from_url(model="prebuilt-invoice", document_url=self.invoice_url_tiff)
 
@@ -162,7 +174,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key), polling_interval=7)
         assert client._client._config.polling_interval ==  7
 
@@ -192,7 +207,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipts_encoded_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             async with client:
                 poller = await client.begin_analyze_document_from_url("prebuilt-receipt", "https://fakeuri.com/blank%20space")
@@ -202,7 +220,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_receipt_url_bad_endpoint(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(ServiceRequestError):
             client = DocumentAnalysisClient("http://notreal.azure.com", AzureKeyCredential(formrecognizer_test_api_key))
             async with client:
@@ -215,7 +236,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_receipt_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             async with client:
@@ -229,7 +253,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_bad_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError):
             async with client:
                 poller = await client.begin_analyze_document_from_url("prebuilt-receipt", "https://badurl.jpg")
@@ -239,7 +266,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_url_pass_stream(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         with open(self.receipt_png, "rb") as fd:
             receipt = fd.read(4)  # makes the recording smaller
@@ -253,7 +283,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_url_transform_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         responses = []
 
@@ -293,7 +326,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_url_png(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         async with client:
             poller = await client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_png)
@@ -316,7 +352,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_multipage_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         async with client:
             poller = await client.begin_analyze_document_from_url("prebuilt-receipt", self.multipage_receipt_url_pdf)
@@ -350,7 +389,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_multipage_transform_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         responses = []
 
@@ -404,7 +446,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_locale_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg, locale="en-IN")
             assert 'en-IN' == poller._polling_method._initial_response.http_response.request.query['locale']
@@ -415,7 +460,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_locale_error(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             async with client:
                 await client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg, locale="not a locale")
@@ -425,7 +473,10 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
     async def test_pages_kwarg_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_analyze_document_from_url("prebuilt-receipt", self.receipt_url_jpg, pages="1")
             assert '1' == poller._polling_method._initial_response.http_response.request.query['pages']

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
@@ -7,7 +7,7 @@
 import pytest
 import uuid
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.formrecognizer import DocumentModelAdministrationClient, DocumentModel
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import GetOperationResponse, ModelInfo
 from testcase import FormRecognizerTest
@@ -26,7 +26,10 @@ class TestTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_compose_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         model_id_1 = str(uuid.uuid4())
         model_id_2 = str(uuid.uuid4())
         composed_id = str(uuid.uuid4())
@@ -57,7 +60,10 @@ class TestTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_compose_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url, "template", description="model1")
         model_1 = poller.result()
 
@@ -109,7 +115,10 @@ class TestTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url, "template")
         model_1 = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
@@ -8,7 +8,7 @@ import pytest
 import uuid
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.ai.formrecognizer.aio import DocumentModelAdministrationClient
 from azure.ai.formrecognizer import DocumentModel
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import GetOperationResponse, ModelInfo
@@ -27,7 +27,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_compose_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         model_id_1 = str(uuid.uuid4())
         model_id_2 = str(uuid.uuid4())
         composed_id = str(uuid.uuid4())
@@ -59,7 +62,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_compose_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         raw_response = []
 
         def callback(response, _, headers):
@@ -113,7 +119,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url, "template")
             model_1 = await poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
@@ -7,7 +7,7 @@
 import functools
 import pytest
 import logging
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import ResourceNotFoundError, ClientAuthenticationError
 from azure.core.pipeline.transport import RequestsTransport
@@ -104,7 +104,10 @@ class TestManagement(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_mgmt_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url, description="mgmt model")
         model = poller.result()
@@ -200,7 +203,10 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_get_document_analysis_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()  
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  
         transport = RequestsTransport()
         dtc = DocumentModelAdministrationClient(endpoint=formrecognizer_test_endpoint, credential=AzureKeyCredential(formrecognizer_test_api_key), transport=transport)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.pipeline.transport import AioHttpTransport
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import ResourceNotFoundError, ClientAuthenticationError
@@ -111,7 +111,10 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_mgmt_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()  
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  
         
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url, "template", description="mgmt model")
@@ -205,7 +208,10 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_get_document_analysis_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()  
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  
         transport = AioHttpTransport()
         dtc = DocumentModelAdministrationClient(endpoint=formrecognizer_test_endpoint, credential=AzureKeyCredential(formrecognizer_test_api_key), transport=transport)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
@@ -7,7 +7,7 @@
 import uuid
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import GetOperationResponse, ModelInfo
@@ -28,7 +28,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_polling_interval(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         def check_poll_value(poll):
             if self.is_live:
                 assert poll == 5
@@ -47,7 +50,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_encoded_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError):
             poller = client.begin_build_model(
                 source="https://fakeuri.com/blank%20space", build_mode="template"
@@ -58,7 +64,10 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_build_model_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = DocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             poller = client.begin_build_model("xx", build_mode="template")
@@ -67,7 +76,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         model_id = str(uuid.uuid4())
         poller = client.begin_build_model(
             formrecognizer_storage_container_sas_url,
@@ -96,7 +108,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_multipage(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_build_model(formrecognizer_multipage_storage_container_sas_url, "template")
         model = poller.result()
@@ -118,7 +133,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_nested_schema(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_build_model(formrecognizer_table_variable_rows_container_sas_url, "template")
         model = poller.result()
@@ -137,7 +155,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         raw_response = []
 
@@ -164,7 +185,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         raw_response = []
 
@@ -186,7 +210,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_nested_schema_transform(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         raw_response = []
 
@@ -214,7 +241,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_azure_blob_path_filter(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             poller = client.begin_build_model(formrecognizer_storage_container_sas_url, "template", prefix="subfolder")
             model = poller.result()
@@ -236,7 +266,10 @@ class TestDMACTraining(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
     def test_build_model_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url, "template")
         assert poller.operation_id
         assert poller.percent_completed is not None

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
@@ -8,7 +8,7 @@ import uuid
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.ai.formrecognizer._generated.v2022_01_30_preview.models import GetOperationResponse, ModelInfo
@@ -31,7 +31,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_build_model_polling_interval(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         def check_poll_value(poll):
             if self.is_live:
                 assert poll == 5
@@ -50,7 +53,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_build_model_encoded_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError):
             async with client:
                 poller = await client.begin_build_model(
@@ -63,7 +69,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_build_model_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = DocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             async with client:
@@ -74,7 +83,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_build_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         model_id = str(uuid.uuid4())
         async with client:
             poller = await client.begin_build_model(
@@ -104,7 +116,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_build_model_multipage(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_build_model(formrecognizer_multipage_storage_container_sas_url, "template")
             model = await poller.result()
@@ -126,7 +141,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_build_model_nested_schema(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_build_model(formrecognizer_table_variable_rows_container_sas_url, "template")
             model = await poller.result()
@@ -146,7 +164,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @recorded_by_proxy_async
     async def test_build_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
 
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         raw_response = []
 
         def callback(response, _, headers):
@@ -174,7 +195,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @recorded_by_proxy_async
     async def test_build_model_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
 
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         raw_response = []
 
         def callback(response, _, headers):
@@ -197,7 +221,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @recorded_by_proxy_async
     async def test_build_model_nested_schema_transform(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
 
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         raw_response = []
 
         def callback(response, _, headers):
@@ -225,7 +252,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_build_model_azure_blob_path_filter(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             async with client:
                 poller = await client.begin_build_model(formrecognizer_storage_container_sas_url, "template", prefix="subfolder")
@@ -249,7 +279,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_build_model_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url, "template")
             assert poller.operation_id

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from io import BytesIO
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.formrecognizer import FormRecognizerClient, FormContentType, FormRecognizerApiVersion
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
@@ -27,7 +27,10 @@ class TestBusinessCard(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_passing_enum_content_type(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with open(self.business_card_png, "rb") as fd:
             my_file = fd.read()
         poller = client.begin_recognize_business_cards(
@@ -73,7 +76,10 @@ class TestBusinessCard(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_business_card_multipage_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with open(self.business_card_multipage_pdf, "rb") as fd:
             receipt = fd.read()
         poller = client.begin_recognize_business_cards(receipt, include_field_elements=True)
@@ -136,7 +142,10 @@ class TestBusinessCard(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_business_card_jpg_include_field_elements(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with open(self.business_card_jpg, "rb") as fd:
             business_card = fd.read()
         poller = client.begin_recognize_business_cards(business_card, include_field_elements=True)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersion
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
@@ -25,7 +25,10 @@ class TestBusinessCardFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_business_card_jpg_include_field_elements(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_business_cards_from_url(self.business_card_url_jpg, include_field_elements=True)
 
         result = poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.ai.formrecognizer import FormRecognizerApiVersion
 from azure.ai.formrecognizer.aio import FormRecognizerClient
 from preparers import FormRecognizerPreparer
@@ -26,7 +26,10 @@ class TestBusinessCardFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_business_card_jpg_include_field_elements(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_business_cards_from_url(self.business_card_url_jpg, include_field_elements=True)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
@@ -28,7 +28,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_content_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             poller = client.begin_recognize_content_from_url(self.invoice_url_pdf)
@@ -37,7 +40,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_url_pass_stream(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with open(self.receipt_jpg, "rb") as receipt:
             with pytest.raises(HttpResponseError):
                 poller = client.begin_recognize_content_from_url(receipt)
@@ -46,7 +52,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_url_transform_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -69,7 +78,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_url_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(self.invoice_url_pdf)
         result = poller.result()
         assert len(result) == 1
@@ -84,7 +96,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_url_transform_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -107,7 +122,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_url_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(self.form_url_jpg)
         result = poller.result()
         assert len(result) == 1
@@ -125,7 +143,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_multipage_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(self.multipage_url_pdf)
         result = poller.result()
 
@@ -136,7 +157,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_multipage_transform_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -172,7 +196,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_multipage_table_span_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(self.multipage_table_url_pdf)
         result = poller.result()
         assert len(result) == 2
@@ -197,7 +224,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_selection_marks(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(form_url=self.selection_mark_url_pdf)
         result = poller.result()
         assert len(result) == 1
@@ -209,7 +239,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy
     def test_content_selection_marks_v2(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(form_url=self.selection_mark_url_pdf)
         result = poller.result()
         assert len(result) == 1
@@ -221,7 +254,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_specify_pages(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(self.multipage_url_pdf, pages=["1"])
         result = poller.result()
         assert len(result) == 1
@@ -242,7 +278,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_reading_order(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(self.form_url_jpg, reading_order="natural")
 
         assert 'natural' == poller._polling_method._initial_response.http_response.request.query['readingOrder']
@@ -253,7 +292,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_language_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_content_from_url(self.form_url_jpg, language="de")
         assert 'de' == poller._polling_method._initial_response.http_response.request.query['language']
         result = poller.result()
@@ -263,7 +305,10 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_content_language_error(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             client.begin_recognize_content_from_url(self.form_url_jpg, language="not a language")
         assert "NotSupportedLanguage" == e.value.error.code

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError, ServiceRequestError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
@@ -30,7 +30,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_content_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             async with client:
@@ -41,7 +44,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_url_pass_stream(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read(4)  # makes the recording smaller
 
@@ -54,7 +60,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_url_transform_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -78,7 +87,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_url_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(self.invoice_url_pdf)
             result = await poller.result()
@@ -94,7 +106,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_multipage_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(self.multipage_url_pdf)
             result = await poller.result()
@@ -105,7 +120,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_multipage_transform_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -143,7 +161,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_multipage_table_span_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(self.multipage_table_url_pdf)
             result = await poller.result()
@@ -169,7 +190,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_selection_marks(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(form_url=self.selection_mark_url_pdf)
             result = await poller.result()
@@ -182,7 +206,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy_async
     async def test_content_selection_marks_v2(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(form_url=self.selection_mark_url_pdf)
             result = await poller.result()
@@ -195,7 +222,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_specify_pages(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(self.multipage_url_pdf, pages=["1"])
             result = await poller.result()
@@ -217,7 +247,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_reading_order(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(self.form_url_jpg, reading_order="natural")
 
@@ -229,7 +262,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_language_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_content_from_url(self.form_url_jpg, language="de")
             assert 'de' == poller._polling_method._initial_response.http_response.request.query['language']
@@ -240,7 +276,10 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_content_language_error(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             with pytest.raises(HttpResponseError) as e:
                 await client.begin_recognize_content_from_url(self.form_url_jpg, language="not a language")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.formrecognizer import FormContentType, FormTrainingClient, _models
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
 from azure.ai.formrecognizer._response_handlers import prepare_form_result
@@ -26,7 +26,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_unlabeled(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
@@ -47,7 +50,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=False)
@@ -71,7 +77,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_labeled(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(
@@ -94,7 +103,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(
@@ -121,7 +133,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_unlabeled_transform(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
@@ -176,7 +191,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=False)
@@ -246,7 +264,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_2_v2, use_training_labels=False)
@@ -288,7 +309,10 @@ class TestCustomForms(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_2_v2, use_training_labels=True)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.ai.formrecognizer import FormContentType
 from azure.ai.formrecognizer.aio import FormTrainingClient
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
@@ -29,7 +29,10 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_unlabeled(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         with open(self.form_jpg, "rb") as fd:
@@ -49,7 +52,10 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         with open(self.multipage_invoice_pdf, "rb") as fd:
             my_file = fd.read()
@@ -76,7 +82,10 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         with open(self.multipage_invoice_pdf, "rb") as fd:
             my_file = fd.read()
@@ -104,7 +113,10 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_forms_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         responses = []
@@ -180,7 +192,10 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         responses = []
@@ -224,7 +239,10 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
 
         responses = []

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.formrecognizer import FormTrainingClient
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
 from azure.ai.formrecognizer._response_handlers import prepare_form_result
@@ -26,7 +26,10 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         fr_client = client.get_form_recognizer_client()
 
@@ -49,7 +52,10 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         fr_client = client.get_form_recognizer_client()
 
@@ -73,7 +79,10 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=False)
@@ -112,7 +121,10 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
@@ -178,7 +190,10 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_2_v2, "multipage-vendor-forms", "multi1.pdf")
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_2_v2, use_training_labels=False)
@@ -217,7 +232,10 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_2_v2, "multipage-vendor-forms", "multi1.pdf")
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_2_v2, use_training_labels=True)
@@ -257,7 +275,10 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy
     def test_pages_kwarg_specified(self, client, formrecognizer_testing_data_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_testing_data_container_sas_url, "testingdata", "multi1.pdf")
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.ai.formrecognizer.aio import FormTrainingClient
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
 from azure.ai.formrecognizer._response_handlers import prepare_form_result
@@ -28,7 +28,10 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         async with client:
@@ -52,7 +55,10 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         async with client:
@@ -77,7 +83,10 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         responses = []
@@ -119,7 +128,10 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_multipage_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_v2, "multipage-training-data", "multipage_invoice1.pdf")
         responses = []
@@ -189,7 +201,10 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_2_v2, "multipage-vendor-forms", "multi1.pdf")
         responses = []
@@ -229,7 +244,10 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_multipage_storage_container_sas_url_2_v2, "multipage-vendor-forms", "multi1.pdf")
         responses = []
@@ -271,7 +289,10 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
     async def test_pages_kwarg_specified(self, client, formrecognizer_testing_data_container_sas_url, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         fr_client = client.get_form_recognizer_client()
         blob_sas_url = _get_blob_url(formrecognizer_testing_data_container_sas_url, "testingdata", "multi1.pdf")
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from datetime import date
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
 from azure.ai.formrecognizer._response_handlers import prepare_prebuilt_models
@@ -27,7 +27,10 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key), polling_interval=7)
         assert client._client._config.polling_interval ==  7
 
@@ -42,7 +45,10 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_identity_document_url_transform_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -79,7 +85,10 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_identity_document_jpg_include_field_elements(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg, include_field_elements=True)
 
         result = poller.result()
@@ -121,7 +130,10 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_pages_kwarg_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg, pages=["1"])
         assert '1' == poller._polling_method._initial_response.http_response.request.query['pages']
         result = poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
 from azure.ai.formrecognizer._response_handlers import prepare_prebuilt_models
@@ -28,7 +28,10 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key), polling_interval=7)
         assert client._client._config.polling_interval ==  7
 
@@ -44,7 +47,10 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_identity_document_url_transform_jpg(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -82,7 +88,10 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_identity_document_jpg_include_field_elements(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg, include_field_elements=True)
 
@@ -127,7 +136,10 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_pages_kwarg_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg, pages=["1"])
             assert '1' == poller._polling_method._initial_response.http_response.request.query['pages']

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
@@ -27,7 +27,10 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key), polling_interval=7)
         assert client._client._config.polling_interval ==  7
 
@@ -42,7 +45,10 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_invoice_bad_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError):
             poller = client.begin_recognize_invoices_from_url("https://badurl.jpg")
 
@@ -50,7 +56,10 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_invoice_url_multipage_transform_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -113,7 +122,10 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_invoice_locale_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_invoices_from_url(self.invoice_url_pdf, locale="en-US")
         assert 'en-US' == poller._polling_method._initial_response.http_response.request.query['locale']
         result = poller.result()
@@ -123,7 +135,10 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_invoice_locale_error(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             client.begin_recognize_invoices_from_url(self.invoice_url_pdf, locale="not a locale")
         assert "locale" in e.value.error.message
@@ -132,7 +147,10 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_pages_kwarg_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         poller = client.begin_recognize_invoices_from_url(self.invoice_url_pdf, pages=["1"])
         assert '1' == poller._polling_method._initial_response.http_response.request.query['pages']
         result = poller.result()
@@ -142,7 +160,10 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_invoice_no_sub_line_items(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_recognize_invoices_from_url(
             invoice_url=self.invoice_no_sub_line_item,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
@@ -30,7 +30,10 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential(formrecognizer_test_api_key), polling_interval=7)
         assert client._client._config.polling_interval ==  7
 
@@ -46,7 +49,10 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_invoice_bad_url(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError):
             async with client:
                 poller = await client.begin_recognize_invoices_from_url("https://badurl.jpg")
@@ -55,7 +61,10 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_invoice_url_multipage_transform_pdf(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -120,7 +129,10 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_invoice_locale_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_invoices_from_url(self.invoice_url_pdf, locale="en-US")
             assert 'en-US' == poller._polling_method._initial_response.http_response.request.query['locale']
@@ -131,7 +143,10 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_invoice_locale_error(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         with pytest.raises(HttpResponseError) as e:
             async with client:
                 await client.begin_recognize_invoices_from_url(self.invoice_url_pdf, locale="not a locale")
@@ -141,7 +156,10 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_pages_kwarg_specified(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_recognize_invoices_from_url(self.invoice_url_pdf, pages=["1"])
             assert '1' == poller._polling_method._initial_response.http_response.request.query['pages']

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from datetime import date, time
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
 from azure.ai.formrecognizer._response_handlers import prepare_prebuilt_models
 from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersion
@@ -26,7 +26,10 @@ class TestReceiptFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_receipt_url_transform_png(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         responses = []
 
@@ -64,7 +67,10 @@ class TestReceiptFromUrl(FormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
     def test_receipt_url_include_field_elements(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_recognize_receipts_from_url(
             self.receipt_url_jpg,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
@@ -8,7 +8,7 @@ import pytest
 import functools
 from datetime import date, time
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.ai.formrecognizer._generated.v2_1.models import AnalyzeOperationResult
 from azure.ai.formrecognizer._response_handlers import prepare_prebuilt_models
 from azure.ai.formrecognizer import FormRecognizerApiVersion
@@ -28,7 +28,10 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_url_transform_png(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         responses = []
 
         def callback(raw_response, _, headers):
@@ -66,7 +69,10 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
     async def test_receipt_url_include_field_elements(self, client):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         async with client:
             poller = await client.begin_recognize_receipts_from_url(

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.ai.formrecognizer import FormTrainingClient, CustomFormModel
 from testcase import FormRecognizerTest
@@ -26,7 +26,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_compose_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
         model_1 = poller.result()
@@ -46,7 +49,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_compose_model_invalid_unlabeled_models_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
         model_1 = poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.ai.formrecognizer.aio import FormTrainingClient
 from azure.ai.formrecognizer import CustomFormModel
@@ -28,7 +28,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_compose_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
             model_1 = await poller.result()
@@ -48,7 +51,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_compose_model_invalid_unlabeled_models_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
             model_1 = await poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
@@ -7,7 +7,7 @@
 import pytest
 import uuid
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.ai.formrecognizer import FormTrainingClient
 from testcase import FormRecognizerTest
@@ -26,7 +26,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
     def test_copy_model_successful_v2(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
         model = poller.result()
@@ -49,7 +52,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_copy_model_with_labeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="mymodel")
         model = poller.result()
@@ -73,7 +79,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_copy_model_with_unlabeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False, model_name="mymodel")
         model = poller.result()
@@ -97,7 +106,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_copy_model_fail_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
         model = poller.result()
@@ -115,7 +127,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_copy_model_case_insensitive_region_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
         model = poller.result()
@@ -136,7 +151,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
     def test_copy_authorization_v2(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         target = client.get_copy_authorization(resource_region="eastus", resource_id=formrecognizer_resource_id)
 
@@ -150,7 +168,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_copy_authorization_v21(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         target = client.get_copy_authorization(resource_region="eastus", resource_id=formrecognizer_resource_id)
 
@@ -164,7 +185,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_copy_model_with_composed_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller_1 = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="model1")
         model_1 = poller_1.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
@@ -8,7 +8,7 @@ import pytest
 import functools
 import uuid
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.ai.formrecognizer.aio import FormTrainingClient
 from preparers import FormRecognizerPreparer
@@ -28,7 +28,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
     async def test_copy_model_successful_v2(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
             model = await poller.result()
@@ -51,7 +54,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_copy_model_with_labeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="mymodel")
             model = await poller.result()
@@ -75,7 +81,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_copy_model_with_unlabeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False, model_name="mymodel")
             model = await poller.result()
@@ -99,7 +108,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_copy_model_fail_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
             model = await poller.result()
@@ -117,7 +129,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_copy_model_case_insensitive_region_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
             model = await poller.result()
@@ -138,7 +153,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
     async def test_copy_authorization_v2(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             target = await client.get_copy_authorization(resource_region="eastus", resource_id=formrecognizer_resource_id)
 
@@ -152,7 +170,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_copy_authorization_v21(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             target = await client.get_copy_authorization(resource_region="eastus", resource_id=formrecognizer_resource_id)
 
@@ -166,7 +187,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_copy_model_with_composed_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller_1 = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="model1")
             model_1 = await poller_1.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
@@ -6,7 +6,7 @@
 
 import functools
 import pytest
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import ResourceNotFoundError
 from azure.core.pipeline.transport import RequestsTransport
@@ -113,7 +113,10 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_get_form_recognizer_client_v2(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()  
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  
         transport = RequestsTransport()
         ftc = FormTrainingClient(endpoint=formrecognizer_test_endpoint, credential=AzureKeyCredential(formrecognizer_test_api_key), transport=transport, api_version="2.1")
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.pipeline.transport import AioHttpTransport
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import ResourceNotFoundError
@@ -114,7 +114,10 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_get_form_recognizer_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
-        set_bodiless_matcher()  
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  
         transport = AioHttpTransport()
         ftc = FormTrainingClient(endpoint=formrecognizer_test_endpoint, credential=AzureKeyCredential(formrecognizer_test_api_key), transport=transport, api_version="2.1")
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
@@ -6,7 +6,7 @@
 
 import pytest
 import functools
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.ai.formrecognizer._models import CustomFormModel
 from azure.ai.formrecognizer import FormTrainingClient
@@ -25,7 +25,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
     def test_training_with_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
         model = poller.result()
@@ -54,7 +57,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
     def test_training_multipage_with_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
         model = poller.result()
@@ -81,7 +87,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
     def test_training_without_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
         model = poller.result()
@@ -110,7 +119,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
     def test_training_multipage_without_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
         model = poller.result()
@@ -136,7 +148,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
     def test_training_with_files_filter_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=False, include_subfolders=True)
         model = poller.result()
@@ -158,7 +173,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_training_with_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="my labeled model")
         model = poller.result()
@@ -188,7 +206,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_training_multipage_with_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
         model = poller.result()
@@ -214,7 +235,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_training_without_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="my labeled model")
         model = poller.result()
@@ -244,7 +268,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_training_multipage_without_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
         model = poller.result()
@@ -270,7 +297,10 @@ class TestTraining(FormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
     def test_training_with_files_filter_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         
         poller = client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=False, include_subfolders=True)
         model = poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
@@ -7,7 +7,7 @@
 import pytest
 import functools
 from devtools_testutils.aio import recorded_by_proxy_async
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from azure.core.exceptions import HttpResponseError
 from azure.ai.formrecognizer._models import CustomFormModel
 from azure.ai.formrecognizer.aio import FormTrainingClient
@@ -28,7 +28,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
     async def test_training_with_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
             model = await poller.result()
@@ -57,7 +60,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
     async def test_training_multipage_with_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
             model = await poller.result()
@@ -84,7 +90,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
     async def test_training_without_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
             model = await poller.result()
@@ -113,7 +122,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
     async def test_training_multipage_without_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
             model = await poller.result()
@@ -139,7 +151,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
     async def test_training_with_files_filter_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=False, include_subfolders=True)
             model = await poller.result()
@@ -161,7 +176,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_training_with_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="my labeled model")
             model = await poller.result()
@@ -191,7 +209,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_training_multipage_with_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
             model = await poller.result()
@@ -217,7 +238,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_training_without_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=True, model_name="my labeled model")
             model = await poller.result()
@@ -247,7 +271,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_training_multipage_without_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(formrecognizer_multipage_storage_container_sas_url_v2, use_training_labels=True)
             model = await poller.result()
@@ -273,7 +300,10 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
     async def test_training_with_files_filter_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         async with client:
             poller = await client.begin_training(training_files_url=formrecognizer_storage_container_sas_url_v2, use_training_labels=False, include_subfolders=True)
             model = await poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -16,7 +16,7 @@ from azure.ai.formrecognizer._helpers import (
     adjust_confidence,
     adjust_text_angle
 )
-from devtools_testutils import AzureRecordedTestCase, set_bodiless_matcher
+from devtools_testutils import AzureRecordedTestCase, set_custom_default_matcher
 
 LOGGING_FORMAT = '%(asctime)s %(name)-20s %(levelname)-5s %(message)s'
 ENABLE_LOGGER = os.getenv('ENABLE_LOGGER', "False")

--- a/sdk/netapp/azure-mgmt-netapp/tests/test_account_backup.py
+++ b/sdk/netapp/azure-mgmt-netapp/tests/test_account_backup.py
@@ -1,6 +1,6 @@
 import pytest
 from azure.mgmt.resource import ResourceManagementClient
-from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 from azure.mgmt.netapp.models import Backup
 from test_account import delete_account
 from test_volume import delete_volume, delete_pool
@@ -18,7 +18,10 @@ class TestNetAppAccountBackup(AzureMgmtRecordedTestCase):
     # Note that when tests are run in live mode it is best to run one test at a time.
     @recorded_by_proxy
     def test_list_account_backups(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_backup(self.client, backup_name=TEST_BACKUP_1, live=self.is_live)
         create_backup(self.client, backup_name=TEST_BACKUP_2, backup_only=True, live=self.is_live)
 
@@ -47,7 +50,10 @@ class TestNetAppAccountBackup(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_get_account_backups(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_backup(self.client, backup_name=TEST_BACKUP_1, live=self.is_live)
 
         account_backup = self.client.account_backups.get(TEST_RG, TEST_ACC_1, TEST_BACKUP_1)
@@ -60,7 +66,10 @@ class TestNetAppAccountBackup(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_delete_account_backups(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_backup(self.client, backup_name=TEST_BACKUP_1, live=self.is_live)
 
         account_backup_list = self.client.account_backups.list(TEST_RG, TEST_ACC_1)

--- a/sdk/netapp/azure-mgmt-netapp/tests/test_backup.py
+++ b/sdk/netapp/azure-mgmt-netapp/tests/test_backup.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 from azure.mgmt.resource import ResourceManagementClient
-from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 from azure.mgmt.netapp.models import Backup, BackupPatch, VolumePatch
 from test_account import delete_account
 from test_volume import create_volume, wait_for_volume, delete_volume, delete_pool
@@ -102,7 +102,10 @@ class TestNetAppBackup(AzureMgmtRecordedTestCase):
     # Note that when tests are run in live mode it is best to run one test at a time.
     @recorded_by_proxy
     def test_create_delete_backup(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         # Create 2 backups since delete backups can only be used when volume has multiple backups
         create_backup(self.client, live=self.is_live)
         create_backup(self.client, backup_name=TEST_BACKUP_2, backup_only=True, live=self.is_live)
@@ -123,7 +126,10 @@ class TestNetAppBackup(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_list_backup(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_backup(self.client, live=self.is_live)
         create_backup(self.client, backup_name=TEST_BACKUP_2, backup_only=True, live=self.is_live)
         backup_list = get_backup_list(self.client)
@@ -143,7 +149,10 @@ class TestNetAppBackup(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_get_backup_by_name(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_backup(self.client, live=self.is_live)
 
         backup = get_backup(self.client, TEST_BACKUP_1)
@@ -153,7 +162,10 @@ class TestNetAppBackup(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_update_backup(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_backup(self.client, live=self.is_live)
         backup_body = BackupPatch(location=LOCATION, label="label1")
         self.client.backups.begin_update(TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, TEST_BACKUP_1, backup_body).wait()
@@ -165,7 +177,10 @@ class TestNetAppBackup(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_get_backup_status(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_backup(self.client, live=self.is_live)
 
         if self.is_live:

--- a/sdk/netapp/azure-mgmt-netapp/tests/test_snapshot.py
+++ b/sdk/netapp/azure-mgmt-netapp/tests/test_snapshot.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 from azure.mgmt.resource import ResourceManagementClient
-from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 from azure.mgmt.netapp.models import Volume, Snapshot
 from test_volume import create_volume, wait_for_volume, delete_volume
 from test_pool import delete_pool
@@ -53,7 +53,10 @@ class TestNetAppSnapshot(AzureMgmtRecordedTestCase):
     # Note that when tests are run in live mode it is best to run one test at a time.
     @recorded_by_proxy
     def test_create_delete_snapshot(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_snapshot(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, TEST_SNAPSHOT_1, LOCATION)
 
         snapshot_list = self.client.snapshots.list(TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1)
@@ -69,7 +72,10 @@ class TestNetAppSnapshot(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_list_snapshots(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_snapshot(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, TEST_SNAPSHOT_1, LOCATION)
         create_snapshot(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, TEST_SNAPSHOT_2, LOCATION, snapshot_only=True)
         snapshots = [TEST_SNAPSHOT_1, TEST_SNAPSHOT_2]
@@ -89,7 +95,10 @@ class TestNetAppSnapshot(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_get_snapshot_by_name(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_snapshot(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, TEST_SNAPSHOT_1, LOCATION)
 
         snapshot = self.client.snapshots.get(TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, TEST_SNAPSHOT_1)

--- a/sdk/netapp/azure-mgmt-netapp/tests/test_snapshot_policies.py
+++ b/sdk/netapp/azure-mgmt-netapp/tests/test_snapshot_policies.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 from azure.mgmt.resource import ResourceManagementClient
-from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 from azure.mgmt.netapp.models import SnapshotPolicy, SnapshotPolicyPatch, HourlySchedule, DailySchedule, VolumeSnapshotProperties, VolumePatchPropertiesDataProtection, VolumePatch
 from test_account import create_account, delete_account
 from test_pool import delete_pool
@@ -125,7 +125,10 @@ class TestNetAppSnapshotPolicy(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_assign_snapshot_policy_to_volume(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         # create volume and snapshot policy
         create_volume(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1)
         snapshot_policy = create_snapshot_policy(self.client, TEST_SNAPSHOT_POLICY_1)

--- a/sdk/netapp/azure-mgmt-netapp/tests/test_vault.py
+++ b/sdk/netapp/azure-mgmt-netapp/tests/test_vault.py
@@ -1,5 +1,5 @@
 import pytest
-from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 from test_volume import create_volume, delete_volume, delete_pool, delete_account
 from setup import *
 import azure.mgmt.netapp.models
@@ -14,7 +14,10 @@ class TestNetAppVault(AzureMgmtRecordedTestCase):
     # Note that when tests are run in live mode it is best to run one test at a time.
     @recorded_by_proxy
     def test_get_vault(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_volume(self.client)
         vaults = self.client.vaults.list(TEST_RG, TEST_ACC_1)
         assert len(list(vaults)) == 1

--- a/sdk/netapp/azure-mgmt-netapp/tests/test_volume.py
+++ b/sdk/netapp/azure-mgmt-netapp/tests/test_volume.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 from azure.mgmt.resource import ResourceManagementClient
-from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 from azure.mgmt.netapp.models import Volume, VolumePatch, ReplicationObject, VolumePropertiesDataProtection, AuthorizeRequest, PoolChangeRequest
 from test_pool import create_pool, delete_pool
 from test_account import delete_account
@@ -172,7 +172,10 @@ class TestNetAppVolume(AzureMgmtRecordedTestCase):
     # Note that when tests are run in live mode it is best to run one test at a time.
     @recorded_by_proxy
     def test_create_delete_list_volume(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         volume = create_volume(
             self.client,
             TEST_RG,
@@ -201,7 +204,10 @@ class TestNetAppVolume(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_list_volumes(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_volume(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, LOCATION, live=self.is_live)
         create_volume(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_2, LOCATION, volume_only=True, live=self.is_live)
         volumes = [TEST_VOL_1, TEST_VOL_2]
@@ -220,7 +226,10 @@ class TestNetAppVolume(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_volume_replication(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         source_volume = create_volume(
             self.client,
             TEST_RG,
@@ -313,7 +322,10 @@ class TestNetAppVolume(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_get_volume_by_name(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_volume(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, LOCATION, live=self.is_live)
 
         volume = self.client.volumes.get(TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1)
@@ -325,7 +337,10 @@ class TestNetAppVolume(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_update_volume(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         volume = create_volume(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, live=self.is_live)
         assert "Premium" == volume.service_level
         assert 100 * GIGABYTE == volume.usage_threshold
@@ -355,7 +370,10 @@ class TestNetAppVolume(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_patch_volume(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         volume = create_volume(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, live=self.is_live)
         assert "Premium" == volume.service_level
         assert 100 * GIGABYTE == volume.usage_threshold
@@ -371,7 +389,10 @@ class TestNetAppVolume(AzureMgmtRecordedTestCase):
 
     @recorded_by_proxy
     def test_pool_change(self):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         create_volume(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_1, TEST_VOL_1, live=self.is_live)
         pool2 = create_pool(self.client, TEST_RG, TEST_ACC_1, TEST_POOL_2, LOCATION, True)
         if self.is_live:

--- a/sdk/tables/azure-data-tables/tests/test_table_aad.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_aad.py
@@ -9,7 +9,7 @@ import pytest
 from datetime import datetime
 import sys
 
-from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.data.tables import (
@@ -178,7 +178,10 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_aad_batch_all_operations_together(self, tables_storage_account_name):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         self._set_up(tables_storage_account_name, self.get_token_credential())
         try:

--- a/sdk/tables/azure-data-tables/tests/test_table_aad_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_aad_async.py
@@ -9,7 +9,7 @@ import pytest
 from datetime import datetime
 import sys
 
-from devtools_testutils import AzureRecordedTestCase, set_bodiless_matcher
+from devtools_testutils import AzureRecordedTestCase, set_custom_default_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
 from azure.data.tables.aio import TableServiceClient, TableClient
@@ -176,7 +176,10 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_aad_batch_all_operations_together(self, tables_storage_account_name):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         await self._set_up(tables_storage_account_name, self.get_token_credential())
         try:

--- a/sdk/tables/azure-data-tables/tests/test_table_batch.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 import os
 import sys
 
-from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 
 from azure.core import MatchConditions
 from azure.core.pipeline.policies import HTTPPolicy
@@ -48,7 +48,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_single_insert(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -82,7 +85,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_single_update(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -120,7 +126,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_update(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -160,7 +169,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -202,7 +214,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_update_if_match(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -233,7 +248,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_update_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -264,7 +282,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_single_op_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -311,7 +332,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_insert_replace(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -344,7 +368,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_insert_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -377,7 +404,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_delete(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -412,7 +442,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_inserts(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -450,7 +483,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_all_operations_together(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -523,7 +559,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_reuse(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -565,7 +604,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_same_row_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -596,7 +638,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_different_partition_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -624,7 +669,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_too_many_ops(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -650,7 +698,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_different_partition_keys(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -670,7 +721,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_new_non_existent_table(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -691,7 +745,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_new_invalid_key(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         invalid_key = tables_primary_storage_account_key.named_key.key[0:-6] + "==" # cut off a bit from the end to invalidate
         tables_primary_storage_account_key = AzureNamedKeyCredential(tables_storage_account_name, invalid_key)
@@ -711,7 +768,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_new_delete_nonexistent_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -730,7 +790,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_delete_batch_with_bad_kwarg(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -761,7 +824,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.live_test_only
     @tables_decorator
     def test_batch_sas_auth(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -813,7 +879,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.live_test_only  # Request bodies are very large
     @tables_decorator
     def test_batch_request_too_large(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -840,7 +909,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_with_mode(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -887,7 +959,10 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
     def test_batch_with_specialchar_partitionkey(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 import os
 import sys
 
-from devtools_testutils import AzureRecordedTestCase, set_bodiless_matcher
+from devtools_testutils import AzureRecordedTestCase, set_custom_default_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
 from azure.core import MatchConditions
@@ -44,7 +44,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_single_insert(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -77,7 +80,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_single_update(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -115,7 +121,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_update(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -152,7 +161,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -193,7 +205,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_update_if_match(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -223,7 +238,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_update_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -254,7 +272,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_insert_replace(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -286,7 +307,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_insert_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -318,7 +342,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_delete(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -353,7 +380,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_inserts(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -393,7 +423,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_all_operations_together(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -468,7 +501,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_same_row_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -496,7 +532,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_different_partition_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -524,7 +563,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_too_many_ops(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -549,7 +591,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_new_non_existent_table(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -569,7 +614,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_new_invalid_key(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         invalid_key = tables_primary_storage_account_key.named_key.key[0:-6] + "==" # cut off a bit from the end to invalidate
         tables_primary_storage_account_key = AzureNamedKeyCredential(tables_storage_account_name, invalid_key)
@@ -587,7 +635,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_new_delete_nonexistent_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -604,7 +655,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.live_test_only
     @tables_decorator_async
     async def test_batch_sas_auth(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -654,7 +708,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.live_test_only  # Request bodies are very large
     @tables_decorator_async
     async def test_batch_request_too_large(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -681,7 +738,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_delete_batch_with_bad_kwarg(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -712,7 +772,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_with_mode(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -759,7 +822,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_batch_with_specialchar_partitionkey(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -820,7 +886,10 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
     async def test_async_batch_inserts(self, tables_storage_account_name, tables_primary_storage_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
@@ -11,7 +11,7 @@ import sys
 
 import pytest
 
-from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy, set_custom_default_matcher
 
 from azure.core import MatchConditions
 from azure.core.credentials import AzureSasCredential
@@ -39,7 +39,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_insert(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -72,7 +75,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -110,7 +116,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -152,7 +161,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_update_if_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -183,7 +195,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_update_if_doesnt_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -214,7 +229,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_insert_replace(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -247,7 +265,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_insert_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -280,7 +301,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_delete(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -315,7 +339,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_inserts(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -353,7 +380,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_all_operations_together(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -426,7 +456,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_different_partition_operations_fail(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -454,7 +487,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_new_non_existent_table(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -475,7 +511,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_new_delete_nonexistent_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -493,7 +532,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_delete_batch_with_bad_kwarg(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -524,7 +566,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.live_test_only
     @cosmos_decorator
     def test_batch_sas_auth(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -575,7 +620,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.live_test_only  # Request bodies are very large
     @cosmos_decorator
     def test_batch_request_too_large(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -601,7 +649,10 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
     def test_batch_with_specialchar_partitionkey(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
@@ -10,7 +10,7 @@ import os
 import sys
 import pytest
 
-from devtools_testutils import AzureRecordedTestCase, set_bodiless_matcher
+from devtools_testutils import AzureRecordedTestCase, set_custom_default_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
 from azure.core import MatchConditions
@@ -44,7 +44,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_single_insert(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -78,7 +81,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_single_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -116,7 +122,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -153,7 +162,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -194,7 +206,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_update_if_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -224,7 +239,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_update_if_doesnt_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -256,7 +274,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_insert_replace(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -288,7 +309,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_insert_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -320,7 +344,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_delete(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -354,7 +381,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_inserts(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -394,7 +424,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_all_operations_together(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -469,7 +502,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_different_partition_operations_fail(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -497,7 +533,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_new_non_existent_table(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -533,7 +572,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_new_delete_nonexistent_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -550,7 +592,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.live_test_only  # Request bodies are very large
     @cosmos_decorator_async
     async def test_batch_request_too_large(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -577,7 +622,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_delete_batch_with_bad_kwarg(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -607,7 +655,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.live_test_only
     @cosmos_decorator_async
     async def test_batch_sas_auth(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -657,7 +708,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_batch_with_specialchar_partitionkey(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -718,7 +772,10 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
     async def test_async_batch_inserts(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
 
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -16,7 +16,7 @@ from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
 from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
-from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.textanalytics import (
     TextAnalyticsClient,
     RecognizeEntitiesAction,
@@ -652,7 +652,10 @@ class TestAnalyze(TextAnalyticsTest):
             textanalytics_custom_entities_project_name,
             textanalytics_custom_entities_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         actions = [
             RecognizeEntitiesAction(disable_service_logs=True),
@@ -1011,7 +1014,10 @@ class TestAnalyze(TextAnalyticsTest):
             textanalytics_single_category_classify_project_name,
             textanalytics_single_category_classify_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
@@ -1051,7 +1057,10 @@ class TestAnalyze(TextAnalyticsTest):
             textanalytics_multi_category_classify_project_name,
             textanalytics_multi_category_classify_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
@@ -1092,7 +1101,10 @@ class TestAnalyze(TextAnalyticsTest):
             textanalytics_custom_entities_project_name,
             textanalytics_custom_entities_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -19,7 +19,7 @@ from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
 from testcase import TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
-from devtools_testutils import set_bodiless_matcher
+from devtools_testutils import set_custom_default_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 from testcase import TextAnalyticsTest
 from azure.ai.textanalytics.aio import TextAnalyticsClient
@@ -708,7 +708,10 @@ class TestAnalyzeAsync(TextAnalyticsTest):
             textanalytics_custom_entities_project_name,
             textanalytics_custom_entities_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         actions = [
             RecognizeEntitiesAction(disable_service_logs=True),
@@ -1081,7 +1084,10 @@ class TestAnalyzeAsync(TextAnalyticsTest):
             textanalytics_single_category_classify_project_name,
             textanalytics_single_category_classify_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
@@ -1124,7 +1130,10 @@ class TestAnalyzeAsync(TextAnalyticsTest):
             textanalytics_multi_category_classify_project_name,
             textanalytics_multi_category_classify_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
@@ -1169,7 +1178,10 @@ class TestAnalyzeAsync(TextAnalyticsTest):
             textanalytics_custom_entities_project_name,
             textanalytics_custom_entities_deployment_name
     ):
-        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )  # don't match on body for this test since we scrub the proj/deployment values
         client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},

--- a/sdk/translation/azure-ai-translation-document/tests/testcase.py
+++ b/sdk/translation/azure-ai-translation-document/tests/testcase.py
@@ -9,7 +9,7 @@ import datetime
 import uuid
 from devtools_testutils import (
     AzureRecordedTestCase,
-    set_bodiless_matcher
+    set_custom_default_matcher
 )
 from azure.storage.blob import generate_container_sas, ContainerClient
 from azure.ai.translation.document import DocumentTranslationInput, TranslationTarget
@@ -78,7 +78,10 @@ class DocumentTranslationTest(AzureRecordedTestCase):
         return self.generate_sas_url(variables[var_key], "wl")
 
     def generate_sas_url(self, container_name, permission):
-        set_bodiless_matcher()
+        # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
+        set_custom_default_matcher(
+            compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
+        )
         sas_token = self.generate_sas(
             generate_container_sas,
             account_name=self.storage_name,

--- a/tools/azure-sdk-tools/devtools_testutils/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/__init__.py
@@ -31,6 +31,7 @@ from .sanitizers import (
     add_request_subscription_id_sanitizer,
     add_uri_regex_sanitizer,
     set_bodiless_matcher,
+    set_custom_default_matcher,
 )
 from .helpers import ResponseCallback, RetryCounter
 from .fake_credentials import FakeTokenCredential
@@ -66,6 +67,7 @@ __all__ = [
     "recorded_by_proxy",
     "test_proxy",
     "set_bodiless_matcher",
+    "set_custom_default_matcher",
     "start_test_proxy",
     "stop_test_proxy",
     "ResponseCallback",

--- a/tools/azure-sdk-tools/devtools_testutils/helpers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/helpers.py
@@ -4,8 +4,52 @@
 # license information.
 # --------------------------------------------------------------------------
 import os
+import sys
 
 from azure_devtools.scenario_tests.config import TestConfig
+
+
+# we store recording IDs in a module-level variable so that sanitizers can access them
+# we map test IDs to recording IDs, rather than storing only the current test's recording ID, for parallelization
+this = sys.modules[__name__]
+this.recording_ids = {}
+
+
+def get_recording_id():
+    """Fetches the recording ID for the currently executing test"""
+    test_id = get_test_id()
+    return this.recording_ids.get(test_id)
+
+
+def set_recording_id(test_id, recording_id):
+    """Used to update a persistent dictionary, mapping test IDs to recording IDs, from outside this module"""
+    this.recording_ids[test_id] = recording_id
+
+
+def get_test_id():
+    # type: () -> str
+    # pytest sets the current running test in an environment variable
+    # the path to the test can depend on the environment, so we can't assume this is the path from the repo root
+    setting_value = os.getenv("PYTEST_CURRENT_TEST")
+    path_to_test = os.path.normpath(setting_value.split(" ")[0])
+    full_path_to_test = os.path.abspath(path_to_test)
+
+    # walk up to the repo root by looking for "sdk" directory or root of file system
+    path_components = []
+    head, tail = os.path.split(full_path_to_test)
+    while tail != "sdk" and tail != "":
+        path_components.append(tail)
+        head, tail = os.path.split(head)
+
+    # reverse path_components to construct components of path from repo root: [sdk, ..., tests, {test}]
+    path_components.append("sdk")
+    path_components.reverse()
+    for idx, val in enumerate(path_components):
+        if val.startswith("test"):
+            path_components.insert(idx + 1, "recordings")
+            break
+
+    return os.sep.join(path_components).replace("::", "").replace("\\", "/")
 
 
 def is_live():

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -18,6 +18,7 @@ import subprocess
 
 from .config import PROXY_URL
 from .helpers import is_live_and_not_recording
+from .sanitizers import add_remove_header_sanitizer, set_custom_default_matcher
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -178,6 +179,11 @@ def start_test_proxy():
 
         # Wait for the proxy server to become available
         check_proxy_availability()
+        # remove headers from recordings if we don't need them, and ignore them if present
+        # Authorization, for example, can contain sensitive info and can cause matching failures during challenge auth
+        headers_to_ignore = "Authorization, x-ms-client-request-id, x-ms-request-id"
+        add_remove_header_sanitizer(headers=headers_to_ignore)
+        set_custom_default_matcher(excluded_headers=headers_to_ignore)
 
 
 def stop_test_proxy():

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import os
 import logging
 import requests
 import six
@@ -18,7 +17,6 @@ except:
     import urlparse as url_parse
 
 import pytest
-import subprocess
 
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.core.pipeline.policies import ContentDecodePolicy
@@ -27,8 +25,9 @@ from azure.core.pipeline.transport import RequestsTransport
 
 # the trimming function to clean up incoming arguments to the test function we are wrapping
 from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
-from .helpers import is_live, is_live_and_not_recording
 from .config import PROXY_URL
+from .helpers import get_test_id, is_live, is_live_and_not_recording, set_recording_id
+from .sanitizers import add_remove_header_sanitizer, set_custom_default_matcher
 
 if TYPE_CHECKING:
     from typing import Tuple
@@ -42,42 +41,6 @@ RECORDING_START_URL = "{}/record/start".format(PROXY_URL)
 RECORDING_STOP_URL = "{}/record/stop".format(PROXY_URL)
 PLAYBACK_START_URL = "{}/playback/start".format(PROXY_URL)
 PLAYBACK_STOP_URL = "{}/playback/stop".format(PROXY_URL)
-
-# we store recording IDs in a module-level variable so that sanitizers can access them
-# we map test IDs to recording IDs, rather than storing only the current test's recording ID, for parallelization
-this = sys.modules[__name__]
-this.recording_ids = {}
-
-
-def get_recording_id():
-    test_id = get_test_id()
-    return this.recording_ids.get(test_id)
-
-
-def get_test_id():
-    # type: () -> str
-    # pytest sets the current running test in an environment variable
-    # the path to the test can depend on the environment, so we can't assume this is the path from the repo root
-    setting_value = os.getenv("PYTEST_CURRENT_TEST")
-    path_to_test = os.path.normpath(setting_value.split(" ")[0])
-    full_path_to_test = os.path.abspath(path_to_test)
-
-    # walk up to the repo root by looking for "sdk" directory or root of file system
-    path_components = []
-    head, tail = os.path.split(full_path_to_test)
-    while tail != "sdk" and tail != "":
-        path_components.append(tail)
-        head, tail = os.path.split(head)
-
-    # reverse path_components to construct components of path from repo root: [sdk, ..., tests, {test}]
-    path_components.append("sdk")
-    path_components.reverse()
-    for idx, val in enumerate(path_components):
-        if val.startswith("test"):
-            path_components.insert(idx + 1, "recordings")
-            break
-
-    return os.sep.join(path_components).replace("::", "").replace("\\", "/")
 
 
 def start_record_or_playback(test_id):
@@ -121,7 +84,7 @@ def start_record_or_playback(test_id):
                 )
 
     # set recording ID in a module-level variable so that sanitizers can access it
-    this.recording_ids[test_id] = recording_id
+    set_recording_id(test_id, recording_id)
     return (recording_id, variables)
 
 

--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -7,8 +7,7 @@ import requests
 from typing import TYPE_CHECKING
 
 from .config import PROXY_URL
-from .helpers import is_live_and_not_recording
-from .proxy_testcase import get_recording_id
+from .helpers import get_recording_id, is_live_and_not_recording
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional

--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -60,7 +60,7 @@ def add_body_key_sanitizer(**kwargs):
     :keyword str json_path: The SelectToken path (which could possibly match multiple entries) that will be used to
         select JTokens for value replacement.
     :keyword str value: The substitution value.
-    :keyword str regex: A regex. Can be defined as a simple regex replace OR if groupForReplace is set, a subsitution
+    :keyword str regex: A regex. Can be defined as a simple regex replace OR if groupForReplace is set, a substitution
         operation. Defaults to replacing the entire string.
     :keyword str group_for_replace: The capture group that needs to be operated upon. Do not provide if you're invoking
         a simple replacement operation.
@@ -96,7 +96,7 @@ def add_continuation_sanitizer(**kwargs):
     requests get this key" as well as "single response/request pair". Defaults to maintaining same key for rest of
     recording.
 
-    :keyword str key: The name of the header whos value will be replaced from response -> next request.
+    :keyword str key: The name of the header whose value will be replaced from response -> next request.
     :keyword str method: The method by which the value of the targeted key will be replaced. Defaults to guid
         replacement.
     :keyword str reset_after_first: Do we need multiple pairs replaced? Or do we want to replace each value with the

--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -11,7 +11,7 @@ from .helpers import is_live_and_not_recording
 from .proxy_testcase import get_recording_id
 
 if TYPE_CHECKING:
-    from typing import Any, Dict
+    from typing import Any, Dict, Optional
 
 
 def set_bodiless_matcher():
@@ -197,7 +197,7 @@ def _get_request_args(**kwargs):
 
     request_args = {}
     if "compare_bodies" in kwargs:
-        request_args["compareBodies"] = str(kwargs.get("compare_bodies"))
+        request_args["compareBodies"] = kwargs.get("compare_bodies")
     if "excluded_headers" in kwargs:
         request_args["excludedHeaders"] = kwargs.get("excluded_headers")
     if "group_for_replace" in kwargs:
@@ -207,7 +207,7 @@ def _get_request_args(**kwargs):
     if "ignored_headers" in kwargs:
         request_args["ignoredHeaders"] = kwargs.get("ignored_headers")
     if "ignore_query_ordering" in kwargs:
-        request_args["ignoreQueryOrdering"] = str(kwargs.get("ignore_query_ordering"))
+        request_args["ignoreQueryOrdering"] = kwargs.get("ignore_query_ordering")
     if "ignored_query_parameters" in kwargs:
         request_args["ignoredQueryParameters"] = kwargs.get("ignored_query_parameters")
     if "json_path" in kwargs:
@@ -226,7 +226,7 @@ def _get_request_args(**kwargs):
 
 
 def _send_matcher_request(matcher, headers, parameters=None):
-    # type: (str, Dict) -> None
+    # type: (str, Dict, Optional[Dict]) -> None
     """Sends a POST request to the test proxy endpoint to register the specified matcher.
 
     If live tests are being run with recording turned off via the AZURE_SKIP_LIVE_RECORDING environment variable, no
@@ -241,11 +241,12 @@ def _send_matcher_request(matcher, headers, parameters=None):
 
     headers_to_send = {"x-abstraction-identifier": matcher}
     headers_to_send.update(headers)
-    requests.post(
+    response = requests.post(
         "{}/Admin/SetMatcher".format(PROXY_URL),
         headers=headers_to_send,
         json=parameters
     )
+    response.raise_for_status()
 
 
 def _send_sanitizer_request(sanitizer, parameters):
@@ -262,8 +263,9 @@ def _send_sanitizer_request(sanitizer, parameters):
     if is_live_and_not_recording():
         return
 
-    requests.post(
+    response = requests.post(
         "{}/Admin/AddSanitizer".format(PROXY_URL),
         headers={"x-abstraction-identifier": sanitizer, "Content-Type": "application/json"},
         json=parameters
     )
+    response.raise_for_status()


### PR DESCRIPTION
# Description

**For reviewers (@scbedd):** The only relevant files for test proxy work are under `devtools_testutils`.

**For package owners:** The only changes to affected libraries are to invocations of `set_bodiless_matcher`.

This adds a `set_custom_default_matcher` method for setting custom matchers, which was motivated by the case where "Authorization" headers get dropped in playback due to challenge authentication cache misses (relevant to KV and ACR).

While looking into this issue, though, it became apparent that we don't actually want to record some headers in the first place -- they were explicitly filtered out in our old `vcrpy` setup because they can contain sensitive information, interfere with matching, and/or take up recording space without a purpose. So, this PR adds a call to the `RemoveHeaderSanitizer` as part of test proxy startup to remove some headers -- `Authorization`, `x-ms-client-request-id`, and `x-ms-request-id`, in particular -- from recordings.

This also sets up a custom default matcher that excludes these headers, since tests will otherwise fail if the header removal sanitizer is set up but the headers exist in recordings (which they will, for all current recordings). I looked into only setting up this sanitizer in live mode, but we need it in playback since playback requests send these headers and the proxy will get upset over this by default. Removing the headers from each recorded test is infeasible because of how many there are, and this solution works when existing references to `set_bodiless_matcher` are replaced with a call to `set_custom_default_matcher` that turns off body matching _and_ excludes the sensitive headers.

Whenever tests are re-recorded, they'll now omit these headers. So, using a plain `set_bodiless_matcher` at that point will continue to work like it did before this PR. Eventually, once these headers are removed from all or most recordings, we'll be able to remove the call to `set_custom_default_matcher` in `proxy_startup.py`. Or, at the very least, we can update recordings library-by-library after this PR is merged to avoid a monstrously large PR today.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
  - Changes are verified by running existing, migrated test suites
