### PR TITLE
[Tables] Resolve dependency conflicts

### DIFF
--- a/sdk/tables/azure-data-tables/setup.py
+++ b/sdk/tables/azure-data-tables/setup.py
@@ -63,7 +63,7 @@ setup(
     ]),
     python_requires=">=3.7",
     install_requires=[
-        "azure-core<2.0.0,>=1.14.0",
+        "azure-core<2.0.0,>=1.15.0",
         "msrest>=0.6.21"
     ],
 )

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -136,7 +136,8 @@ chardet<5,>=3.0.2
 #override azure-core-tracing-opencensus azure-core<2.0.0,>=1.13.0
 #override azure-core-tracing-opentelemetry azure-core<2.0.0,>=1.13.0
 #override azure-cosmos azure-core<2.0.0,>=1.0.0
-#override azure-data-tables azure-core<2.0.0,>=1.14.0
+#override azure-data-tables azure-core<2.0.0,>=1.15.0
+#override azure-data-tables msrest>=0.6.10
 #override azure-eventhub azure-core<2.0.0,>=1.14.0
 #override azure-identity azure-core<2.0.0,>=1.11.0
 #override azure-keyvault-administration azure-core<2.0.0,>=1.15.0
@@ -185,7 +186,6 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-synapse-artifacts azure-core>=1.20.0,<2.0.0
 #override azure-synapse-monitoring azure-core>=1.20.0,<2.0.0
 #override azure-synapse-managedprivateendpoints azure-core>=1.20.0,<2.0.0
-#override azure-data-tables msrest>=0.6.10
 #override azure-ai-anomalydetector azure-core>=1.6.0,<2.0.0
 #override azure-eventgrid azure-core<2.0.0,>=1.18.0
 #override azure-monitor-query msrest>=0.6.19


### PR DESCRIPTION
The conflict is from `azure-mgmt-core` where requires `azure-core` version to be at least **1.15.0**.
This is where the error was found: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1386229&view=logs&j=4fa73ede-de59-50b0-851d-db96582ea108&t=813eb0cd-e8db-59f1-2e13-b4deadd36a36&l=2762
Thanks @kristapratico for letting me know!