### PR TITLE
[metricsadvisor] fix mypy

### DIFF
--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/_metrics_advisor_client.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/_metrics_advisor_client.py
@@ -424,6 +424,7 @@ class MetricsAdvisorClient(object):
     @overload
     def list_anomalies(
         self,
+        *,
         alert_configuration_id,  # type: str
         alert_id,  # type: str
         **kwargs  # type: Any
@@ -453,6 +454,7 @@ class MetricsAdvisorClient(object):
     @overload
     def list_anomalies(
         self,
+        *,
         detection_configuration_id,  # type: str
         start_time,  # type: Union[str, datetime.datetime]
         end_time,  # type: Union[str, datetime.datetime]
@@ -594,6 +596,7 @@ class MetricsAdvisorClient(object):
     @overload
     def list_incidents(
         self,
+        *,
         alert_configuration_id,  # type: str
         alert_id,  # type: str
         **kwargs  # type: Any
@@ -623,6 +626,7 @@ class MetricsAdvisorClient(object):
     @overload
     def list_incidents(
         self,
+        *,
         detection_configuration_id,  # type: str
         start_time,  # type: Union[str, datetime.datetime]
         end_time,  # type: Union[str, datetime.datetime]

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/aio/_metrics_advisor_client_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/aio/_metrics_advisor_client_async.py
@@ -423,7 +423,7 @@ class MetricsAdvisorClient(object):
 
     @overload
     def list_anomalies(
-        self, alert_configuration_id: str, alert_id: str, **kwargs: Any
+        self, *, alert_configuration_id: str, alert_id: str, **kwargs: Any
     ) -> AsyncItemPaged[DataPointAnomaly]:
         """Query anomalies under a specific alert.
 
@@ -449,6 +449,7 @@ class MetricsAdvisorClient(object):
     @overload
     def list_anomalies(
         self,
+        *,
         detection_configuration_id: str,
         start_time: Union[str, datetime.datetime],
         end_time: Union[str, datetime.datetime],
@@ -591,7 +592,7 @@ class MetricsAdvisorClient(object):
 
     @overload
     def list_incidents(
-        self, alert_configuration_id: str, alert_id: str, **kwargs: Any
+        self, *, alert_configuration_id: str, alert_id: str, **kwargs: Any
     ) -> AsyncItemPaged[AnomalyIncident]:
 
         """Query incidents under a specific alert.
@@ -618,6 +619,7 @@ class MetricsAdvisorClient(object):
     @overload
     def list_incidents(
         self,
+        *,
         detection_configuration_id: str,
         start_time: Union[str, datetime.datetime],
         end_time: Union[str, datetime.datetime],


### PR DESCRIPTION
Noticed that we are seeing some new mypy errors despite passing CI on the version bump PR and pinning the mypy version in CI. The errors seem valid so fixing them here, but confused why this didn't come up before. @scbedd do you see anything weird with CI here?

Version bump PR where mypy passed for metricsadvisor: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1386232&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=e3f8f308-6e5f-58aa-3a2a-fe425958de32
Recent CI where mypy failed for metricsadvisor: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1408275&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=e3f8f308-6e5f-58aa-3a2a-fe425958de32

Also see the same issue for keyvault: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1408247&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=e3f8f308-6e5f-58aa-3a2a-fe425958de32

@mccoyp let me know if you want me to make a PR to address the above.