### PR TITLE
[Key Vault] Fix key rotation bug

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.1.0 (2022-03-25)
+## 4.1.0 (2022-03-28)
 
 ### Features Added
 - Key Vault API version 7.3 is now the default

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.4.0 (2022-03-25)
+## 4.4.0 (2022-03-28)
 
 ### Features Added
 - Key Vault API version 7.3 is now the default

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.5.0 (2022-03-25)
+## 4.5.0 (2022-03-28)
 
 ### Features Added
 - Key Vault API version 7.3 is now the default

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -815,7 +815,7 @@ class KeyClient(KeyVaultClientBase):
             ]
 
         attributes = self._models.KeyRotationPolicyAttributes(expiry_time=kwargs.pop("expires_in", policy.expires_in))
-        new_policy = self._models.KeyRotationPolicy(lifetime_actions=lifetime_actions, attributes=attributes)
+        new_policy = self._models.KeyRotationPolicy(lifetime_actions=lifetime_actions or [], attributes=attributes)
         result = self._client.update_key_rotation_policy(
             vault_base_url=self._vault_url, key_name=key_name, key_rotation_policy=new_policy
         )

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -798,7 +798,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             ]
 
         attributes = self._models.KeyRotationPolicyAttributes(expiry_time=kwargs.pop("expires_in", policy.expires_in))
-        new_policy = self._models.KeyRotationPolicy(lifetime_actions=lifetime_actions, attributes=attributes)
+        new_policy = self._models.KeyRotationPolicy(lifetime_actions=lifetime_actions or [], attributes=attributes)
         result = await self._client.update_key_rotation_policy(
             vault_base_url=self._vault_url, key_name=key_name, key_rotation_policy=new_policy
         )

--- a/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import os
 from azure.identity import DefaultAzureCredential
-from azure.keyvault.keys import KeyClient, KeyRotationLifetimeAction, KeyRotationPolicyAction
+from azure.keyvault.keys import KeyClient, KeyRotationLifetimeAction, KeyRotationPolicy, KeyRotationPolicyAction
 
 # ----------------------------------------------------------------------------------------------------------
 # Prerequisites:
@@ -45,30 +45,51 @@ key_name = "rotation-sample-key"
 key = client.create_rsa_key(key_name)
 print("\nCreated a key; new version is {}".format(key.properties.version))
 
-# Set the key's automated rotation policy to rotate the key two months after the key was created
-actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE, time_after_create="P2M")]
-updated_policy = client.update_key_rotation_policy(key_name, lifetime_actions=actions)
+# Set the key's automated rotation policy to rotate the key two months after the key was created.
+# If you pass an empty KeyRotationPolicy() as the `policy` parameter, the rotation policy will be set to the
+# default policy. Any keyword arguments will update specified properties of the policy.
+actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
+updated_policy = client.update_key_rotation_policy(
+    key_name, KeyRotationPolicy(), expires_in="P90D", lifetime_actions=actions
+)
+assert updated_policy.expires_in == "P90D"
 
-# The created policy should only have one action
-assert len(updated_policy.lifetime_actions) == 1, "There should be exactly one rotation policy action"
-policy_action = updated_policy.lifetime_actions[0]
+# The updated policy should have the specified lifetime action
+policy_action = None
+for i in range(len(updated_policy.lifetime_actions)):
+    if updated_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+        policy_action = updated_policy.lifetime_actions[i]
+assert policy_action, "The specified action should exist in the key rotation policy"
+assert policy_action.time_after_create == "P2M", "The action should have the specified time_after_create"
+assert policy_action.time_before_expiry is None, "The action shouldn't have a time_before_expiry"
 print("\nCreated a new key rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
 
 # Get the key's current rotation policy
 current_policy = client.get_key_rotation_policy(key_name)
-policy_action = current_policy.lifetime_actions[0]
+policy_action = None
+for i in range(len(current_policy.lifetime_actions)):
+    if current_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+        policy_action = current_policy.lifetime_actions[i]
 print("\nCurrent rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
 
-# Update the key's automated rotation policy to notify 30 days before the key expires
-new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.NOTIFY, time_before_expiry="P30D")]
-# You may also specify the duration after which the newly rotated key will expire
-# In this example, any new key versions will expire after 90 days
-new_policy = client.update_key_rotation_policy(key_name, expires_in="P90D", lifetime_actions=new_actions)
+# Update the key's automated rotation policy to notify 10 days before the key expires
+new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P10D")]
+# To preserve an existing rotation policy, pass in the existing policy as the `policy` parameter.
+# Any property specified as a keyword argument will be overridden completely by the provided value.
+# In this case, the rotate action we created earlier will be removed from the policy.
+new_policy = client.update_key_rotation_policy(key_name, current_policy, lifetime_actions=new_actions)
+assert new_policy.expires_in == "P90D", "The key's expiry time should have been preserved"
 
-# The updated policy should only have one action
-assert len(new_policy.lifetime_actions) == 1, "There should be exactly one rotation policy action"
-policy_action = new_policy.lifetime_actions[0]
-print("\nUpdated rotation policy: {} {} before expiry".format(policy_action.action, policy_action.time_before_expiry))
+# The updated policy should include the new notify action
+notify_action = None
+for i in range(len(new_policy.lifetime_actions)):
+    if new_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
+        notify_action = new_policy.lifetime_actions[i]
+
+assert notify_action, "The specified action should exist in the key rotation policy"
+assert notify_action.time_after_create is None, "The action shouldn't have a time_after_create"
+assert notify_action.time_before_expiry == "P10D", "The action should have the specified time_before_expiry"
+print("\nNew policy action: {} {} before expiry".format(notify_action.action, notify_action.time_before_expiry))
 
 # Finally, you can rotate a key on-demand by creating a new version of the key
 rotated_key = client.rotate_key(key_name)

--- a/sdk/keyvault/azure-keyvault-keys/samples/key_rotation_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/key_rotation_async.py
@@ -5,7 +5,7 @@
 import asyncio
 import os
 from azure.identity.aio import DefaultAzureCredential
-from azure.keyvault.keys import KeyRotationLifetimeAction, KeyRotationPolicyAction
+from azure.keyvault.keys import KeyRotationLifetimeAction, KeyRotationPolicy, KeyRotationPolicyAction
 from azure.keyvault.keys.aio import KeyClient
 
 # ----------------------------------------------------------------------------------------------------------
@@ -48,34 +48,53 @@ async def run_sample():
     key = await client.create_rsa_key(key_name)
     print("\nCreated a key; new version is {}".format(key.properties.version))
 
-    # Set the key's automated rotation policy to rotate the key two months after the key was created
-    actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE, time_after_create="P2M")]
-    updated_policy = await client.update_key_rotation_policy(key_name, lifetime_actions=actions)
+    # Set the key's automated rotation policy to rotate the key two months after the key was created.
+    # If you pass an empty KeyRotationPolicy() as the `policy` parameter, the rotation policy will be set to the
+    # default policy. Any keyword arguments will update specified properties of the policy.
+    actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
+    updated_policy = await client.update_key_rotation_policy(
+        key_name, KeyRotationPolicy(), expires_in="P90D", lifetime_actions=actions
+    )
+    assert updated_policy.expires_in == "P90D"
 
-    # The created policy should only have one action
-    assert len(updated_policy.lifetime_actions) == 1, "There should be exactly one rotation policy action"
-    policy_action = updated_policy.lifetime_actions[0]
+    # The updated policy should have the specified lifetime action
+    policy_action = None
+    for i in range(len(updated_policy.lifetime_actions)):
+        if updated_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            policy_action = updated_policy.lifetime_actions[i]
+    assert policy_action, "The specified action should exist in the key rotation policy"
+    assert policy_action.time_after_create == "P2M", "The action should have the specified time_after_create"
+    assert policy_action.time_before_expiry is None, "The action shouldn't have a time_before_expiry"
     print(
         "\nCreated a new key rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create)
     )
 
     # Get the key's current rotation policy
     current_policy = await client.get_key_rotation_policy(key_name)
-    policy_action = current_policy.lifetime_actions[0]
+    policy_action = None
+    for i in range(len(current_policy.lifetime_actions)):
+        if current_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            policy_action = current_policy.lifetime_actions[i]
     print("\nCurrent rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
 
-    # Update the key's automated rotation policy to notify 30 days before the key expires
-    new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.NOTIFY, time_before_expiry="P30D")]
-    # You may also specify the duration after which the newly rotated key will expire
-    # In this example, any new key versions will expire after 90 days
-    new_policy = await client.update_key_rotation_policy(key_name, expires_in="P90D", lifetime_actions=new_actions)
+    # Update the key's automated rotation policy to notify 10 days before the key expires
+    new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P10D")]
+    # To preserve an existing rotation policy, pass in the existing policy as the `policy` parameter.
+    # Any property specified as a keyword argument will be overridden completely by the provided value.
+    # In this case, the rotate action we created earlier will be removed from the policy.
+    new_policy = await client.update_key_rotation_policy(key_name, current_policy, lifetime_actions=new_actions)
+    assert new_policy.expires_in == "P90D", "The key's expiry time should have been preserved"
 
-    # The updated policy should only have one action
-    assert len(new_policy.lifetime_actions) == 1, "There should be exactly one rotation policy action"
-    policy_action = new_policy.lifetime_actions[0]
-    print(
-        "\nUpdated rotation policy: {} {} before expiry".format(policy_action.action, policy_action.time_before_expiry)
-    )
+    # The updated policy should include the new notify action
+    notify_action = None
+    for i in range(len(new_policy.lifetime_actions)):
+        if new_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
+            notify_action = new_policy.lifetime_actions[i]
+
+    assert notify_action, "The specified action should exist in the key rotation policy"
+    assert notify_action.time_after_create is None, "The action shouldn't have a time_after_create"
+    assert notify_action.time_before_expiry == "P10D", "The action should have the specified time_before_expiry"
+    print("\nNew policy action: {} {} before expiry".format(notify_action.action, notify_action.time_before_expiry))
 
     # Finally, you can rotate a key on-demand by creating a new version of the key
     rotated_key = await client.rotate_key(key_name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_rotation_policy_7_3_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_rotation_policy_7_3_vault.yaml
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 23 Mar 2022 00:32:06 GMT
+      - Sat, 26 Mar 2022 01:54:15 GMT
       expires:
       - '-1'
       pragma:
@@ -43,7 +43,7 @@ interactions:
       x-ms-keyvault-network-info:
       - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
-      - westus2
+      - westus
       x-ms-keyvault-service-version:
       - 1.9.331.5
       x-powered-by:
@@ -70,16 +70,16 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/create?api-version=7.3
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/bd49e2d5569d4d80aeeacdcb0a15ae86","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"5QZMg4maf_3zCvz5Nq5kj4uDHu4wtRr1CycAUrd9OyXbw9u-L23hhRjuuHRUnw8uzeQMcn_qr9TiqxZ4CNDspmsZVlAM7FNI5vz2mZfgwVvyx_REgLNCYU3xraZHDinU910o5hIVW1M7ehP6L84a03Dp93pQk9Y-bTgCrtsomAt1MNE1-z0XI8VyTULBMY287vJnY_pHNx_jnODE7Z6R14bMesiS1RgUaA6O58X6o7QT4d3rN4iWRJlCo1tWYW-3xCKCfM0JYobzA7Uws9QL5KuZjGBN-h1xA-cwmLDVIqOmugqEFRcvuhr23ZQSvYCEopYlw38TW8JZVr7YsKE9DQ","e":"AQAB"},"attributes":{"enabled":true,"created":1647995527,"updated":1647995527,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/f06c49db76704338b79c6ec17e94bbc6","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"qw67sE2XxpRYPky3-D0XIgNyG_Po27492HgYigs6eypoar9NVYuo0QnRlpwi1dAEt4oUAlMASukwGo1qUKVvBs6L5UvyQZL2imXtNat_LHK-28u7FqUkpaNTFzyy32Fj0EFtLY7QE1fmYFaHDwdFXDqGXexhUzsFrEghgYst5jHBwvt4ANNSvCAbmsxFLgHevOI3T2-clsXA-zH7uhzRg7h3MXxUgsJr0VSas-0N4cJEhjzS-nofR4V3KzYvwdoZUYaSeH93F3qhA5fneDsseTPU7DElKuMyZO5UdiEjbBJlG7w3KnM8fzyHkWqZLwWshLn0NiMNv9KF2CBlYx-2nQ","e":"AQAB"},"attributes":{"enabled":true,"exp":1656035656,"created":1648259656,"updated":1648259656,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '703'
+      - '722'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 23 Mar 2022 00:32:07 GMT
+      - Sat, 26 Mar 2022 01:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -90,12 +90,56 @@ interactions:
       - nosniff
       x-ms-keyvault-network-info:
       - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id:
-      - 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache:
-      - ra_age=129;da_age=4355;rd_age=4355;brd_age=22912;ra_notif_age=573;dec_lev=2;
       x-ms-keyvault-region:
-      - westus2
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.331.5
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"lifetimeActions": [], "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy?api-version=7.3
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1648258801,"updated":1648259656}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sat, 26 Mar 2022 01:54:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
       x-ms-keyvault-service-version:
       - 1.9.331.5
       x-powered-by:
@@ -123,16 +167,16 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1647995527,"updated":1647995527}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1648258801,"updated":1648259657}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '301'
+      - '303'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 23 Mar 2022 00:32:07 GMT
+      - Sat, 26 Mar 2022 01:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -143,12 +187,8 @@ interactions:
       - nosniff
       x-ms-keyvault-network-info:
       - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id:
-      - 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache:
-      - ra_age=129;da_age=4355;rd_age=4355;brd_age=22912;ra_notif_age=573;dec_lev=1;
       x-ms-keyvault-region:
-      - westus2
+      - westus
       x-ms-keyvault-service-version:
       - 1.9.331.5
       x-powered-by:
@@ -171,16 +211,16 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1647995527,"updated":1647995527}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1648258801,"updated":1648259657}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '301'
+      - '303'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 23 Mar 2022 00:32:07 GMT
+      - Sat, 26 Mar 2022 01:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -191,12 +231,8 @@ interactions:
       - nosniff
       x-ms-keyvault-network-info:
       - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id:
-      - 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache:
-      - ra_age=129;da_age=4355;rd_age=4355;brd_age=22912;ra_notif_age=573;dec_lev=1;
       x-ms-keyvault-region:
-      - westus2
+      - westus
       x-ms-keyvault-service-version:
       - 1.9.331.5
       x-powered-by:
@@ -225,16 +261,16 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1647995527,"updated":1647995527}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1648258801,"updated":1648259657}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '321'
+      - '323'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 23 Mar 2022 00:32:07 GMT
+      - Sat, 26 Mar 2022 01:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -245,12 +281,8 @@ interactions:
       - nosniff
       x-ms-keyvault-network-info:
       - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id:
-      - 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache:
-      - ra_age=129;da_age=4355;rd_age=4355;brd_age=22912;ra_notif_age=573;dec_lev=0;
       x-ms-keyvault-region:
-      - westus2
+      - westus
       x-ms-keyvault-service-version:
       - 1.9.331.5
       x-powered-by:
@@ -259,7 +291,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P30D"}, "action":
+    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P60D"}, "action":
       {"type": "Notify"}}], "attributes": {"expiryTime": "P90D"}}'
     headers:
       Accept:
@@ -278,16 +310,16 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1647995527,"updated":1647995527}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P60D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1648258801,"updated":1648259657}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '256'
+      - '258'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 23 Mar 2022 00:32:07 GMT
+      - Sat, 26 Mar 2022 01:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -298,12 +330,8 @@ interactions:
       - nosniff
       x-ms-keyvault-network-info:
       - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id:
-      - 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache:
-      - ra_age=130;da_age=4355;rd_age=4355;brd_age=22912;ra_notif_age=573;dec_lev=0;
       x-ms-keyvault-region:
-      - westus2
+      - westus
       x-ms-keyvault-service-version:
       - 1.9.331.5
       x-powered-by:
@@ -326,16 +354,16 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1647995527,"updated":1647995527}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keybb0144e/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P60D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1648258801,"updated":1648259657}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '256'
+      - '258'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 23 Mar 2022 00:32:07 GMT
+      - Sat, 26 Mar 2022 01:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -346,12 +374,8 @@ interactions:
       - nosniff
       x-ms-keyvault-network-info:
       - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id:
-      - 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache:
-      - ra_age=130;da_age=4355;rd_age=4355;brd_age=22912;ra_notif_age=573;dec_lev=0;
       x-ms-keyvault-region:
-      - westus2
+      - westus
       x-ms-keyvault-service-version:
       - 1.9.331.5
       x-powered-by:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_rotation_policy_7_3_vault.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_rotation_policy_7_3_vault.yaml
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '97'
       content-type: application/json; charset=utf-8
-      date: Wed, 23 Mar 2022 00:25:09 GMT
+      date: Sat, 26 Mar 2022 01:54:29 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
@@ -28,13 +28,13 @@ interactions:
         resource="https://vault.azure.net"
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus2
+      x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.9.331.5
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: https://malegerec.vault.azure.net/keys/livekvtestrotation-keyeb61460/create?api-version=7.3
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/create?api-version=7.3
 - request:
     body: '{"kty": "RSA"}'
     headers:
@@ -50,26 +50,57 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/create?api-version=7.3
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/a2abe1710b5942f898b98ca06649a554","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oYfjc-wszliZnG6FXtCJoW0mNteUtgc4I2ZFVhDg8TxuyiomjtP-W_8P7Q2YYO6j0V3-acpmPjO-_TzX5FKDq8Zqqe9Lkk4BLG3IhmC7pGqvLjxf3fmwcKpGRitc8Bu9SCp6OLRItUydXR8aKTXn7-rFs_cwnlGtct6MDjnZnuZ_WHlQ41sCsSfnA7FjhYshmT9OEpkrhdqzGUZG9tHldIeiQPgoqIp2DJDo0aZd1hpng8NIG3CgXj8ot14bxODwjfPtXipDXrU-PCXlGR7FbROzM8EjUX1zGtnhiMibIEz8SDvP2CWslXTEwJ_oPQ6iAvr5tULAIknZFCYBwZtsfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1647995111,"updated":1647995111,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/6999e52198844f728895884af4336253","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6lXiTUBodwwHNKGdhtHcLB4Jj3SxH6whqf3OfL6aaBjamGpsXJdE7nHL6ziTAcsguXWYJ51jSrUyLPjNrYz9oT-1G3GVljmXLRgyc9DFEEF8i20UQHhfCCX7fCiWXJa8CU4Ca8t2AY61rExQDAuovGXLbGO11NK-kYLKURkYJK_Hz6tjkIlZIrBNJnEtGMmX9eeqHB5vqM8pTWtumxV8tNkLcBrf-TsQMNGBIKD_hTK4AN1fS6Ppy_wnQr9Xw73NGt9Sv7gPEg9IgLqDplaCN-u2R4MGngIdsY_vvoIcN2HM6-bGxm7VxFpkHrSzsI41voumxCi_J_bj0pRHAQHCVQ","e":"AQAB"},"attributes":{"enabled":true,"created":1648259670,"updated":1648259670,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}'
     headers:
       cache-control: no-cache
-      content-length: '703'
+      content-length: '705'
       content-type: application/json; charset=utf-8
-      date: Wed, 23 Mar 2022 00:25:10 GMT
+      date: Sat, 26 Mar 2022 01:54:30 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id: 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache: ra_age=0;da_age=3939;rd_age=3939;brd_age=22496;ra_notif_age=157;dec_lev=3;
-      x-ms-keyvault-region: westus2
+      x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.9.331.5
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://malegerec.vault.azure.net/keys/livekvtestrotation-keyeb61460/create?api-version=7.3
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/create?api-version=7.3
+- request:
+    body: '{"lifetimeActions": [], "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.5.0 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1648259671,"updated":1648259671}}'
+    headers:
+      cache-control: no-cache
+      content-length: '238'
+      content-type: application/json; charset=utf-8
+      date: Sat, 26 Mar 2022 01:54:30 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.9.331.5
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
 - request:
     body: '{"lifetimeActions": [{"trigger": {"timeAfterCreate": "P2M"}, "action":
       {"type": "Rotate"}}], "attributes": {}}'
@@ -86,26 +117,24 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1647995111,"updated":1647995111}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1648259671,"updated":1648259671}}'
     headers:
       cache-control: no-cache
-      content-length: '301'
+      content-length: '303'
       content-type: application/json; charset=utf-8
-      date: Wed, 23 Mar 2022 00:25:10 GMT
+      date: Sat, 26 Mar 2022 01:54:30 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id: 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache: ra_age=0;da_age=3939;rd_age=3939;brd_age=22496;ra_notif_age=157;dec_lev=1;
-      x-ms-keyvault-region: westus2
+      x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.9.331.5
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://malegerec.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
 - request:
     body: null
     headers:
@@ -117,26 +146,24 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1647995111,"updated":1647995111}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"created":1648259671,"updated":1648259671}}'
     headers:
       cache-control: no-cache
-      content-length: '301'
+      content-length: '303'
       content-type: application/json; charset=utf-8
-      date: Wed, 23 Mar 2022 00:25:10 GMT
+      date: Sat, 26 Mar 2022 01:54:30 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id: 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache: ra_age=0;da_age=3939;rd_age=3939;brd_age=22496;ra_notif_age=157;dec_lev=1;
-      x-ms-keyvault-region: westus2
+      x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.9.331.5
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://malegerec.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
 - request:
     body: '{"lifetimeActions": [{"trigger": {"timeAfterCreate": "P2M"}, "action":
       {"type": "Rotate"}}, {"trigger": {"timeBeforeExpiry": "P30D"}, "action": {"type":
@@ -154,28 +181,26 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1647995111,"updated":1647995111}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeAfterCreate":"P2M"},"action":{"type":"Rotate"}},{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1648259671,"updated":1648259671}}'
     headers:
       cache-control: no-cache
-      content-length: '321'
+      content-length: '323'
       content-type: application/json; charset=utf-8
-      date: Wed, 23 Mar 2022 00:25:11 GMT
+      date: Sat, 26 Mar 2022 01:54:30 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id: 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache: ra_age=0;da_age=3939;rd_age=3939;brd_age=22496;ra_notif_age=157;dec_lev=0;
-      x-ms-keyvault-region: westus2
+      x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.9.331.5
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://malegerec.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
 - request:
-    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P30D"}, "action":
+    body: '{"lifetimeActions": [{"trigger": {"timeBeforeExpiry": "P60D"}, "action":
       {"type": "Notify"}}], "attributes": {"expiryTime": "P90D"}}'
     headers:
       Accept:
@@ -190,26 +215,24 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1647995111,"updated":1647995111}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P60D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1648259671,"updated":1648259671}}'
     headers:
       cache-control: no-cache
-      content-length: '256'
+      content-length: '258'
       content-type: application/json; charset=utf-8
-      date: Wed, 23 Mar 2022 00:25:11 GMT
+      date: Sat, 26 Mar 2022 01:54:30 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id: 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache: ra_age=0;da_age=3939;rd_age=3939;brd_age=22496;ra_notif_age=157;dec_lev=0;
-      x-ms-keyvault-region: westus2
+      x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.9.331.5
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://malegerec.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
 - request:
     body: null
     headers:
@@ -221,24 +244,22 @@ interactions:
     uri: https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P30D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1647995111,"updated":1647995111}}'
+      string: '{"id":"https://vaultname.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy","lifetimeActions":[{"trigger":{"timeBeforeExpiry":"P60D"},"action":{"type":"Notify"}}],"attributes":{"expiryTime":"P90D","created":1648259671,"updated":1648259671}}'
     headers:
       cache-control: no-cache
-      content-length: '256'
+      content-length: '258'
       content-type: application/json; charset=utf-8
-      date: Wed, 23 Mar 2022 00:25:11 GMT
+      date: Sat, 26 Mar 2022 01:54:30 GMT
       expires: '-1'
       pragma: no-cache
       strict-transport-security: max-age=31536000;includeSubDomains
       x-content-type-options: nosniff
       x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
-      x-ms-keyvault-rbac-assignment-id: 95a02d0c-52aa-59c1-8ea1-3849ee7c4bb5
-      x-ms-keyvault-rbac-cache: ra_age=0;da_age=3939;rd_age=3939;brd_age=22496;ra_notif_age=157;dec_lev=0;
-      x-ms-keyvault-region: westus2
+      x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.9.331.5
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: https://malegerec.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
+    url: https://mcpatino-kv.vault.azure.net/keys/livekvtestrotation-keyeb61460/rotationpolicy?api-version=7.3
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -629,6 +629,9 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
         key_name = self.get_resource_name("rotation-key")
         self._create_rsa_key(client, key_name)
 
+        # ensure passing an empty policy with no kwargs doesn't raise an error
+        client.update_key_rotation_policy(key_name, KeyRotationPolicy())
+
         # updating a rotation policy with an empty policy and override
         actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
         updated_policy = client.update_key_rotation_policy(key_name, KeyRotationPolicy(), lifetime_actions=actions)
@@ -636,30 +639,51 @@ class KeyClientTests(KeysTestCase, KeyVaultTestCase):
         assert updated_policy.expires_in is None
         _assert_rotation_policies_equal(updated_policy, fetched_policy)
 
-        updated_policy_actions = updated_policy.lifetime_actions[0]
-        fetched_policy_actions = fetched_policy.lifetime_actions[0]
+        updated_policy_actions = None
+        for i in range(len(updated_policy.lifetime_actions)):
+            if updated_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+                updated_policy_actions = updated_policy.lifetime_actions[i]
+        assert updated_policy_actions, "Specified rotation policy action not found in updated policy"
         assert updated_policy_actions.action == KeyRotationPolicyAction.rotate
         assert updated_policy_actions.time_after_create == "P2M"
         assert updated_policy_actions.time_before_expiry is None
+
+        fetched_policy_actions = None
+        for i in range(len(fetched_policy.lifetime_actions)):
+            if fetched_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+                fetched_policy_actions = fetched_policy.lifetime_actions[i]
+        assert fetched_policy_actions, "Specified rotation policy action not found in fetched policy"
         _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
 
         # updating with a round-tripped policy and overriding expires_in
         new_policy = client.update_key_rotation_policy(key_name, policy=updated_policy, expires_in="P90D")
         assert new_policy.expires_in == "P90D"
-        _assert_lifetime_actions_equal(updated_policy_actions, new_policy.lifetime_actions[0])
+
+        new_policy_actions = None
+        for i in range(len(new_policy.lifetime_actions)):
+            if new_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+                new_policy_actions = new_policy.lifetime_actions[i]
+        _assert_lifetime_actions_equal(updated_policy_actions, new_policy_actions)
 
         # updating with a round-tripped policy and overriding lifetime_actions
-        newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P30D")]
+        newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
         newest_policy = client.update_key_rotation_policy(key_name, policy=new_policy, lifetime_actions=newest_actions)
         newest_fetched_policy = client.get_key_rotation_policy(key_name)
         assert newest_policy.expires_in == "P90D"
         _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
 
-        newest_policy_actions = newest_policy.lifetime_actions[0]
-        newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[0]
+        newest_policy_actions = None
+        for i in range(len(newest_policy.lifetime_actions)):
+            if newest_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
+                newest_policy_actions = newest_policy.lifetime_actions[i]
         assert newest_policy_actions.action == KeyRotationPolicyAction.notify
         assert newest_policy_actions.time_after_create is None
-        assert newest_policy_actions.time_before_expiry == "P30D"
+        assert newest_policy_actions.time_before_expiry == "P60D"
+
+        newest_fetched_policy_actions = None
+        for i in range(len(newest_fetched_policy.lifetime_actions)):
+            if newest_fetched_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
+                newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
         _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
 
     @all_api_versions()

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.4.0 (2022-03-25)
+## 4.4.0 (2022-03-28)
 
 ### Features Added
 - Key Vault API version 7.3 is now the default


### PR DESCRIPTION
# Description

**Context:** While running samples to make sure things were ready for release, I noticed that our key rotation sample was out of date. While updating it, I found that we had a bug when updating a rotation policy with no specified `lifetime_actions` -- we would pass `None` to the service for the property, which would prompt an error.

This makes five updates:

1. Updates `KeyClient.update_key_rotation_policy` to send an empty list instead of `None` for `lifetime_actions`, if unspecified
2. Updates key rotation tests to test for this case
3. Updates key rotation test logic to more accurately find lifetime actions (we can't assume the only action in the policy will be the one we specified in a request, because of default policy values that may not be overridden)
4. Updates samples to run successfully
5. Updates changelog release dates for Monday, 3/28

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
