### PR TITLE
[CredScan] Suppress warnings for "username" string

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -14,6 +14,7 @@
                 ":code:`<pfx-file-password>`",
                 "000000000000000000000000000000000000000000000000000",
                 "fakekeyfakekeyfakekeyfakekeyfakekeyfakekeyA=",
+                "username",
                 "UsernameAndPassword",
                 "123456",
                 "Password1!",


### PR DESCRIPTION
# Description

The [remaining active CredScan warnings](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1409067&view=logs&j=3b141548-98d7-5be1-7ef8-eeb08ca02972&t=41e0d8dc-42df-5fff-2417-80cd016cccdb&l=72) -- coming from `azure-mgmt-containerregistry` and `azure-mgmt-containerservice` -- all seem to come from the presence of the string `"username"` in generated code. This is a little surprising, considering the string appears in... a lot of places, but CredScan knows more than me about why it's particularly suspicious in these files.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
  - Verifying a clean CredScan run for each affected package by running their respective CI pipelines.
