### PR TITLE
[ServiceBus] update auto lock renew strategy with other languages

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
@@ -187,7 +187,7 @@ class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
         on_lock_renew_failure=None,
         renew_period_override=None,
     ):
-        # pylint: disable=protected-access
+        # pylint: disable=protected-access,too-many-nested-blocks
         error = None
         clean_shutdown = False  # Only trigger the on_lock_renew_failure if halting was not expected (shutdown, etc)
         renew_period = renew_period_override or self._renew_period

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
@@ -220,7 +220,7 @@ class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
                         receiver.renew_message_lock(renewable)  # type: ignore
                     finally:
                         # Update next renew_period_override after renewing
-                        renew_period_override = min(remaining_time/2, self._renew_period)
+                        renew_period_override = min(remaining_time.total_seconds()/2, self._renew_period)
                 time.sleep(self._sleep_time)
                 # enqueue a new task, keeping renewing the renewable
                 if self._renewable(renewable):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
@@ -204,7 +204,8 @@ class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
                             max_lock_renewal_duration
                         )
                     )
-                if (renewable.locked_until_utc - utc_now()) <= datetime.timedelta(
+                remaining_time = renewable.locked_until_utc - utc_now()
+                if remaining_time <= datetime.timedelta(
                     seconds=renew_period
                 ):
                     _log.debug(
@@ -217,6 +218,9 @@ class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
                     except AttributeError:
                         # Renewable is a message
                         receiver.renew_message_lock(renewable)  # type: ignore
+                    finally:
+                        # Update next renew_period_override after renewing
+                        renew_period_override = min(remaining_time/2, self._renew_period)
                 time.sleep(self._sleep_time)
                 # enqueue a new task, keeping renewing the renewable
                 if self._renewable(renewable):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
@@ -114,7 +114,7 @@ class AutoLockRenewer:
         on_lock_renew_failure: Optional[AsyncLockRenewFailureCallback] = None,
         renew_period_override: float = None,
     ) -> None:
-        # pylint: disable=protected-access
+        # pylint: disable=protected-access,too-many-nested-blocks
         _log.debug(
             "Running async lock auto-renew for %r seconds", max_lock_renewal_duration
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
@@ -150,7 +150,7 @@ class AutoLockRenewer:
                         await receiver.renew_message_lock(renewable)  # type: ignore
                     finally:
                         # Update next renew_period_override after renewing
-                        renew_period_override = min(remaining_time/2, self._renew_period)
+                        renew_period = min(remaining_time.total_seconds()/2, self._renew_period)
                 await asyncio.sleep(self._sleep_time)
             clean_shutdown = not renewable._lock_expired
         except AutoLockRenewTimeout as e:


### PR DESCRIPTION
addressing issue: https://github.com/Azure/azure-sdk-for-python/issues/18513

auto lock renewer alignment increases the chance of auto lock renew failure due to the python single thread model and the way auto lock renewer is implemented:
- in current impl, whenever the renewable's expiration time is less than 10s from now, the auto lock renewer will try renew, with sleeping 1s interval in the while loop
- in alignment, we're shrinking the time frame from expiration to now in each cycle, e.g., initially 10s from now, then 5s from now, then 2s from now. leading to less auto lock renewer execution and then failure.

macos and windows tests keep failing in the PR due to the auto lock renewer change.

I think for Python it's better to keep the current strategy and deviate from other languages on this issue.