### PR TITLE
Pin APIView parser version

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -315,7 +315,7 @@ deps =
   {[base]deps}
 commands =
     # install API stub generator
-    {envbindir}/python -m pip install "git+https://github.com/azure/azure-sdk-tools.git#subdirectory=packages/python-packages/api-stub-generator&egg=api-stub-generator"
+    {envbindir}/python -m pip install "git+https://github.com/azure/azure-sdk-tools.git@api-stub-generator_v0.2.10"
     {envbindir}/python -m pip freeze
     {envbindir}/python {toxinidir}/../../../eng/tox/run_apistubgen.py -t {toxinidir} -w {envtmpdir} {posargs}
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -315,7 +315,7 @@ deps =
   {[base]deps}
 commands =
     # install API stub generator
-    {envbindir}/python -m pip install "git+https://github.com/azure/azure-sdk-tools.git@api-stub-generator_v0.2.10"
+    {envbindir}/python -m pip install "git+https://github.com/azure/azure-sdk-tools.git@api-stub-generator_v0.2.10#subdirectory=packages/python-packages/api-stub-generator&egg=api-stub-generator"
     {envbindir}/python -m pip freeze
     {envbindir}/python {toxinidir}/../../../eng/tox/run_apistubgen.py -t {toxinidir} -w {envtmpdir} {posargs}
 


### PR DESCRIPTION
We are moving to doing tagged "releases" of api-stub-generator in the azure-sdk-tools repo so we avoid the all-too-frequent situation where a merged PR for APIView wreaks havoc on our build system at the worst possible time. 