### PR TITLE
[Core] Clearer guidance for unused TokenCredential kwargs

### DIFF
--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -560,6 +560,12 @@ implement additional methods. The [`azure-identity`][identity_github] package ha
 implementations that can be used for reference. For example, the [`InteractiveCredential`][interactive_cred] is used as
 a base class for multiple credentials and uses `claims` and `tenant_id` in token requests.
 
+If a `TokenCredential` implementation doesn't have a use for a keyword argument in a given scenario, the unused
+keyword argument should be removed from `kwargs` before getting passed elsewhere. The documentation for the
+implementation should mention that this keyword argument will not be used when making token requests, as well as any
+potential consequences of this. For example, if a `TokenCredential` implementation doesn't use `tenant_id`, it should
+document that fetched tokens may not authorize requests made to the specified tenant.
+
 There is also an async protocol -- the `AsyncTokenCredential` protocol -- that specifies a class with an aysnc
 `get_token` method with the same arguments. An `AsyncTokenCredential` implementation additionally needs to be a context
 manager, with `__aenter__`, `__aexit__`, and `close` methods.


### PR DESCRIPTION
# Description

This explicitly recommends ignoring unused keyword arguments that are included in `get_token` requests, removing them from `kwargs` before passing them elsewhere, and documenting their lack of use and any consequences of it.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
