### PR TITLE
Adds Env Var that overrides x-ms-useragent, to correct test pipeline

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/test/_shared/utils.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/_shared/utils.py
@@ -4,7 +4,7 @@
 # license information.
 # -------------------------------------------------------------------------
 
-from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.pipeline.policies import HttpLoggingPolicy, HeadersPolicy 
 
 def create_token_credential():
     # type: () -> FakeTokenCredential or DefaultAzureCredential
@@ -32,3 +32,13 @@ def get_http_logging_policy(**kwargs):
         }
     )
     return http_logging_policy
+
+def get_header_policy(**kwargs):
+    header_policy = HeadersPolicy(**kwargs)
+
+    import os
+    useragent = os.getenv("AZURE_USERAGENT_OVERRIDE")
+    if useragent:
+        header_policy.add_header("x-ms-useragent", useragent)
+
+    return header_policy


### PR DESCRIPTION
Adds a way to mark test related requests as test traffic.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
