### PR TITLE
API Key Not Being Passed On Paged Requests

### DIFF
--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Bug fix for async paged requests to use api keys
+- Fixed issue where async `search` call would fail with a 403 error when retrieving large number of documents.
 
 ### Other Changes
 

--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Bug fix for async paged requests to use api keys
 
 ### Other Changes
 

--- a/sdk/search/azure-search-documents/azure/search/documents/aio/_paging.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/aio/_paging.py
@@ -107,7 +107,7 @@ class AsyncSearchPageIterator(AsyncPageIterator[ReturnType]):
         _next_link, next_page_request = unpack_continuation_token(continuation_token)
 
         return await self._client.documents.search_post(
-            search_request=next_page_request
+            search_request=next_page_request, **self._kwargs
         )
 
     async def _extract_data_cb(self, response):  # pylint:disable=no-self-use

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
@@ -148,3 +148,18 @@ class TestClientTestAsync(AzureRecordedTestCase):
             {"hotelId": "2", "text": "Cheapest hotel in town. Infact, a motel."},
             {"hotelId": "9", "text": "Secret Point Motel"},
         ]
+
+    @SearchEnvVarPreparer()
+    @search_decorator(schema="hotel_schema.json", index_batch="hotel_large.json")
+    @recorded_by_proxy_async
+    async def test_search_client(self, endpoint, api_key, index_name):
+        client = SearchClient(endpoint, index_name, api_key)
+        async with client:
+            await self._test_get_search_simple_large(client)
+
+    async def _test_get_search_simple_large(self, client):
+        results = []
+        async for x in await client.search(search_text = ''):
+            results.append(x)
+        assert len(results) == 60
+            

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
@@ -152,7 +152,7 @@ class TestClientTestAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_large.json")
     @recorded_by_proxy_async
-    async def test_search_client(self, endpoint, api_key, index_name):
+    async def test_search_client_large(self, endpoint, api_key, index_name):
         client = SearchClient(endpoint, index_name, api_key)
         async with client:
             await self._test_get_search_simple_large(client)

--- a/sdk/search/azure-search-documents/tests/hotel_large.json
+++ b/sdk/search/azure-search-documents/tests/hotel_large.json
@@ -1,0 +1,1504 @@
+{
+    "value": [
+      {
+        "@search.action": "upload",
+        "hotelId": "1",
+        "hotelName": "Fancy Stay",
+        "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+        "descriptionFr": "Meilleur hôtel en ville si vous aimez les hôtels de luxe. Ils ont une magnifique piscine à débordement, un spa et un concierge très utile. L'emplacement est parfait – en plein centre, à proximité de toutes les attractions touristiques. Nous recommandons fortement cet hôtel.",
+        "category": "Luxury",
+        "tags": [
+          "pool",
+          "view",
+          "wifi",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2010-06-27T00:00:00+00:00",
+        "rating": 5,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "2",
+        "hotelName": "Roach Motel",
+        "description": "Cheapest hotel in town. Infact, a motel.",
+        "descriptionFr": "Hôtel le moins cher en ville. Infact, un motel.",
+        "category": "Budget",
+        "tags": [
+          "motel",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1982-04-28T00:00:00+00:00",
+        "rating": 1,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            49.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "3",
+        "hotelName": "EconoStay",
+        "description": "Very popular hotel in town",
+        "descriptionFr": "Hôtel le plus populaire en ville",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            46.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "4",
+        "hotelName": "Express Rooms",
+        "description": "Pretty good hotel",
+        "descriptionFr": "Assez bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "5",
+        "hotelName": "Comfy Place",
+        "description": "Another good hotel",
+        "descriptionFr": "Un autre bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2012-08-12T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "6",
+        "description": "Surprisingly expensive. Model suites have an ocean-view."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "7",
+        "hotelName": "Modern Stay",
+        "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+        "descriptionFr": "Architecture moderne, personnel poli et très propre. Aussi très abordable."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "8",
+        "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+        "descriptionFr": "Il y a du bruit de la route et se trouve à côté de la station de police. Les salles de bain avaient des revêtements de morilles."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "9",
+        "hotelName": "Secret Point Motel",
+        "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time's Square and the historic centre of the city, as well as other places of interest that make New York one of America's most attractive and cosmopolitan cities.",
+        "descriptionFr": "L'hôtel est idéalement situé sur la principale artère commerciale de la ville en plein cœur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d'autres lieux d'intérêt qui font de New York l'une des villes les plus attractives et cosmopolites de l'Amérique.",
+        "category": "Boutique",
+        "tags": [
+          "pool",
+          "air conditioning",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1970-01-18T00:00:00-05:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -73.975403,
+            40.760586
+          ]
+        },
+        "address": {
+          "streetAddress": "677 5th Ave",
+          "city": "New York",
+          "stateProvince": "NY",
+          "country": "USA",
+          "postalCode": "10022"
+        },
+        "rooms": [
+          {
+            "description": "Budget Room, 1 Queen Bed (Cityside)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (côté ville)",
+            "type": "Budget Room",
+            "baseRate": 9.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 King Bed (Mountain View)",
+            "descriptionFr": "Chambre Économique, 1 très grand lit (Mountain View)",
+            "type": "Budget Room",
+            "baseRate": 8.09,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd",
+              "jacuzzi tub"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "10",
+        "hotelName": "Countryside Hotel",
+        "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer & dryer, 24/7 support, bowling alley, fitness center and more.",
+        "descriptionFr": "Économisez jusqu'à 50% sur les hôtels traditionnels.  WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24/7, bowling, centre de fitness et plus encore.",
+        "category": "Budget",
+        "tags": [
+          "24-hour front desk service",
+          "coffee in lobby",
+          "restaurant"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1999-09-06T00:00:00+00:00",
+        "rating": 3,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -78.940483,
+            35.90416
+          ]
+        },
+        "address": {
+          "streetAddress": "6910 Fayetteville Rd",
+          "city": "Durham",
+          "stateProvince": "NC",
+          "country": "USA",
+          "postalCode": "27713"
+        },
+        "rooms": [
+          {
+            "description": "Suite, 1 King Bed (Amenities)",
+            "descriptionFr": "Suite, 1 très grand lit (Services)",
+            "type": "Suite",
+            "baseRate": 2.44,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "coffee maker"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 Queen Bed (Amenities)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (Services)",
+            "type": "Budget Room",
+            "baseRate": 7.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": false,
+            "tags": [
+              "coffee maker"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "11",
+        "hotelName": "Fancy Stay 1",
+        "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+        "descriptionFr": "Meilleur hôtel en ville si vous aimez les hôtels de luxe. Ils ont une magnifique piscine à débordement, un spa et un concierge très utile. L'emplacement est parfait – en plein centre, à proximité de toutes les attractions touristiques. Nous recommandons fortement cet hôtel.",
+        "category": "Luxury",
+        "tags": [
+          "pool",
+          "view",
+          "wifi",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2010-06-27T00:00:00+00:00",
+        "rating": 5,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "12",
+        "hotelName": "Roach Motel 1",
+        "description": "Cheapest hotel in town. Infact, a motel.",
+        "descriptionFr": "Hôtel le moins cher en ville. Infact, un motel.",
+        "category": "Budget",
+        "tags": [
+          "motel",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1982-04-28T00:00:00+00:00",
+        "rating": 1,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            49.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "13",
+        "hotelName": "EconoStay 1",
+        "description": "Very popular hotel in town",
+        "descriptionFr": "Hôtel le plus populaire en ville",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            46.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "14",
+        "hotelName": "Express Rooms 1",
+        "description": "Pretty good hotel",
+        "descriptionFr": "Assez bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "15",
+        "hotelName": "Comfy Place 1",
+        "description": "Another good hotel",
+        "descriptionFr": "Un autre bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2012-08-12T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "16",
+        "description": "Surprisingly expensive. Model suites have an ocean-view."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "17",
+        "hotelName": "Modern Stay1",
+        "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+        "descriptionFr": "Architecture moderne, personnel poli et très propre. Aussi très abordable."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "18",
+        "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+        "descriptionFr": "Il y a du bruit de la route et se trouve à côté de la station de police. Les salles de bain avaient des revêtements de morilles."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "19",
+        "hotelName": "Secret Point Motel 1",
+        "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time's Square and the historic centre of the city, as well as other places of interest that make New York one of America's most attractive and cosmopolitan cities.",
+        "descriptionFr": "L'hôtel est idéalement situé sur la principale artère commerciale de la ville en plein cœur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d'autres lieux d'intérêt qui font de New York l'une des villes les plus attractives et cosmopolites de l'Amérique.",
+        "category": "Boutique",
+        "tags": [
+          "pool",
+          "air conditioning",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1970-01-18T00:00:00-05:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -73.975403,
+            40.760586
+          ]
+        },
+        "address": {
+          "streetAddress": "677 5th Ave",
+          "city": "New York",
+          "stateProvince": "NY",
+          "country": "USA",
+          "postalCode": "10022"
+        },
+        "rooms": [
+          {
+            "description": "Budget Room, 1 Queen Bed (Cityside)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (côté ville)",
+            "type": "Budget Room",
+            "baseRate": 9.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 King Bed (Mountain View)",
+            "descriptionFr": "Chambre Économique, 1 très grand lit (Mountain View)",
+            "type": "Budget Room",
+            "baseRate": 8.09,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd",
+              "jacuzzi tub"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "20",
+        "hotelName": "Countryside Hotel 1",
+        "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer & dryer, 24/7 support, bowling alley, fitness center and more.",
+        "descriptionFr": "Économisez jusqu'à 50% sur les hôtels traditionnels.  WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24/7, bowling, centre de fitness et plus encore.",
+        "category": "Budget",
+        "tags": [
+          "24-hour front desk service",
+          "coffee in lobby",
+          "restaurant"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1999-09-06T00:00:00+00:00",
+        "rating": 3,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -78.940483,
+            35.90416
+          ]
+        },
+        "address": {
+          "streetAddress": "6910 Fayetteville Rd",
+          "city": "Durham",
+          "stateProvince": "NC",
+          "country": "USA",
+          "postalCode": "27713"
+        },
+        "rooms": [
+          {
+            "description": "Suite, 1 King Bed (Amenities)",
+            "descriptionFr": "Suite, 1 très grand lit (Services)",
+            "type": "Suite",
+            "baseRate": 2.44,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "coffee maker"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 Queen Bed (Amenities)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (Services)",
+            "type": "Budget Room",
+            "baseRate": 7.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": false,
+            "tags": [
+              "coffee maker"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "21",
+        "hotelName": "Fancy Stay 2",
+        "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+        "descriptionFr": "Meilleur hôtel en ville si vous aimez les hôtels de luxe. Ils ont une magnifique piscine à débordement, un spa et un concierge très utile. L'emplacement est parfait – en plein centre, à proximité de toutes les attractions touristiques. Nous recommandons fortement cet hôtel.",
+        "category": "Luxury",
+        "tags": [
+          "pool",
+          "view",
+          "wifi",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2010-06-27T00:00:00+00:00",
+        "rating": 5,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "22",
+        "hotelName": "Roach Motel2",
+        "description": "Cheapest hotel in town. Infact, a motel.",
+        "descriptionFr": "Hôtel le moins cher en ville. Infact, un motel.",
+        "category": "Budget",
+        "tags": [
+          "motel",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1982-04-28T00:00:00+00:00",
+        "rating": 1,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            49.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "23",
+        "hotelName": "EconoStay2",
+        "description": "Very popular hotel in town",
+        "descriptionFr": "Hôtel le plus populaire en ville",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            46.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "24",
+        "hotelName": "Express Rooms2",
+        "description": "Pretty good hotel",
+        "descriptionFr": "Assez bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "25",
+        "hotelName": "Comfy Place2",
+        "description": "Another good hotel",
+        "descriptionFr": "Un autre bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2012-08-12T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "26",
+        "description": "Surprisingly expensive. Model suites have an ocean-view."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "27",
+        "hotelName": "Modern Stay2",
+        "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+        "descriptionFr": "Architecture moderne, personnel poli et très propre. Aussi très abordable."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "28",
+        "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+        "descriptionFr": "Il y a du bruit de la route et se trouve à côté de la station de police. Les salles de bain avaient des revêtements de morilles."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "29",
+        "hotelName": "Secret Point Motel2",
+        "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time's Square and the historic centre of the city, as well as other places of interest that make New York one of America's most attractive and cosmopolitan cities.",
+        "descriptionFr": "L'hôtel est idéalement situé sur la principale artère commerciale de la ville en plein cœur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d'autres lieux d'intérêt qui font de New York l'une des villes les plus attractives et cosmopolites de l'Amérique.",
+        "category": "Boutique",
+        "tags": [
+          "pool",
+          "air conditioning",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1970-01-18T00:00:00-05:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -73.975403,
+            40.760586
+          ]
+        },
+        "address": {
+          "streetAddress": "677 5th Ave",
+          "city": "New York",
+          "stateProvince": "NY",
+          "country": "USA",
+          "postalCode": "10022"
+        },
+        "rooms": [
+          {
+            "description": "Budget Room, 1 Queen Bed (Cityside)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (côté ville)",
+            "type": "Budget Room",
+            "baseRate": 9.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 King Bed (Mountain View)",
+            "descriptionFr": "Chambre Économique, 1 très grand lit (Mountain View)",
+            "type": "Budget Room",
+            "baseRate": 8.09,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd",
+              "jacuzzi tub"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "30",
+        "hotelName": "Countryside Hotel 2",
+        "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer & dryer, 24/7 support, bowling alley, fitness center and more.",
+        "descriptionFr": "Économisez jusqu'à 50% sur les hôtels traditionnels.  WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24/7, bowling, centre de fitness et plus encore.",
+        "category": "Budget",
+        "tags": [
+          "24-hour front desk service",
+          "coffee in lobby",
+          "restaurant"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1999-09-06T00:00:00+00:00",
+        "rating": 3,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -78.940483,
+            35.90416
+          ]
+        },
+        "address": {
+          "streetAddress": "6910 Fayetteville Rd",
+          "city": "Durham",
+          "stateProvince": "NC",
+          "country": "USA",
+          "postalCode": "27713"
+        },
+        "rooms": [
+          {
+            "description": "Suite, 1 King Bed (Amenities)",
+            "descriptionFr": "Suite, 1 très grand lit (Services)",
+            "type": "Suite",
+            "baseRate": 2.44,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "coffee maker"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 Queen Bed (Amenities)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (Services)",
+            "type": "Budget Room",
+            "baseRate": 7.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": false,
+            "tags": [
+              "coffee maker"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "31",
+        "hotelName": "Fancy Stay3",
+        "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+        "descriptionFr": "Meilleur hôtel en ville si vous aimez les hôtels de luxe. Ils ont une magnifique piscine à débordement, un spa et un concierge très utile. L'emplacement est parfait – en plein centre, à proximité de toutes les attractions touristiques. Nous recommandons fortement cet hôtel.",
+        "category": "Luxury",
+        "tags": [
+          "pool",
+          "view",
+          "wifi",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2010-06-27T00:00:00+00:00",
+        "rating": 5,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "32",
+        "hotelName": "Roach Motel3",
+        "description": "Cheapest hotel in town. Infact, a motel.",
+        "descriptionFr": "Hôtel le moins cher en ville. Infact, un motel.",
+        "category": "Budget",
+        "tags": [
+          "motel",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1982-04-28T00:00:00+00:00",
+        "rating": 1,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            49.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "33",
+        "hotelName": "EconoStay3",
+        "description": "Very popular hotel in town",
+        "descriptionFr": "Hôtel le plus populaire en ville",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            46.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "34",
+        "hotelName": "Express Rooms3",
+        "description": "Pretty good hotel",
+        "descriptionFr": "Assez bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "35",
+        "hotelName": "Comfy Place3",
+        "description": "Another good hotel",
+        "descriptionFr": "Un autre bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2012-08-12T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "36",
+        "description": "Surprisingly expensive. Model suites have an ocean-view."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "37",
+        "hotelName": "Modern Stay3",
+        "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+        "descriptionFr": "Architecture moderne, personnel poli et très propre. Aussi très abordable."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "38",
+        "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+        "descriptionFr": "Il y a du bruit de la route et se trouve à côté de la station de police. Les salles de bain avaient des revêtements de morilles."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "39",
+        "hotelName": "Secret Point Motel3",
+        "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time's Square and the historic centre of the city, as well as other places of interest that make New York one of America's most attractive and cosmopolitan cities.",
+        "descriptionFr": "L'hôtel est idéalement situé sur la principale artère commerciale de la ville en plein cœur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d'autres lieux d'intérêt qui font de New York l'une des villes les plus attractives et cosmopolites de l'Amérique.",
+        "category": "Boutique",
+        "tags": [
+          "pool",
+          "air conditioning",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1970-01-18T00:00:00-05:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -73.975403,
+            40.760586
+          ]
+        },
+        "address": {
+          "streetAddress": "677 5th Ave",
+          "city": "New York",
+          "stateProvince": "NY",
+          "country": "USA",
+          "postalCode": "10022"
+        },
+        "rooms": [
+          {
+            "description": "Budget Room, 1 Queen Bed (Cityside)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (côté ville)",
+            "type": "Budget Room",
+            "baseRate": 9.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 King Bed (Mountain View)",
+            "descriptionFr": "Chambre Économique, 1 très grand lit (Mountain View)",
+            "type": "Budget Room",
+            "baseRate": 8.09,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd",
+              "jacuzzi tub"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "40",
+        "hotelName": "Countryside Hotel",
+        "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer & dryer, 24/7 support, bowling alley, fitness center and more.",
+        "descriptionFr": "Économisez jusqu'à 50% sur les hôtels traditionnels.  WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24/7, bowling, centre de fitness et plus encore.",
+        "category": "Budget",
+        "tags": [
+          "24-hour front desk service",
+          "coffee in lobby",
+          "restaurant"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1999-09-06T00:00:00+00:00",
+        "rating": 3,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -78.940483,
+            35.90416
+          ]
+        },
+        "address": {
+          "streetAddress": "6910 Fayetteville Rd",
+          "city": "Durham",
+          "stateProvince": "NC",
+          "country": "USA",
+          "postalCode": "27713"
+        },
+        "rooms": [
+          {
+            "description": "Suite, 1 King Bed (Amenities)",
+            "descriptionFr": "Suite, 1 très grand lit (Services)",
+            "type": "Suite",
+            "baseRate": 2.44,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "coffee maker"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 Queen Bed (Amenities)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (Services)",
+            "type": "Budget Room",
+            "baseRate": 7.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": false,
+            "tags": [
+              "coffee maker"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "41",
+        "hotelName": "Fancy Stay4",
+        "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+        "descriptionFr": "Meilleur hôtel en ville si vous aimez les hôtels de luxe. Ils ont une magnifique piscine à débordement, un spa et un concierge très utile. L'emplacement est parfait – en plein centre, à proximité de toutes les attractions touristiques. Nous recommandons fortement cet hôtel.",
+        "category": "Luxury",
+        "tags": [
+          "pool",
+          "view",
+          "wifi",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2010-06-27T00:00:00+00:00",
+        "rating": 5,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "42",
+        "hotelName": "Roach Motel4",
+        "description": "Cheapest hotel in town. Infact, a motel.",
+        "descriptionFr": "Hôtel le moins cher en ville. Infact, un motel.",
+        "category": "Budget",
+        "tags": [
+          "motel",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1982-04-28T00:00:00+00:00",
+        "rating": 1,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            49.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "43",
+        "hotelName": "EconoStay4",
+        "description": "Very popular hotel in town",
+        "descriptionFr": "Hôtel le plus populaire en ville",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            46.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "44",
+        "hotelName": "Express Rooms4",
+        "description": "Pretty good hotel",
+        "descriptionFr": "Assez bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "45",
+        "hotelName": "Comfy Place4",
+        "description": "Another good hotel",
+        "descriptionFr": "Un autre bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2012-08-12T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "46",
+        "description": "Surprisingly expensive. Model suites have an ocean-view."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "47",
+        "hotelName": "Modern Stay4",
+        "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+        "descriptionFr": "Architecture moderne, personnel poli et très propre. Aussi très abordable."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "48",
+        "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+        "descriptionFr": "Il y a du bruit de la route et se trouve à côté de la station de police. Les salles de bain avaient des revêtements de morilles."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "49",
+        "hotelName": "Secret Point Motel4",
+        "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time's Square and the historic centre of the city, as well as other places of interest that make New York one of America's most attractive and cosmopolitan cities.",
+        "descriptionFr": "L'hôtel est idéalement situé sur la principale artère commerciale de la ville en plein cœur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d'autres lieux d'intérêt qui font de New York l'une des villes les plus attractives et cosmopolites de l'Amérique.",
+        "category": "Boutique",
+        "tags": [
+          "pool",
+          "air conditioning",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1970-01-18T00:00:00-05:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -73.975403,
+            40.760586
+          ]
+        },
+        "address": {
+          "streetAddress": "677 5th Ave",
+          "city": "New York",
+          "stateProvince": "NY",
+          "country": "USA",
+          "postalCode": "10022"
+        },
+        "rooms": [
+          {
+            "description": "Budget Room, 1 Queen Bed (Cityside)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (côté ville)",
+            "type": "Budget Room",
+            "baseRate": 9.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 King Bed (Mountain View)",
+            "descriptionFr": "Chambre Économique, 1 très grand lit (Mountain View)",
+            "type": "Budget Room",
+            "baseRate": 8.09,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd",
+              "jacuzzi tub"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "50",
+        "hotelName": "Countryside Hotel",
+        "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer & dryer, 24/7 support, bowling alley, fitness center and more.",
+        "descriptionFr": "Économisez jusqu'à 50% sur les hôtels traditionnels.  WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24/7, bowling, centre de fitness et plus encore.",
+        "category": "Budget",
+        "tags": [
+          "24-hour front desk service",
+          "coffee in lobby",
+          "restaurant"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1999-09-06T00:00:00+00:00",
+        "rating": 3,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -78.940483,
+            35.90416
+          ]
+        },
+        "address": {
+          "streetAddress": "6910 Fayetteville Rd",
+          "city": "Durham",
+          "stateProvince": "NC",
+          "country": "USA",
+          "postalCode": "27713"
+        },
+        "rooms": [
+          {
+            "description": "Suite, 1 King Bed (Amenities)",
+            "descriptionFr": "Suite, 1 très grand lit (Services)",
+            "type": "Suite",
+            "baseRate": 2.44,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "coffee maker"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 Queen Bed (Amenities)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (Services)",
+            "type": "Budget Room",
+            "baseRate": 7.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": false,
+            "tags": [
+              "coffee maker"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "51",
+        "hotelName": "Fancy Stay5",
+        "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+        "descriptionFr": "Meilleur hôtel en ville si vous aimez les hôtels de luxe. Ils ont une magnifique piscine à débordement, un spa et un concierge très utile. L'emplacement est parfait – en plein centre, à proximité de toutes les attractions touristiques. Nous recommandons fortement cet hôtel.",
+        "category": "Luxury",
+        "tags": [
+          "pool",
+          "view",
+          "wifi",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2010-06-27T00:00:00+00:00",
+        "rating": 5,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "52",
+        "hotelName": "Roach Motel5",
+        "description": "Cheapest hotel in town. Infact, a motel.",
+        "descriptionFr": "Hôtel le moins cher en ville. Infact, un motel.",
+        "category": "Budget",
+        "tags": [
+          "motel",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1982-04-28T00:00:00+00:00",
+        "rating": 1,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            49.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "53",
+        "hotelName": "EconoStay5",
+        "description": "Very popular hotel in town",
+        "descriptionFr": "Hôtel le plus populaire en ville",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            46.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "54",
+        "hotelName": "Express Rooms5",
+        "description": "Pretty good hotel",
+        "descriptionFr": "Assez bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "1995-07-01T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "55",
+        "hotelName": "Comfy Place5",
+        "description": "Another good hotel",
+        "descriptionFr": "Un autre bon hôtel",
+        "category": "Budget",
+        "tags": [
+          "wifi",
+          "budget"
+        ],
+        "parkingIncluded": true,
+        "smokingAllowed": false,
+        "lastRenovationDate": "2012-08-12T00:00:00+00:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            48.678581
+          ]
+        }
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "56",
+        "description": "Surprisingly expensive. Model suites have an ocean-view."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "57",
+        "hotelName": "Modern Stay5",
+        "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+        "descriptionFr": "Architecture moderne, personnel poli et très propre. Aussi très abordable."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "58",
+        "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+        "descriptionFr": "Il y a du bruit de la route et se trouve à côté de la station de police. Les salles de bain avaient des revêtements de morilles."
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "59",
+        "hotelName": "Secret Point Motel5",
+        "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time's Square and the historic centre of the city, as well as other places of interest that make New York one of America's most attractive and cosmopolitan cities.",
+        "descriptionFr": "L'hôtel est idéalement situé sur la principale artère commerciale de la ville en plein cœur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d'autres lieux d'intérêt qui font de New York l'une des villes les plus attractives et cosmopolites de l'Amérique.",
+        "category": "Boutique",
+        "tags": [
+          "pool",
+          "air conditioning",
+          "concierge"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1970-01-18T00:00:00-05:00",
+        "rating": 4,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -73.975403,
+            40.760586
+          ]
+        },
+        "address": {
+          "streetAddress": "677 5th Ave",
+          "city": "New York",
+          "stateProvince": "NY",
+          "country": "USA",
+          "postalCode": "10022"
+        },
+        "rooms": [
+          {
+            "description": "Budget Room, 1 Queen Bed (Cityside)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (côté ville)",
+            "type": "Budget Room",
+            "baseRate": 9.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 King Bed (Mountain View)",
+            "descriptionFr": "Chambre Économique, 1 très grand lit (Mountain View)",
+            "type": "Budget Room",
+            "baseRate": 8.09,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "vcr/dvd",
+              "jacuzzi tub"
+            ]
+          }
+        ]
+      },
+      {
+        "@search.action": "upload",
+        "hotelId": "60",
+        "hotelName": "Countryside Hotel 5",
+        "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer & dryer, 24/7 support, bowling alley, fitness center and more.",
+        "descriptionFr": "Économisez jusqu'à 50% sur les hôtels traditionnels.  WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24/7, bowling, centre de fitness et plus encore.",
+        "category": "Budget",
+        "tags": [
+          "24-hour front desk service",
+          "coffee in lobby",
+          "restaurant"
+        ],
+        "parkingIncluded": false,
+        "smokingAllowed": true,
+        "lastRenovationDate": "1999-09-06T00:00:00+00:00",
+        "rating": 3,
+        "location": {
+          "type": "Point",
+          "coordinates": [
+            -78.940483,
+            35.90416
+          ]
+        },
+        "address": {
+          "streetAddress": "6910 Fayetteville Rd",
+          "city": "Durham",
+          "stateProvince": "NC",
+          "country": "USA",
+          "postalCode": "27713"
+        },
+        "rooms": [
+          {
+            "description": "Suite, 1 King Bed (Amenities)",
+            "descriptionFr": "Suite, 1 très grand lit (Services)",
+            "type": "Suite",
+            "baseRate": 2.44,
+            "bedOptions": "1 King Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": true,
+            "tags": [
+              "coffee maker"
+            ]
+          },
+          {
+            "description": "Budget Room, 1 Queen Bed (Amenities)",
+            "descriptionFr": "Chambre Économique, 1 grand lit (Services)",
+            "type": "Budget Room",
+            "baseRate": 7.69,
+            "bedOptions": "1 Queen Bed",
+            "sleepsCount": 2,
+            "smokingAllowed": false,
+            "tags": [
+              "coffee maker"
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/sdk/search/azure-search-documents/tests/recordings/async_tests/test_search_client_search_live_async.pyTestClientTestAsynctest_search_client.json
+++ b/sdk/search/azure-search-documents/tests/recordings/async_tests/test_search_client_search_live_async.pyTestClientTestAsynctest_search_client.json
@@ -8,8 +8,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "19",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a4214271-7fc3-11ec-9e22-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7b695115-a3ac-11ec-adfa-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "hotel"
@@ -20,13 +20,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "6156",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:18 GMT",
-        "elapsed-time": "45",
+        "Date": "Mon, 14 Mar 2022 15:36:16 GMT",
+        "elapsed-time": "95",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a4214271-7fc3-11ec-9e22-74c63bed1137",
+        "request-id": "7b695115-a3ac-11ec-adfa-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -327,8 +327,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "19",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a4911c47-7fc3-11ec-9e2c-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7bda1da1-a3ac-11ec-8f22-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "motel"
@@ -339,13 +339,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "2277",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "11",
+        "Date": "Mon, 14 Mar 2022 15:36:16 GMT",
+        "elapsed-time": "12",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a4911c47-7fc3-11ec-9e2c-74c63bed1137",
+        "request-id": "7bda1da1-a3ac-11ec-8f22-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -457,8 +457,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "29",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a4a816ca-7fc3-11ec-b22b-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7be92735-a3ac-11ec-8c89-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "hotel",
@@ -470,13 +470,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "2998",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "13",
+        "Date": "Mon, 14 Mar 2022 15:36:16 GMT",
+        "elapsed-time": "15",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a4a816ca-7fc3-11ec-b22b-74c63bed1137",
+        "request-id": "7be92735-a3ac-11ec-8c89-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -620,8 +620,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "29",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a4bcef02-7fc3-11ec-aff1-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7bf98408-a3ac-11ec-bf25-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "motel",
@@ -633,13 +633,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "2277",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "14",
+        "Date": "Mon, 14 Mar 2022 15:36:16 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a4bcef02-7fc3-11ec-aff1-74c63bed1137",
+        "request-id": "7bf98408-a3ac-11ec-bf25-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -751,8 +751,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "125",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a4d0b694-7fc3-11ec-bb18-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c0831e4-a3ac-11ec-b233-a04a5ed0778b"
       },
       "RequestBody": {
         "filter": "category eq \u0027Budget\u0027",
@@ -766,13 +766,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "608",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "12",
+        "Date": "Mon, 14 Mar 2022 15:36:16 GMT",
+        "elapsed-time": "313",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a4d0b694-7fc3-11ec-bb18-74c63bed1137",
+        "request-id": "7c0831e4-a3ac-11ec-b233-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -813,8 +813,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "125",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a4e4b25c-7fc3-11ec-b027-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c43f614-a3ac-11ec-bc42-a04a5ed0778b"
       },
       "RequestBody": {
         "filter": "category eq \u0027Budget\u0027",
@@ -828,13 +828,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "608",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "13",
+        "Date": "Mon, 14 Mar 2022 15:36:16 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a4e4b25c-7fc3-11ec-b027-74c63bed1137",
+        "request-id": "7c43f614-a3ac-11ec-bc42-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -875,8 +875,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "19",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a4f95fde-7fc3-11ec-885a-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c5228c7-a3ac-11ec-996d-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "hotel"
@@ -887,13 +887,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "6156",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "15",
+        "Date": "Mon, 14 Mar 2022 15:36:16 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a4f95fde-7fc3-11ec-885a-74c63bed1137",
+        "request-id": "7c5228c7-a3ac-11ec-996d-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -1194,8 +1194,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "34",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a50e1138-7fc3-11ec-a7c7-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c600450-a3ac-11ec-a7d4-a04a5ed0778b"
       },
       "RequestBody": {
         "count": true,
@@ -1207,13 +1207,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "6173",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "12",
+        "Date": "Mon, 14 Mar 2022 15:36:17 GMT",
+        "elapsed-time": "16",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a50e1138-7fc3-11ec-a7c7-74c63bed1137",
+        "request-id": "7c600450-a3ac-11ec-a7d4-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -1515,8 +1515,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "19",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a5215405-7fc3-11ec-924c-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c6e756e-a3ac-11ec-b6fd-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "hotel"
@@ -1527,13 +1527,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "6156",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:19 GMT",
-        "elapsed-time": "12",
+        "Date": "Mon, 14 Mar 2022 15:36:17 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a5215405-7fc3-11ec-924c-74c63bed1137",
+        "request-id": "7c6e756e-a3ac-11ec-b6fd-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -1834,8 +1834,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a5358541-7fc3-11ec-b9dc-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c7c5221-a3ac-11ec-b9e8-a04a5ed0778b"
       },
       "RequestBody": {
         "minimumCoverage": 50.0,
@@ -1847,13 +1847,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "6181",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:20 GMT",
-        "elapsed-time": "16",
+        "Date": "Mon, 14 Mar 2022 15:36:17 GMT",
+        "elapsed-time": "12",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a5358541-7fc3-11ec-b9dc-74c63bed1137",
+        "request-id": "7c7c5221-a3ac-11ec-b9e8-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -2155,8 +2155,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a54ad321-7fc3-11ec-ba7a-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c8a6644-a3ac-11ec-90f0-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "WiFi",
@@ -2168,13 +2168,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "932",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:20 GMT",
-        "elapsed-time": "16",
+        "Date": "Mon, 14 Mar 2022 15:36:17 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a54ad321-7fc3-11ec-ba7a-74c63bed1137",
+        "request-id": "7c8a6644-a3ac-11ec-90f0-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -2221,8 +2221,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "86",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a55e129d-7fc3-11ec-8916-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7c97077c-a3ac-11ec-8a91-a04a5ed0778b"
       },
       "RequestBody": {
         "facets": [
@@ -2237,13 +2237,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "1022",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:20 GMT",
-        "elapsed-time": "18",
+        "Date": "Mon, 14 Mar 2022 15:36:17 GMT",
+        "elapsed-time": "94",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a55e129d-7fc3-11ec-8916-74c63bed1137",
+        "request-id": "7c97077c-a3ac-11ec-8a91-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -2302,8 +2302,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "40",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a572137e-7fc3-11ec-87f2-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7cb4765d-a3ac-11ec-b15c-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "mot",
@@ -2315,13 +2315,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "52",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:20 GMT",
-        "elapsed-time": "8",
+        "Date": "Mon, 14 Mar 2022 15:36:17 GMT",
+        "elapsed-time": "83",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a572137e-7fc3-11ec-87f2-74c63bed1137",
+        "request-id": "7cb4765d-a3ac-11ec-b15c-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -2342,8 +2342,8 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "40",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "a58ce1e7-7fc3-11ec-9abe-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7cd43e18-a3ac-11ec-8414-a04a5ed0778b"
       },
       "RequestBody": {
         "search": "mot",
@@ -2355,13 +2355,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "137",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 27 Jan 2022 22:51:20 GMT",
-        "elapsed-time": "45",
+        "Date": "Mon, 14 Mar 2022 15:36:17 GMT",
+        "elapsed-time": "82",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a58ce1e7-7fc3-11ec-9abe-74c63bed1137",
+        "request-id": "7cd43e18-a3ac-11ec-8414-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },

--- a/sdk/search/azure-search-documents/tests/recordings/async_tests/test_search_client_search_live_async.pyTestClientTestAsynctest_search_client_large.json
+++ b/sdk/search/azure-search-documents/tests/recordings/async_tests/test_search_client_search_live_async.pyTestClientTestAsynctest_search_client_large.json
@@ -1,0 +1,2073 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/indexes(\u0027drgqefsg\u0027)/docs/search.post.search?api-version=2021-04-30-Preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=none",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "14",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "809b463d-a3ac-11ec-95ea-a04a5ed0778b"
+      },
+      "RequestBody": {
+        "search": ""
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "38374",
+        "Content-Type": "application/json; odata.metadata=none",
+        "Date": "Mon, 14 Mar 2022 15:36:23 GMT",
+        "elapsed-time": "36",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "809b463d-a3ac-11ec-95ea-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@search.nextPageParameters": {
+          "search": "",
+          "skip": 50
+        },
+        "value": [
+          {
+            "@search.score": 1.0,
+            "hotelId": "20",
+            "hotelName": "Countryside Hotel 1",
+            "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.",
+            "descriptionFr": "\u00C3\u2030conomisez jusqu\u0027\u00C3\u00A0 50% sur les h\u00C3\u00B4tels traditionnels.  WiFi gratuit, tr\u00C3\u00A8s bien situ\u00C3\u00A9 pr\u00C3\u00A8s du centre-ville, cuisine compl\u00C3\u00A8te, laveuse \u0026 s\u00C3\u00A9cheuse, support 24/7, bowling, centre de fitness et plus encore.",
+            "category": "Budget",
+            "tags": [
+              "24-hour front desk service",
+              "coffee in lobby",
+              "restaurant"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1999-09-06T00:00:00Z",
+            "rating": 3,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "6910 Fayetteville Rd",
+              "city": "Durham",
+              "stateProvince": "NC",
+              "country": "USA",
+              "postalCode": "27713"
+            },
+            "rooms": [
+              {
+                "description": "Suite, 1 King Bed (Amenities)",
+                "descriptionFr": "Suite, 1 tr\u00C3\u00A8s grand lit (Services)",
+                "type": "Suite",
+                "baseRate": 2.44,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "coffee maker"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 Queen Bed (Amenities)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (Services)",
+                "type": "Budget Room",
+                "baseRate": 7.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": false,
+                "tags": [
+                  "coffee maker"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "31",
+            "hotelName": "Fancy Stay3",
+            "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "descriptionFr": "Meilleur h\u00C3\u00B4tel en ville si vous aimez les h\u00C3\u00B4tels de luxe. Ils ont une magnifique piscine \u00C3\u00A0 d\u00C3\u00A9bordement, un spa et un concierge tr\u00C3\u00A8s utile. L\u0027emplacement est parfait \u00E2\u20AC\u201C en plein centre, \u00C3\u00A0 proximit\u00C3\u00A9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00C3\u00B4tel.",
+            "category": "Luxury",
+            "tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2010-06-27T00:00:00Z",
+            "rating": 5,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "45",
+            "hotelName": "Comfy Place4",
+            "description": "Another good hotel",
+            "descriptionFr": "Un autre bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2012-08-12T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "60",
+            "hotelName": "Countryside Hotel 5",
+            "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.",
+            "descriptionFr": "\u00C3\u2030conomisez jusqu\u0027\u00C3\u00A0 50% sur les h\u00C3\u00B4tels traditionnels.  WiFi gratuit, tr\u00C3\u00A8s bien situ\u00C3\u00A9 pr\u00C3\u00A8s du centre-ville, cuisine compl\u00C3\u00A8te, laveuse \u0026 s\u00C3\u00A9cheuse, support 24/7, bowling, centre de fitness et plus encore.",
+            "category": "Budget",
+            "tags": [
+              "24-hour front desk service",
+              "coffee in lobby",
+              "restaurant"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1999-09-06T00:00:00Z",
+            "rating": 3,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "6910 Fayetteville Rd",
+              "city": "Durham",
+              "stateProvince": "NC",
+              "country": "USA",
+              "postalCode": "27713"
+            },
+            "rooms": [
+              {
+                "description": "Suite, 1 King Bed (Amenities)",
+                "descriptionFr": "Suite, 1 tr\u00C3\u00A8s grand lit (Services)",
+                "type": "Suite",
+                "baseRate": 2.44,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "coffee maker"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 Queen Bed (Amenities)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (Services)",
+                "type": "Budget Room",
+                "baseRate": 7.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": false,
+                "tags": [
+                  "coffee maker"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "3",
+            "hotelName": "EconoStay",
+            "description": "Very popular hotel in town",
+            "descriptionFr": "H\u00C3\u00B4tel le plus populaire en ville",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "9",
+            "hotelName": "Secret Point Motel",
+            "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.",
+            "descriptionFr": "L\u0027h\u00C3\u00B4tel est id\u00C3\u00A9alement situ\u00C3\u00A9 sur la principale art\u00C3\u00A8re commerciale de la ville en plein c\u00C5\u201Cur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\u00C3\u00A9r\u00C3\u00AAt qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\u00C3\u00A9rique.",
+            "category": "Boutique",
+            "tags": [
+              "pool",
+              "air conditioning",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1970-01-18T05:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "677 5th Ave",
+              "city": "New York",
+              "stateProvince": "NY",
+              "country": "USA",
+              "postalCode": "10022"
+            },
+            "rooms": [
+              {
+                "description": "Budget Room, 1 Queen Bed (Cityside)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (c\u00C3\u00B4t\u00C3\u00A9 ville)",
+                "type": "Budget Room",
+                "baseRate": 9.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 King Bed (Mountain View)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 tr\u00C3\u00A8s grand lit (Mountain View)",
+                "type": "Budget Room",
+                "baseRate": 8.09,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd",
+                  "jacuzzi tub"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "23",
+            "hotelName": "EconoStay2",
+            "description": "Very popular hotel in town",
+            "descriptionFr": "H\u00C3\u00B4tel le plus populaire en ville",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "27",
+            "hotelName": "Modern Stay2",
+            "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+            "descriptionFr": "Architecture moderne, personnel poli et tr\u00C3\u00A8s propre. Aussi tr\u00C3\u00A8s abordable.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "39",
+            "hotelName": "Secret Point Motel3",
+            "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.",
+            "descriptionFr": "L\u0027h\u00C3\u00B4tel est id\u00C3\u00A9alement situ\u00C3\u00A9 sur la principale art\u00C3\u00A8re commerciale de la ville en plein c\u00C5\u201Cur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\u00C3\u00A9r\u00C3\u00AAt qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\u00C3\u00A9rique.",
+            "category": "Boutique",
+            "tags": [
+              "pool",
+              "air conditioning",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1970-01-18T05:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "677 5th Ave",
+              "city": "New York",
+              "stateProvince": "NY",
+              "country": "USA",
+              "postalCode": "10022"
+            },
+            "rooms": [
+              {
+                "description": "Budget Room, 1 Queen Bed (Cityside)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (c\u00C3\u00B4t\u00C3\u00A9 ville)",
+                "type": "Budget Room",
+                "baseRate": 9.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 King Bed (Mountain View)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 tr\u00C3\u00A8s grand lit (Mountain View)",
+                "type": "Budget Room",
+                "baseRate": 8.09,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd",
+                  "jacuzzi tub"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "2",
+            "hotelName": "Roach Motel",
+            "description": "Cheapest hotel in town. Infact, a motel.",
+            "descriptionFr": "H\u00C3\u00B4tel le moins cher en ville. Infact, un motel.",
+            "category": "Budget",
+            "tags": [
+              "motel",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1982-04-28T00:00:00Z",
+            "rating": 1,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "4",
+            "hotelName": "Express Rooms",
+            "description": "Pretty good hotel",
+            "descriptionFr": "Assez bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "5",
+            "hotelName": "Comfy Place",
+            "description": "Another good hotel",
+            "descriptionFr": "Un autre bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2012-08-12T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "11",
+            "hotelName": "Fancy Stay 1",
+            "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "descriptionFr": "Meilleur h\u00C3\u00B4tel en ville si vous aimez les h\u00C3\u00B4tels de luxe. Ils ont une magnifique piscine \u00C3\u00A0 d\u00C3\u00A9bordement, un spa et un concierge tr\u00C3\u00A8s utile. L\u0027emplacement est parfait \u00E2\u20AC\u201C en plein centre, \u00C3\u00A0 proximit\u00C3\u00A9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00C3\u00B4tel.",
+            "category": "Luxury",
+            "tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2010-06-27T00:00:00Z",
+            "rating": 5,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "18",
+            "hotelName": null,
+            "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+            "descriptionFr": "Il y a du bruit de la route et se trouve \u00C3\u00A0 c\u00C3\u00B4t\u00C3\u00A9 de la station de police. Les salles de bain avaient des rev\u00C3\u00AAtements de morilles.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "21",
+            "hotelName": "Fancy Stay 2",
+            "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "descriptionFr": "Meilleur h\u00C3\u00B4tel en ville si vous aimez les h\u00C3\u00B4tels de luxe. Ils ont une magnifique piscine \u00C3\u00A0 d\u00C3\u00A9bordement, un spa et un concierge tr\u00C3\u00A8s utile. L\u0027emplacement est parfait \u00E2\u20AC\u201C en plein centre, \u00C3\u00A0 proximit\u00C3\u00A9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00C3\u00B4tel.",
+            "category": "Luxury",
+            "tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2010-06-27T00:00:00Z",
+            "rating": 5,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "24",
+            "hotelName": "Express Rooms2",
+            "description": "Pretty good hotel",
+            "descriptionFr": "Assez bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "36",
+            "hotelName": null,
+            "description": "Surprisingly expensive. Model suites have an ocean-view.",
+            "descriptionFr": null,
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "17",
+            "hotelName": "Modern Stay1",
+            "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+            "descriptionFr": "Architecture moderne, personnel poli et tr\u00C3\u00A8s propre. Aussi tr\u00C3\u00A8s abordable.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "30",
+            "hotelName": "Countryside Hotel 2",
+            "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.",
+            "descriptionFr": "\u00C3\u2030conomisez jusqu\u0027\u00C3\u00A0 50% sur les h\u00C3\u00B4tels traditionnels.  WiFi gratuit, tr\u00C3\u00A8s bien situ\u00C3\u00A9 pr\u00C3\u00A8s du centre-ville, cuisine compl\u00C3\u00A8te, laveuse \u0026 s\u00C3\u00A9cheuse, support 24/7, bowling, centre de fitness et plus encore.",
+            "category": "Budget",
+            "tags": [
+              "24-hour front desk service",
+              "coffee in lobby",
+              "restaurant"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1999-09-06T00:00:00Z",
+            "rating": 3,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "6910 Fayetteville Rd",
+              "city": "Durham",
+              "stateProvince": "NC",
+              "country": "USA",
+              "postalCode": "27713"
+            },
+            "rooms": [
+              {
+                "description": "Suite, 1 King Bed (Amenities)",
+                "descriptionFr": "Suite, 1 tr\u00C3\u00A8s grand lit (Services)",
+                "type": "Suite",
+                "baseRate": 2.44,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "coffee maker"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 Queen Bed (Amenities)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (Services)",
+                "type": "Budget Room",
+                "baseRate": 7.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": false,
+                "tags": [
+                  "coffee maker"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "25",
+            "hotelName": "Comfy Place2",
+            "description": "Another good hotel",
+            "descriptionFr": "Un autre bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2012-08-12T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "33",
+            "hotelName": "EconoStay3",
+            "description": "Very popular hotel in town",
+            "descriptionFr": "H\u00C3\u00B4tel le plus populaire en ville",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "41",
+            "hotelName": "Fancy Stay4",
+            "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "descriptionFr": "Meilleur h\u00C3\u00B4tel en ville si vous aimez les h\u00C3\u00B4tels de luxe. Ils ont une magnifique piscine \u00C3\u00A0 d\u00C3\u00A9bordement, un spa et un concierge tr\u00C3\u00A8s utile. L\u0027emplacement est parfait \u00E2\u20AC\u201C en plein centre, \u00C3\u00A0 proximit\u00C3\u00A9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00C3\u00B4tel.",
+            "category": "Luxury",
+            "tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2010-06-27T00:00:00Z",
+            "rating": 5,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "46",
+            "hotelName": null,
+            "description": "Surprisingly expensive. Model suites have an ocean-view.",
+            "descriptionFr": null,
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "52",
+            "hotelName": "Roach Motel5",
+            "description": "Cheapest hotel in town. Infact, a motel.",
+            "descriptionFr": "H\u00C3\u00B4tel le moins cher en ville. Infact, un motel.",
+            "category": "Budget",
+            "tags": [
+              "motel",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1982-04-28T00:00:00Z",
+            "rating": 1,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "54",
+            "hotelName": "Express Rooms5",
+            "description": "Pretty good hotel",
+            "descriptionFr": "Assez bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "57",
+            "hotelName": "Modern Stay5",
+            "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+            "descriptionFr": "Architecture moderne, personnel poli et tr\u00C3\u00A8s propre. Aussi tr\u00C3\u00A8s abordable.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "58",
+            "hotelName": null,
+            "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+            "descriptionFr": "Il y a du bruit de la route et se trouve \u00C3\u00A0 c\u00C3\u00B4t\u00C3\u00A9 de la station de police. Les salles de bain avaient des rev\u00C3\u00AAtements de morilles.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "7",
+            "hotelName": "Modern Stay",
+            "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+            "descriptionFr": "Architecture moderne, personnel poli et tr\u00C3\u00A8s propre. Aussi tr\u00C3\u00A8s abordable.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "38",
+            "hotelName": null,
+            "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+            "descriptionFr": "Il y a du bruit de la route et se trouve \u00C3\u00A0 c\u00C3\u00B4t\u00C3\u00A9 de la station de police. Les salles de bain avaient des rev\u00C3\u00AAtements de morilles.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "42",
+            "hotelName": "Roach Motel4",
+            "description": "Cheapest hotel in town. Infact, a motel.",
+            "descriptionFr": "H\u00C3\u00B4tel le moins cher en ville. Infact, un motel.",
+            "category": "Budget",
+            "tags": [
+              "motel",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1982-04-28T00:00:00Z",
+            "rating": 1,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "51",
+            "hotelName": "Fancy Stay5",
+            "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "descriptionFr": "Meilleur h\u00C3\u00B4tel en ville si vous aimez les h\u00C3\u00B4tels de luxe. Ils ont une magnifique piscine \u00C3\u00A0 d\u00C3\u00A9bordement, un spa et un concierge tr\u00C3\u00A8s utile. L\u0027emplacement est parfait \u00E2\u20AC\u201C en plein centre, \u00C3\u00A0 proximit\u00C3\u00A9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00C3\u00B4tel.",
+            "category": "Luxury",
+            "tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2010-06-27T00:00:00Z",
+            "rating": 5,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "15",
+            "hotelName": "Comfy Place 1",
+            "description": "Another good hotel",
+            "descriptionFr": "Un autre bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2012-08-12T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "29",
+            "hotelName": "Secret Point Motel2",
+            "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.",
+            "descriptionFr": "L\u0027h\u00C3\u00B4tel est id\u00C3\u00A9alement situ\u00C3\u00A9 sur la principale art\u00C3\u00A8re commerciale de la ville en plein c\u00C5\u201Cur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\u00C3\u00A9r\u00C3\u00AAt qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\u00C3\u00A9rique.",
+            "category": "Boutique",
+            "tags": [
+              "pool",
+              "air conditioning",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1970-01-18T05:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "677 5th Ave",
+              "city": "New York",
+              "stateProvince": "NY",
+              "country": "USA",
+              "postalCode": "10022"
+            },
+            "rooms": [
+              {
+                "description": "Budget Room, 1 Queen Bed (Cityside)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (c\u00C3\u00B4t\u00C3\u00A9 ville)",
+                "type": "Budget Room",
+                "baseRate": 9.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 King Bed (Mountain View)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 tr\u00C3\u00A8s grand lit (Mountain View)",
+                "type": "Budget Room",
+                "baseRate": 8.09,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd",
+                  "jacuzzi tub"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "56",
+            "hotelName": null,
+            "description": "Surprisingly expensive. Model suites have an ocean-view.",
+            "descriptionFr": null,
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "59",
+            "hotelName": "Secret Point Motel5",
+            "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.",
+            "descriptionFr": "L\u0027h\u00C3\u00B4tel est id\u00C3\u00A9alement situ\u00C3\u00A9 sur la principale art\u00C3\u00A8re commerciale de la ville en plein c\u00C5\u201Cur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\u00C3\u00A9r\u00C3\u00AAt qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\u00C3\u00A9rique.",
+            "category": "Boutique",
+            "tags": [
+              "pool",
+              "air conditioning",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1970-01-18T05:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "677 5th Ave",
+              "city": "New York",
+              "stateProvince": "NY",
+              "country": "USA",
+              "postalCode": "10022"
+            },
+            "rooms": [
+              {
+                "description": "Budget Room, 1 Queen Bed (Cityside)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (c\u00C3\u00B4t\u00C3\u00A9 ville)",
+                "type": "Budget Room",
+                "baseRate": 9.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 King Bed (Mountain View)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 tr\u00C3\u00A8s grand lit (Mountain View)",
+                "type": "Budget Room",
+                "baseRate": 8.09,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd",
+                  "jacuzzi tub"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "19",
+            "hotelName": "Secret Point Motel 1",
+            "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.",
+            "descriptionFr": "L\u0027h\u00C3\u00B4tel est id\u00C3\u00A9alement situ\u00C3\u00A9 sur la principale art\u00C3\u00A8re commerciale de la ville en plein c\u00C5\u201Cur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\u00C3\u00A9r\u00C3\u00AAt qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\u00C3\u00A9rique.",
+            "category": "Boutique",
+            "tags": [
+              "pool",
+              "air conditioning",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1970-01-18T05:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "677 5th Ave",
+              "city": "New York",
+              "stateProvince": "NY",
+              "country": "USA",
+              "postalCode": "10022"
+            },
+            "rooms": [
+              {
+                "description": "Budget Room, 1 Queen Bed (Cityside)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (c\u00C3\u00B4t\u00C3\u00A9 ville)",
+                "type": "Budget Room",
+                "baseRate": 9.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 King Bed (Mountain View)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 tr\u00C3\u00A8s grand lit (Mountain View)",
+                "type": "Budget Room",
+                "baseRate": 8.09,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd",
+                  "jacuzzi tub"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "22",
+            "hotelName": "Roach Motel2",
+            "description": "Cheapest hotel in town. Infact, a motel.",
+            "descriptionFr": "H\u00C3\u00B4tel le moins cher en ville. Infact, un motel.",
+            "category": "Budget",
+            "tags": [
+              "motel",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1982-04-28T00:00:00Z",
+            "rating": 1,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "34",
+            "hotelName": "Express Rooms3",
+            "description": "Pretty good hotel",
+            "descriptionFr": "Assez bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "37",
+            "hotelName": "Modern Stay3",
+            "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+            "descriptionFr": "Architecture moderne, personnel poli et tr\u00C3\u00A8s propre. Aussi tr\u00C3\u00A8s abordable.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "49",
+            "hotelName": "Secret Point Motel4",
+            "description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.",
+            "descriptionFr": "L\u0027h\u00C3\u00B4tel est id\u00C3\u00A9alement situ\u00C3\u00A9 sur la principale art\u00C3\u00A8re commerciale de la ville en plein c\u00C5\u201Cur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\u00C3\u00A9r\u00C3\u00AAt qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\u00C3\u00A9rique.",
+            "category": "Boutique",
+            "tags": [
+              "pool",
+              "air conditioning",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1970-01-18T05:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "677 5th Ave",
+              "city": "New York",
+              "stateProvince": "NY",
+              "country": "USA",
+              "postalCode": "10022"
+            },
+            "rooms": [
+              {
+                "description": "Budget Room, 1 Queen Bed (Cityside)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (c\u00C3\u00B4t\u00C3\u00A9 ville)",
+                "type": "Budget Room",
+                "baseRate": 9.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 King Bed (Mountain View)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 tr\u00C3\u00A8s grand lit (Mountain View)",
+                "type": "Budget Room",
+                "baseRate": 8.09,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "vcr/dvd",
+                  "jacuzzi tub"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "6",
+            "hotelName": null,
+            "description": "Surprisingly expensive. Model suites have an ocean-view.",
+            "descriptionFr": null,
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "13",
+            "hotelName": "EconoStay 1",
+            "description": "Very popular hotel in town",
+            "descriptionFr": "H\u00C3\u00B4tel le plus populaire en ville",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "28",
+            "hotelName": null,
+            "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+            "descriptionFr": "Il y a du bruit de la route et se trouve \u00C3\u00A0 c\u00C3\u00B4t\u00C3\u00A9 de la station de police. Les salles de bain avaient des rev\u00C3\u00AAtements de morilles.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "40",
+            "hotelName": "Countryside Hotel",
+            "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.",
+            "descriptionFr": "\u00C3\u2030conomisez jusqu\u0027\u00C3\u00A0 50% sur les h\u00C3\u00B4tels traditionnels.  WiFi gratuit, tr\u00C3\u00A8s bien situ\u00C3\u00A9 pr\u00C3\u00A8s du centre-ville, cuisine compl\u00C3\u00A8te, laveuse \u0026 s\u00C3\u00A9cheuse, support 24/7, bowling, centre de fitness et plus encore.",
+            "category": "Budget",
+            "tags": [
+              "24-hour front desk service",
+              "coffee in lobby",
+              "restaurant"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1999-09-06T00:00:00Z",
+            "rating": 3,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "6910 Fayetteville Rd",
+              "city": "Durham",
+              "stateProvince": "NC",
+              "country": "USA",
+              "postalCode": "27713"
+            },
+            "rooms": [
+              {
+                "description": "Suite, 1 King Bed (Amenities)",
+                "descriptionFr": "Suite, 1 tr\u00C3\u00A8s grand lit (Services)",
+                "type": "Suite",
+                "baseRate": 2.44,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "coffee maker"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 Queen Bed (Amenities)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (Services)",
+                "type": "Budget Room",
+                "baseRate": 7.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": false,
+                "tags": [
+                  "coffee maker"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "44",
+            "hotelName": "Express Rooms4",
+            "description": "Pretty good hotel",
+            "descriptionFr": "Assez bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "48",
+            "hotelName": null,
+            "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+            "descriptionFr": "Il y a du bruit de la route et se trouve \u00C3\u00A0 c\u00C3\u00B4t\u00C3\u00A9 de la station de police. Les salles de bain avaient des rev\u00C3\u00AAtements de morilles.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "50",
+            "hotelName": "Countryside Hotel",
+            "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.",
+            "descriptionFr": "\u00C3\u2030conomisez jusqu\u0027\u00C3\u00A0 50% sur les h\u00C3\u00B4tels traditionnels.  WiFi gratuit, tr\u00C3\u00A8s bien situ\u00C3\u00A9 pr\u00C3\u00A8s du centre-ville, cuisine compl\u00C3\u00A8te, laveuse \u0026 s\u00C3\u00A9cheuse, support 24/7, bowling, centre de fitness et plus encore.",
+            "category": "Budget",
+            "tags": [
+              "24-hour front desk service",
+              "coffee in lobby",
+              "restaurant"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1999-09-06T00:00:00Z",
+            "rating": 3,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "6910 Fayetteville Rd",
+              "city": "Durham",
+              "stateProvince": "NC",
+              "country": "USA",
+              "postalCode": "27713"
+            },
+            "rooms": [
+              {
+                "description": "Suite, 1 King Bed (Amenities)",
+                "descriptionFr": "Suite, 1 tr\u00C3\u00A8s grand lit (Services)",
+                "type": "Suite",
+                "baseRate": 2.44,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "coffee maker"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 Queen Bed (Amenities)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (Services)",
+                "type": "Budget Room",
+                "baseRate": 7.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": false,
+                "tags": [
+                  "coffee maker"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "53",
+            "hotelName": "EconoStay5",
+            "description": "Very popular hotel in town",
+            "descriptionFr": "H\u00C3\u00B4tel le plus populaire en ville",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "55",
+            "hotelName": "Comfy Place5",
+            "description": "Another good hotel",
+            "descriptionFr": "Un autre bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2012-08-12T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "8",
+            "hotelName": null,
+            "description": "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+            "descriptionFr": "Il y a du bruit de la route et se trouve \u00C3\u00A0 c\u00C3\u00B4t\u00C3\u00A9 de la station de police. Les salles de bain avaient des rev\u00C3\u00AAtements de morilles.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          }
+        ],
+        "@odata.nextLink": "https://fakesearchendpoint.search.windows.net/indexes(\u0027drgqefsg\u0027)/docs/search.post.search?api-version=2021-04-30-Preview"
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/indexes(\u0027drgqefsg\u0027)/docs/search.post.search?api-version=2021-04-30-Preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=none",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "80b10d54-a3ac-11ec-bb9d-a04a5ed0778b"
+      },
+      "RequestBody": {
+        "search": "",
+        "skip": 50
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "5873",
+        "Content-Type": "application/json; odata.metadata=none",
+        "Date": "Mon, 14 Mar 2022 15:36:23 GMT",
+        "elapsed-time": "13",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "80b10d54-a3ac-11ec-bb9d-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "@search.score": 1.0,
+            "hotelId": "12",
+            "hotelName": "Roach Motel 1",
+            "description": "Cheapest hotel in town. Infact, a motel.",
+            "descriptionFr": "H\u00C3\u00B4tel le moins cher en ville. Infact, un motel.",
+            "category": "Budget",
+            "tags": [
+              "motel",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1982-04-28T00:00:00Z",
+            "rating": 1,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "14",
+            "hotelName": "Express Rooms 1",
+            "description": "Pretty good hotel",
+            "descriptionFr": "Assez bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "16",
+            "hotelName": null,
+            "description": "Surprisingly expensive. Model suites have an ocean-view.",
+            "descriptionFr": null,
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "26",
+            "hotelName": null,
+            "description": "Surprisingly expensive. Model suites have an ocean-view.",
+            "descriptionFr": null,
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "35",
+            "hotelName": "Comfy Place3",
+            "description": "Another good hotel",
+            "descriptionFr": "Un autre bon h\u00C3\u00B4tel",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2012-08-12T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "43",
+            "hotelName": "EconoStay4",
+            "description": "Very popular hotel in town",
+            "descriptionFr": "H\u00C3\u00B4tel le plus populaire en ville",
+            "category": "Budget",
+            "tags": [
+              "wifi",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": false,
+            "lastRenovationDate": "1995-07-01T00:00:00Z",
+            "rating": 4,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "1",
+            "hotelName": "Fancy Stay",
+            "description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "descriptionFr": "Meilleur h\u00C3\u00B4tel en ville si vous aimez les h\u00C3\u00B4tels de luxe. Ils ont une magnifique piscine \u00C3\u00A0 d\u00C3\u00A9bordement, un spa et un concierge tr\u00C3\u00A8s utile. L\u0027emplacement est parfait \u00E2\u20AC\u201C en plein centre, \u00C3\u00A0 proximit\u00C3\u00A9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00C3\u00B4tel.",
+            "category": "Luxury",
+            "tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": false,
+            "lastRenovationDate": "2010-06-27T00:00:00Z",
+            "rating": 5,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "10",
+            "hotelName": "Countryside Hotel",
+            "description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.",
+            "descriptionFr": "\u00C3\u2030conomisez jusqu\u0027\u00C3\u00A0 50% sur les h\u00C3\u00B4tels traditionnels.  WiFi gratuit, tr\u00C3\u00A8s bien situ\u00C3\u00A9 pr\u00C3\u00A8s du centre-ville, cuisine compl\u00C3\u00A8te, laveuse \u0026 s\u00C3\u00A9cheuse, support 24/7, bowling, centre de fitness et plus encore.",
+            "category": "Budget",
+            "tags": [
+              "24-hour front desk service",
+              "coffee in lobby",
+              "restaurant"
+            ],
+            "parkingIncluded": false,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1999-09-06T00:00:00Z",
+            "rating": 3,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": {
+              "streetAddress": "6910 Fayetteville Rd",
+              "city": "Durham",
+              "stateProvince": "NC",
+              "country": "USA",
+              "postalCode": "27713"
+            },
+            "rooms": [
+              {
+                "description": "Suite, 1 King Bed (Amenities)",
+                "descriptionFr": "Suite, 1 tr\u00C3\u00A8s grand lit (Services)",
+                "type": "Suite",
+                "baseRate": 2.44,
+                "bedOptions": "1 King Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": true,
+                "tags": [
+                  "coffee maker"
+                ]
+              },
+              {
+                "description": "Budget Room, 1 Queen Bed (Amenities)",
+                "descriptionFr": "Chambre \u00C3\u2030conomique, 1 grand lit (Services)",
+                "type": "Budget Room",
+                "baseRate": 7.69,
+                "bedOptions": "1 Queen Bed",
+                "sleepsCount": 2,
+                "smokingAllowed": false,
+                "tags": [
+                  "coffee maker"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "32",
+            "hotelName": "Roach Motel3",
+            "description": "Cheapest hotel in town. Infact, a motel.",
+            "descriptionFr": "H\u00C3\u00B4tel le moins cher en ville. Infact, un motel.",
+            "category": "Budget",
+            "tags": [
+              "motel",
+              "budget"
+            ],
+            "parkingIncluded": true,
+            "smokingAllowed": true,
+            "lastRenovationDate": "1982-04-28T00:00:00Z",
+            "rating": 1,
+            "location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "address": null,
+            "rooms": []
+          },
+          {
+            "@search.score": 1.0,
+            "hotelId": "47",
+            "hotelName": "Modern Stay4",
+            "description": "Modern architecture, very polite staff and very clean. Also very affordable.",
+            "descriptionFr": "Architecture moderne, personnel poli et tr\u00C3\u00A8s propre. Aussi tr\u00C3\u00A8s abordable.",
+            "category": null,
+            "tags": [],
+            "parkingIncluded": null,
+            "smokingAllowed": null,
+            "lastRenovationDate": null,
+            "rating": null,
+            "location": null,
+            "address": null,
+            "rooms": []
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}


### PR DESCRIPTION
Fixes #23467

The issue was caused by **kwargs not being passed in to `search_post` resulting in  an API call being without an `api key` in the header.