### PR TITLE
[Storage] Added `creation_time` and `expiry_time` to `get_paths()`

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Features Added
 - Added support for service version 2021-06-08 as well as previous versions.
-- Add support for Customer-Provided Keys (cpk) to all required APIs.
+- Added support for Customer-Provided Keys (cpk) to all required APIs.
 - Added support for `create_if_not_exists()` for `FileSystemClient`
+- The `get_paths()` API now returns `creation_time` and `expiry_time` for each path. 
 
 ### Bugs Fixed
 - Updated `create_file_system()` docstring to have the correct return-type of `None`

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/parser.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/parser.py
@@ -5,6 +5,10 @@
 # --------------------------------------------------------------------------
 
 import sys
+from datetime import datetime, timezone
+
+EPOCH_AS_FILETIME = 116444736000000000  # January 1, 1970 as MS filetime
+HUNDREDS_OF_NANOSECONDS = 10000000
 
 if sys.version_info < (3,):
     def _str(value):
@@ -18,3 +22,28 @@ else:
 
 def _to_utc_datetime(value):
     return value.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+def _rfc_1123_to_datetime(rfc_1123: str) -> datetime:
+    """Converts an RFC 1123 date string to a UTC datetime.
+    """
+    return datetime.strptime(rfc_1123, "%a, %d %b %Y %H:%M:%S %Z")
+
+def _filetime_to_datetime(filetime: str) -> datetime:
+    """Converts an MS filetime string to a UTC datetime. "0" indicates None.
+    If parsing MS Filetime fails, tries RFC 1123 as backup.
+    """
+    if not filetime:
+        return None
+
+    # Try to convert to MS Filetime
+    try:
+        filetime = int(filetime)
+        if filetime == 0:
+            return None
+
+        return datetime.fromtimestamp((filetime - EPOCH_AS_FILETIME) / HUNDREDS_OF_NANOSECONDS, tz=timezone.utc)
+    except ValueError:
+        pass
+
+    # Try RFC 1123 as backup
+    return _rfc_1123_to_datetime(filetime)

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_list_paths_create_expiry.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_list_paths_create_expiry.yaml
@@ -1,0 +1,259 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:38 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystemc028131f?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Sat, 19 Mar 2022 22:38:39 GMT
+      etag:
+      - '"0x8DA09F9369C62F9"'
+      last-modified:
+      - Sat, 19 Mar 2022 22:38:39 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:39 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesystemc028131f/file1?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Sat, 19 Mar 2022 22:38:39 GMT
+      etag:
+      - '"0x8DA09F936F91AC9"'
+      last-modified:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      x-ms-expiry-option:
+      - Absolute
+      x-ms-expiry-time:
+      - Sun, 20 Mar 2022 22:38:40 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystemc028131f/file1?comp=expiry
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Sat, 19 Mar 2022 22:38:39 GMT
+      etag:
+      - '"0x8DA09F936F91AC9"'
+      last-modified:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: GET
+    uri: https://storagename.dfs.core.windows.net/filesystemc028131f?resource=filesystem&recursive=true&upn=true
+  response:
+    body:
+      string: '{"paths":[{"contentLength":"0","creationTime":"132922031200148169","etag":"0x8DA09F936F91AC9","expiryTime":"132922895200000000","group":"$superuser","lastModified":"Sat,
+        19 Mar 2022 22:38:40 GMT","name":"file1","owner":"$superuser","permissions":"rw-r-----"}]}
+
+        '
+    headers:
+      content-type:
+      - application/json;charset=utf-8
+      date:
+      - Sat, 19 Mar 2022 22:38:39 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/filesystemc028131f/file1
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '0'
+      content-type:
+      - application/octet-stream
+      date:
+      - Sat, 19 Mar 2022 22:38:39 GMT
+      etag:
+      - '"0x8DA09F936F91AC9"'
+      last-modified:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier:
+      - Hot
+      x-ms-access-tier-inferred:
+      - 'true'
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      x-ms-expiry-time:
+      - Sun, 20 Mar 2022 22:38:40 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:40 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystemc028131f?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Sat, 19 Mar 2022 22:38:41 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_list_paths_no_expiry.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_list_paths_no_expiry.yaml
@@ -1,0 +1,153 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:48 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystem77161188?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Sat, 19 Mar 2022 22:38:47 GMT
+      etag:
+      - '"0x8DA09F93BFC3BFA"'
+      last-modified:
+      - Sat, 19 Mar 2022 22:38:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:48 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesystem77161188/file1?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Sat, 19 Mar 2022 22:38:48 GMT
+      etag:
+      - '"0x8DA09F93C283CE3"'
+      last-modified:
+      - Sat, 19 Mar 2022 22:38:48 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:48 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: GET
+    uri: https://storagename.dfs.core.windows.net/filesystem77161188?resource=filesystem&recursive=true&upn=true
+  response:
+    body:
+      string: '{"paths":[{"contentLength":"0","creationTime":"132922031287123171","etag":"0x8DA09F93C283CE3","expiryTime":"0","group":"$superuser","lastModified":"Sat,
+        19 Mar 2022 22:38:48 GMT","name":"file1","owner":"$superuser","permissions":"rw-r-----"}]}
+
+        '
+    headers:
+      content-type:
+      - application/json;charset=utf-8
+      date:
+      - Sat, 19 Mar 2022 22:38:49 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:38:49 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystem77161188?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Sat, 19 Mar 2022 22:38:49 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_list_paths_create_expiry.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_list_paths_create_expiry.yaml
@@ -1,0 +1,185 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:50:43 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystem3c0a159c?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Sat, 19 Mar 2022 22:50:42 GMT
+      etag: '"0x8DA09FAE6499A40"'
+      last-modified: Sat, 19 Mar 2022 22:50:43 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-06-08'
+    status:
+      code: 201
+      message: Created
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystem3c0a159c?restype=container
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:50:43 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesystem3c0a159c/file1?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Sat, 19 Mar 2022 22:50:43 GMT
+      etag: '"0x8DA09FAE698D942"'
+      last-modified: Sat, 19 Mar 2022 22:50:44 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2021-06-08'
+    status:
+      code: 201
+      message: Created
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/filesystem3c0a159c/file1?resource=file
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:50:44 GMT
+      x-ms-expiry-option:
+      - Absolute
+      x-ms-expiry-time:
+      - Sun, 20 Mar 2022 22:50:44 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystem3c0a159c/file1?comp=expiry
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Sat, 19 Mar 2022 22:50:43 GMT
+      etag: '"0x8DA09FAE698D942"'
+      last-modified: Sat, 19 Mar 2022 22:50:44 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-06-08'
+    status:
+      code: 200
+      message: OK
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystem3c0a159c/file1?comp=expiry
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:50:44 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: GET
+    uri: https://storagename.dfs.core.windows.net/filesystem3c0a159c?resource=filesystem&recursive=true&upn=true
+  response:
+    body:
+      string: '{"paths":[{"contentLength":"0","creationTime":"132922038441597250","etag":"0x8DA09FAE698D942","expiryTime":"132922902440000000","group":"$superuser","lastModified":"Sat,
+        19 Mar 2022 22:50:44 GMT","name":"file1","owner":"$superuser","permissions":"rw-r-----"}]}
+
+        '
+    headers:
+      content-type: application/json;charset=utf-8
+      date: Sat, 19 Mar 2022 22:50:44 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2021-06-08'
+    status:
+      code: 200
+      message: OK
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/filesystem3c0a159c?resource=filesystem&recursive=true&upn=true
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:50:44 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/filesystem3c0a159c/file1
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges: bytes
+      content-length: '0'
+      content-type: application/octet-stream
+      date: Sat, 19 Mar 2022 22:50:43 GMT
+      etag: '"0x8DA09FAE698D942"'
+      last-modified: Sat, 19 Mar 2022 22:50:44 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier: Hot
+      x-ms-access-tier-inferred: 'true'
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Sat, 19 Mar 2022 22:50:44 GMT
+      x-ms-expiry-time: Sun, 20 Mar 2022 22:50:44 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-06-08'
+    status:
+      code: 200
+      message: OK
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystem3c0a159c/file1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:51:10 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystem3c0a159c?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Sat, 19 Mar 2022 22:51:09 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-06-08'
+    status:
+      code: 202
+      message: Accepted
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystem3c0a159c?restype=container
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_list_paths_no_expiry.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_list_paths_no_expiry.yaml
@@ -1,0 +1,113 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:39:08 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesysteme8f51405?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Sat, 19 Mar 2022 22:39:08 GMT
+      etag: '"0x8DA09F9485724AD"'
+      last-modified: Sat, 19 Mar 2022 22:39:09 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-06-08'
+    status:
+      code: 201
+      message: Created
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesysteme8f51405?restype=container
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:39:09 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesysteme8f51405/file1?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Sat, 19 Mar 2022 22:39:08 GMT
+      etag: '"0x8DA09F94884C4CF"'
+      last-modified: Sat, 19 Mar 2022 22:39:09 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2021-06-08'
+    status:
+      code: 201
+      message: Created
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/filesysteme8f51405/file1?resource=file
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:39:09 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: GET
+    uri: https://storagename.dfs.core.windows.net/filesysteme8f51405?resource=filesystem&recursive=true&upn=true
+  response:
+    body:
+      string: '{"paths":[{"contentLength":"0","creationTime":"132922031494513871","etag":"0x8DA09F94884C4CF","expiryTime":"0","group":"$superuser","lastModified":"Sat,
+        19 Mar 2022 22:39:09 GMT","name":"file1","owner":"$superuser","permissions":"rw-r-----"}]}
+
+        '
+    headers:
+      content-type: application/json;charset=utf-8
+      date: Sat, 19 Mar 2022 22:39:08 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2021-06-08'
+    status:
+      code: 200
+      message: OK
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/filesysteme8f51405?resource=filesystem&recursive=true&upn=true
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Sat, 19 Mar 2022 22:39:09 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesysteme8f51405?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Sat, 19 Mar 2022 22:39:08 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-06-08'
+    status:
+      code: 202
+      message: Accepted
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesysteme8f51405?restype=container
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -5,24 +5,25 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import time
+import pytest
 import unittest
 from datetime import datetime, timedelta
-import pytest
-
-from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
 from azure.core import MatchConditions
+from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
-from azure.storage.filedatalake import DataLakeServiceClient, PublicAccess, generate_account_sas, ResourceTypes, \
-    AccountSasPermissions
+from azure.storage.filedatalake import(
+    AccessPolicy,
+    AccountSasPermissions,
+    DataLakeServiceClient,
+    FileSystemSasPermissions,
+    PublicAccess,
+    ResourceTypes,
+    generate_account_sas)
 from settings.testcase import DataLakePreparer
 from devtools_testutils.storage import StorageTestCase
-# ------------------------------------------------------------------------------
-from azure.storage.filedatalake import AccessPolicy, FileSystemSasPermissions
-from azure.storage.filedatalake._list_paths_helper import DirectoryPrefix
-from azure.storage.filedatalake._models import DeletedPathProperties
 
+# ------------------------------------------------------------------------------
 TEST_FILE_SYSTEM_PREFIX = 'filesystem'
 # ------------------------------------------------------------------------------
 
@@ -426,6 +427,40 @@ class FileSystemTest(StorageTestCase):
 
         self.assertEqual(len(paths), 6)
         self.assertTrue(isinstance(paths[0].last_modified, datetime))
+
+    @DataLakePreparer()
+    def test_list_paths_create_expiry(self, datalake_storage_account_name, datalake_storage_account_key):
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+        # Arrange
+        file_system = self._create_file_system()
+        file_client = file_system.create_file('file1')
+
+        expires_on = datetime.utcnow() + timedelta(days=1)
+        file_client.set_file_expiry("Absolute", expires_on=expires_on)
+
+        # Act
+        paths = list(file_system.get_paths(upn=True))
+
+        # Assert
+        self.assertEqual(1, len(paths))
+        props = file_client.get_file_properties()
+        # Properties do not include microseconds so let them vary by 1 second
+        self.assertAlmostEqual(props.creation_time, paths[0].creation_time, delta=timedelta(seconds=1))
+        self.assertAlmostEqual(props.expiry_time, paths[0].expiry_time, delta=timedelta(seconds=1))
+
+    @DataLakePreparer()
+    def test_list_paths_no_expiry(self, datalake_storage_account_name, datalake_storage_account_key):
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+        # Arrange
+        file_system = self._create_file_system()
+        file_system.create_file('file1')
+
+        # Act
+        paths = list(file_system.get_paths(upn=True))
+
+        # Assert
+        self.assertEqual(1, len(paths))
+        self.assertIsNone(paths[0].expiry_time)
 
     @DataLakePreparer()
     def test_get_deleted_paths(self, datalake_storage_account_name, datalake_storage_account_key):


### PR DESCRIPTION
`get_paths()` now returns the additional properties `creation_time` and `expiry_time` for each path. These properties are returned from the service as MS Filetimes which is not natively supported by Python's `datetime` so a custom parser was created to convert MS Filetime to `datetime` objects.