### PR TITLE
[Storeage] Update `rename_directory` lease param name

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -369,7 +369,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         :paramtype file_last_write_time:~datetime.datetime or str
         :keyword Dict[str,str] metadata:
             A name-value pair to associate with a file storage object.
-        :keyword lease:
+        :keyword destination_lease:
             Required if the destination file has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :paramtype lease: ~azure.storage.fileshare.ShareLeaseClient or str
@@ -403,14 +403,14 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         headers = kwargs.pop('headers', {})
         headers.update(add_metadata_headers(metadata))
 
-        access_conditions = get_dest_access_conditions(kwargs.pop('lease', None))
+        destination_access_conditions = get_dest_access_conditions(kwargs.pop('destination_lease', None))
 
         try:
             new_directory_client._client.directory.rename(  # pylint: disable=protected-access
                 self.url,
                 timeout=timeout,
                 replace_if_exists=overwrite,
-                destination_lease_access_conditions=access_conditions,
+                destination_lease_access_conditions=destination_access_conditions,
                 headers=headers,
                 **kwargs)
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
@@ -249,7 +249,7 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
         :paramtype file_last_write_time:~datetime.datetime or str
         :keyword Dict[str,str] metadata:
             A name-value pair to associate with a file storage object.
-        :keyword lease:
+        :keyword destination_lease:
             Required if the destination file has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :paramtype lease: ~azure.storage.fileshare.ShareLeaseClient or str
@@ -283,14 +283,14 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
         headers = kwargs.pop('headers', {})
         headers.update(add_metadata_headers(metadata))
 
-        access_conditions = get_dest_access_conditions(kwargs.pop('lease', None))
+        destination_access_conditions = get_dest_access_conditions(kwargs.pop('destination_lease', None))
 
         try:
             await new_directory_client._client.directory.rename(  # pylint: disable=protected-access
                 self.url,
                 timeout=timeout,
                 replace_if_exists=overwrite,
-                destination_lease_access_conditions=access_conditions,
+                destination_lease_access_conditions=destination_access_conditions,
                 headers=headers,
                 **kwargs)
 

--- a/sdk/storage/azure-storage-file-share/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory.py
@@ -681,7 +681,7 @@ class StorageDirectoryTest(StorageTestCase):
         # Act
         new_directory = source_directory.rename_directory(
             dest_directory.directory_path + '/' + dest_file.file_name,
-            overwrite=True, lease=lease)
+            overwrite=True, destination_lease=lease)
 
         # Assert
         props = new_directory.get_directory_properties()

--- a/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
@@ -796,7 +796,7 @@ class StorageDirectoryTest(AsyncStorageTestCase):
         # Act
         new_directory = await source_directory.rename_directory(
             dest_directory.directory_path + '/' + dest_file.file_name,
-            overwrite=True, lease=lease)
+            overwrite=True, destination_lease=lease)
 
         # Assert
         props = await new_directory.get_directory_properties()


### PR DESCRIPTION
Change the lease parameter name from `lease` to `destination_lease` in `rename_directory()`.