### PR TITLE
add app service api 2017 backward compatibility support

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_ml.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_ml.py
@@ -44,6 +44,7 @@ def _get_client_args(**kwargs):
 
     return dict(
         kwargs,
+        _content_callback=_parse_expires_on,
         identity_config=identity_config,
         base_headers={"secret": secret},
         request_factory=functools.partial(_get_request, url),
@@ -55,3 +56,36 @@ def _get_request(url, scope, identity_config):
     request = HttpRequest("GET", url)
     request.format_parameters(dict({"api-version": "2017-09-01", "resource": scope}, **identity_config))
     return request
+
+def _parse_expires_on(content):
+    # type: (dict) -> None
+    """Parse an App Service MSI version 2017-09-01 expires_on value to epoch seconds.
+    This version of the API returns expires_on as a UTC datetime string rather than epoch seconds. The string's
+    format depends on the OS. Responses on Windows include AM/PM, for example "1/16/2020 5:24:12 AM +00:00".
+    Responses on Linux do not, for example "06/20/2019 02:57:58 +00:00".
+    :raises ValueError: ``expires_on`` didn't match an expected format
+    """
+
+    # Azure ML sets the same environment variables as App Service but returns expires_on as an integer.
+    # That means we could have an Azure ML response here, so let's first try to parse expires_on as an int.
+    try:
+        content["expires_on"] = int(content["expires_on"])
+        return
+    except ValueError:
+        pass
+
+    import calendar
+    import time
+
+    expires_on = content["expires_on"]
+    if expires_on.endswith(" +00:00"):
+        date_string = expires_on[: -len(" +00:00")]
+        for format_string in ("%m/%d/%Y %H:%M:%S", "%m/%d/%Y %I:%M:%S %p"):  # (Linux, Windows)
+            try:
+                t = time.strptime(date_string, format_string)
+                content["expires_on"] = calendar.timegm(t)
+                return
+            except ValueError:
+                pass
+
+    raise ValueError("'{}' doesn't match the expected format".format(expires_on))

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -378,6 +378,63 @@ def test_cloud_shell_user_assigned_identity():
         assert token.expires_on == expires_on
 
 
+def test_app_service_2017_09_01():
+    """When the environment for 2019-08-01 is not configured, 2017-09-01 should be used."""
+
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+
+    transport = validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"secret": secret, "User-Agent": USER_AGENT},
+                required_params={"api-version": "2017-09-01", "resource": scope},
+            )
+        ]
+        * 2,
+        responses=[
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "01/01/1970 00:00:{} +00:00".format(expires_on),  # linux format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "1/1/1970 12:00:{} AM +00:00".format(expires_on),  # windows format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    with mock.patch.dict(
+        MANAGED_IDENTITY_ENVIRON,
+        {
+            EnvironmentVariables.MSI_ENDPOINT: url,
+            EnvironmentVariables.MSI_SECRET: secret,
+        },
+        clear=True,
+    ):
+        token = ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
+
+        token = ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
+
+
 def test_prefers_app_service_2019_08_01():
     """When the environment is configured for both App Service versions, the credential should prefer the most recent"""
 


### PR DESCRIPTION
If app service 2019 env vars are not found, we treat it as Azure ML credential.

Add this backward compatibility support in case it is running on early version of app service.