### PR TITLE
[EventHubs] Add keep_alive_interval to producer client

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -279,7 +279,7 @@ class ClientBase(object):  # pylint:disable=too-many-instance-attributes
             self._credential = EventhubAzureNamedKeyTokenCredential(credential)  # type: ignore
         else:
             self._credential = credential  # type: ignore
-        self._keep_alive = kwargs.get("keep_alive", 30)
+        self._keep_alive_interval = kwargs.get("keep_alive_interval")
         self._auto_reconnect = kwargs.get("auto_reconnect", True)
         self._mgmt_target = "amqps://{}/{}".format(
             self._address.hostname, self.eventhub_name

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
@@ -85,7 +85,7 @@ class EventHubProducer(
         # type: (EventHubProducerClient, str, Any) -> None
         partition = kwargs.get("partition", None)
         send_timeout = kwargs.get("send_timeout", 60)
-        keep_alive = kwargs.get("keep_alive", None)
+        keep_alive_interval = kwargs.get("keep_alive_interval")
         auto_reconnect = kwargs.get("auto_reconnect", True)
         idle_timeout = kwargs.get("idle_timeout", None)
 
@@ -99,7 +99,7 @@ class EventHubProducer(
         self._timeout = send_timeout
         self._idle_timeout = (idle_timeout * 1000) if idle_timeout else None
         self._error = None
-        self._keep_alive = keep_alive
+        self._keep_alive_interval = keep_alive_interval
         self._auto_reconnect = auto_reconnect
         self._retry_policy = errors.ErrorPolicy(
             max_retries=self._client._config.max_retries, on_error=_error_handler  # pylint: disable=protected-access
@@ -127,7 +127,7 @@ class EventHubProducer(
             msg_timeout=self._timeout * 1000,
             idle_timeout=self._idle_timeout,
             error_policy=self._retry_policy,
-            keep_alive_interval=self._keep_alive,
+            keep_alive_interval=self._keep_alive_interval,
             client_name=self._name,
             link_properties=self._link_properties,
             properties=create_properties(self._client._config.user_agent),  # pylint: disable=protected-access

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -76,6 +76,11 @@ class EventHubProducerClient(ClientBase):
     :keyword str connection_verify: Path to the custom CA_BUNDLE file of the SSL certificate which is used to
      authenticate the identity of the connection endpoint.
      Default is None in which case `certifi.where()` will be used.
+    :keyword keep_alive_interval: If set, a thread will be started to keep the connection
+     alive during periods of user inactivity. The value will determine how long the
+     thread will sleep (in seconds) between pinging the connection. If 0 or None, no
+     thread will be started. Default is None.
+    :paramtype keep_alive_interval: int or None
 
     .. admonition:: Example:
 
@@ -176,6 +181,7 @@ class EventHubProducerClient(ClientBase):
             partition=partition_id,
             send_timeout=send_timeout,
             idle_timeout=self._idle_timeout,
+            keep_alive_interval=self._keep_alive_interval
         )
         return handler
 
@@ -221,6 +227,11 @@ class EventHubProducerClient(ClientBase):
         :keyword str connection_verify: Path to the custom CA_BUNDLE file of the SSL certificate which is used to
          authenticate the identity of the connection endpoint.
          Default is None in which case `certifi.where()` will be used.
+        :keyword keep_alive_interval: If set, a thread will be started to keep the connection
+         alive during periods of user inactivity. The value will determine how long the
+         thread will sleep (in seconds) between pinging the connection. If 0 or None, no
+         thread will be started. Default is None.
+        :paramtype keep_alive_interval: int or None
         :rtype: ~azure.eventhub.EventHubProducerClient
 
         .. admonition:: Example:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_version.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "5.9.0b2"
+VERSION = "5.10.0b1"

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
@@ -63,7 +63,7 @@ class EventHubProducer(
         super().__init__()
         partition = kwargs.get("partition", None)
         send_timeout = kwargs.get("send_timeout", 60)
-        keep_alive = kwargs.get("keep_alive", None)
+        keep_alive_interval = kwargs.get("keep_alive_interval")
         auto_reconnect = kwargs.get("auto_reconnect", True)
         idle_timeout = kwargs.get("idle_timeout", None)
 
@@ -75,7 +75,7 @@ class EventHubProducer(
         self._client = client
         self._target = target
         self._partition = partition
-        self._keep_alive = keep_alive
+        self._keep_alive_interval = keep_alive_interval
         self._auto_reconnect = auto_reconnect
         self._timeout = send_timeout
         self._idle_timeout = (idle_timeout * 1000) if idle_timeout else None
@@ -105,7 +105,7 @@ class EventHubProducer(
             msg_timeout=self._timeout * 1000,
             idle_timeout=self._idle_timeout,
             error_policy=self._retry_policy,
-            keep_alive_interval=self._keep_alive,
+            keep_alive_interval=self._keep_alive_interval,
             client_name=self._name,
             link_properties=self._link_properties,
             properties=create_properties(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
@@ -75,6 +75,11 @@ class EventHubProducerClient(ClientBaseAsync):
     :keyword str connection_verify: Path to the custom CA_BUNDLE file of the SSL certificate which is used to
      authenticate the identity of the connection endpoint.
      Default is None in which case `certifi.where()` will be used.
+    :keyword keep_alive_interval: If set, a coroutine will be started to keep the connection
+     alive during periods of user inactivity. The value will determine how long the
+     coroutine will sleep (in seconds) between pinging the connection. If 0 or None, no
+     coroutine will be started. Default is None.
+    :paramtype keep_alive_interval: int or None
 
     .. admonition:: Example:
 
@@ -180,6 +185,7 @@ class EventHubProducerClient(ClientBaseAsync):
             partition=partition_id,
             send_timeout=send_timeout,
             idle_timeout=self._idle_timeout,
+            keep_alive_interval=self._keep_alive_interval,
             **self._internal_kwargs
         )
         return handler
@@ -237,6 +243,11 @@ class EventHubProducerClient(ClientBaseAsync):
         :keyword str connection_verify: Path to the custom CA_BUNDLE file of the SSL certificate which is used to
          authenticate the identity of the connection endpoint.
          Default is None in which case `certifi.where()` will be used.
+        :keyword keep_alive_interval: If set, a coroutine will be started to keep the connection
+         alive during periods of user inactivity. The value will determine how long the
+         coroutine will sleep (in seconds) between pinging the connection. If 0 or None, no
+         coroutine will be started. Default is None.
+        :paramtype keep_alive_interval: int or None
         :rtype: ~azure.eventhub.aio.EventHubProducerClient
 
         .. admonition:: Example:


### PR DESCRIPTION
Expose keep alive config on producer client

potentially addressing issue: https://github.com/Azure/azure-sdk-for-python/issues/21849


two issues:

1. connection idletimeout
- The connection between EH client and EH service is a long bidirectional amqp connection.
- The EH service would disconnect the client for 240s idle timeout.
- azure function is event driven, which means producer would stay idle until next incoming request
- by expose keep alive, the client would send heartbeat every `keep_alive_interval` seconds

2. execution hangs
It is still unclear why the execution hangs after connection closed
- probably because of segmentation fault?


addressing issue 1 might help the end to end scenario, however, azure function's behavior is unclear -- whether it's stateful or stateless:
- by keep alive, we turn azure function into sort of a long operation and assume azure function is stateful, it could keep the producer, won't suspend the execution of background thread/coroutine.
  - ask azure function team/test the behavior
  - migrate to durable function/azure web app?