### PR TITLE
Fix remote rendering test pipeline

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 1.0.0b2 (2022-11-03)
+
 ## 1.0.0b1 (2021-11-15)
 
 - Initial release.

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Release History
 
-## 1.0.0b2 (2022-11-03)
-
-- Fixed bug in testing pipeline.
-
 ## 1.0.0b1 (2021-11-15)
 
 - Initial release.

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
@@ -1,14 +1,8 @@
 # Release History
 
-## 1.0.0b2 (Unreleased)
+## 1.0.0b2 (2022-11-03)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Fixed bug in testing pipeline.
 
 ## 1.0.0b1 (2021-11-15)
 

--- a/sdk/remoterendering/cspell.json
+++ b/sdk/remoterendering/cspell.json
@@ -1,0 +1,7 @@
+{
+    "version": "0.2",
+    "language": "en",
+    "ignorePaths": [
+        "./test-resources.json"
+    ]
+}

--- a/sdk/remoterendering/test-resources.json
+++ b/sdk/remoterendering/test-resources.json
@@ -116,6 +116,10 @@
       "REMOTERENDERING_ARR_SERVICE_ENDPOINT": {
         "type": "string",
         "value": "[concat('https://remoterendering.', parameters('location'), '.mixedreality.azure.com')]"
+      },
+      "REMOTERENDERING_STORAGE_ENDPOINT_SUFFIX": {
+        "type": "string",
+        "value": "core.windows.net"
       }
     }
 }


### PR DESCRIPTION
# Description

The test pipeline for the remoterendering sdk is missing an environment variable, thus all tests run fail in the setup process.
This PR adds this environment variable and should fix the tests or at least will run them, so we can see if something is really broken and not only the environment.