### PR TITLE
[Key Vault] Allow case-insensitive KeyType declaration

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- `KeyType` now ignores casing during declaration, which resolves a scenario where Key Vault
+  keys created with non-standard casing could not be fetched with the SDK
+  ([#22797](https://github.com/Azure/azure-sdk-for-python/issues/22797))
 
 ### Other Changes
 - (From 4.4.0b3) Python 2.7 is no longer supported. Please use Python version 3.6 or later.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_enums.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_enums.py
@@ -2,24 +2,28 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+# pylint:skip-file (avoids crash due to six.with_metaclass https://github.com/PyCQA/astroid/issues/713)
 from enum import Enum
+from six import with_metaclass
+
+from azure.core import CaseInsensitiveEnumMeta
 
 
-class CertificatePolicyAction(str, Enum):
+class CertificatePolicyAction(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     """The supported action types for the lifetime of a certificate"""
 
     email_contacts = "EmailContacts"
     auto_renew = "AutoRenew"
 
 
-class CertificateContentType(str, Enum):
+class CertificateContentType(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     """Content type of the secrets as specified in Certificate Policy"""
 
     pkcs12 = "application/x-pkcs12"
     pem = "application/x-pem-file"
 
 
-class KeyUsageType(str, Enum):
+class KeyUsageType(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     """The supported types of key usages"""
 
     digital_signature = "digitalSignature"
@@ -33,16 +37,25 @@ class KeyUsageType(str, Enum):
     decipher_only = "decipherOnly"
 
 
-class KeyType(str, Enum):
+class KeyType(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     """Supported key types"""
 
     ec = "EC"  #: Elliptic Curve
     ec_hsm = "EC-HSM"  #: Elliptic Curve with a private key which is not exportable from the HSM
     rsa = "RSA"  #: RSA (https://tools.ietf.org/html/rfc3447)
     rsa_hsm = "RSA-HSM"  #: RSA with a private key which is not exportable from the HSM
+    oct = "oct"  #: Octet sequence (used to represent symmetric keys)
+    oct_hsm = "oct-HSM"  #: Octet sequence with a private key which is not exportable from the HSM
+
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+        raise ValueError(f"{value} is not a valid KeyType")
 
 
-class KeyCurveName(str, Enum):
+class KeyCurveName(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     """Supported elliptic curves"""
 
     p_256 = "P-256"  #: The NIST P-256 elliptic curve, AKA SECG curve SECP256R1.
@@ -51,7 +64,7 @@ class KeyCurveName(str, Enum):
     p_256_k = "P-256K"  #: The SECG SECP256K1 elliptic curve.
 
 
-class WellKnownIssuerNames(str, Enum):
+class WellKnownIssuerNames(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     """Collection of well-known issuer names"""
 
     self = "Self"  #: Use this issuer for a self-signed certificate

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
@@ -48,12 +48,12 @@ class KeyVaultOperationPoller(LROPoller):
 
     @distributed_trace
     def wait(self, timeout=None):
-        # type: (Optional[int]) -> None
+        # type: (Optional[float]) -> None
         """Wait on the long running operation for a number of seconds.
 
         You can check if this call has ended with timeout with the "done()" method.
 
-        :param int timeout: Period of time to wait for the long running
+        :param float timeout: Period of time to wait for the long running
          operation to complete (in seconds).
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -731,3 +731,15 @@ def test_custom_hook_policy():
 
     client = CertificateClient("...", object(), custom_hook_policy=CustomHookPolicy())
     assert isinstance(client._client._config.custom_hook_policy, CustomHookPolicy)
+
+
+def test_case_insensitive_key_type():
+    """Ensure a KeyType can be created regardless of casing since the service can create keys with non-standard casing.
+    See https://github.com/Azure/azure-sdk-for-python/issues/22797
+    """
+    # KeyType with all upper-case value
+    assert KeyType("rsa") == KeyType.rsa
+    # KeyType with all lower-case value
+    assert KeyType("OCT") == KeyType.oct
+    # KeyType with mixed-case value
+    assert KeyType("oct-hsm") == KeyType.oct_hsm

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- `KeyType` now ignores casing during declaration, which resolves a scenario where Key Vault
+  keys created with non-standard casing could not be fetched with the SDK
+  ([#22797](https://github.com/Azure/azure-sdk-for-python/issues/22797))
 
 ### Other Changes
 - (From 4.5.0b6) Python 2.7 is no longer supported. Please use Python version 3.6 or later.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_enums.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_enums.py
@@ -51,7 +51,14 @@ class KeyType(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
 
     ec = "EC"  #: Elliptic Curve
     ec_hsm = "EC-HSM"  #: Elliptic Curve with a private key which is not exportable from the HSM
-    rsa = "RSA"
+    rsa = "RSA"  #: RSA (https://tools.ietf.org/html/rfc3447)
     rsa_hsm = "RSA-HSM"  #: RSA with a private key which is not exportable from the HSM
     oct = "oct"  #: Octet sequence (used to represent symmetric keys)
     oct_hsm = "oct-HSM"  #: Octet sequence with a private key which is not exportable from the HSM
+
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+        raise ValueError(f"{value} is not a valid KeyType")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
@@ -48,12 +48,12 @@ class KeyVaultOperationPoller(LROPoller):
 
     @distributed_trace
     def wait(self, timeout=None):
-        # type: (Optional[int]) -> None
+        # type: (Optional[float]) -> None
         """Wait on the long running operation for a number of seconds.
 
         You can check if this call has ended with timeout with the "done()" method.
 
-        :param int timeout: Period of time to wait for the long running
+        :param float timeout: Period of time to wait for the long running
          operation to complete (in seconds).
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -18,6 +18,7 @@ from azure.keyvault.keys import (
     KeyReleasePolicy,
     KeyRotationLifetimeAction,
     KeyRotationPolicyAction,
+    KeyType,
 )
 import pytest
 from six import byte2int
@@ -709,3 +710,15 @@ def test_custom_hook_policy():
 
     client = KeyClient("...", object(), custom_hook_policy=CustomHookPolicy())
     assert isinstance(client._client._config.custom_hook_policy, CustomHookPolicy)
+
+
+def test_case_insensitive_key_type():
+    """Ensure a KeyType can be created regardless of casing since the service can create keys with non-standard casing.
+    See https://github.com/Azure/azure-sdk-for-python/issues/22797
+    """
+    # KeyType with all upper-case value
+    assert KeyType("rsa") == KeyType.rsa
+    # KeyType with all lower-case value
+    assert KeyType("OCT") == KeyType.oct
+    # KeyType with mixed-case value
+    assert KeyType("oct-hsm") == KeyType.oct_hsm

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
@@ -48,12 +48,12 @@ class KeyVaultOperationPoller(LROPoller):
 
     @distributed_trace
     def wait(self, timeout=None):
-        # type: (Optional[int]) -> None
+        # type: (Optional[float]) -> None
         """Wait on the long running operation for a number of seconds.
 
         You can check if this call has ended with timeout with the "done()" method.
 
-        :param int timeout: Period of time to wait for the long running
+        :param float timeout: Period of time to wait for the long running
          operation to complete (in seconds).
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/22797. This also updates `azure-keyvault-certificates` enums to inherit from CaseInsensitiveEnumMeta, per SDK guidelines.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
