### PR TITLE
[Mgmt Compute] Sanitize SAS tokens in recordings

### DIFF
--- a/sdk/compute/azure-mgmt-compute/tests/conftest.py
+++ b/sdk/compute/azure-mgmt-compute/tests/conftest.py
@@ -24,14 +24,13 @@
 #
 # --------------------------------------------------------------------------
 import os
-import re
 import platform
 import pytest
 import sys
 
 from dotenv import load_dotenv
 
-from devtools_testutils import test_proxy, add_general_regex_sanitizer,add_body_regex_sanitizer
+from devtools_testutils import test_proxy, add_general_regex_sanitizer, add_body_key_sanitizer
 
 # Ignore async tests for Python < 3.5
 collect_ignore_glob = []
@@ -49,3 +48,4 @@ def add_sanitizers(test_proxy):
     add_general_regex_sanitizer(regex=tenant_id, value="00000000-0000-0000-0000-000000000000")
     add_general_regex_sanitizer(regex='eyJ0eXAiOiJKV.*?"', value='access_token"')
     add_general_regex_sanitizer(regex='fpc=.*?;', value='fpc=fpc;')
+    add_body_key_sanitizer(json_path="$..accessSAS")

--- a/sdk/compute/azure-mgmt-compute/tests/recordings/test_mgmt_compute_disks.pyTestMgmtComputeMultiVersiontest_compute_disks_multi.json
+++ b/sdk/compute/azure-mgmt-compute/tests/recordings/test_mgmt_compute_disks.pyTestMgmtComputeMultiVersiontest_compute_disks_multi.json
@@ -7,7 +7,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)"
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -17,17 +17,18 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:15 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:48 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:03:15 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:39:49 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr6JIbei2tvRP_I7dw2czxB2TYKEuUlNruQwqFukgcIBYb-fdRRcpQU4rMiufrvFk0cXnHvVz22VkwzeOO0B3CO3ute1YqJw4qs2aqOVAUNCxwDNnne46wk4GCcv8PP74XDr7TJWL20iAl38pvWTcmFfLyqsOHZpIpPjgLvop5Bz4gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12507.17 - NCUS ProdSlices",
-        "x-ms-request-id": "9460e8b4-3927-46ea-8c0a-3c1230500300"
+        "x-ms-ests-server": "2.1.12529.17 - NCUS ProdSlices",
+        "x-ms-request-id": "3f075fdc-e84b-4126-84b7-7b5af1193c00"
       },
       "ResponseBody": {
         "token_endpoint": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token",
@@ -90,7 +91,7 @@
           "email"
         ],
         "kerberos_endpoint": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/kerberos",
-        "tenant_region_scope": "NA",
+        "tenant_region_scope": "WW",
         "cloud_instance_name": "microsoftonline.com",
         "cloud_graph_host_name": "graph.windows.net",
         "msgraph_host": "graph.microsoft.com",
@@ -105,7 +106,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Cookie": "fpc=fpc; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)"
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -115,17 +116,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:15 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:48 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:03:15 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:39:49 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12507.17 - KRSLR1 ProdSlices",
-        "x-ms-request-id": "e329a6bc-fb41-495b-b759-39d185bb0000"
+        "x-ms-ests-server": "2.1.12507.17 - NCUS ProdSlices",
+        "x-ms-request-id": "9b1780fb-7304-46b1-bef9-7fc4c1d01100"
       },
       "ResponseBody": {
         "tenant_discovery_endpoint": "https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -180,46 +181,47 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "client-request-id": "1d821aff-ca3e-49d6-ad4c-c27ac9ab935c",
+        "client-request-id": "5f26b50e-811e-4620-8155-ae1210d73544",
         "Connection": "keep-alive",
-        "Content-Length": "289",
+        "Content-Length": "286",
         "Content-Type": "application/x-www-form-urlencoded",
         "Cookie": "fpc=fpc; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
         "x-client-cpu": "x64",
         "x-client-current-telemetry": "4|730,0|",
         "x-client-last-telemetry": "4|0|||",
         "x-client-os": "win32",
         "x-client-sku": "MSAL.Python",
-        "x-client-ver": "1.16.0",
+        "x-client-ver": "1.15.0",
         "x-ms-lib-capability": "retry-after, h429"
       },
-      "RequestBody": "client_id=a2df54d5-ab03-4725-9b80-9a00b3b1967f\u0026grant_type=client_credentials\u0026client_info=1\u0026client_secret=0vj7Q~IsFayrD0V_8oyOfygU-GE3ELOabq95a\u0026claims=%7B%22access_token%22%3A\u002B%7B%22xms_cc%22%3A\u002B%7B%22values%22%3A\u002B%5B%22CP1%22%5D%7D%7D%7D\u0026scope=https%3A%2F%2Fmanagement.azure.com%2F.default",
+      "RequestBody": "client_id=c51fbd7b-3a8a-4043-b5e1-b4631b45fdbb\u0026grant_type=client_credentials\u0026client_info=1\u0026client_secret=OqR445KX.Mj-I70qnfGeYHPsFi.vDjh7~Z\u0026claims=%7B%22access_token%22%3A\u002B%7B%22xms_cc%22%3A\u002B%7B%22values%22%3A\u002B%5B%22CP1%22%5D%7D%7D%7D\u0026scope=https%3A%2F%2Fmanagement.azure.com%2F.default",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",
-        "client-request-id": "1d821aff-ca3e-49d6-ad4c-c27ac9ab935c",
-        "Content-Length": "93",
+        "client-request-id": "5f26b50e-811e-4620-8155-ae1210d73544",
+        "Content-Length": "114",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:16 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:49 GMT",
         "Expires": "-1",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Pragma": "no-cache",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:03:16 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:39:49 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-clitelem": "1,0,0,,",
-        "x-ms-ests-server": "2.1.12507.17 - EUS ProdSlices",
-        "x-ms-request-id": "aed45cb0-3ae1-4a13-82a4-4269184e0e00"
+        "x-ms-ests-server": "2.1.12529.17 - EUS ProdSlices",
+        "x-ms-request-id": "0b8a2fe9-a604-4003-9ae5-d04a797b3500"
       },
       "ResponseBody": {
         "token_type": "Bearer",
-        "expires_in": 3599,
-        "ext_expires_in": 3599,
+        "expires_in": 86399,
+        "ext_expires_in": 86399,
+        "refresh_in": 43199,
         "access_token": "access_token"
       }
     },
@@ -233,8 +235,8 @@
         "Connection": "keep-alive",
         "Content-Length": "100",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "4e2f3c1f-99d5-11ec-9fa5-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "5cde2c2d-9b64-11ec-bbfb-c8348e51ab51"
       },
       "RequestBody": {
         "location": "eastus",
@@ -247,13 +249,13 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8f2d594b-34c9-4250-addc-c028eec723a7?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/df5ac4ce-3243-429c-8b70-d715dbe53838?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
         "Cache-Control": "no-cache",
         "Content-Length": "236",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:20 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:53 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8f2d594b-34c9-4250-addc-c028eec723a7?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2019-03-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/df5ac4ce-3243-429c-8b70-d715dbe53838?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2019-03-01",
         "Pragma": "no-cache",
         "Retry-After": "2",
         "Server": [
@@ -262,12 +264,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "adae1c6f-5dae-402d-9d35-ae77a75e553c",
+        "x-ms-correlation-request-id": "9efaebc6-0f1e-46e5-a751-86b656876d95",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateUpdateDisks3Min;999,Microsoft.Compute/CreateUpdateDisks30Min;7999",
-        "x-ms-ratelimit-remaining-subscription-writes": "1194",
-        "x-ms-request-id": "8f2d594b-34c9-4250-addc-c028eec723a7",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030320Z:adae1c6f-5dae-402d-9d35-ae77a75e553c",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "df5ac4ce-3243-429c-8b70-d715dbe53838",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023953Z:9efaebc6-0f1e-46e5-a751-86b656876d95",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamex2e663141",
@@ -283,15 +285,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8f2d594b-34c9-4250-addc-c028eec723a7?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/df5ac4ce-3243-429c-8b70-d715dbe53838?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "4e2f3c1f-99d5-11ec-9fa5-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "5cde2c2d-9b64-11ec-bbfb-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -299,7 +301,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:22 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -310,16 +312,16 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "523a64a5-7450-45ea-a225-93a94ca4e24e",
+        "x-ms-correlation-request-id": "6dabdc21-5de8-4ca3-ac03-c5107bc7b661",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49999,Microsoft.Compute/GetOperation30Min;399999",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "52249d3e-ad5f-4efd-af8f-69f4c57721f6",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030323Z:523a64a5-7450-45ea-a225-93a94ca4e24e",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-request-id": "f5f9abb0-cc73-4cb5-9d0b-951403cd22a3",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023956Z:6dabdc21-5de8-4ca3-ac03-c5107bc7b661",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:03:20.5857036\u002B00:00",
-        "endTime": "2022-03-02T03:03:20.6638302\u002B00:00",
+        "startTime": "2022-03-04T02:39:53.7958361\u002B00:00",
+        "endTime": "2022-03-04T02:39:53.9364207\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
@@ -338,15 +340,15 @@
               "diskSizeGB": 200,
               "diskIOPSReadWrite": 500,
               "diskMBpsReadWrite": 60,
-              "timeCreated": "2022-03-02T03:03:20.5857036\u002B00:00",
+              "timeCreated": "2022-03-04T02:39:53.8114685\u002B00:00",
               "provisioningState": "Succeeded",
               "diskState": "Unattached",
               "diskSizeBytes": 214748364800,
-              "uniqueId": "c63be73a-79dc-43b1-83fd-bc7542732f2b"
+              "uniqueId": "6a31906a-3c3c-44c5-bab6-ae152c4924f7"
             }
           }
         },
-        "name": "8f2d594b-34c9-4250-addc-c028eec723a7"
+        "name": "df5ac4ce-3243-429c-8b70-d715dbe53838"
       }
     },
     {
@@ -357,8 +359,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "4e2f3c1f-99d5-11ec-9fa5-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "5cde2c2d-9b64-11ec-bbfb-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -366,7 +368,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:23 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -377,12 +379,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "a4631866-bd16-4d62-beb2-1ec4b89fd0a8",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14999,Microsoft.Compute/LowCostGet30Min;119999",
-        "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "631dfa65-884b-40b7-988f-77249ba8a81d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030324Z:a4631866-bd16-4d62-beb2-1ec4b89fd0a8",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "da6e1780-f06a-4f50-8783-e86b2c042d5a",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4999,Microsoft.Compute/LowCostGet30Min;39999",
+        "x-ms-ratelimit-remaining-subscription-reads": "11998",
+        "x-ms-request-id": "966e8823-12bd-4f22-ad1b-f9caa53af7da",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023956Z:da6e1780-f06a-4f50-8783-e86b2c042d5a",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamex2e663141",
@@ -400,11 +402,11 @@
           "diskSizeGB": 200,
           "diskIOPSReadWrite": 500,
           "diskMBpsReadWrite": 60,
-          "timeCreated": "2022-03-02T03:03:20.5857036\u002B00:00",
+          "timeCreated": "2022-03-04T02:39:53.8114685\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "c63be73a-79dc-43b1-83fd-bc7542732f2b"
+          "uniqueId": "6a31906a-3c3c-44c5-bab6-ae152c4924f7"
         }
       }
     },
@@ -416,8 +418,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "5352c372-99d5-11ec-ad79-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "611c4d76-9b64-11ec-b3dc-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -425,7 +427,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:23 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -436,12 +438,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "2bd6d2ff-f3fc-45ff-8023-7585d5e48b53",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14998,Microsoft.Compute/LowCostGet30Min;119998",
-        "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "def64483-e308-4224-b522-2dcb7edbd2d4",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030324Z:2bd6d2ff-f3fc-45ff-8023-7585d5e48b53",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "5a098056-d7f4-4a50-9063-712329044529",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4998,Microsoft.Compute/LowCostGet30Min;39998",
+        "x-ms-ratelimit-remaining-subscription-reads": "11997",
+        "x-ms-request-id": "33f331be-499d-4d32-be75-4970da03879e",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023956Z:5a098056-d7f4-4a50-9063-712329044529",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamex2e663141",
@@ -459,11 +461,11 @@
           "diskSizeGB": 200,
           "diskIOPSReadWrite": 500,
           "diskMBpsReadWrite": 60,
-          "timeCreated": "2022-03-02T03:03:20.5857036\u002B00:00",
+          "timeCreated": "2022-03-04T02:39:53.8114685\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "c63be73a-79dc-43b1-83fd-bc7542732f2b"
+          "uniqueId": "6a31906a-3c3c-44c5-bab6-ae152c4924f7"
         }
       }
     },
@@ -477,8 +479,8 @@
         "Connection": "keep-alive",
         "Content-Length": "35",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "5386eab4-99d5-11ec-8b11-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "612d5b69-9b64-11ec-8887-c8348e51ab51"
       },
       "RequestBody": {
         "properties": {
@@ -487,13 +489,13 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/56219175-e14f-454f-a5ad-73a2276931be?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/fb337484-aa3d-421a-aab7-9459309da0b4?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
         "Cache-Control": "no-cache",
         "Content-Length": "341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:24 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:55 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/56219175-e14f-454f-a5ad-73a2276931be?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2019-03-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/fb337484-aa3d-421a-aab7-9459309da0b4?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2019-03-01",
         "Pragma": "no-cache",
         "Retry-After": "2",
         "Server": [
@@ -502,12 +504,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "70dd090d-6f8d-4ed7-b03c-fead9d2f7908",
+        "x-ms-correlation-request-id": "1651d1f1-ca7a-4fc4-8481-59e751a6ca66",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateUpdateDisks3Min;998,Microsoft.Compute/CreateUpdateDisks30Min;7998",
-        "x-ms-ratelimit-remaining-subscription-writes": "1193",
-        "x-ms-request-id": "56219175-e14f-454f-a5ad-73a2276931be",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030324Z:70dd090d-6f8d-4ed7-b03c-fead9d2f7908",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "fb337484-aa3d-421a-aab7-9459309da0b4",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023956Z:1651d1f1-ca7a-4fc4-8481-59e751a6ca66",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamex2e663141",
@@ -528,15 +530,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/56219175-e14f-454f-a5ad-73a2276931be?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/fb337484-aa3d-421a-aab7-9459309da0b4?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "5386eab4-99d5-11ec-8b11-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "612d5b69-9b64-11ec-8887-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -544,7 +546,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:26 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -555,16 +557,16 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "914f2f54-4d50-4e93-b6a3-bfaa39a397c6",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49997,Microsoft.Compute/GetOperation30Min;399997",
-        "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "3f62c76d-e3b5-46b5-a779-80d43a68d693",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030327Z:914f2f54-4d50-4e93-b6a3-bfaa39a397c6",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "b5d073d7-f20f-4575-8b07-383638b7d787",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;399998",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "b43f0d06-ccde-42c3-8635-42f1247ae454",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023958Z:b5d073d7-f20f-4575-8b07-383638b7d787",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:03:24.7107217\u002B00:00",
-        "endTime": "2022-03-02T03:03:24.7888581\u002B00:00",
+        "startTime": "2022-03-04T02:39:56.4208119\u002B00:00",
+        "endTime": "2022-03-04T02:39:56.5614282\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
@@ -583,15 +585,15 @@
               "diskSizeGB": 200,
               "diskIOPSReadWrite": 500,
               "diskMBpsReadWrite": 60,
-              "timeCreated": "2022-03-02T03:03:20.5857036\u002B00:00",
+              "timeCreated": "2022-03-04T02:39:53.8114685\u002B00:00",
               "provisioningState": "Succeeded",
               "diskState": "Unattached",
               "diskSizeBytes": 214748364800,
-              "uniqueId": "c63be73a-79dc-43b1-83fd-bc7542732f2b"
+              "uniqueId": "6a31906a-3c3c-44c5-bab6-ae152c4924f7"
             }
           }
         },
-        "name": "56219175-e14f-454f-a5ad-73a2276931be"
+        "name": "fb337484-aa3d-421a-aab7-9459309da0b4"
       }
     },
     {
@@ -602,8 +604,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "5386eab4-99d5-11ec-8b11-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "612d5b69-9b64-11ec-8887-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -611,7 +613,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:26 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -622,12 +624,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "40b83dc2-70be-42af-a7ff-6c584c9d2dea",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14995,Microsoft.Compute/LowCostGet30Min;119995",
-        "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "0cd5dbd8-34d3-4c6b-b890-66581b12da2c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030327Z:40b83dc2-70be-42af-a7ff-6c584c9d2dea",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "f85861d1-7dcb-455e-adf1-e9787b6f9dca",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4996,Microsoft.Compute/LowCostGet30Min;39996",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "89a63f35-d3bf-44c6-bc61-ca94dfeba7ac",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023958Z:f85861d1-7dcb-455e-adf1-e9787b6f9dca",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamex2e663141",
@@ -645,11 +647,11 @@
           "diskSizeGB": 200,
           "diskIOPSReadWrite": 500,
           "diskMBpsReadWrite": 60,
-          "timeCreated": "2022-03-02T03:03:20.5857036\u002B00:00",
+          "timeCreated": "2022-03-04T02:39:53.8114685\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "c63be73a-79dc-43b1-83fd-bc7542732f2b"
+          "uniqueId": "6a31906a-3c3c-44c5-bab6-ae152c4924f7"
         }
       }
     },
@@ -663,8 +665,8 @@
         "Connection": "keep-alive",
         "Content-Length": "45",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "555c0207-99d5-11ec-b3fe-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "62a376dc-9b64-11ec-a099-c8348e51ab51"
       },
       "RequestBody": {
         "access": "Read",
@@ -672,12 +674,12 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/27948dc8-9517-4bad-8a35-a3ead563e67b?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/991f0f27-f00a-4db6-b806-6a70645b8e15?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:03:27 GMT",
+        "Date": "Fri, 04 Mar 2022 02:39:58 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/27948dc8-9517-4bad-8a35-a3ead563e67b?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2019-03-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/991f0f27-f00a-4db6-b806-6a70645b8e15?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2019-03-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -685,25 +687,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "22b82589-5dbe-4aa8-9ff7-fef2afba49ca",
+        "x-ms-correlation-request-id": "fa54afc5-7e36-47b1-a470-4c64fb2962de",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/HighCostDiskHydrate3Min;999,Microsoft.Compute/HighCostDiskHydrate30Min;7999",
-        "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "27948dc8-9517-4bad-8a35-a3ead563e67b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030327Z:22b82589-5dbe-4aa8-9ff7-fef2afba49ca",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "991f0f27-f00a-4db6-b806-6a70645b8e15",
+        "x-ms-routing-request-id": "WESTUS2:20220304T023958Z:fa54afc5-7e36-47b1-a470-4c64fb2962de",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/27948dc8-9517-4bad-8a35-a3ead563e67b?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/991f0f27-f00a-4db6-b806-6a70645b8e15?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "555c0207-99d5-11ec-b3fe-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "62a376dc-9b64-11ec-a099-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -711,7 +713,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:57 GMT",
+        "Date": "Fri, 04 Mar 2022 02:40:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -722,35 +724,35 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "435dc5ce-6203-415a-adcf-20ea17dea480",
+        "x-ms-correlation-request-id": "effeb2a8-041c-4e28-9b79-ee69fe4e8bd6",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49995,Microsoft.Compute/GetOperation30Min;399995",
-        "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "4a87bfe0-6b69-415b-8ba8-3785e4d54a0e",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030358Z:435dc5ce-6203-415a-adcf-20ea17dea480",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11994",
+        "x-ms-request-id": "efb81a19-e626-4e79-8b4a-eeac82940262",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024029Z:effeb2a8-041c-4e28-9b79-ee69fe4e8bd6",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:03:27.7888678\u002B00:00",
-        "endTime": "2022-03-02T03:03:28.0544762\u002B00:00",
+        "startTime": "2022-03-04T02:39:58.8583408\u002B00:00",
+        "endTime": "2022-03-04T02:39:59.2020594\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
-            "accessSAS": "https://md-hdd-mj00qbptmqfg.z11.blob.storage.azure.net/pclb3rwcrpqm/abcd?sv=2018-03-28\u0026sr=b\u0026si=9d992885-3f97-44ff-a374-62cf33013f49\u0026sig=msKSLwWpvBI1Ay5BpVHWHgUjotgVBbvA8W6C3Haa15E%3D"
+            "accessSAS": "Sanitized"
           }
         },
-        "name": "27948dc8-9517-4bad-8a35-a3ead563e67b"
+        "name": "991f0f27-f00a-4db6-b806-6a70645b8e15"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/27948dc8-9517-4bad-8a35-a3ead563e67b?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2019-03-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/991f0f27-f00a-4db6-b806-6a70645b8e15?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2019-03-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "555c0207-99d5-11ec-b3fe-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "62a376dc-9b64-11ec-a099-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -758,7 +760,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:03:57 GMT",
+        "Date": "Fri, 04 Mar 2022 02:40:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -769,15 +771,15 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "c15b2ab0-0756-4fbd-ab04-ad997043b389",
+        "x-ms-correlation-request-id": "7d333647-f3ed-44b0-9108-6e2ec3d3a4e5",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49994,Microsoft.Compute/GetOperation30Min;399994",
-        "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "e43be8d5-504f-4606-96ba-b33306a88d3d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030358Z:c15b2ab0-0756-4fbd-ab04-ad997043b389",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11993",
+        "x-ms-request-id": "2e5db321-bfeb-4f2d-b446-2ccc90764f23",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024029Z:7d333647-f3ed-44b0-9108-6e2ec3d3a4e5",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "accessSAS": "https://md-hdd-mj00qbptmqfg.z11.blob.storage.azure.net/pclb3rwcrpqm/abcd?sv=2018-03-28\u0026sr=b\u0026si=9d992885-3f97-44ff-a374-62cf33013f49\u0026sig=msKSLwWpvBI1Ay5BpVHWHgUjotgVBbvA8W6C3Haa15E%3D"
+        "accessSAS": "Sanitized"
       }
     },
     {
@@ -789,18 +791,18 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "67eb4bfc-99d5-11ec-a951-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "74ca7966-9b64-11ec-8641-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/cd7eb1a0-2d9f-4cb9-93ba-38a3c438f426?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/b8641688-eb5f-4cac-9802-7e63c3cfc393?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:03:58 GMT",
+        "Date": "Fri, 04 Mar 2022 02:40:28 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/cd7eb1a0-2d9f-4cb9-93ba-38a3c438f426?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2019-03-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/b8641688-eb5f-4cac-9802-7e63c3cfc393?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2019-03-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -808,25 +810,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "278d8564-1c25-49da-a48a-d329b5da81fe",
+        "x-ms-correlation-request-id": "1c7e951e-67a7-4f36-8a9c-4c140767cef4",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/HighCostDiskHydrate3Min;998,Microsoft.Compute/HighCostDiskHydrate30Min;7998",
-        "x-ms-ratelimit-remaining-subscription-writes": "1196",
-        "x-ms-request-id": "cd7eb1a0-2d9f-4cb9-93ba-38a3c438f426",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030359Z:278d8564-1c25-49da-a48a-d329b5da81fe",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "b8641688-eb5f-4cac-9802-7e63c3cfc393",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024029Z:1c7e951e-67a7-4f36-8a9c-4c140767cef4",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/cd7eb1a0-2d9f-4cb9-93ba-38a3c438f426?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/b8641688-eb5f-4cac-9802-7e63c3cfc393?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "67eb4bfc-99d5-11ec-a951-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "74ca7966-9b64-11ec-8641-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -834,7 +836,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:04:29 GMT",
+        "Date": "Fri, 04 Mar 2022 02:40:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -845,37 +847,37 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "e7420d53-0789-446a-9386-06e5d4dcefdf",
+        "x-ms-correlation-request-id": "eb29fbea-a4e3-42d0-8d1d-be848f2d8dcf",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49992,Microsoft.Compute/GetOperation30Min;399992",
-        "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "fa5f6ba0-d335-4616-b819-587969d100db",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030429Z:e7420d53-0789-446a-9386-06e5d4dcefdf",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11992",
+        "x-ms-request-id": "05e9465f-5875-4746-9c38-a691a807894a",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024059Z:eb29fbea-a4e3-42d0-8d1d-be848f2d8dcf",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:03:58.9326001\u002B00:00",
-        "endTime": "2022-03-02T03:03:59.026348\u002B00:00",
+        "startTime": "2022-03-04T02:40:29.3115998\u002B00:00",
+        "endTime": "2022-03-04T02:40:29.467954\u002B00:00",
         "status": "Succeeded",
-        "name": "cd7eb1a0-2d9f-4cb9-93ba-38a3c438f426"
+        "name": "b8641688-eb5f-4cac-9802-7e63c3cfc393"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/cd7eb1a0-2d9f-4cb9-93ba-38a3c438f426?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2019-03-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/b8641688-eb5f-4cac-9802-7e63c3cfc393?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2019-03-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "67eb4bfc-99d5-11ec-a951-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "74ca7966-9b64-11ec-8641-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:04:29 GMT",
+        "Date": "Fri, 04 Mar 2022 02:40:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -884,12 +886,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "0dc8aab1-de23-49cc-97c2-85281ab96fec",
+        "x-ms-correlation-request-id": "f46b73ce-2a0a-43a6-a4c3-9bf33137a75a",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49991,Microsoft.Compute/GetOperation30Min;399991",
-        "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "f473b42e-0724-4bf8-babe-40db52cad37d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030429Z:0dc8aab1-de23-49cc-97c2-85281ab96fec",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11991",
+        "x-ms-request-id": "7951acb0-fbce-4bfa-8c5d-22ee8978bf31",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024059Z:f46b73ce-2a0a-43a6-a4c3-9bf33137a75a",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
@@ -902,18 +904,18 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "7a7528d6-99d5-11ec-89a9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "86eba4ca-9b64-11ec-8179-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c3857091-85b8-4698-982a-e0e4f65d15bf?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/658f687a-7540-4f21-88f6-c15b42c9d513?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:04:30 GMT",
+        "Date": "Fri, 04 Mar 2022 02:40:59 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c3857091-85b8-4698-982a-e0e4f65d15bf?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2019-03-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/658f687a-7540-4f21-88f6-c15b42c9d513?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2019-03-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -921,25 +923,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "0d248b84-def6-4655-a426-3f94c5430ae8",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/DeleteDisks3Min;2999,Microsoft.Compute/DeleteDisks30Min;23999",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14997",
-        "x-ms-request-id": "c3857091-85b8-4698-982a-e0e4f65d15bf",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030430Z:0d248b84-def6-4655-a426-3f94c5430ae8",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "a9878bf6-2716-4b23-905f-7e33ba6f7e74",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/DeleteDisks3Min;999,Microsoft.Compute/DeleteDisks30Min;7999",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
+        "x-ms-request-id": "658f687a-7540-4f21-88f6-c15b42c9d513",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024100Z:a9878bf6-2716-4b23-905f-7e33ba6f7e74",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c3857091-85b8-4698-982a-e0e4f65d15bf?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2019-03-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/658f687a-7540-4f21-88f6-c15b42c9d513?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2019-03-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "7a7528d6-99d5-11ec-89a9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "86eba4ca-9b64-11ec-8179-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -947,7 +949,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:00 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -958,18 +960,18 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "e34fc391-e2f7-4204-9080-5fbf270ae53c",
+        "x-ms-correlation-request-id": "e9e00c88-3bff-48cd-ad82-24e1f3ed776e",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;399989",
-        "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "10e1687e-0a4f-4b25-9a19-074715dfc22b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030501Z:e34fc391-e2f7-4204-9080-5fbf270ae53c",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11990",
+        "x-ms-request-id": "7b127bc0-ce42-48a0-9cb6-7d8b0c57824b",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024130Z:e9e00c88-3bff-48cd-ad82-24e1f3ed776e",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:04:30.4954007\u002B00:00",
-        "endTime": "2022-03-02T03:04:30.6984998\u002B00:00",
+        "startTime": "2022-03-04T02:40:59.9523458\u002B00:00",
+        "endTime": "2022-03-04T02:41:00.2336206\u002B00:00",
         "status": "Succeeded",
-        "name": "c3857091-85b8-4698-982a-e0e4f65d15bf"
+        "name": "658f687a-7540-4f21-88f6-c15b42c9d513"
       }
     }
   ],

--- a/sdk/compute/azure-mgmt-compute/tests/recordings/test_mgmt_compute_disks.pyTestMgmtComputetest_compute_disks.json
+++ b/sdk/compute/azure-mgmt-compute/tests/recordings/test_mgmt_compute_disks.pyTestMgmtComputetest_compute_disks.json
@@ -7,7 +7,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)"
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -17,17 +17,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:48 GMT",
+        "Date": "Fri, 04 Mar 2022 02:44:56 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:08:48 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:44:56 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12507.17 - EUS ProdSlices",
-        "x-ms-request-id": "da3adaab-cea6-457f-9443-df69ea230f00"
+        "x-ms-ests-server": "2.1.12529.17 - NCUS ProdSlices",
+        "x-ms-request-id": "2e703af4-d72d-4ca0-9331-d799e4493500"
       },
       "ResponseBody": {
         "token_endpoint": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token",
@@ -90,7 +90,7 @@
           "email"
         ],
         "kerberos_endpoint": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/kerberos",
-        "tenant_region_scope": "NA",
+        "tenant_region_scope": "WW",
         "cloud_instance_name": "microsoftonline.com",
         "cloud_graph_host_name": "graph.windows.net",
         "msgraph_host": "graph.microsoft.com",
@@ -105,7 +105,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Cookie": "fpc=fpc; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)"
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -115,17 +115,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:48 GMT",
+        "Date": "Fri, 04 Mar 2022 02:44:56 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:08:48 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:44:56 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12507.17 - KRSLR1 ProdSlices",
-        "x-ms-request-id": "6ebbb573-e26c-4ca8-8dec-fac30fa50000"
+        "x-ms-ests-server": "2.1.12529.17 - EUS ProdSlices",
+        "x-ms-request-id": "3a361078-6131-4f10-9b03-b6e6e1e51e00"
       },
       "ResponseBody": {
         "tenant_discovery_endpoint": "https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -180,46 +180,47 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "client-request-id": "a1eacb7f-c481-48d6-a865-ffcf18caed7f",
+        "client-request-id": "5f28846c-b6f7-4303-83ac-b04ea520c1be",
         "Connection": "keep-alive",
-        "Content-Length": "289",
+        "Content-Length": "286",
         "Content-Type": "application/x-www-form-urlencoded",
         "Cookie": "fpc=fpc; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
         "x-client-cpu": "x64",
         "x-client-current-telemetry": "4|730,0|",
         "x-client-last-telemetry": "4|0|||",
         "x-client-os": "win32",
         "x-client-sku": "MSAL.Python",
-        "x-client-ver": "1.16.0",
+        "x-client-ver": "1.15.0",
         "x-ms-lib-capability": "retry-after, h429"
       },
-      "RequestBody": "client_id=a2df54d5-ab03-4725-9b80-9a00b3b1967f\u0026grant_type=client_credentials\u0026client_info=1\u0026client_secret=0vj7Q~IsFayrD0V_8oyOfygU-GE3ELOabq95a\u0026claims=%7B%22access_token%22%3A\u002B%7B%22xms_cc%22%3A\u002B%7B%22values%22%3A\u002B%5B%22CP1%22%5D%7D%7D%7D\u0026scope=https%3A%2F%2Fmanagement.azure.com%2F.default",
+      "RequestBody": "client_id=c51fbd7b-3a8a-4043-b5e1-b4631b45fdbb\u0026grant_type=client_credentials\u0026client_info=1\u0026client_secret=OqR445KX.Mj-I70qnfGeYHPsFi.vDjh7~Z\u0026claims=%7B%22access_token%22%3A\u002B%7B%22xms_cc%22%3A\u002B%7B%22values%22%3A\u002B%5B%22CP1%22%5D%7D%7D%7D\u0026scope=https%3A%2F%2Fmanagement.azure.com%2F.default",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",
-        "client-request-id": "a1eacb7f-c481-48d6-a865-ffcf18caed7f",
-        "Content-Length": "93",
+        "client-request-id": "5f28846c-b6f7-4303-83ac-b04ea520c1be",
+        "Content-Length": "114",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:48 GMT",
+        "Date": "Fri, 04 Mar 2022 02:44:56 GMT",
         "Expires": "-1",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Pragma": "no-cache",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:08:49 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:44:56 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-clitelem": "1,0,0,,",
-        "x-ms-ests-server": "2.1.12507.17 - NCUS ProdSlices",
-        "x-ms-request-id": "7fe2b7d9-45f9-4dc3-bea8-2428c7820200"
+        "x-ms-ests-server": "2.1.12529.17 - SCUS ProdSlices",
+        "x-ms-request-id": "cbf3bd0b-aa0d-4d27-9970-d2b3fee43700"
       },
       "ResponseBody": {
         "token_type": "Bearer",
-        "expires_in": 3599,
-        "ext_expires_in": 3599,
+        "expires_in": 86399,
+        "ext_expires_in": 86399,
+        "refresh_in": 43199,
         "access_token": "access_token"
       }
     },
@@ -233,8 +234,8 @@
         "Connection": "keep-alive",
         "Content-Length": "100",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1457e90a-99d6-11ec-bac9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "13db2217-9b65-11ec-ba5c-c8348e51ab51"
       },
       "RequestBody": {
         "location": "eastus",
@@ -247,13 +248,13 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/737422e6-47f8-42c3-8a68-b470a665650f?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/dae3e68a-0de2-46a8-b50d-12845305239b?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "236",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:51 GMT",
+        "Date": "Fri, 04 Mar 2022 02:44:58 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/737422e6-47f8-42c3-8a68-b470a665650f?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/dae3e68a-0de2-46a8-b50d-12845305239b?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Retry-After": "2",
         "Server": [
@@ -262,12 +263,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "c209fc5d-8068-4f36-9b85-e68b929304f3",
+        "x-ms-correlation-request-id": "69fed8c6-6398-461a-ace7-845e5ffed2ec",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateUpdateDisks3Min;998,Microsoft.Compute/CreateUpdateDisks30Min;7995",
-        "x-ms-ratelimit-remaining-subscription-writes": "1187",
-        "x-ms-request-id": "737422e6-47f8-42c3-8a68-b470a665650f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030852Z:c209fc5d-8068-4f36-9b85-e68b929304f3",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1192",
+        "x-ms-request-id": "dae3e68a-0de2-46a8-b50d-12845305239b",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024458Z:69fed8c6-6398-461a-ace7-845e5ffed2ec",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamexe6ad29c6",
@@ -283,15 +284,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/737422e6-47f8-42c3-8a68-b470a665650f?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/dae3e68a-0de2-46a8-b50d-12845305239b?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1457e90a-99d6-11ec-bac9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "13db2217-9b65-11ec-ba5c-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -299,7 +300,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:53 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -310,16 +311,16 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "1051190b-86ff-42b2-b4aa-606a5a2d87e9",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49987,Microsoft.Compute/GetOperation30Min;399969",
-        "x-ms-ratelimit-remaining-subscription-reads": "11967",
-        "x-ms-request-id": "a72d855d-4d64-48b3-bf65-ba18037da601",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030854Z:1051190b-86ff-42b2-b4aa-606a5a2d87e9",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "be925009-8f11-4c2f-a7e9-1587e6572904",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;399969",
+        "x-ms-ratelimit-remaining-subscription-reads": "11971",
+        "x-ms-request-id": "51fb3f3e-5185-47fd-9b8e-5a82625d1fd4",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024500Z:be925009-8f11-4c2f-a7e9-1587e6572904",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:08:51.9177593\u002B00:00",
-        "endTime": "2022-03-02T03:08:51.9803788\u002B00:00",
+        "startTime": "2022-03-04T02:44:58.7546832\u002B00:00",
+        "endTime": "2022-03-04T02:44:58.8953115\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
@@ -343,15 +344,15 @@
               },
               "networkAccessPolicy": "AllowAll",
               "publicNetworkAccess": "Enabled",
-              "timeCreated": "2022-03-02T03:08:51.9177593\u002B00:00",
+              "timeCreated": "2022-03-04T02:44:58.7546832\u002B00:00",
               "provisioningState": "Succeeded",
               "diskState": "Unattached",
               "diskSizeBytes": 214748364800,
-              "uniqueId": "da425fb5-8783-4c81-8f9c-b6ece3d1f405"
+              "uniqueId": "88ed7a6c-1b72-4476-be97-549450a4d3e2"
             }
           }
         },
-        "name": "737422e6-47f8-42c3-8a68-b470a665650f"
+        "name": "dae3e68a-0de2-46a8-b50d-12845305239b"
       }
     },
     {
@@ -362,8 +363,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1457e90a-99d6-11ec-bac9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "13db2217-9b65-11ec-ba5c-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -371,7 +372,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:54 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -382,12 +383,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "bca6ab40-c1f8-4f35-a467-ff2025a78b09",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14995,Microsoft.Compute/LowCostGet30Min;119979",
-        "x-ms-ratelimit-remaining-subscription-reads": "11966",
-        "x-ms-request-id": "6821e89a-ecdf-4205-a874-067851a51eba",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030854Z:bca6ab40-c1f8-4f35-a467-ff2025a78b09",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "b31e944c-399b-4082-8b6c-9aff155dbce7",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4995,Microsoft.Compute/LowCostGet30Min;39979",
+        "x-ms-ratelimit-remaining-subscription-reads": "11970",
+        "x-ms-request-id": "83763f4e-5284-4570-8fd8-4f1528fcfb51",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024501Z:b31e944c-399b-4082-8b6c-9aff155dbce7",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamexe6ad29c6",
@@ -410,11 +411,11 @@
           },
           "networkAccessPolicy": "AllowAll",
           "publicNetworkAccess": "Enabled",
-          "timeCreated": "2022-03-02T03:08:51.9177593\u002B00:00",
+          "timeCreated": "2022-03-04T02:44:58.7546832\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "da425fb5-8783-4c81-8f9c-b6ece3d1f405"
+          "uniqueId": "88ed7a6c-1b72-4476-be97-549450a4d3e2"
         }
       }
     },
@@ -426,8 +427,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "187b2007-99d6-11ec-9fd8-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "16d7a4d5-9b65-11ec-93c1-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -435,7 +436,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:54 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -446,12 +447,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "f690f696-60d2-4a54-93ca-7d9948f60820",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14994,Microsoft.Compute/LowCostGet30Min;119978",
-        "x-ms-ratelimit-remaining-subscription-reads": "11965",
-        "x-ms-request-id": "5bab70da-a2b4-4c35-b4cd-92ae362c1b75",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030855Z:f690f696-60d2-4a54-93ca-7d9948f60820",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "3f0e720c-0a55-4d8a-bcfa-ea6ed137fcc2",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4994,Microsoft.Compute/LowCostGet30Min;39978",
+        "x-ms-ratelimit-remaining-subscription-reads": "11969",
+        "x-ms-request-id": "230b1e42-b08b-4489-86ad-ea7f83dd695d",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024501Z:3f0e720c-0a55-4d8a-bcfa-ea6ed137fcc2",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamexe6ad29c6",
@@ -474,11 +475,11 @@
           },
           "networkAccessPolicy": "AllowAll",
           "publicNetworkAccess": "Enabled",
-          "timeCreated": "2022-03-02T03:08:51.9177593\u002B00:00",
+          "timeCreated": "2022-03-04T02:44:58.7546832\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "da425fb5-8783-4c81-8f9c-b6ece3d1f405"
+          "uniqueId": "88ed7a6c-1b72-4476-be97-549450a4d3e2"
         }
       }
     },
@@ -492,8 +493,8 @@
         "Connection": "keep-alive",
         "Content-Length": "35",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "18afefc9-99d6-11ec-9d71-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "16e8632e-9b65-11ec-9ac7-c8348e51ab51"
       },
       "RequestBody": {
         "properties": {
@@ -502,13 +503,13 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/3dae6262-8603-403e-9647-812cf3c27f02?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/ae9627e8-c8ac-432b-9c91-ddabb1c5344a?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:54 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:00 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/3dae6262-8603-403e-9647-812cf3c27f02?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/ae9627e8-c8ac-432b-9c91-ddabb1c5344a?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Retry-After": "2",
         "Server": [
@@ -517,12 +518,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "dcb194d9-319b-467e-ac3d-87c3bc154d64",
+        "x-ms-correlation-request-id": "f846994e-1aff-4836-a97c-d6bdba0b5add",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateUpdateDisks3Min;997,Microsoft.Compute/CreateUpdateDisks30Min;7994",
-        "x-ms-ratelimit-remaining-subscription-writes": "1186",
-        "x-ms-request-id": "3dae6262-8603-403e-9647-812cf3c27f02",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030855Z:dcb194d9-319b-467e-ac3d-87c3bc154d64",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1191",
+        "x-ms-request-id": "ae9627e8-c8ac-432b-9c91-ddabb1c5344a",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024501Z:f846994e-1aff-4836-a97c-d6bdba0b5add",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamexe6ad29c6",
@@ -543,15 +544,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/3dae6262-8603-403e-9647-812cf3c27f02?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/ae9627e8-c8ac-432b-9c91-ddabb1c5344a?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "18afefc9-99d6-11ec-9d71-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "16e8632e-9b65-11ec-9ac7-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -559,7 +560,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:57 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -570,16 +571,16 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "e4687003-2d13-4d1b-a352-22cfd89c4e28",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49986,Microsoft.Compute/GetOperation30Min;399968",
-        "x-ms-ratelimit-remaining-subscription-reads": "11964",
-        "x-ms-request-id": "350675e3-ae4f-4b82-837d-4c7885916d20",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030858Z:e4687003-2d13-4d1b-a352-22cfd89c4e28",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "4e325531-dd50-4879-b870-9cd044047138",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49987,Microsoft.Compute/GetOperation30Min;399968",
+        "x-ms-ratelimit-remaining-subscription-reads": "11968",
+        "x-ms-request-id": "364226e5-2aec-4203-93dc-a48ed82c43d8",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024503Z:4e325531-dd50-4879-b870-9cd044047138",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:08:55.495918\u002B00:00",
-        "endTime": "2022-03-02T03:08:55.5583881\u002B00:00",
+        "startTime": "2022-03-04T02:45:01.3171869\u002B00:00",
+        "endTime": "2022-03-04T02:45:01.4578044\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
@@ -603,15 +604,15 @@
               },
               "networkAccessPolicy": "AllowAll",
               "publicNetworkAccess": "Enabled",
-              "timeCreated": "2022-03-02T03:08:51.9177593\u002B00:00",
+              "timeCreated": "2022-03-04T02:44:58.7546832\u002B00:00",
               "provisioningState": "Succeeded",
               "diskState": "Unattached",
               "diskSizeBytes": 214748364800,
-              "uniqueId": "da425fb5-8783-4c81-8f9c-b6ece3d1f405"
+              "uniqueId": "88ed7a6c-1b72-4476-be97-549450a4d3e2"
             }
           }
         },
-        "name": "3dae6262-8603-403e-9647-812cf3c27f02"
+        "name": "ae9627e8-c8ac-432b-9c91-ddabb1c5344a"
       }
     },
     {
@@ -622,8 +623,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "18afefc9-99d6-11ec-9d71-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "16e8632e-9b65-11ec-9ac7-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -631,7 +632,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:57 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -642,12 +643,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "afa8149f-d6fd-486f-a293-aba865690343",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14991,Microsoft.Compute/LowCostGet30Min;119975",
-        "x-ms-ratelimit-remaining-subscription-reads": "11963",
-        "x-ms-request-id": "bb1133b0-eab4-4647-97db-2fe93318599c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030858Z:afa8149f-d6fd-486f-a293-aba865690343",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "71850b54-a922-4ff5-a852-388be63e4fe1",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4992,Microsoft.Compute/LowCostGet30Min;39976",
+        "x-ms-ratelimit-remaining-subscription-reads": "11967",
+        "x-ms-request-id": "dac54d89-8b3d-4c25-9de0-1c0ad8bbbaf9",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024503Z:71850b54-a922-4ff5-a852-388be63e4fe1",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamexe6ad29c6",
@@ -670,11 +671,11 @@
           },
           "networkAccessPolicy": "AllowAll",
           "publicNetworkAccess": "Enabled",
-          "timeCreated": "2022-03-02T03:08:51.9177593\u002B00:00",
+          "timeCreated": "2022-03-04T02:44:58.7546832\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "da425fb5-8783-4c81-8f9c-b6ece3d1f405"
+          "uniqueId": "88ed7a6c-1b72-4476-be97-549450a4d3e2"
         }
       }
     },
@@ -688,8 +689,8 @@
         "Connection": "keep-alive",
         "Content-Length": "45",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1a8a063c-99d6-11ec-8f4e-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "1875532d-9b65-11ec-b165-c8348e51ab51"
       },
       "RequestBody": {
         "access": "Read",
@@ -697,12 +698,12 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8296efab-7d5d-4277-aa33-3b4ab81743ae?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/301da8cb-ff8b-4d31-abb5-ebef5099d7be?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:08:58 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:03 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8296efab-7d5d-4277-aa33-3b4ab81743ae?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/301da8cb-ff8b-4d31-abb5-ebef5099d7be?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -710,25 +711,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "ff823c75-0339-40bc-85cd-80228dee2e0f",
+        "x-ms-correlation-request-id": "7aa14323-2fcd-46c6-b1b6-d5148ea7e374",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/HighCostDiskHydrate3Min;999,Microsoft.Compute/HighCostDiskHydrate30Min;7997",
-        "x-ms-ratelimit-remaining-subscription-writes": "1193",
-        "x-ms-request-id": "8296efab-7d5d-4277-aa33-3b4ab81743ae",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030858Z:ff823c75-0339-40bc-85cd-80228dee2e0f",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1195",
+        "x-ms-request-id": "301da8cb-ff8b-4d31-abb5-ebef5099d7be",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024504Z:7aa14323-2fcd-46c6-b1b6-d5148ea7e374",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8296efab-7d5d-4277-aa33-3b4ab81743ae?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/301da8cb-ff8b-4d31-abb5-ebef5099d7be?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1a8a063c-99d6-11ec-8f4e-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "1875532d-9b65-11ec-b165-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -736,7 +737,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:09:28 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -747,35 +748,35 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "8cc260ab-a48f-4661-9b1c-5487d4981a97",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49984,Microsoft.Compute/GetOperation30Min;399965",
-        "x-ms-ratelimit-remaining-subscription-reads": "11962",
-        "x-ms-request-id": "1552a9f9-3772-4f48-9fd2-07c37016fda2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030929Z:8cc260ab-a48f-4661-9b1c-5487d4981a97",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "0231eac7-6b7e-4e19-ac33-6b624cc22eef",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49985,Microsoft.Compute/GetOperation30Min;399965",
+        "x-ms-ratelimit-remaining-subscription-reads": "11966",
+        "x-ms-request-id": "d3078fd8-d18f-41fd-8baa-f02a758df09e",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024534Z:0231eac7-6b7e-4e19-ac33-6b624cc22eef",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:08:58.6052535\u002B00:00",
-        "endTime": "2022-03-02T03:08:58.7771687\u002B00:00",
+        "startTime": "2022-03-04T02:45:03.8953286\u002B00:00",
+        "endTime": "2022-03-04T02:45:04.1609738\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
-            "accessSAS": "https://md-hdd-d2f4qhrdv02d.z21.blob.storage.azure.net/cj15h13hftg3/abcd?sv=2018-03-28\u0026sr=b\u0026si=e82f2ccf-1958-4117-b1a0-d23a1847a877\u0026sig=q%2Fsq48%2B0j6xgOhFB7dIRkFtvi2CYc0eV%2Fqk0DbCKOr4%3D"
+            "accessSAS": "Sanitized"
           }
         },
-        "name": "8296efab-7d5d-4277-aa33-3b4ab81743ae"
+        "name": "301da8cb-ff8b-4d31-abb5-ebef5099d7be"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8296efab-7d5d-4277-aa33-3b4ab81743ae?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/301da8cb-ff8b-4d31-abb5-ebef5099d7be?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1a8a063c-99d6-11ec-8f4e-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "1875532d-9b65-11ec-b165-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -783,7 +784,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:09:28 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -794,15 +795,15 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "407997b1-4f1b-42a7-b507-bfbd99632775",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49983,Microsoft.Compute/GetOperation30Min;399964",
-        "x-ms-ratelimit-remaining-subscription-reads": "11961",
-        "x-ms-request-id": "e3d68cc6-c80b-4e62-bf8e-c443ca0b3aa4",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030929Z:407997b1-4f1b-42a7-b507-bfbd99632775",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "71324bb3-d60b-41e3-8d95-e6d0a24af540",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49984,Microsoft.Compute/GetOperation30Min;399964",
+        "x-ms-ratelimit-remaining-subscription-reads": "11965",
+        "x-ms-request-id": "08f6fdd8-3789-4ce0-8393-dd16d3fa0b66",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024534Z:71324bb3-d60b-41e3-8d95-e6d0a24af540",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "accessSAS": "https://md-hdd-d2f4qhrdv02d.z21.blob.storage.azure.net/cj15h13hftg3/abcd?sv=2018-03-28\u0026sr=b\u0026si=e82f2ccf-1958-4117-b1a0-d23a1847a877\u0026sig=q%2Fsq48%2B0j6xgOhFB7dIRkFtvi2CYc0eV%2Fqk0DbCKOr4%3D"
+        "accessSAS": "Sanitized"
       }
     },
     {
@@ -814,18 +815,18 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "2d13d230-99d6-11ec-a873-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "2a9ab4ec-9b65-11ec-b8bd-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c6c5aaf5-8ff8-42f9-8010-371a70cdfa80?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/7c630ec4-d599-4965-8f95-9072185aaa86?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:09:28 GMT",
+        "Date": "Fri, 04 Mar 2022 02:45:33 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c6c5aaf5-8ff8-42f9-8010-371a70cdfa80?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/7c630ec4-d599-4965-8f95-9072185aaa86?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -833,25 +834,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "4367b356-eef5-4c08-a5a6-2def0153c21e",
+        "x-ms-correlation-request-id": "fcb2fb76-ed97-4369-8e4c-17661ae37346",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/HighCostDiskHydrate3Min;998,Microsoft.Compute/HighCostDiskHydrate30Min;7996",
-        "x-ms-ratelimit-remaining-subscription-writes": "1192",
-        "x-ms-request-id": "c6c5aaf5-8ff8-42f9-8010-371a70cdfa80",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030929Z:4367b356-eef5-4c08-a5a6-2def0153c21e",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1194",
+        "x-ms-request-id": "7c630ec4-d599-4965-8f95-9072185aaa86",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024534Z:fcb2fb76-ed97-4369-8e4c-17661ae37346",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c6c5aaf5-8ff8-42f9-8010-371a70cdfa80?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/7c630ec4-d599-4965-8f95-9072185aaa86?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "2d13d230-99d6-11ec-a873-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "2a9ab4ec-9b65-11ec-b8bd-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -859,7 +860,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:10:00 GMT",
+        "Date": "Fri, 04 Mar 2022 02:46:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -870,37 +871,37 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "94410206-687c-46c1-b852-a19e359fdf4e",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49986,Microsoft.Compute/GetOperation30Min;399962",
-        "x-ms-ratelimit-remaining-subscription-reads": "11960",
-        "x-ms-request-id": "9bff110c-75f6-4e00-b9ff-e4ebcca3e3bd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T031000Z:94410206-687c-46c1-b852-a19e359fdf4e",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "e482fed5-ce7c-439f-8317-410651d3f443",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49985,Microsoft.Compute/GetOperation30Min;399962",
+        "x-ms-ratelimit-remaining-subscription-reads": "11964",
+        "x-ms-request-id": "599a5f41-81c0-431c-b72a-fa455e9b88e9",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024604Z:e482fed5-ce7c-439f-8317-410651d3f443",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:09:29.7147362\u002B00:00",
-        "endTime": "2022-03-02T03:09:29.8084881\u002B00:00",
+        "startTime": "2022-03-04T02:45:34.3490248\u002B00:00",
+        "endTime": "2022-03-04T02:45:34.4896808\u002B00:00",
         "status": "Succeeded",
-        "name": "c6c5aaf5-8ff8-42f9-8010-371a70cdfa80"
+        "name": "7c630ec4-d599-4965-8f95-9072185aaa86"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c6c5aaf5-8ff8-42f9-8010-371a70cdfa80?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/7c630ec4-d599-4965-8f95-9072185aaa86?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "2d13d230-99d6-11ec-a873-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "2a9ab4ec-9b65-11ec-b8bd-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:10:00 GMT",
+        "Date": "Fri, 04 Mar 2022 02:46:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -909,12 +910,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "85520935-faee-48bc-9c4c-a712fdcc74e2",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49985,Microsoft.Compute/GetOperation30Min;399961",
-        "x-ms-ratelimit-remaining-subscription-reads": "11959",
-        "x-ms-request-id": "533fb647-1de0-43b0-aacd-c604e62cea2a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T031000Z:85520935-faee-48bc-9c4c-a712fdcc74e2",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "6b03c02e-acd3-4ec9-a4af-16a79f6b07e4",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49984,Microsoft.Compute/GetOperation30Min;399961",
+        "x-ms-ratelimit-remaining-subscription-reads": "11963",
+        "x-ms-request-id": "5b657fe3-2799-44a2-8675-ec675a5d99b6",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024604Z:6b03c02e-acd3-4ec9-a4af-16a79f6b07e4",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
@@ -927,18 +928,18 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "3fa3716d-99d6-11ec-9f5e-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "3cb9cbd3-9b65-11ec-80c7-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/af260d11-cc05-4fb0-91e2-9c82e440767e?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/1ad8a5bd-9a32-44a8-8efc-6cf0b7cf63f9?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:10:01 GMT",
+        "Date": "Fri, 04 Mar 2022 02:46:04 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/af260d11-cc05-4fb0-91e2-9c82e440767e?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/1ad8a5bd-9a32-44a8-8efc-6cf0b7cf63f9?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -946,25 +947,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "5d4acc2b-9d48-4b98-83e6-20463814746d",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/DeleteDisks3Min;2997,Microsoft.Compute/DeleteDisks30Min;23996",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14994",
-        "x-ms-request-id": "af260d11-cc05-4fb0-91e2-9c82e440767e",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T031001Z:5d4acc2b-9d48-4b98-83e6-20463814746d",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "d45a8d3f-537d-4f5d-b9ff-ffbe1b1d65f6",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/DeleteDisks3Min;997,Microsoft.Compute/DeleteDisks30Min;7996",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14996",
+        "x-ms-request-id": "1ad8a5bd-9a32-44a8-8efc-6cf0b7cf63f9",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024605Z:d45a8d3f-537d-4f5d-b9ff-ffbe1b1d65f6",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/af260d11-cc05-4fb0-91e2-9c82e440767e?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/1ad8a5bd-9a32-44a8-8efc-6cf0b7cf63f9?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "3fa3716d-99d6-11ec-9f5e-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "3cb9cbd3-9b65-11ec-80c7-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -972,7 +973,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:10:31 GMT",
+        "Date": "Fri, 04 Mar 2022 02:46:34 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -983,18 +984,18 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "e4098091-8059-4874-84b1-97a95929dd2c",
+        "x-ms-correlation-request-id": "bc1bdf20-e6dc-4ab4-ad5d-486a80920202",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49986,Microsoft.Compute/GetOperation30Min;399958",
-        "x-ms-ratelimit-remaining-subscription-reads": "11958",
-        "x-ms-request-id": "e287c486-7b03-42b0-8294-c89eb390495f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T031031Z:e4098091-8059-4874-84b1-97a95929dd2c",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11962",
+        "x-ms-request-id": "00a37b2b-f174-4340-894d-770959e01e1f",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024635Z:bc1bdf20-e6dc-4ab4-ad5d-486a80920202",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:10:01.3084758\u002B00:00",
-        "endTime": "2022-03-02T03:10:06.0428601\u002B00:00",
+        "startTime": "2022-03-04T02:46:04.9589314\u002B00:00",
+        "endTime": "2022-03-04T02:46:05.4432987\u002B00:00",
         "status": "Succeeded",
-        "name": "af260d11-cc05-4fb0-91e2-9c82e440767e"
+        "name": "1ad8a5bd-9a32-44a8-8efc-6cf0b7cf63f9"
       }
     }
   ],

--- a/sdk/compute/azure-mgmt-compute/tests/recordings/test_mgmt_compute_disks.pyTestMgmtComputetest_compute_shot.json
+++ b/sdk/compute/azure-mgmt-compute/tests/recordings/test_mgmt_compute_disks.pyTestMgmtComputetest_compute_shot.json
@@ -7,7 +7,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)"
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -17,17 +17,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:10 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:34 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:05:11 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:41:34 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12507.17 - WUS2 ProdSlices",
-        "x-ms-request-id": "932ea9bd-a81b-4b0f-b234-9ff9de3b6a00"
+        "x-ms-ests-server": "2.1.12529.17 - NCUS ProdSlices",
+        "x-ms-request-id": "2e703af4-d72d-4ca0-9331-d799102e3500"
       },
       "ResponseBody": {
         "token_endpoint": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token",
@@ -90,7 +90,7 @@
           "email"
         ],
         "kerberos_endpoint": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/kerberos",
-        "tenant_region_scope": "NA",
+        "tenant_region_scope": "WW",
         "cloud_instance_name": "microsoftonline.com",
         "cloud_graph_host_name": "graph.windows.net",
         "msgraph_host": "graph.microsoft.com",
@@ -105,7 +105,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Cookie": "fpc=fpc; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)"
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -115,17 +115,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:11 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:34 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:05:11 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:41:34 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12529.16 - SEASLR2 ProdSlices",
-        "x-ms-request-id": "548eb271-eb2a-4e0f-9967-fd67c3852400"
+        "x-ms-ests-server": "2.1.12507.17 - EUS ProdSlices",
+        "x-ms-request-id": "1c4028dd-2364-452e-8446-09e2c0e41200"
       },
       "ResponseBody": {
         "tenant_discovery_endpoint": "https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -180,46 +180,47 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "client-request-id": "e22d9f42-e8dc-43ef-9bad-7d6cc691d062",
+        "client-request-id": "9eed2f11-6e8d-49ae-b382-e61fc8d3b693",
         "Connection": "keep-alive",
-        "Content-Length": "289",
+        "Content-Length": "286",
         "Content-Type": "application/x-www-form-urlencoded",
         "Cookie": "fpc=fpc; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.8.0b2 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
+        "User-Agent": "azsdk-python-identity/1.9.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
         "x-client-cpu": "x64",
         "x-client-current-telemetry": "4|730,0|",
         "x-client-last-telemetry": "4|0|||",
         "x-client-os": "win32",
         "x-client-sku": "MSAL.Python",
-        "x-client-ver": "1.16.0",
+        "x-client-ver": "1.15.0",
         "x-ms-lib-capability": "retry-after, h429"
       },
-      "RequestBody": "client_id=a2df54d5-ab03-4725-9b80-9a00b3b1967f\u0026grant_type=client_credentials\u0026client_info=1\u0026client_secret=0vj7Q~IsFayrD0V_8oyOfygU-GE3ELOabq95a\u0026claims=%7B%22access_token%22%3A\u002B%7B%22xms_cc%22%3A\u002B%7B%22values%22%3A\u002B%5B%22CP1%22%5D%7D%7D%7D\u0026scope=https%3A%2F%2Fmanagement.azure.com%2F.default",
+      "RequestBody": "client_id=c51fbd7b-3a8a-4043-b5e1-b4631b45fdbb\u0026grant_type=client_credentials\u0026client_info=1\u0026client_secret=OqR445KX.Mj-I70qnfGeYHPsFi.vDjh7~Z\u0026claims=%7B%22access_token%22%3A\u002B%7B%22xms_cc%22%3A\u002B%7B%22values%22%3A\u002B%5B%22CP1%22%5D%7D%7D%7D\u0026scope=https%3A%2F%2Fmanagement.azure.com%2F.default",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",
-        "client-request-id": "e22d9f42-e8dc-43ef-9bad-7d6cc691d062",
-        "Content-Length": "93",
+        "client-request-id": "9eed2f11-6e8d-49ae-b382-e61fc8d3b693",
+        "Content-Length": "114",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:11 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:35 GMT",
         "Expires": "-1",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Pragma": "no-cache",
         "Set-Cookie": [
-          "fpc=fpc; expires=Fri, 01-Apr-2022 03:05:11 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=fpc; expires=Sun, 03-Apr-2022 02:41:35 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-clitelem": "1,0,0,,",
-        "x-ms-ests-server": "2.1.12507.17 - WUS2 ProdSlices",
-        "x-ms-request-id": "8f3d0348-d3be-4db0-abff-5171f1b06e00"
+        "x-ms-ests-server": "2.1.12529.17 - SCUS ProdSlices",
+        "x-ms-request-id": "71283c17-ff25-4a64-a637-fe8d967a3600"
       },
       "ResponseBody": {
         "token_type": "Bearer",
-        "expires_in": 3599,
-        "ext_expires_in": 3599,
+        "expires_in": 86399,
+        "ext_expires_in": 86399,
+        "refresh_in": 43199,
         "access_token": "access_token"
       }
     },
@@ -233,8 +234,8 @@
         "Connection": "keep-alive",
         "Content-Length": "100",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "92927e1f-99d5-11ec-8910-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "9baf8027-9b64-11ec-aa84-c8348e51ab51"
       },
       "RequestBody": {
         "location": "eastus",
@@ -247,13 +248,13 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/fa240536-a732-4c3b-b69a-41abba7d7124?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/53c23f6c-3669-478e-a5bb-9e96034631a4?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "236",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:13 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:36 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/fa240536-a732-4c3b-b69a-41abba7d7124?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/53c23f6c-3669-478e-a5bb-9e96034631a4?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Retry-After": "2",
         "Server": [
@@ -262,12 +263,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "084514a1-c582-4340-9f25-ca037e0bf474",
+        "x-ms-correlation-request-id": "d3c5ce8e-6db5-4ce7-91b3-bed39604c3ab",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateUpdateDisks3Min;997,Microsoft.Compute/CreateUpdateDisks30Min;7997",
-        "x-ms-ratelimit-remaining-subscription-writes": "1192",
-        "x-ms-request-id": "fa240536-a732-4c3b-b69a-41abba7d7124",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030514Z:084514a1-c582-4340-9f25-ca037e0bf474",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "53c23f6c-3669-478e-a5bb-9e96034631a4",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024137Z:d3c5ce8e-6db5-4ce7-91b3-bed39604c3ab",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamexbc8e2966",
@@ -283,15 +284,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/fa240536-a732-4c3b-b69a-41abba7d7124?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/53c23f6c-3669-478e-a5bb-9e96034631a4?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "92927e1f-99d5-11ec-8910-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "9baf8027-9b64-11ec-aa84-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -299,7 +300,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:16 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -310,16 +311,16 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "bf861e06-1613-42fa-91e5-f5c65ec496b6",
+        "x-ms-correlation-request-id": "f74729dd-c8bc-4dc4-ba22-c57aacaf3f21",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;399988",
-        "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "f90507e9-be00-4636-a7f5-e6df29105643",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030517Z:bf861e06-1613-42fa-91e5-f5c65ec496b6",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-reads": "11989",
+        "x-ms-request-id": "47c93e28-1a8e-4d44-81a7-bf4f70f43052",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024139Z:f74729dd-c8bc-4dc4-ba22-c57aacaf3f21",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:05:14.4955784\u002B00:00",
-        "endTime": "2022-03-02T03:05:14.5736891\u002B00:00",
+        "startTime": "2022-03-04T02:41:36.9688838\u002B00:00",
+        "endTime": "2022-03-04T02:41:37.1095277\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
@@ -343,15 +344,15 @@
               },
               "networkAccessPolicy": "AllowAll",
               "publicNetworkAccess": "Enabled",
-              "timeCreated": "2022-03-02T03:05:14.5112184\u002B00:00",
+              "timeCreated": "2022-03-04T02:41:36.9688838\u002B00:00",
               "provisioningState": "Succeeded",
               "diskState": "Unattached",
               "diskSizeBytes": 214748364800,
-              "uniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+              "uniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
             }
           }
         },
-        "name": "fa240536-a732-4c3b-b69a-41abba7d7124"
+        "name": "53c23f6c-3669-478e-a5bb-9e96034631a4"
       }
     },
     {
@@ -362,8 +363,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "92927e1f-99d5-11ec-8910-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "9baf8027-9b64-11ec-aa84-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -371,7 +372,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:16 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -382,12 +383,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "2850ceae-f5a5-411c-9c29-bfb2ddb1b8f2",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14991,Microsoft.Compute/LowCostGet30Min;119991",
-        "x-ms-ratelimit-remaining-subscription-reads": "11984",
-        "x-ms-request-id": "f3b3989e-24b7-4592-acfe-9525a30324f1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030517Z:2850ceae-f5a5-411c-9c29-bfb2ddb1b8f2",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "d10ae7e2-c95f-4ba3-b34a-8c76a23db22d",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4991,Microsoft.Compute/LowCostGet30Min;39991",
+        "x-ms-ratelimit-remaining-subscription-reads": "11988",
+        "x-ms-request-id": "88b6f0e6-4b12-4ded-824b-ab120b4b42d2",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024139Z:d10ae7e2-c95f-4ba3-b34a-8c76a23db22d",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "disknamexbc8e2966",
@@ -410,11 +411,11 @@
           },
           "networkAccessPolicy": "AllowAll",
           "publicNetworkAccess": "Enabled",
-          "timeCreated": "2022-03-02T03:05:14.5112184\u002B00:00",
+          "timeCreated": "2022-03-04T02:41:36.9688838\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+          "uniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
         }
       }
     },
@@ -428,8 +429,8 @@
         "Connection": "keep-alive",
         "Content-Length": "222",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "96cfd4f1-99d5-11ec-afb9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "9e962284-9b64-11ec-9619-c8348e51ab51"
       },
       "RequestBody": {
         "location": "eastus",
@@ -442,13 +443,13 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/e75f2069-da9e-44c8-b85d-bc4a738f861f?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/b14fde72-4012-47f2-ab9a-c20558d1a706?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "432",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:18 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:39 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/e75f2069-da9e-44c8-b85d-bc4a738f861f?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/b14fde72-4012-47f2-ab9a-c20558d1a706?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Retry-After": "2",
         "Server": [
@@ -457,12 +458,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "f3786b4c-6e93-4341-bc67-a0595d8436df",
+        "x-ms-correlation-request-id": "7b963321-640b-4e75-a8ba-27217af46c8c",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;999,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;7999",
-        "x-ms-ratelimit-remaining-subscription-writes": "1191",
-        "x-ms-request-id": "e75f2069-da9e-44c8-b85d-bc4a738f861f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030519Z:f3786b4c-6e93-4341-bc67-a0595d8436df",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1196",
+        "x-ms-request-id": "b14fde72-4012-47f2-ab9a-c20558d1a706",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024140Z:7b963321-640b-4e75-a8ba-27217af46c8c",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "location": "eastus",
@@ -470,7 +471,7 @@
           "creationData": {
             "createOption": "Copy",
             "sourceUri": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/disks/disknamexbc8e2966",
-            "sourceUniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+            "sourceUniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
           },
           "publicNetworkAccess": "Enabled",
           "provisioningState": "Updating",
@@ -479,15 +480,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/e75f2069-da9e-44c8-b85d-bc4a738f861f?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/b14fde72-4012-47f2-ab9a-c20558d1a706?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "96cfd4f1-99d5-11ec-afb9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "9e962284-9b64-11ec-9619-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -495,7 +496,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:21 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -506,16 +507,16 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "828146e4-2acd-4676-9d13-0b9cd6953b71",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49986,Microsoft.Compute/GetOperation30Min;399986",
-        "x-ms-ratelimit-remaining-subscription-reads": "11983",
-        "x-ms-request-id": "d1e45650-0af6-409c-96c0-5d6adeac1aa5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030521Z:828146e4-2acd-4676-9d13-0b9cd6953b71",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "5019bfa5-bdf0-44ff-b0e0-dce55e4547fb",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49987,Microsoft.Compute/GetOperation30Min;399987",
+        "x-ms-ratelimit-remaining-subscription-reads": "11987",
+        "x-ms-request-id": "43f20319-9188-441f-8c15-e99ba4776362",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024142Z:5019bfa5-bdf0-44ff-b0e0-dce55e4547fb",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:05:19.2768585\u002B00:00",
-        "endTime": "2022-03-02T03:05:20.323721\u002B00:00",
+        "startTime": "2022-03-04T02:41:40.1720575\u002B00:00",
+        "endTime": "2022-03-04T02:41:41.3595442\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
@@ -531,7 +532,7 @@
               "creationData": {
                 "createOption": "Copy",
                 "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/disks/disknamexbc8e2966",
-                "sourceUniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+                "sourceUniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
               },
               "diskSizeGB": 200,
               "encryption": {
@@ -540,15 +541,15 @@
               "incremental": false,
               "networkAccessPolicy": "AllowAll",
               "publicNetworkAccess": "Enabled",
-              "timeCreated": "2022-03-02T03:05:19.2768585\u002B00:00",
+              "timeCreated": "2022-03-04T02:41:40.187671\u002B00:00",
               "provisioningState": "Succeeded",
               "diskState": "Unattached",
               "diskSizeBytes": 214748364800,
-              "uniqueId": "68c6f729-3de5-4ce0-ab81-62ad67b728cd"
+              "uniqueId": "7e36f8c3-a64d-472d-8574-33c825730848"
             }
           }
         },
-        "name": "e75f2069-da9e-44c8-b85d-bc4a738f861f"
+        "name": "b14fde72-4012-47f2-ab9a-c20558d1a706"
       }
     },
     {
@@ -559,8 +560,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "96cfd4f1-99d5-11ec-afb9-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "9e962284-9b64-11ec-9619-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -568,7 +569,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:21 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -579,12 +580,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "561a796d-bedb-47ee-85e3-e8b7d0ca4867",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14989,Microsoft.Compute/LowCostGet30Min;119989",
-        "x-ms-ratelimit-remaining-subscription-reads": "11982",
-        "x-ms-request-id": "9653398a-0832-427f-914e-a99df5d1b9a5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030522Z:561a796d-bedb-47ee-85e3-e8b7d0ca4867",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "60bf85a4-d860-4ad6-9615-20dbabda0b97",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4990,Microsoft.Compute/LowCostGet30Min;39990",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "e4622f0c-f08b-4362-9691-1d82aaec36ee",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024142Z:60bf85a4-d860-4ad6-9615-20dbabda0b97",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "snapshotxbc8e2966",
@@ -599,7 +600,7 @@
           "creationData": {
             "createOption": "Copy",
             "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/disks/disknamexbc8e2966",
-            "sourceUniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+            "sourceUniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
           },
           "diskSizeGB": 200,
           "encryption": {
@@ -608,11 +609,11 @@
           "incremental": false,
           "networkAccessPolicy": "AllowAll",
           "publicNetworkAccess": "Enabled",
-          "timeCreated": "2022-03-02T03:05:19.2768585\u002B00:00",
+          "timeCreated": "2022-03-04T02:41:40.187671\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "68c6f729-3de5-4ce0-ab81-62ad67b728cd"
+          "uniqueId": "7e36f8c3-a64d-472d-8574-33c825730848"
         }
       }
     },
@@ -626,8 +627,8 @@
         "Connection": "keep-alive",
         "Content-Length": "317",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "99ab41c2-99d5-11ec-900a-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "a0e990f6-9b64-11ec-afd4-c8348e51ab51"
       },
       "RequestBody": {
         "location": "eastus",
@@ -648,11 +649,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/e33c196c-c571-4074-b21a-dd64fbf5e129?p=54253b73-cb53-496f-ab42-5e5ee19426f8\u0026api-version=2021-11-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/abcf528a-8501-4ba9-b73e-47e0e514963c?p=da74df64-2927-47c5-bfaf-ab3f7b37c044\u0026api-version=2021-11-01",
         "Cache-Control": "no-cache",
         "Content-Length": "762",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:24 GMT",
+        "Date": "Fri, 04 Mar 2022 02:41:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -661,11 +662,11 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "92ef9d62-b1b4-4078-9606-ff0b15f7ce54",
+        "x-ms-correlation-request-id": "ff7df3b9-422b-4582-a5ab-7471447b51b2",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateImages3Min;39,Microsoft.Compute/CreateImages30Min;199",
-        "x-ms-ratelimit-remaining-subscription-writes": "1190",
-        "x-ms-request-id": "e33c196c-c571-4074-b21a-dd64fbf5e129",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030525Z:92ef9d62-b1b4-4078-9606-ff0b15f7ce54"
+        "x-ms-ratelimit-remaining-subscription-writes": "1195",
+        "x-ms-request-id": "abcf528a-8501-4ba9-b73e-47e0e514963c",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024144Z:ff7df3b9-422b-4582-a5ab-7471447b51b2"
       },
       "ResponseBody": {
         "name": "imagexbc8e2966",
@@ -692,15 +693,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/e33c196c-c571-4074-b21a-dd64fbf5e129?p=54253b73-cb53-496f-ab42-5e5ee19426f8\u0026api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/abcf528a-8501-4ba9-b73e-47e0e514963c?p=da74df64-2927-47c5-bfaf-ab3f7b37c044\u0026api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "99ab41c2-99d5-11ec-900a-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "a0e990f6-9b64-11ec-afd4-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -708,7 +709,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:55 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -719,17 +720,17 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "c08d4265-1bd2-46de-a778-863713c5ee1f",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29997",
-        "x-ms-ratelimit-remaining-subscription-reads": "11981",
-        "x-ms-request-id": "0fb50b0d-1cb6-40db-9cf7-f31fe1549b4b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030555Z:c08d4265-1bd2-46de-a778-863713c5ee1f"
+        "x-ms-correlation-request-id": "c0d8a35e-eb71-4840-ba56-d506ce6e4f18",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;14999,Microsoft.Compute/GetOperation30Min;29999",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "f0dfa15b-f8da-46de-980f-b15f2ff71cad",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024214Z:c0d8a35e-eb71-4840-ba56-d506ce6e4f18"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:05:24.0214513\u002B00:00",
-        "endTime": "2022-03-02T03:05:29.2402825\u002B00:00",
+        "startTime": "2022-03-04T02:41:43.9494313\u002B00:00",
+        "endTime": "2022-03-04T02:41:49.0744912\u002B00:00",
         "status": "Succeeded",
-        "name": "e33c196c-c571-4074-b21a-dd64fbf5e129"
+        "name": "abcf528a-8501-4ba9-b73e-47e0e514963c"
       }
     },
     {
@@ -740,8 +741,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "99ab41c2-99d5-11ec-900a-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "a0e990f6-9b64-11ec-afd4-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -749,7 +750,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:56 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -760,11 +761,11 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "69cf06f0-96ad-49ce-a69f-4a7af1b86747",
+        "x-ms-correlation-request-id": "d32ff558-3e65-4547-8703-4dc6e654bce1",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetImages3Min;358,Microsoft.Compute/GetImages30Min;1798",
-        "x-ms-ratelimit-remaining-subscription-reads": "11980",
-        "x-ms-request-id": "20c1d3a5-5862-476f-832c-e28b269b2246",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030556Z:69cf06f0-96ad-49ce-a69f-4a7af1b86747"
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "4313094b-ae5e-47fc-93a7-6882966b921e",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024214Z:d32ff558-3e65-4547-8703-4dc6e654bce1"
       },
       "ResponseBody": {
         "name": "imagexbc8e2966",
@@ -799,8 +800,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "adede0c4-99d5-11ec-8516-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "b3bc0e34-9b64-11ec-9c7b-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -808,7 +809,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:57 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -819,12 +820,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "6f3598a7-e6cd-4505-974f-51d7f0b7bfeb",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14984,Microsoft.Compute/LowCostGet30Min;119984",
-        "x-ms-ratelimit-remaining-subscription-reads": "11979",
-        "x-ms-request-id": "a9175322-5c84-45f5-9822-283cff2dc597",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030557Z:6f3598a7-e6cd-4505-974f-51d7f0b7bfeb",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "029fbd5f-5065-4ebf-9181-632ec1740896",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4984,Microsoft.Compute/LowCostGet30Min;39984",
+        "x-ms-ratelimit-remaining-subscription-reads": "11983",
+        "x-ms-request-id": "4fbf2cc2-ae6d-4021-b48b-b0332e7b4a89",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024214Z:029fbd5f-5065-4ebf-9181-632ec1740896",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "snapshotxbc8e2966",
@@ -839,7 +840,7 @@
           "creationData": {
             "createOption": "Copy",
             "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/disks/disknamexbc8e2966",
-            "sourceUniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+            "sourceUniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
           },
           "diskSizeGB": 200,
           "encryption": {
@@ -848,11 +849,11 @@
           "incremental": false,
           "networkAccessPolicy": "AllowAll",
           "publicNetworkAccess": "Enabled",
-          "timeCreated": "2022-03-02T03:05:19.2768585\u002B00:00",
+          "timeCreated": "2022-03-04T02:41:40.187671\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "68c6f729-3de5-4ce0-ab81-62ad67b728cd"
+          "uniqueId": "7e36f8c3-a64d-472d-8574-33c825730848"
         }
       }
     },
@@ -864,8 +865,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "ae8836f8-99d5-11ec-8010-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "b3cfa370-9b64-11ec-b5f9-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -873,7 +874,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:57 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -884,11 +885,11 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "84bec38c-2550-4c2e-af3f-75d6eff3793e",
+        "x-ms-correlation-request-id": "3f673131-0e7b-421f-918e-4a2e8b136e4a",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetImages3Min;357,Microsoft.Compute/GetImages30Min;1797",
-        "x-ms-ratelimit-remaining-subscription-reads": "11978",
-        "x-ms-request-id": "dbb177f6-66e3-4127-ba1e-5a061601ff51",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030557Z:84bec38c-2550-4c2e-af3f-75d6eff3793e"
+        "x-ms-ratelimit-remaining-subscription-reads": "11982",
+        "x-ms-request-id": "1b4f4b39-ee0c-470e-8ff4-8a9e1c7c16a7",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024215Z:3f673131-0e7b-421f-918e-4a2e8b136e4a"
       },
       "ResponseBody": {
         "name": "imagexbc8e2966",
@@ -925,8 +926,8 @@
         "Connection": "keep-alive",
         "Content-Length": "30",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "aeb9e243-99d5-11ec-b84c-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "b3df6a44-9b64-11ec-9c62-c8348e51ab51"
       },
       "RequestBody": {
         "tags": {
@@ -936,11 +937,11 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/f3a53295-dd13-499e-8dfd-afe425a4ccfd?p=54253b73-cb53-496f-ab42-5e5ee19426f8\u0026api-version=2021-11-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/4b0f7cce-7f4a-480c-b3ee-1585e3b8354f?p=da74df64-2927-47c5-bfaf-ab3f7b37c044\u0026api-version=2021-11-01",
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:05:59 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -951,11 +952,11 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "0112ec38-42a5-4b60-b586-947ad08f2aaa",
+        "x-ms-correlation-request-id": "9489c46e-554e-4fa5-b30a-b93136960615",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateImages3Min;38,Microsoft.Compute/CreateImages30Min;198",
-        "x-ms-ratelimit-remaining-subscription-writes": "1189",
-        "x-ms-request-id": "f3a53295-dd13-499e-8dfd-afe425a4ccfd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030600Z:0112ec38-42a5-4b60-b586-947ad08f2aaa"
+        "x-ms-ratelimit-remaining-subscription-writes": "1194",
+        "x-ms-request-id": "4b0f7cce-7f4a-480c-b3ee-1585e3b8354f",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024215Z:9489c46e-554e-4fa5-b30a-b93136960615"
       },
       "ResponseBody": {
         "name": "imagexbc8e2966",
@@ -986,15 +987,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/f3a53295-dd13-499e-8dfd-afe425a4ccfd?p=54253b73-cb53-496f-ab42-5e5ee19426f8\u0026api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/4b0f7cce-7f4a-480c-b3ee-1585e3b8354f?p=da74df64-2927-47c5-bfaf-ab3f7b37c044\u0026api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "aeb9e243-99d5-11ec-b84c-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "b3df6a44-9b64-11ec-9c62-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1002,7 +1003,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:06:29 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1013,17 +1014,17 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "50079c64-248f-42ea-9bbb-b429f3f8d22d",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29996",
-        "x-ms-ratelimit-remaining-subscription-reads": "11977",
-        "x-ms-request-id": "02218a8e-fd68-417f-b28d-a0d3958a9eb4",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030630Z:50079c64-248f-42ea-9bbb-b429f3f8d22d"
+        "x-ms-correlation-request-id": "98cae140-d3f2-497b-8abf-8b0e03788afe",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29998",
+        "x-ms-ratelimit-remaining-subscription-reads": "11981",
+        "x-ms-request-id": "ae2491a5-7e1c-4de2-a31e-175a40152a0c",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024246Z:98cae140-d3f2-497b-8abf-8b0e03788afe"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:05:58.037055\u002B00:00",
-        "endTime": "2022-03-02T03:06:03.1143647\u002B00:00",
+        "startTime": "2022-03-04T02:42:15.2620189\u002B00:00",
+        "endTime": "2022-03-04T02:42:20.308925\u002B00:00",
         "status": "Succeeded",
-        "name": "f3a53295-dd13-499e-8dfd-afe425a4ccfd"
+        "name": "4b0f7cce-7f4a-480c-b3ee-1585e3b8354f"
       }
     },
     {
@@ -1034,8 +1035,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "aeb9e243-99d5-11ec-b84c-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "b3df6a44-9b64-11ec-9c62-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1043,7 +1044,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:06:30 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1054,11 +1055,11 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "bee600c7-411b-4e5f-a0da-4de25afc80bc",
+        "x-ms-correlation-request-id": "5a1f62d0-23d7-42a4-a88a-dd3b1c0718db",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetImages3Min;355,Microsoft.Compute/GetImages30Min;1795",
-        "x-ms-ratelimit-remaining-subscription-reads": "11976",
-        "x-ms-request-id": "1d74c5f9-51c8-46e3-acf4-81ec7402b825",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030630Z:bee600c7-411b-4e5f-a0da-4de25afc80bc"
+        "x-ms-ratelimit-remaining-subscription-reads": "11980",
+        "x-ms-request-id": "f4591af5-c2dd-4e68-b4cb-d61ea7894868",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024246Z:5a1f62d0-23d7-42a4-a88a-dd3b1c0718db"
       },
       "ResponseBody": {
         "name": "imagexbc8e2966",
@@ -1098,19 +1099,19 @@
         "Connection": "keep-alive",
         "Content-Length": "2",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "c285d03b-99d5-11ec-a700-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "c6705170-9b64-11ec-9c27-c8348e51ab51"
       },
       "RequestBody": {},
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/41062f8f-8713-4f28-a1ed-24688bf26820?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/d00e9df5-0550-4a50-8314-0027e78deb7f?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "552",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:06:30 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:45 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/41062f8f-8713-4f28-a1ed-24688bf26820?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/d00e9df5-0550-4a50-8314-0027e78deb7f?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Retry-After": "2",
         "Server": [
@@ -1119,12 +1120,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "3a1cd92c-b75f-4c9a-95bd-efab179966d6",
+        "x-ms-correlation-request-id": "bf062c87-2908-49fb-8124-4ff90a024072",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/CreateUpdateDisks3Min;998,Microsoft.Compute/CreateUpdateDisks30Min;7996",
-        "x-ms-ratelimit-remaining-subscription-writes": "1188",
-        "x-ms-request-id": "41062f8f-8713-4f28-a1ed-24688bf26820",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030631Z:3a1cd92c-b75f-4c9a-95bd-efab179966d6",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1193",
+        "x-ms-request-id": "d00e9df5-0550-4a50-8314-0027e78deb7f",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024246Z:bf062c87-2908-49fb-8124-4ff90a024072",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "location": "eastus",
@@ -1136,7 +1137,7 @@
           "creationData": {
             "createOption": "Copy",
             "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/disks/disknamexbc8e2966",
-            "sourceUniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+            "sourceUniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
           },
           "diskSizeGB": 200,
           "provisioningState": "Updating",
@@ -1147,15 +1148,15 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/41062f8f-8713-4f28-a1ed-24688bf26820?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/d00e9df5-0550-4a50-8314-0027e78deb7f?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "c285d03b-99d5-11ec-a700-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "c6705170-9b64-11ec-9c27-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1163,7 +1164,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:06:33 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1174,16 +1175,16 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "17805913-84ff-4d88-aa9f-e90f90bbb392",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49986,Microsoft.Compute/GetOperation30Min;399980",
-        "x-ms-ratelimit-remaining-subscription-reads": "11975",
-        "x-ms-request-id": "17e19897-7269-48c9-b148-01bd6677ea6b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030633Z:17805913-84ff-4d88-aa9f-e90f90bbb392",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "6b997d7c-311c-4307-a490-078d966698cf",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49983,Microsoft.Compute/GetOperation30Min;399980",
+        "x-ms-ratelimit-remaining-subscription-reads": "11979",
+        "x-ms-request-id": "09d479f6-2a7d-4cbb-b93a-039f404180c5",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024248Z:6b997d7c-311c-4307-a490-078d966698cf",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:06:30.9646511\u002B00:00",
-        "endTime": "2022-03-02T03:06:31.0271457\u002B00:00",
+        "startTime": "2022-03-04T02:42:46.3286148\u002B00:00",
+        "endTime": "2022-03-04T02:42:46.4692246\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
@@ -1199,7 +1200,7 @@
               "creationData": {
                 "createOption": "Copy",
                 "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/disks/disknamexbc8e2966",
-                "sourceUniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+                "sourceUniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
               },
               "diskSizeGB": 200,
               "encryption": {
@@ -1208,15 +1209,15 @@
               "incremental": false,
               "networkAccessPolicy": "AllowAll",
               "publicNetworkAccess": "Enabled",
-              "timeCreated": "2022-03-02T03:05:19.2768585\u002B00:00",
+              "timeCreated": "2022-03-04T02:41:40.187671\u002B00:00",
               "provisioningState": "Succeeded",
               "diskState": "Unattached",
               "diskSizeBytes": 214748364800,
-              "uniqueId": "68c6f729-3de5-4ce0-ab81-62ad67b728cd"
+              "uniqueId": "7e36f8c3-a64d-472d-8574-33c825730848"
             }
           }
         },
-        "name": "41062f8f-8713-4f28-a1ed-24688bf26820"
+        "name": "d00e9df5-0550-4a50-8314-0027e78deb7f"
       }
     },
     {
@@ -1227,8 +1228,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "c285d03b-99d5-11ec-a700-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "c6705170-9b64-11ec-9c27-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1236,7 +1237,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:06:33 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1247,12 +1248,12 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "7de7ebcb-846f-425a-949d-d0de7b7cbb18",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;14988,Microsoft.Compute/LowCostGet30Min;119982",
-        "x-ms-ratelimit-remaining-subscription-reads": "11974",
-        "x-ms-request-id": "42556342-0a1b-431a-b846-ea74857e1a12",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030633Z:7de7ebcb-846f-425a-949d-d0de7b7cbb18",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "d1ac5b58-00f4-40db-822b-0562d189cab0",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/LowCostGet3Min;4987,Microsoft.Compute/LowCostGet30Min;39982",
+        "x-ms-ratelimit-remaining-subscription-reads": "11978",
+        "x-ms-request-id": "8b0d672c-b6d9-497b-ac31-7c4fe99a3890",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024248Z:d1ac5b58-00f4-40db-822b-0562d189cab0",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
         "name": "snapshotxbc8e2966",
@@ -1267,7 +1268,7 @@
           "creationData": {
             "createOption": "Copy",
             "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/disks/disknamexbc8e2966",
-            "sourceUniqueId": "d6895781-2588-44d5-bee6-303736796f84"
+            "sourceUniqueId": "2f7cda66-e149-4968-88d7-23560473dce1"
           },
           "diskSizeGB": 200,
           "encryption": {
@@ -1276,11 +1277,11 @@
           "incremental": false,
           "networkAccessPolicy": "AllowAll",
           "publicNetworkAccess": "Enabled",
-          "timeCreated": "2022-03-02T03:05:19.2768585\u002B00:00",
+          "timeCreated": "2022-03-04T02:41:40.187671\u002B00:00",
           "provisioningState": "Succeeded",
           "diskState": "Unattached",
           "diskSizeBytes": 214748364800,
-          "uniqueId": "68c6f729-3de5-4ce0-ab81-62ad67b728cd"
+          "uniqueId": "7e36f8c3-a64d-472d-8574-33c825730848"
         }
       }
     },
@@ -1294,8 +1295,8 @@
         "Connection": "keep-alive",
         "Content-Length": "45",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "c45f631f-99d5-11ec-a6b7-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "c7f1de73-9b64-11ec-805e-c8348e51ab51"
       },
       "RequestBody": {
         "access": "Read",
@@ -1303,12 +1304,12 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/266243b8-5345-4131-bf2a-e6034da7074d?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d4cac75-be35-47b7-b71f-5afec50db6f6?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:06:33 GMT",
+        "Date": "Fri, 04 Mar 2022 02:42:47 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/266243b8-5345-4131-bf2a-e6034da7074d?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d4cac75-be35-47b7-b71f-5afec50db6f6?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -1316,25 +1317,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "69c61ec9-c9d2-4e84-808c-7258e9c2baec",
+        "x-ms-correlation-request-id": "58ef31cb-d046-4d01-98b6-b374d5d4403c",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;998,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;7998",
-        "x-ms-ratelimit-remaining-subscription-writes": "1195",
-        "x-ms-request-id": "266243b8-5345-4131-bf2a-e6034da7074d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030634Z:69c61ec9-c9d2-4e84-808c-7258e9c2baec",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "8d4cac75-be35-47b7-b71f-5afec50db6f6",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024248Z:58ef31cb-d046-4d01-98b6-b374d5d4403c",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/266243b8-5345-4131-bf2a-e6034da7074d?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d4cac75-be35-47b7-b71f-5afec50db6f6?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "c45f631f-99d5-11ec-a6b7-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "c7f1de73-9b64-11ec-805e-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1342,7 +1343,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:07:03 GMT",
+        "Date": "Fri, 04 Mar 2022 02:43:18 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1353,35 +1354,35 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "b3749770-e07e-433c-8d64-10f3f7ac3315",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49987,Microsoft.Compute/GetOperation30Min;399978",
-        "x-ms-ratelimit-remaining-subscription-reads": "11973",
-        "x-ms-request-id": "d9c4c83e-d2df-4cc3-96d7-effc39624e55",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030704Z:b3749770-e07e-433c-8d64-10f3f7ac3315",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "450cd609-fadf-47a7-bc65-5c55eb18d78f",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49984,Microsoft.Compute/GetOperation30Min;399978",
+        "x-ms-ratelimit-remaining-subscription-reads": "11977",
+        "x-ms-request-id": "1ac64a0a-9bfc-47a8-9ce6-731c33e5682b",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024319Z:450cd609-fadf-47a7-bc65-5c55eb18d78f",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:06:34.0427589\u002B00:00",
-        "endTime": "2022-03-02T03:06:34.1677777\u002B00:00",
+        "startTime": "2022-03-04T02:42:48.8286182\u002B00:00",
+        "endTime": "2022-03-04T02:42:49.0161107\u002B00:00",
         "status": "Succeeded",
         "properties": {
           "output": {
-            "accessSAS": "https://md-c1gsvlkmxpbn.z35.blob.storage.azure.net/2qzgp0v2l1bn/abcd?sv=2018-03-28\u0026sr=b\u0026si=67299baf-7cb3-417f-a5bc-957f2d3c0825\u0026sig=SCSznODc%2BqQjSU5Y7%2Fi2hMqTFQT2hg5C3Nxm%2BWeOXNM%3D"
+            "accessSAS": "Sanitized"
           }
         },
-        "name": "266243b8-5345-4131-bf2a-e6034da7074d"
+        "name": "8d4cac75-be35-47b7-b71f-5afec50db6f6"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/266243b8-5345-4131-bf2a-e6034da7074d?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d4cac75-be35-47b7-b71f-5afec50db6f6?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "c45f631f-99d5-11ec-a6b7-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "c7f1de73-9b64-11ec-805e-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1389,7 +1390,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:07:04 GMT",
+        "Date": "Fri, 04 Mar 2022 02:43:18 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1400,15 +1401,15 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "84db9b93-13e3-47d5-ae1d-26432a4556d7",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49986,Microsoft.Compute/GetOperation30Min;399977",
-        "x-ms-ratelimit-remaining-subscription-reads": "11972",
-        "x-ms-request-id": "465b7447-c61d-4967-8a98-46255149d38f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030705Z:84db9b93-13e3-47d5-ae1d-26432a4556d7",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "b2db2771-9746-481e-94ed-aca70f7566ee",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49983,Microsoft.Compute/GetOperation30Min;399977",
+        "x-ms-ratelimit-remaining-subscription-reads": "11976",
+        "x-ms-request-id": "33c7a1b7-85c5-4577-a088-118103bd23fa",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024319Z:b2db2771-9746-481e-94ed-aca70f7566ee",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "accessSAS": "https://md-c1gsvlkmxpbn.z35.blob.storage.azure.net/2qzgp0v2l1bn/abcd?sv=2018-03-28\u0026sr=b\u0026si=67299baf-7cb3-417f-a5bc-957f2d3c0825\u0026sig=SCSznODc%2BqQjSU5Y7%2Fi2hMqTFQT2hg5C3Nxm%2BWeOXNM%3D"
+        "accessSAS": "Sanitized"
       }
     },
     {
@@ -1420,18 +1421,18 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "d6ffd59f-99d5-11ec-a64c-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "da18755a-9b64-11ec-b32f-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/f7b79ada-270d-4f27-8c2c-98f6b3112015?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/feb5ea87-230e-455f-91e0-4388061324f0?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:07:04 GMT",
+        "Date": "Fri, 04 Mar 2022 02:43:18 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/f7b79ada-270d-4f27-8c2c-98f6b3112015?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/feb5ea87-230e-455f-91e0-4388061324f0?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -1439,25 +1440,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "c3305fca-4590-4e20-b982-e0ef08e7dc47",
+        "x-ms-correlation-request-id": "86498f3f-cb90-4422-b73d-e00483d8d3b2",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;997,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;7997",
-        "x-ms-ratelimit-remaining-subscription-writes": "1194",
-        "x-ms-request-id": "f7b79ada-270d-4f27-8c2c-98f6b3112015",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030705Z:c3305fca-4590-4e20-b982-e0ef08e7dc47",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-ratelimit-remaining-subscription-writes": "1196",
+        "x-ms-request-id": "feb5ea87-230e-455f-91e0-4388061324f0",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024319Z:86498f3f-cb90-4422-b73d-e00483d8d3b2",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/f7b79ada-270d-4f27-8c2c-98f6b3112015?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/feb5ea87-230e-455f-91e0-4388061324f0?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "d6ffd59f-99d5-11ec-a64c-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "da18755a-9b64-11ec-b32f-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1465,7 +1466,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:07:34 GMT",
+        "Date": "Fri, 04 Mar 2022 02:43:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1476,37 +1477,37 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "53694d3a-74c8-43cd-be65-a9a9b71a01cf",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49985,Microsoft.Compute/GetOperation30Min;399975",
-        "x-ms-ratelimit-remaining-subscription-reads": "11971",
-        "x-ms-request-id": "b5d372fa-d66a-4fe1-a750-f27b928de6f5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030735Z:53694d3a-74c8-43cd-be65-a9a9b71a01cf",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "f9896624-b397-4dea-8de3-c1816bb28161",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49984,Microsoft.Compute/GetOperation30Min;399975",
+        "x-ms-ratelimit-remaining-subscription-reads": "11975",
+        "x-ms-request-id": "2218c3e8-705b-417f-a445-c980c5dd0184",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024349Z:f9896624-b397-4dea-8de3-c1816bb28161",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:07:05.2771794\u002B00:00",
-        "endTime": "2022-03-02T03:07:05.3708958\u002B00:00",
+        "startTime": "2022-03-04T02:43:19.2662503\u002B00:00",
+        "endTime": "2022-03-04T02:43:19.4381411\u002B00:00",
         "status": "Succeeded",
-        "name": "f7b79ada-270d-4f27-8c2c-98f6b3112015"
+        "name": "feb5ea87-230e-455f-91e0-4388061324f0"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/f7b79ada-270d-4f27-8c2c-98f6b3112015?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/feb5ea87-230e-455f-91e0-4388061324f0?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "d6ffd59f-99d5-11ec-a64c-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "da18755a-9b64-11ec-b32f-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:07:35 GMT",
+        "Date": "Fri, 04 Mar 2022 02:43:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1515,12 +1516,12 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "f8d2af05-cfb1-474a-9d21-8d7b2df2916d",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49984,Microsoft.Compute/GetOperation30Min;399974",
-        "x-ms-ratelimit-remaining-subscription-reads": "11970",
-        "x-ms-request-id": "96f2bf49-a2fb-40de-8642-c2aee58da553",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030736Z:f8d2af05-cfb1-474a-9d21-8d7b2df2916d",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "ce9a3803-2141-4fac-a6c1-a5403f9cf77a",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49983,Microsoft.Compute/GetOperation30Min;399974",
+        "x-ms-ratelimit-remaining-subscription-reads": "11974",
+        "x-ms-request-id": "ccc96756-b16f-41dd-822b-c43de3817966",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024349Z:ce9a3803-2141-4fac-a6c1-a5403f9cf77a",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
@@ -1533,19 +1534,19 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "e984e45c-99d5-11ec-9561-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "ec39bbbe-9b64-11ec-b26c-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/1701349c-f5c5-47ce-8133-d4b0054d7c5a?p=54253b73-cb53-496f-ab42-5e5ee19426f8\u0026api-version=2021-11-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/0bb384f1-679b-40f8-aa00-6c044c943366?p=da74df64-2927-47c5-bfaf-ab3f7b37c044\u0026api-version=2021-11-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:07:36 GMT",
+        "Date": "Fri, 04 Mar 2022 02:43:50 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/1701349c-f5c5-47ce-8133-d4b0054d7c5a?p=54253b73-cb53-496f-ab42-5e5ee19426f8\u0026monitor=true\u0026api-version=2021-11-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/0bb384f1-679b-40f8-aa00-6c044c943366?p=da74df64-2927-47c5-bfaf-ab3f7b37c044\u0026monitor=true\u0026api-version=2021-11-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -1553,24 +1554,24 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "03a2c3c3-ef01-44b1-a6f7-bef18be63637",
+        "x-ms-correlation-request-id": "4a1c1584-6412-4b79-9f6b-9c268a91499a",
         "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/DeleteImages3Min;119,Microsoft.Compute/DeleteImages30Min;599",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14996",
-        "x-ms-request-id": "1701349c-f5c5-47ce-8133-d4b0054d7c5a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030736Z:03a2c3c3-ef01-44b1-a6f7-bef18be63637"
+        "x-ms-ratelimit-remaining-subscription-deletes": "14998",
+        "x-ms-request-id": "0bb384f1-679b-40f8-aa00-6c044c943366",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024350Z:4a1c1584-6412-4b79-9f6b-9c268a91499a"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/1701349c-f5c5-47ce-8133-d4b0054d7c5a?p=54253b73-cb53-496f-ab42-5e5ee19426f8\u0026api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/0bb384f1-679b-40f8-aa00-6c044c943366?p=da74df64-2927-47c5-bfaf-ab3f7b37c044\u0026api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "e984e45c-99d5-11ec-9561-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "ec39bbbe-9b64-11ec-b26c-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1578,7 +1579,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:07 GMT",
+        "Date": "Fri, 04 Mar 2022 02:44:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1589,17 +1590,17 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "54f249ef-7e29-4bc9-b345-27cc25f03598",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;14995,Microsoft.Compute/GetOperation30Min;29993",
-        "x-ms-ratelimit-remaining-subscription-reads": "11969",
-        "x-ms-request-id": "2062c666-6d46-41d4-801e-fb5a30eb23d5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030807Z:54f249ef-7e29-4bc9-b345-27cc25f03598"
+        "x-ms-correlation-request-id": "3ba6880e-1c31-41d4-a82c-ee2195130126",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;14995,Microsoft.Compute/GetOperation30Min;29995",
+        "x-ms-ratelimit-remaining-subscription-reads": "11973",
+        "x-ms-request-id": "aba34bbf-4bf9-4ba3-b921-3b4b949bc06b",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024420Z:3ba6880e-1c31-41d4-a82c-ee2195130126"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:07:36.8186794\u002B00:00",
-        "endTime": "2022-03-02T03:07:41.9280023\u002B00:00",
+        "startTime": "2022-03-04T02:43:49.9027926\u002B00:00",
+        "endTime": "2022-03-04T02:43:54.9809014\u002B00:00",
         "status": "Succeeded",
-        "name": "1701349c-f5c5-47ce-8133-d4b0054d7c5a"
+        "name": "0bb384f1-679b-40f8-aa00-6c044c943366"
       }
     },
     {
@@ -1611,18 +1612,18 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "fc1c4826-99d5-11ec-bf0f-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "fe72499c-9b64-11ec-85e4-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/a83b54a8-851d-4c62-befa-a49db0ff9c0b?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c26ba0f7-7a8d-416b-a766-2dc3ecd890e0?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 02 Mar 2022 03:08:08 GMT",
+        "Date": "Fri, 04 Mar 2022 02:44:19 GMT",
         "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/a83b54a8-851d-4c62-befa-a49db0ff9c0b?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026monitor=true\u0026api-version=2021-12-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c26ba0f7-7a8d-416b-a766-2dc3ecd890e0?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026monitor=true\u0026api-version=2021-12-01",
         "Pragma": "no-cache",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -1630,25 +1631,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "c28f3435-1bd1-4617-a590-cd33f0b2cb23",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/DeleteDisks3Min;2999,Microsoft.Compute/DeleteDisks30Min;23998",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14995",
-        "x-ms-request-id": "a83b54a8-851d-4c62-befa-a49db0ff9c0b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030808Z:c28f3435-1bd1-4617-a590-cd33f0b2cb23",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "fc158a7c-99f0-4f94-98e8-887eb49c63b1",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/DeleteDisks3Min;999,Microsoft.Compute/DeleteDisks30Min;7998",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14997",
+        "x-ms-request-id": "c26ba0f7-7a8d-416b-a766-2dc3ecd890e0",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024420Z:fc158a7c-99f0-4f94-98e8-887eb49c63b1",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/a83b54a8-851d-4c62-befa-a49db0ff9c0b?p=36ee1309-094c-4cec-b989-37cf5e794c1b\u0026api-version=2021-12-01",
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/DiskOperations/c26ba0f7-7a8d-416b-a766-2dc3ecd890e0?p=20470d06-ecfc-4c0c-87cc-b2f60cfb9feb\u0026api-version=2021-12-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "fc1c4826-99d5-11ec-bf0f-70b5e82527ff"
+        "User-Agent": "azsdk-python-azure-mgmt-compute/26.1.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "fe72499c-9b64-11ec-85e4-c8348e51ab51"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -1656,7 +1657,7 @@
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Mar 2022 03:08:38 GMT",
+        "Date": "Fri, 04 Mar 2022 02:44:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1667,18 +1668,18 @@
         "Transfer-Encoding": "chunked",
         "Vary": "Accept-Encoding",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "92b55a2f-9a1f-4882-a481-19574044de74",
-        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;399970",
-        "x-ms-ratelimit-remaining-subscription-reads": "11968",
-        "x-ms-request-id": "50dd8e66-06a0-42e1-b92d-0dbef6c74008",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20220302T030838Z:92b55a2f-9a1f-4882-a481-19574044de74",
-        "x-ms-served-by": "36ee1309-094c-4cec-b989-37cf5e794c1b_132629837319766262"
+        "x-ms-correlation-request-id": "c08ef2ea-7149-4ea4-bb4a-728dca0b87a5",
+        "x-ms-ratelimit-remaining-resource": "Microsoft.Compute/GetOperation3Min;49987,Microsoft.Compute/GetOperation30Min;399970",
+        "x-ms-ratelimit-remaining-subscription-reads": "11972",
+        "x-ms-request-id": "7ad6581a-396f-4ccf-83b6-f2acbf14e30e",
+        "x-ms-routing-request-id": "WESTUS2:20220304T024450Z:c08ef2ea-7149-4ea4-bb4a-728dca0b87a5",
+        "x-ms-served-by": "20470d06-ecfc-4c0c-87cc-b2f60cfb9feb_132772209049489152"
       },
       "ResponseBody": {
-        "startTime": "2022-03-02T03:08:08.0427897\u002B00:00",
-        "endTime": "2022-03-02T03:08:08.1989973\u002B00:00",
+        "startTime": "2022-03-04T02:44:20.4732726\u002B00:00",
+        "endTime": "2022-03-04T02:44:20.6920241\u002B00:00",
         "status": "Succeeded",
-        "name": "a83b54a8-851d-4c62-befa-a49db0ff9c0b"
+        "name": "c26ba0f7-7a8d-416b-a766-2dc3ecd890e0"
       }
     }
   ],


### PR DESCRIPTION
# Description

Some recently checked-in recordings in `azure-mgmt-compute` contain SAS tokens for test resources -- this raised [CredScan warnings](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1405931&view=logs&j=3b141548-98d7-5be1-7ef8-eeb08ca02972&t=41e0d8dc-42df-5fff-2417-80cd016cccdb&l=54) that can be resolved by sanitizing the value of `accessSAS` keys in recording bodies. This adds a sanitizer to do this and updates recordings accordingly.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
