### PR TITLE
[Perf] Avoid blocking event loop

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_batch_perf_test.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_batch_perf_test.py
@@ -6,6 +6,7 @@
 import cProfile
 import os
 import aiohttp
+import asyncio
 import time
 from typing import Optional, Any, Dict, List
 
@@ -160,6 +161,9 @@ class BatchPerfTest(_PerfTestBase):
         """
         Run all async tests, including both warmup and duration.
         """
+        print("await asyncio.sleep(0)")
+        # Avoid blocking the event loop, to ensure all instances execute in parallel
+        await asyncio.sleep(0)
         self._completed_operations = 0
         self._last_completion_time = 0.0
         starttime = time.time()

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
@@ -193,7 +193,8 @@ class _PerfStressRunner:
                         future.result()
                     
             else:
-                tasks = [test.run_all_async(duration) for test in self._tests]
+                print("asyncio.create_task")
+                tasks = [asyncio.create_task(test.run_all_async(duration)) for test in self._tests]
                 await asyncio.gather(*tasks)
         finally:
             status_thread.stop()


### PR DESCRIPTION
I thought either of these two changes would prevent blocking the event loop, but neither seem to be working.  Either would work in .NET, but Python might be different.  I'll create a simpler repro to investigate.