### PR TITLE
Correct docstrings to render links for "Callable" 

### DIFF
--- a/sdk/attestation/azure-security-attestation/azure/security/attestation/_configuration.py
+++ b/sdk/attestation/azure-security-attestation/azure/security/attestation/_configuration.py
@@ -22,7 +22,7 @@ class AttestationClientConfiguration(Configuration):
     :keyword validation_callback: Function callback to allow clients to perform custom validation of the token.
         if the token is invalid, the `validation_callback` function should throw
         an exception.
-    :paramtype validation_callback: Callable[[AttestationToken, AttestationSigner], None]
+    :paramtype validation_callback: typing.Callable[[AttestationToken, AttestationSigner], None]
     :keyword bool validate_signature: if True, validate the signature of the token being validated.
     :keyword bool validate_expiration: If True, validate the expiration time of the token being validated.
     :keyword str issuer: Expected issuer, used if validate_issuer is true.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
@@ -412,21 +412,21 @@ class EventHubConsumerClient(ClientBase):
          the process of load-balance. The callback should be defined like: `on_error(partition_context, error)`.
          The `on_error` callback will also be called if an unhandled exception is raised during
          the `on_event` callback.
-        :paramtype on_error: Callable[[~azure.eventhub.PartitionContext, Exception]]
+        :paramtype on_error: typing.Callable[[~azure.eventhub.PartitionContext, Exception]]
         :keyword on_partition_initialize: The callback function that will be called after a consumer for a certain
          partition finishes initialization. It would also be called when a new internal partition consumer is created
          to take over the receiving process for a failed and closed internal partition consumer.
          The callback takes a single parameter: `partition_context`
          which contains the partition information. The callback should be defined
          like: `on_partition_initialize(partition_context)`.
-        :paramtype on_partition_initialize: Callable[[~azure.eventhub.PartitionContext]]
+        :paramtype on_partition_initialize: typing.Callable[[~azure.eventhub.PartitionContext]]
         :keyword on_partition_close: The callback function that will be called after a consumer for a certain
          partition is closed. It would be also called when error is raised during receiving after retry attempts are
          exhausted. The callback takes two parameters: `partition_context` which contains partition
          information and `reason` for the close. The callback should be defined like:
          `on_partition_close(partition_context, reason)`.
          Please refer to :class:`CloseReason<azure.eventhub.CloseReason>` for the various closing reasons.
-        :paramtype on_partition_close: Callable[[~azure.eventhub.PartitionContext, ~azure.eventhub.CloseReason]]
+        :paramtype on_partition_close: typing.Callable[[~azure.eventhub.PartitionContext, ~azure.eventhub.CloseReason]]
         :rtype: None
 
         .. admonition:: Example:
@@ -493,21 +493,21 @@ class EventHubConsumerClient(ClientBase):
          the process of load-balance. The callback should be defined like: `on_error(partition_context, error)`.
          The `on_error` callback will also be called if an unhandled exception is raised during
          the `on_event` callback.
-        :paramtype on_error: Callable[[~azure.eventhub.PartitionContext, Exception]]
+        :paramtype on_error: typing.Callable[[~azure.eventhub.PartitionContext, Exception]]
         :keyword on_partition_initialize: The callback function that will be called after a consumer for a certain
          partition finishes initialization. It would also be called when a new internal partition consumer is created
          to take over the receiving process for a failed and closed internal partition consumer.
          The callback takes a single parameter: `partition_context`
          which contains the partition information. The callback should be defined
          like: `on_partition_initialize(partition_context)`.
-        :paramtype on_partition_initialize: Callable[[~azure.eventhub.PartitionContext]]
+        :paramtype on_partition_initialize: typing.Callable[[~azure.eventhub.PartitionContext]]
         :keyword on_partition_close: The callback function that will be called after a consumer for a certain
          partition is closed. It would be also called when error is raised during receiving after retry attempts are
          exhausted. The callback takes two parameters: `partition_context` which contains partition
          information and `reason` for the close. The callback should be defined like:
          `on_partition_close(partition_context, reason)`.
          Please refer to :class:`CloseReason<azure.eventhub.CloseReason>` for the various closing reasons.
-        :paramtype on_partition_close: Callable[[~azure.eventhub.PartitionContext, ~azure.eventhub.CloseReason]]
+        :paramtype on_partition_close: typing.Callable[[~azure.eventhub.PartitionContext, ~azure.eventhub.CloseReason]]
         :rtype: None
 
         .. admonition:: Example:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
@@ -482,21 +482,21 @@ class EventHubConsumerClient(ClientBaseAsync):
          the process of load-balance. The callback should be defined like: `on_error(partition_context, error)`.
          The `on_error` callback will also be called if an unhandled exception is raised during
          the `on_event` callback.
-        :paramtype on_error: Callable[[~azure.eventhub.aio.PartitionContext, Exception]]
+        :paramtype on_error: typing.Callable[[~azure.eventhub.aio.PartitionContext, Exception]]
         :keyword on_partition_initialize: The callback function that will be called after a consumer for a certain
          partition finishes initialization. It would also be called when a new internal partition consumer is created
          to take over the receiving process for a failed and closed internal partition consumer.
          The callback takes a single parameter: `partition_context`
          which contains the partition information. The callback should be defined
          like: `on_partition_initialize(partition_context)`.
-        :paramtype on_partition_initialize: Callable[[~azure.eventhub.aio.PartitionContext]]
+        :paramtype on_partition_initialize: typing.Callable[[~azure.eventhub.aio.PartitionContext]]
         :keyword on_partition_close: The callback function that will be called after a consumer for a certain
          partition is closed. It would be also called when error is raised during receiving after retry attempts are
          exhausted. The callback takes two parameters: `partition_context` which contains partition
          information and `reason` for the close. The callback should be defined like:
          `on_partition_close(partition_context, reason)`.
          Please refer to :class:`CloseReason<azure.eventhub.CloseReason>` for the various closing reasons.
-        :paramtype on_partition_close: Callable[[~azure.eventhub.aio.PartitionContext, ~azure.eventhub.CloseReason]]
+        :paramtype on_partition_close: typing.Callable[[~azure.eventhub.aio.PartitionContext, ~azure.eventhub.CloseReason]]
         :rtype: None
 
         .. admonition:: Example:
@@ -598,21 +598,21 @@ class EventHubConsumerClient(ClientBaseAsync):
          the process of load-balance. The callback should be defined like: `on_error(partition_context, error)`.
          The `on_error` callback will also be called if an unhandled exception is raised during
          the `on_event` callback.
-        :paramtype on_error: Callable[[~azure.eventhub.aio.PartitionContext, Exception]]
+        :paramtype on_error: typing.Callable[[~azure.eventhub.aio.PartitionContext, Exception]]
         :keyword on_partition_initialize: The callback function that will be called after a consumer for a certain
          partition finishes initialization. It would also be called when a new internal partition consumer is created
          to take over the receiving process for a failed and closed internal partition consumer.
          The callback takes a single parameter: `partition_context`
          which contains the partition information. The callback should be defined
          like: `on_partition_initialize(partition_context)`.
-        :paramtype on_partition_initialize: Callable[[~azure.eventhub.aio.PartitionContext]]
+        :paramtype on_partition_initialize: typing.Callable[[~azure.eventhub.aio.PartitionContext]]
         :keyword on_partition_close: The callback function that will be called after a consumer for a certain
          partition is closed. It would be also called when error is raised during receiving after retry attempts are
          exhausted. The callback takes two parameters: `partition_context` which contains partition
          information and `reason` for the close. The callback should be defined like:
          `on_partition_close(partition_context, reason)`.
          Please refer to :class:`CloseReason<azure.eventhub.CloseReason>` for the various closing reasons.
-        :paramtype on_partition_close: Callable[[~azure.eventhub.aio.PartitionContext, ~azure.eventhub.CloseReason]]
+        :paramtype on_partition_close: typing.Callable[[~azure.eventhub.aio.PartitionContext, ~azure.eventhub.CloseReason]]
         :rtype: None
 
         .. admonition:: Example:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_assertion.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_assertion.py
@@ -24,7 +24,7 @@ class ClientAssertionCredential(GetTokenMixin):
         :param str client_id: the principal's client ID
         :param get_assertion: a callable that returns a string assertion. The credential will call this every time it
             acquires a new token.
-        :paramtype get_assertion: Callable[[], str]
+        :paramtype get_assertion: typing.Callable[[], str]
 
         :keyword str authority: authority of an Azure Active Directory endpoint, for example
             "login.microsoftonline.com", the authority for Azure Public Cloud (which is the default).

--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -48,7 +48,7 @@ class DeviceCodeCredential(InteractiveCredential):
         - ``user_code`` (str) the code the user must enter there
         - ``expires_on`` (datetime.datetime) the UTC time at which the code will expire
         If this argument isn't provided, the credential will print instructions to stdout.
-    :paramtype prompt_callback: Callable[str, str, ~datetime.datetime]
+    :paramtype prompt_callback: typing.Callable[str, str, ~datetime.datetime]
     :keyword AuthenticationRecord authentication_record: :class:`AuthenticationRecord` returned by :func:`authenticate`
     :keyword bool disable_automatic_authentication: if True, :func:`get_token` will raise
         :class:`AuthenticationRequiredError` when user interaction is required to acquire a token. Defaults to False.

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_assertion.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_assertion.py
@@ -23,7 +23,7 @@ class ClientAssertionCredential(AsyncContextManager, GetTokenMixin):
         :param str client_id: the principal's client ID
         :param get_assertion: a callable that returns a string assertion. The credential will call this every time it
             acquires a new token.
-        :paramtype get_assertion: Callable[[], str]
+        :paramtype get_assertion: typing.Callable[[], str]
 
         :keyword str authority: authority of an Azure Active Directory endpoint, for example
             "login.microsoftonline.com", the authority for Azure Public Cloud (which is the default).

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/azure/schemaregistry/encoder/avroencoder/_schema_registry_avro_encoder.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/azure/schemaregistry/encoder/avroencoder/_schema_registry_avro_encoder.py
@@ -156,7 +156,7 @@ class AvroEncoder(object):
          If callback function, it must have the following method signature:
          `(content: bytes, content_type: str, **kwargs) -> MessageType`, where `content` and `content_type`
          are positional parameters.
-        :paramtype message_type: Callable or None
+        :paramtype message_type: typing.Callable or None
         :keyword request_options: The keyword arguments for http requests to be passed to the client.
         :paramtype request_options: Dict[str, Any]
         :rtype: MessageType or MessageContent

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/azure/schemaregistry/encoder/avroencoder/aio/_schema_registry_avro_encoder_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/azure/schemaregistry/encoder/avroencoder/aio/_schema_registry_avro_encoder_async.py
@@ -153,7 +153,7 @@ class AvroEncoder(object):
          If callback function, it must have the following method signature:
          `(content: bytes, content_type: str, **kwargs) -> MessageType`, where `content` and `content_type`
          are positional parameters.
-        :paramtype message_type: Callable or None
+        :paramtype message_type: typing.Callable or None
         :keyword request_options: The keyword arguments for http requests to be passed to the client.
         :paramtype request_options: Dict[str, Any]
         :rtype: MessageType or MessageContent

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_base_handler.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_base_handler.py
@@ -467,7 +467,7 @@ class BaseHandler:  # pylint:disable=too-many-instance-attributes
         :param message: The message to send in the management request.
         :paramtype message: Any
         :param callback: The callback which is used to parse the returning message.
-        :paramtype callback: Callable[int, ~uamqp.message.Message, str]
+        :paramtype callback: typing.Callable[int, ~uamqp.message.Message, str]
         :param keep_alive_associated_link: A boolean flag for keeping associated amqp sender/receiver link alive when
          executing operation on mgmt links.
         :param timeout: timeout in seconds executing the mgmt operation.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_base_handler_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_base_handler_async.py
@@ -310,7 +310,7 @@ class BaseHandler:  # pylint:disable=too-many-instance-attributes
         :param message: The message to send in the management request.
         :paramtype message: ~uamqp.message.Message
         :param callback: The callback which is used to parse the returning message.
-        :paramtype callback: Callable[int, ~uamqp.message.Message, str]
+        :paramtype callback: typing.Callable[int, ~uamqp.message.Message, str]
         :param keep_alive_associated_link: A boolean flag for keeping associated amqp sender/receiver link alive when
          executing operation on mgmt links.
         :param timeout: timeout in seconds for executing the mgmt operation.


### PR DESCRIPTION
Original issue: https://ceapex.visualstudio.com/Engineering/_workitems/edit/438504

In the course of validating the fix for above issue I discovered that the Python code is using incorrect syntax for documenting `Callable` types in all of the `paramtype` docstrings. It should be `typing.Callable[...]` ... Since I already had a jig assembled to look for these and build docs it was trivially easy to also make the update to the docstrings. 

Original use of the docstring (`Callable` is not linked): 
```
:paramtype prompt_callback: Callable[str, str, ~datetime.datetime]
```
![image](https://user-images.githubusercontent.com/2158838/156817555-c67f09a9-1302-4577-8aad-f5c0792e9446.png)


Updated docstring (note that sphinx doc renders the link properly): 

```
:paramtype prompt_callback: typing.Callable[str, str, ~datetime.datetime]
```

![image](https://user-images.githubusercontent.com/2158838/156817649-afb40a74-5b0c-4b9b-b862-6e55a9ffac7a.png)


@scbedd -- PTAL 