### PR TITLE
Implementing logging exporter for Azure Monitor

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.0.0b6 (Unreleased)
 
 ### Features Added
+- Implement log exporter using experimental OT logging sdk
+    ([#20489](https://github.com/Azure/azure-sdk-for-python/pull/20489))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Implement log exporter using experimental OT logging sdk
-    ([#20489](https://github.com/Azure/azure-sdk-for-python/pull/20489))
+    ([#23486](https://github.com/Azure/azure-sdk-for-python/pull/23486))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -2,7 +2,7 @@
 
 [![Gitter chat](https://img.shields.io/gitter/room/Microsoft/azure-monitor-python)](https://gitter.im/Azure/azure-sdk-for-python)
 
-The exporter for Azure Monitor allows you to export tracing data utilizing the OpenTelemetry SDK and send telemetry data to Azure Monitor for applications written in Python.
+The exporter for Azure Monitor allows you to export data utilizing the OpenTelemetry SDK and send telemetry data to Azure Monitor for applications written in Python.
 
 [Source code](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter) | [Package (PyPi)][pypi] | [API reference documentation][api_docs] | [Product documentation][product_docs] | [Samples](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples) | [Changelog](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md)
 
@@ -25,10 +25,19 @@ To use this package, you must have:
 
 ### Instantiate the client
 
-Interaction with Azure monitor exporter starts with an instance of the `AzureMonitorTraceExporter` class. You will need a **connection_string** to instantiate the object.
+Interaction with Azure monitor exporter starts with an instance of the `AzureMonitorTraceExporter` class for distributed tracing or `AzureMonitorTraceExporter` for logging. You will need a **connection_string** to instantiate the object.
 Please find the samples linked below for demonstration as to how to construct the exporter using a connection string.
 
-#### [Create Exporter from connection string][sample_authenticate_client_connstr]
+#### Logging
+
+```Python
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+exporter = AzureMonitorLogExporter.from_connection_string(
+    conn_str = os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+)
+```
+
+#### Tracing
 
 ```Python
 from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter
@@ -38,6 +47,11 @@ exporter = AzureMonitorTraceExporter.from_connection_string(
 ```
 
 You can also instantiate the exporter directly via the constructor. In this case, the connection string will be automatically populated from the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable.
+
+```python
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+exporter = AzureMonitorLogExporter()
+```
 
 ```python
 from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter
@@ -52,26 +66,164 @@ Some of the key concepts for the Azure monitor exporter include:
 
 * [Instrumentation][instrumentation_library]: The ability to call the opentelemetry API directly by any application is facilitated by instrumentation. A library that enables OpenTelemetry observability for another library is called an instrumentation Library.
 
-* [Trace][trace_concept]: Trace refers to distributed tracing. It can be thought of as a directed acyclic graph (DAG) of Spans, where the edges between Spans are defined as parent/child relationship.
+* [Log][log_concept]: Log refers to capturing of logging, exception and events.
+
+* [LogRecord][log_record]: Represents a log record emitted from a supported logging library.
+
+* [LogEmitter][log_emitter]: Converts a `LogRecord` into a readable `LogData`, and will be pushed through the SDK to be exported.
+
+* [LogEmitter Provider][log_emitter_provider]: Provides a `LogEmitter` for the given instrumentation library.
+
+* [LogProcessor][log_processor]: Inteface to hook the log record emitting action.
+
+* [LoggingHandler][logging_handler]: A handler class which writes logging records in OpenTelemetry format from the standard Python `logging` library.
+
+* [AzureMonitorLogExporter][log_reference]: This is the class that is initialized to send logging related telemetry to Azure Monitor.
+
+* [Trace][trace_concept]: Trace refers to distributed tracing. It can be thought of as a directed acyclic graph (DAG) of `Span`s, where the edges between `Span`s are defined as parent/child relationship.
+
+* [Span][span]: Represents a single operation within a `Trace`. Can be nested to form a trace tree. Each trace contains a root span, which typically describes the entire operation and, optionally, one ore more sub-spans for its sub-operations.
+
+* [Tracer][tracer]: Responsible for creating `Span`s.
 
 * [Tracer Provider][tracer_provider]: Provides a `Tracer` for use by the given instrumentation library.
 
 * [Span Processor][span_processor]: A span processor allows hooks for SDK's `Span` start and end method invocations. Follow the link for more information.
 
-* [Sampling][sampler_ref]: Sampling is a mechanism to control the noise and overhead introduced by OpenTelemetry by reducing the number of samples of traces collected and sent to the backend.
+* [AzureMonitorTraceExporter][trace_reference]: This is the class that is initialized to send tracing related telemetry to Azure Monitor.
 
-* [AzureMonitorTraceExporter][client_reference]: This is the class that is initialized to send tracing related telemetry to Azure Monitor.
+* [Sampling][sampler_ref]: Sampling is a mechanism to control the noise and overhead introduced by OpenTelemetry by reducing the number of samples of traces collected and sent to the backend.
 
 For more information about these resources, see [What is Azure Monitor?][product_docs].
 
 ## Examples
+
+### Logging
+
+The following sections provide several code snippets covering some of the most common tasks, including:
+
+* [Exporting a log record](#export-hello-world-log)
+* [Exporting correlated log record](#export-correlated-log)
+* [Exporting log record with custom properties](#export-custom-properties-log)
+
+#### Export Hello World Log
+
+```Python
+import os
+import logging
+
+from opentelemetry.sdk._logs import (
+    LogEmitterProvider,
+    OTLPHandler,
+    set_log_emitter_provider,
+)
+from opentelemetry.sdk._logs.export import BatchLogProcessor
+
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+
+log_emitter_provider = LogEmitterProvider()
+set_log_emitter_provider(log_emitter_provider)
+
+exporter = AzureMonitorLogExporter.from_connection_string(
+    os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+)
+
+log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
+handler = OTLPHandler()
+
+# Attach OTLPhandler to root logger
+logging.getLogger().addHandler(handler)
+logging.getLogger().setLevel(logging.NOTSET)
+
+logger = logging.getLogger(__name__)
+
+logger.warning("Hello World!")
+```
+
+#### Export Correlated Log
+
+```Python
+import os
+import logging
+
+from opentelemetry import trace
+from opentelemetry.sdk._logs import (
+    LogEmitterProvider,
+    OTLPHandler,
+    set_log_emitter_provider,
+)
+from opentelemetry.sdk._logs.export import BatchLogProcessor
+from opentelemetry.sdk.trace import TracerProvider
+
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer(__name__)
+log_emitter_provider = LogEmitterProvider()
+set_log_emitter_provider(LogEmitterProvider())
+
+exporter = AzureMonitorLogExporter.from_connection_string(
+    os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+)
+
+log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
+handler = OTLPHandler()
+
+# Attach OTel handler to root logger
+logging.getLogger().addHandler(handler)
+logging.getLogger().setLevel(logging.NOTSET)
+
+logger = logging.getLogger(__name__)
+
+logger.info("INFO: Outside of span")
+with tracer.start_as_current_span("foo"):
+    logger.warning("WARNING: Inside of span")
+logger.error("ERROR: After span")
+```
+
+#### Export Custom Properties Log
+
+```Python
+import os
+import logging
+
+from opentelemetry.sdk._logs import (
+    LogEmitterProvider,
+    OTLPHandler,
+    set_log_emitter_provider,
+)
+from opentelemetry.sdk._logs.export import BatchLogProcessor
+
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+
+log_emitter_provider = LogEmitterProvider()
+set_log_emitter_provider(LogEmitterProvider())
+
+exporter = AzureMonitorLogExporter.from_connection_string(
+    os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+)
+
+log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
+handler = OTLPHandler()
+
+# Attach OTel handler to root logger
+logging.getLogger().addHandler(handler)
+logging.getLogger().setLevel(logging.NOTSET)
+
+logger = logging.getLogger(__name__)
+
+# Custom properties
+logger.debug("DEBUG: Debug with properties", extra={"debug": "true"})
+```
+
+### Tracing
 
 The following sections provide several code snippets covering some of the most common tasks, including:
 
 * [Exporting a custom span](#export-hello-world-trace)
 * [Using an instrumentation to track a library](#instrumentation-with-requests-library)
 
-### Export Hello World Trace
+#### Export Hello World Trace
 
 ```Python
 import os
@@ -93,7 +245,7 @@ with tracer.start_as_current_span("hello"):
     print("Hello, World!")
 ```
 
-### Instrumentation with requests library
+#### Instrumentation with requests library
 
 OpenTelemetry also supports several instrumentations which allows to instrument with third party libraries.
 
@@ -174,12 +326,19 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [virtualenv]: https://virtualenv.pypa.io
 [ot_sdk_python]: https://github.com/open-telemetry/opentelemetry-python
 [application_insights_namespace]: https://docs.microsoft.com/azure/azure-monitor/app/app-insights-overview#how-do-i-use-application-insights
-[trace_concept]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#trace
-[client_reference]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py#L30
 [opentelemtry_spec]: https://opentelemetry.io/
 [instrumentation_library]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#instrumentation-libraries
+[log_concept]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#log-signal
+[log_record]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogRecord
+[log_emitter]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogEmitter
+[log_emitter_provider]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogEmitterProvider
+[log_processor]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogProcessor
+[logging_handler]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.OTLPHandler
+[log_reference]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py#L30
+[trace_concept]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#tracing-signal
+[span]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html?highlight=TracerProvider#opentelemetry.trace.Span
+[tracer]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html?highlight=TracerProvider#opentelemetry.trace.Tracer
 [tracer_provider]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html?highlight=TracerProvider#opentelemetry.trace.TracerProvider
 [span_processor]: https://opentelemetry-python.readthedocs.io/en/stable/_modules/opentelemetry/sdk/trace.html?highlight=SpanProcessor#
+[trace_reference]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py#L30
 [sampler_ref]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling
-
-[sample_authenticate_client_connstr]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/traces/sample_trace.py

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/__init__.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/__init__.py
@@ -4,8 +4,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------
 
+from azure.monitor.opentelemetry.exporter.export.logs._exporter import AzureMonitorLogExporter
 from azure.monitor.opentelemetry.exporter.export.trace._exporter import AzureMonitorTraceExporter
 from ._version import VERSION
 
-__all__ = ["AzureMonitorTraceExporter"]
+__all__ = ["AzureMonitorLogExporter", "AzureMonitorTraceExporter"]
 __version__ = VERSION

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -7,8 +7,9 @@ import time
 
 import pkg_resources
 
-from azure.monitor.opentelemetry.exporter._version import VERSION as ext_version
 from opentelemetry.semconv.resource import ResourceAttributes
+
+from azure.monitor.opentelemetry.exporter._version import VERSION as ext_version
 
 
 # Workaround for missing version file

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -8,6 +8,7 @@ import time
 import pkg_resources
 
 from azure.monitor.opentelemetry.exporter._version import VERSION as ext_version
+from opentelemetry.semconv.resource import ResourceAttributes
 
 
 # Workaround for missing version file
@@ -71,3 +72,22 @@ class PeriodicTask(threading.Thread):
 
     def cancel(self):
         self.finished.set()
+
+def _populate_part_a_fields(resource):
+    tags = {}
+    if resource and resource.attributes:
+        service_name = resource.attributes.get(ResourceAttributes.SERVICE_NAME)
+        service_namespace = resource.attributes.get(ResourceAttributes.SERVICE_NAMESPACE)
+        service_instance_id = resource.attributes.get(ResourceAttributes.SERVICE_INSTANCE_ID)
+        if service_name:
+            if service_namespace:
+                tags["ai.cloud.role"] = service_namespace + \
+                    "." + service_name
+            else:
+                tags["ai.cloud.role"] = service_name
+        if service_instance_id:
+            tags["ai.cloud.roleInstance"] = service_instance_id
+        else:
+            tags["ai.cloud.roleInstance"] = platform.node()  # hostname default
+        tags["ai.internal.nodeName"] = tags["ai.cloud.roleInstance"]
+    return tags

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -7,8 +7,6 @@ from enum import Enum
 from typing import List, Any
 from urllib.parse import urlparse
 
-from opentelemetry.sdk.trace.export import SpanExportResult
-
 from azure.core.exceptions import HttpResponseError, ServiceRequestError
 from azure.core.pipeline.policies import ContentDecodePolicy, HttpLoggingPolicy, RedirectPolicy, RequestIdPolicy
 from azure.monitor.opentelemetry.exporter._generated import AzureMonitorClient

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -194,14 +194,3 @@ def _is_retryable_code(response_code: int) -> bool:
         503,  # Service Unavailable
         504,  # Gateway timeout
     ))
-
-
-def get_trace_export_result(result: ExportResult) -> SpanExportResult:
-    if result == ExportResult.SUCCESS:
-        return SpanExportResult.SUCCESS
-    if result in (
-        ExportResult.FAILED_RETRYABLE,
-        ExportResult.FAILED_NOT_RETRYABLE,
-    ):
-        return SpanExportResult.FAILURE
-    return None

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -1,0 +1,131 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import logging
+from typing import Sequence, Any
+
+from opentelemetry.sdk._logs import LogData
+from opentelemetry.sdk._logs.export import LogExporter, LogExportResult
+from opentelemetry.sdk.util import ns_to_iso_str
+from opentelemetry.trace import Span, SpanKind
+
+from azure.monitor.opentelemetry.exporter import _utils
+from azure.monitor.opentelemetry.exporter._generated.models import (
+    MessageData,
+    MonitorBase,
+    TelemetryItem
+)
+from azure.monitor.opentelemetry.exporter.export._base import (
+    BaseExporter,
+    ExportResult,
+)
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_SPAN_ID = "0x0000000000000000"
+_DEFAULT_TRACE_ID = "0x00000000000000000000000000000000"
+
+__all__ = ["AzureMonitorLogExporter"]
+
+
+class AzureMonitorLogExporter(BaseExporter, LogExporter):
+    """Azure Monitor Log exporter for OpenTelemetry."""
+
+    def export(self, batch: Sequence[LogData], **kwargs: Any) -> LogExportResult: # pylint: disable=unused-argument
+        """Export log data
+        :param logs: Open Telemetry LogData to export.
+        :type logs: Sequence[~opentelemetry._logs.LogData]
+        :rtype: ~opentelemetry.sdk._logs.export.LogData
+        """
+        envelopes = [self._log_to_envelope(log) for log in batch]
+        try:
+            result = self._transmit(envelopes)
+            if result == ExportResult.FAILED_RETRYABLE:
+                envelopes_to_store = [x.as_dict() for x in envelopes]
+                self.storage.put(envelopes_to_store, 1)
+            if result == ExportResult.SUCCESS:
+                # Try to send any cached events
+                self._transmit_from_storage()
+            return _get_log_export_result(result)
+        except Exception:  # pylint: disable=broad-except
+            _logger.exception("Exception occurred while exporting the data.")
+            return _get_log_export_result(ExportResult.FAILED_NOT_RETRYABLE)
+
+    def shutdown(self) -> None:
+        """Shuts down the exporter.
+
+        Called when the SDK is shut down.
+        """
+        self.storage.close()
+
+    def _log_to_envelope(self, log: LogData) -> TelemetryItem:
+        if not log:
+            return None
+        envelope = _convert_log_to_envelope(log)
+        envelope.instrumentation_key = self._instrumentation_key
+        return envelope
+
+    @classmethod
+    def from_connection_string(cls, conn_str: str, **kwargs: Any) -> "AzureMonitorLogExporter":
+        """
+        Create an AzureMonitorLogExporter from a connection string.
+
+        This is the recommended way of instantation if a connection string is passed in explicitly.
+        If a user wants to use a connection string provided by environment variable, the constructor
+        of the exporter can be called directly.
+
+        :param str conn_str: The connection string to be used for authentication.
+        :keyword str api_version: The service API version used. Defaults to latest.
+        :returns an instance of ~AzureMonitorLogExporter
+        """
+        return cls(connection_string=conn_str, **kwargs)
+
+def _convert_log_to_envelope(log: LogData) -> TelemetryItem:
+    envelope = TelemetryItem(
+        name="",
+        instrumentation_key="",
+        tags=dict(_utils.azure_monitor_context),
+        time=ns_to_iso_str(log.timestamp),
+    )
+    # pylint: disable=protected-access
+    envelope.tags.update(_utils._populate_part_a_fields(log.resource))
+
+    envelope.tags['ai.operation.id'] = log.trace_id or _DEFAULT_TRACE_ID
+    envelope.tags['ai.operation.parentId'] = log.span_id or _DEFAULT_SPAN_ID
+
+    # TODO: Properties
+    properties = {}
+    # properties = {
+    #     'process': record.processName,
+    #     'module': record.module,
+    #     'fileName': record.pathname,
+    #     'lineNumber': record.lineno,
+    #     'level': record.levelname,
+    # }
+    # TODO: Custom dimensions
+    # TODO: Exceptions
+
+    envelope.name = 'Microsoft.ApplicationInsights.Message'
+    # Severity number: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
+    data = MessageData(
+        message=log.body,
+        severityLevel= _get_severity_level(log.severity_number),
+        properties=properties,
+    )
+    envelope.data = MonitorBase(baseData=data, baseType='MessageData')
+
+    return envelope
+
+def _get_log_export_result(result: ExportResult) -> LogExportResult:
+    if result == ExportResult.SUCCESS:
+        return LogExportResult.SUCCESS
+    if result in (
+        ExportResult.FAILED_RETRYABLE,
+        ExportResult.FAILED_NOT_RETRYABLE,
+    ):
+        return LogExportResult.FAILURE
+    return None
+
+def _get_severity_level(severity_number):
+    if severity_number < 9:
+        return 0
+    return (severity_number-1)/4 - 1

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -129,7 +129,9 @@ def _get_log_export_result(result: ExportResult) -> LogExportResult:
         return LogExportResult.FAILURE
     return None
 
+# Common schema: https://github.com/microsoft/common-schema/blob/main/Mappings/AzureMonitor-AI.md#messageseveritylevel
+# SeverityNumber specs: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
 def _get_severity_level(severity_number: SeverityNumber):
     if severity_number.value < 9:
         return 0
-    return (severity_number.value-1)/4 - 1
+    return int((severity_number.value-1)/4 - 1)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -32,8 +32,8 @@ class AzureMonitorLogExporter(BaseExporter, LogExporter):
 
     def export(self, batch: Sequence[LogData], **kwargs: Any) -> LogExportResult: # pylint: disable=unused-argument
         """Export log data
-        :param logs: Open Telemetry LogData to export.
-        :type logs: Sequence[~opentelemetry._logs.LogData]
+        :param batch: Open Telemetry LogData(s) to export.
+        :type batch: Sequence[~opentelemetry._logs.LogData]
         :rtype: ~opentelemetry.sdk._logs.export.LogData
         """
         envelopes = [self._log_to_envelope(log) for log in batch]
@@ -109,6 +109,7 @@ def _convert_log_to_envelope(log_data: LogData) -> TelemetryItem:
     # TODO: Exceptions
 
     envelope.name = 'Microsoft.ApplicationInsights.Message'
+    # pylint: disable=line-too-long
     # Severity number: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
     data = MessageData(
         message=log_record.body,
@@ -129,6 +130,7 @@ def _get_log_export_result(result: ExportResult) -> LogExportResult:
         return LogExportResult.FAILURE
     return None
 
+# pylint: disable=line-too-long
 # Common schema: https://github.com/microsoft/common-schema/blob/main/Mappings/AzureMonitor-AI.md#messageseveritylevel
 # SeverityNumber specs: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
 def _get_severity_level(severity_number: SeverityNumber):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/README.md
@@ -1,0 +1,38 @@
+---
+page_type: sample
+languages:
+  - python
+products:
+  - azure-monitor
+---
+
+# Microsoft Azure Monitor Opentelemetry Exporter Log Python Samples
+
+These code samples show common champion scenario operations with the AzureMonitorLogExporter.
+
+* Log: [sample_log.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py)
+
+
+## Installation
+
+```sh
+$ pip install azure-monitor-opentelemetry-exporter --pre
+```
+
+## Run the Applications
+
+### Trace
+
+* Update `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
+
+* Run the sample
+
+```sh
+$ # from this directory
+$ python sample_log.py
+```
+
+## Explore the data
+
+After running the applications, data would be available in [Azure](
+https://docs.microsoft.com/azure/azure-monitor/app/app-insights-overview#where-do-i-see-my-telemetry)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/README.md
@@ -10,7 +10,9 @@ products:
 
 These code samples show common champion scenario operations with the AzureMonitorLogExporter.
 
-* Log: [sample_log.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py)
+* Logs: [sample_log.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py)
+* Trace correlation: [sample_log.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_correlate.py)
+* Custom properties: [sample_properties.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_properties.py)
 
 
 ## Installation
@@ -21,7 +23,7 @@ $ pip install azure-monitor-opentelemetry-exporter --pre
 
 ## Run the Applications
 
-### Trace
+### Logs
 
 * Update `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
 
@@ -30,6 +32,28 @@ $ pip install azure-monitor-opentelemetry-exporter --pre
 ```sh
 $ # from this directory
 $ python sample_log.py
+```
+
+### Trace correlation
+
+* Update `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
+
+* Run the sample
+
+```sh
+$ # from this directory
+$ python sample_correlate.py
+```
+
+### Custom properties
+
+* Update `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
+
+* Run the sample
+
+```sh
+$ # from this directory
+$ python sample_properties.py
 ```
 
 ## Explore the data

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""
+An example to show an application using Opentelemetry logging sdk. Logging calls to the standard Python
+logging library are tracked and telemetry is exported to application insights with the AzureMonitorLogExporter.
+"""
+import os
+import logging
+
+from opentelemetry import trace
+from opentelemetry.sdk._logs import (
+    LogEmitterProvider,
+    OTLPHandler,
+    set_log_emitter_provider,
+)
+from opentelemetry.sdk._logs.export import BatchLogProcessor, ConsoleLogExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer(__name__)
+log_emitter_provider = LogEmitterProvider(
+    resource=Resource.create(
+        {
+            "service.name": "shoppingcart",
+            "service.instance.id": "instance-12",
+        }
+    ),
+)
+set_log_emitter_provider(log_emitter_provider)
+
+exporter = AzureMonitorLogExporter.from_connection_string(
+    os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+)
+exporter2 = ConsoleLogExporter()
+
+# You can also instantiate the exporter via the constructor
+# The connection string will be automatically populated via the
+# APPLICATIONINSIGHTS_CONNECTION_STRING environment variable
+# exporter = AzureMonitorLogExporter()
+
+log_emitter_provider.add_log_processor(BatchLogProcessor(exporter2))
+handler = OTLPHandler()
+
+# Attach OTel handler to root logger
+logging.getLogger().addHandler(handler)
+logging.getLogger().setLevel(logging.NOTSET)
+
+logger = logging.getLogger(__name__)
+
+logger.info("INFO: Outside of span")
+with tracer.start_as_current_span("foo"):
+    logger.warning("WARNING: Inside of span")
+logger.error("ERROR: After span")
+
+# Custom properties
+logger.debug("DEBUG: Debug with properties", extra={"debug": "true"})
+
+log_emitter_provider.shutdown()
+
+input(...)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py
@@ -13,7 +13,7 @@ from opentelemetry.sdk._logs import (
     OTLPHandler,
     set_log_emitter_provider,
 )
-from opentelemetry.sdk._logs.export import BatchLogProcessor, ConsoleLogExporter
+from opentelemetry.sdk._logs.export import BatchLogProcessor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 
@@ -34,14 +34,13 @@ set_log_emitter_provider(log_emitter_provider)
 exporter = AzureMonitorLogExporter.from_connection_string(
     os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
 )
-exporter2 = ConsoleLogExporter()
 
 # You can also instantiate the exporter via the constructor
 # The connection string will be automatically populated via the
 # APPLICATIONINSIGHTS_CONNECTION_STRING environment variable
 # exporter = AzureMonitorLogExporter()
 
-log_emitter_provider.add_log_processor(BatchLogProcessor(exporter2))
+log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
 handler = OTLPHandler()
 
 # Attach OTel handler to root logger
@@ -59,5 +58,3 @@ logger.error("ERROR: After span")
 logger.debug("DEBUG: Debug with properties", extra={"debug": "true"})
 
 log_emitter_provider.shutdown()
-
-input(...)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_properties.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_properties.py
@@ -17,7 +17,7 @@ from opentelemetry.sdk._logs.export import BatchLogProcessor
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 
 log_emitter_provider = LogEmitterProvider()
-set_log_emitter_provider(log_emitter_provider)
+set_log_emitter_provider(LogEmitterProvider())
 
 exporter = AzureMonitorLogExporter.from_connection_string(
     os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
@@ -32,4 +32,5 @@ logging.getLogger().setLevel(logging.NOTSET)
 
 logger = logging.getLogger(__name__)
 
-logger.warning("Hello World!")
+# Custom properties
+logger.debug("DEBUG: Debug with properties", extra={"debug": "true"})

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/traces/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/traces/README.md
@@ -6,7 +6,7 @@ products:
   - azure-monitor
 ---
 
-# Microsoft Azure Monitor Opentelemetry Exporter Python Samples
+# Microsoft Azure Monitor Opentelemetry Exporter Trace Python Samples
 
 These code samples show common champion scenario operations with the AzureMonitorTraceExporter.
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/traces/sample_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/traces/sample_trace.py
@@ -16,11 +16,6 @@ exporter = AzureMonitorTraceExporter.from_connection_string(
     os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
 )
 
-# You can also instantiate the exporter via the constructor
-# The connection string will be automatically populated via the
-# APPLICATIONINSIGHTS_CONNECTION_STRING environment variable
-# exporter = AzureMonitorTraceExporter()
-
 trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 span_processor = BatchSpanProcessor(exporter)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -78,7 +78,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.23.0",
         "msrest>=0.6.10",
-        "opentelemetry-api<2.0.0,>=1.5.0,!=1.10a0",
-        "opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0",
+        "opentelemetry-api<2.0.0,>=1.9.0,!=1.10a0",
+        "opentelemetry-sdk<2.0.0,>=1.9.0,!=1.10a0",
     ],
 )

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/__init__.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
@@ -196,3 +196,19 @@ class TestAzureLogExporterUtils(unittest.TestCase):
             LogExportResult.FAILURE,
         )
         self.assertEqual(_get_log_export_result(None), None)
+
+    def test_get_severity_level(self):
+        for sev_num in SeverityNumber:
+            num = sev_num.value
+            level = _get_severity_level(sev_num)
+            print(num)
+            if num in range(0,9):
+                self.assertEqual(level, 0)
+            elif num in range(9,13):
+                self.assertEqual(level, 1)
+            elif num in range(13,17):
+                self.assertEqual(level, 2)
+            elif num in range(17,21):
+                self.assertEqual(level, 3)
+            else:
+                self.assertEqual(level, 4)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_base_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_base_exporter.py
@@ -16,7 +16,6 @@ from azure.core.pipeline.transport import HttpResponse
 from azure.monitor.opentelemetry.exporter.export._base import (
     BaseExporter,
     ExportResult,
-    get_trace_export_result,
 )
 from azure.monitor.opentelemetry.exporter._generated import AzureMonitorClient
 from azure.monitor.opentelemetry.exporter._generated.models import TelemetryItem, TrackResponse
@@ -292,21 +291,6 @@ class TestBaseExporter(unittest.TestCase):
     def test_transmission_empty(self):
         status = self._base._transmit([])
         self.assertEqual(status, ExportResult.SUCCESS)
-
-    def test_get_trace_export_result(self):
-        self.assertEqual(
-            get_trace_export_result(ExportResult.SUCCESS),
-            SpanExportResult.SUCCESS,
-        )
-        self.assertEqual(
-            get_trace_export_result(ExportResult.FAILED_NOT_RETRYABLE),
-            SpanExportResult.FAILURE,
-        )
-        self.assertEqual(
-            get_trace_export_result(ExportResult.FAILED_RETRYABLE),
-            SpanExportResult.FAILURE,
-        )
-        self.assertEqual(get_trace_export_result(None), None)
 
 
 class MockResponse:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
@@ -2,10 +2,11 @@
 # Licensed under the MIT License.
 
 import os
+import platform
 import unittest
 
 from azure.monitor.opentelemetry.exporter import _utils
-
+from opentelemetry.sdk.resources import Resource
 
 class TestUtils(unittest.TestCase):
     def setUp(self):
@@ -22,3 +23,23 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(ns_to_duration(60 * 1000000000), "0.00:01:00.000")
         self.assertEqual(ns_to_duration(3600 * 1000000000), "0.01:00:00.000")
         self.assertEqual(ns_to_duration(86400 * 1000000000), "1.00:00:00.000")
+
+    def test_populate_part_a_fields(self):
+        resource = Resource(
+            {"service.name": "testServiceName",
+             "service.namespace": "testServiceNamespace",
+             "service.instance.id": "testServiceInstanceId"})
+        tags = _utils._populate_part_a_fields(resource)
+        self.assertIsNotNone(tags)
+        self.assertEqual(tags.get("ai.cloud.role"), "testServiceNamespace.testServiceName")
+        self.assertEqual(tags.get("ai.cloud.roleInstance"), "testServiceInstanceId")
+        self.assertEqual(tags.get("ai.internal.nodeName"), "testServiceInstanceId")
+
+    def test_populate_part_a_fields_default(self):
+        resource = Resource(
+            {"service.name": "testServiceName"})
+        tags = _utils._populate_part_a_fields(resource)
+        self.assertIsNotNone(tags)
+        self.assertEqual(tags.get("ai.cloud.role"), "testServiceName")
+        self.assertEqual(tags.get("ai.cloud.roleInstance"), platform.node())
+        self.assertEqual(tags.get("ai.internal.nodeName"), tags.get("ai.cloud.roleInstance"))

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -204,8 +204,8 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-ai-translation-document azure-core<2.0.0,>=1.14.0
 #override azure-monitor-opentelemetry-exporter azure-core<2.0.0,>=1.23.0
 #override azure-monitor-opentelemetry-exporter msrest>=0.6.10
-#override azure-monitor-opentelemetry-exporter opentelemetry-api<2.0.0,>=1.5.0,!=1.10a0
-#override azure-monitor-opentelemetry-exporter opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
+#override azure-monitor-opentelemetry-exporter opentelemetry-api<2.0.0,>=1.9.0,!=1.10a0
+#override azure-monitor-opentelemetry-exporter opentelemetry-sdk<2.0.0,>=1.9.0,!=1.10a0
 #override azure-core-tracing-opentelemetry opentelemetry-api<2.0.0,>=1.0.0
 #override azure-identity six>=1.12.0
 #override azure-keyvault-keys six>=1.12.0


### PR DESCRIPTION
This PR implements AzureMonitorLogExporter similar to the trace exporter for distributed tracing.

Follow common schema to AI mapping doc: https://github.com/microsoft/common-schema/blob/main/Mappings/AzureMonitor-AI.md

