### PR TITLE
Trigger template instead of core for eng/common

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -12,6 +12,8 @@ trigger:
     - sdk/core/
     - eng/
     - tools/
+    exclude:
+    - eng/common/
 
 pr:
   branches:
@@ -26,6 +28,8 @@ pr:
     - sdk/core/
     - eng/
     - tools/
+    exclude:
+    - eng/common/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -11,6 +11,8 @@ trigger:
     include:
     - sdk/template/
     - scripts/
+    # eng/common code changes trigger template pipeline for basic checking.
+    - eng/common/
 
 pr:
   branches:
@@ -23,6 +25,8 @@ pr:
   paths:
     include:
     - sdk/template/
+    # eng/common code changes trigger template pipeline for basic checking.
+    - eng/common/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

**Current workflow for eng work:**
For work under `eng/common` like PR: https://github.com/Azure/azure-sdk-tools/pull/2861.

It will trigger 9 PRs like below:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/48036328/158711136-401f0b2e-ff1a-4398-be0c-fd4a8922ce41.png">

For PR to lang repo, they trigger core pipeline for testing the changes. Like sync PR here: https://github.com/Azure/azure-sdk-for-python/pull/23507

Java has switched to template already and run for a while. The PR is to align with Java trigger branch and path.
If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
