### PR TITLE
[Storage] Refactor tier test in hopes of making it less flaky (again)

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/recordings/test_blob_storage_account.test_standard_blob_tier_set_tier_api.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_blob_storage_account.test_standard_blob_tier_set_tier_api.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.blob.core.windows.net/utcontainer21831965?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:42:43 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       etag:
-      - '"0x8D7597B1FB91D52"'
+      - '"0x8DA0F74A21CA2D8"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: hello world
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -53,15 +53,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Archive21831965
   response:
     body:
       string: ''
@@ -71,11 +71,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Fri, 25 Oct 2019 18:42:43 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       etag:
-      - '"0x8D7597B1FC3CF52"'
+      - '"0x8DA0F74A228D98C"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -83,7 +83,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -91,19 +91,19 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Archive21831965
   response:
     body:
       string: ''
@@ -117,13 +117,15 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:42:43 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       etag:
-      - '"0x8D7597B1FC3CF52"'
+      - '"0x8DA0F74A228D98C"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-inferred:
@@ -131,7 +133,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -139,7 +141,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -148,46 +150,6 @@ interactions:
     headers:
       Accept:
       - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainer21831965\"><Blobs><Blob><Name>blob21831965</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:42:44 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:42:44
-        GMT</Last-Modified><Etag>0x8D7597B1FC3CF52</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type:
-      - application/xml
-      date:
-      - Fri, 25 Oct 2019 18:42:43 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2019-02-02'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -195,15 +157,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - Archive
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965?comp=tier
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Archive21831965?comp=tier
   response:
     body:
       string: ''
@@ -211,11 +173,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:42:43 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -223,19 +185,19 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Archive21831965
   response:
     body:
       string: ''
@@ -249,21 +211,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       etag:
-      - '"0x8D7597B1FC3CF52"'
+      - '"0x8DA0F74A228D98C"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
       - Archive
       x-ms-access-tier-change-time:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -271,7 +235,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -280,47 +244,6 @@ interactions:
     headers:
       Accept:
       - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainer21831965\"><Blobs><Blob><Name>blob21831965</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:42:44 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:42:44
-        GMT</Last-Modified><Etag>0x8D7597B1FC3CF52</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Archive</AccessTier><AccessTierChangeTime>Fri,
-        25 Oct 2019 18:42:44 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type:
-      - application/xml
-      date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2019-02-02'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -328,13 +251,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Archive21831965
   response:
     body:
       string: ''
@@ -342,13 +265,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 202
       message: Accepted
@@ -356,7 +279,7 @@ interactions:
     body: hello world
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -368,15 +291,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Cool21831965
   response:
     body:
       string: ''
@@ -386,11 +309,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       etag:
-      - '"0x8D7597B1FFE9890"'
+      - '"0x8DA0F74A265D9BE"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -398,7 +321,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -406,19 +329,19 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Cool21831965
   response:
     body:
       string: ''
@@ -432,13 +355,15 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:43 GMT
       etag:
-      - '"0x8D7597B1FFE9890"'
+      - '"0x8DA0F74A265D9BE"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-inferred:
@@ -446,7 +371,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -454,7 +379,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -463,46 +388,6 @@ interactions:
     headers:
       Accept:
       - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainer21831965\"><Blobs><Blob><Name>blob21831965</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:42:44 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:42:44
-        GMT</Last-Modified><Etag>0x8D7597B1FFE9890</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type:
-      - application/xml
-      date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2019-02-02'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -510,15 +395,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - Cool
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965?comp=tier
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Cool21831965?comp=tier
   response:
     body:
       string: ''
@@ -526,11 +411,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -538,19 +423,19 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Cool21831965
   response:
     body:
       string: ''
@@ -564,21 +449,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       etag:
-      - '"0x8D7597B1FFE9890"'
+      - '"0x8DA0F74A265D9BE"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
       - Cool
       x-ms-access-tier-change-time:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -586,7 +473,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -595,47 +482,6 @@ interactions:
     headers:
       Accept:
       - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainer21831965\"><Blobs><Blob><Name>blob21831965</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:42:44 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:42:44
-        GMT</Last-Modified><Etag>0x8D7597B1FFE9890</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Fri,
-        25 Oct 2019 18:42:45 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type:
-      - application/xml
-      date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2019-02-02'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -643,13 +489,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Cool21831965
   response:
     body:
       string: ''
@@ -657,13 +503,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 202
       message: Accepted
@@ -671,7 +517,7 @@ interactions:
     body: hello world
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -683,15 +529,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Hot21831965
   response:
     body:
       string: ''
@@ -701,11 +547,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       etag:
-      - '"0x8D7597B2036C940"'
+      - '"0x8DA0F74A29B39EA"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -713,7 +559,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -721,19 +567,19 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Hot21831965
   response:
     body:
       string: ''
@@ -747,13 +593,15 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       etag:
-      - '"0x8D7597B2036C940"'
+      - '"0x8DA0F74A29B39EA"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-inferred:
@@ -761,7 +609,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -769,7 +617,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -778,46 +626,6 @@ interactions:
     headers:
       Accept:
       - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainer21831965\"><Blobs><Blob><Name>blob21831965</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:42:45 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:42:45
-        GMT</Last-Modified><Etag>0x8D7597B2036C940</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type:
-      - application/xml
-      date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2019-02-02'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -825,15 +633,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - Hot
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965?comp=tier
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Hot21831965?comp=tier
   response:
     body:
       string: ''
@@ -841,11 +649,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -853,19 +661,19 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Hot21831965
   response:
     body:
       string: ''
@@ -879,21 +687,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       etag:
-      - '"0x8D7597B2036C940"'
+      - '"0x8DA0F74A29B39EA"'
       last-modified:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -901,7 +711,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -910,47 +720,6 @@ interactions:
     headers:
       Accept:
       - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainer21831965\"><Blobs><Blob><Name>blob21831965</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:42:45 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:42:45
-        GMT</Last-Modified><Etag>0x8D7597B2036C940</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierChangeTime>Fri,
-        25 Oct 2019 18:42:45 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type:
-      - application/xml
-      date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2019-02-02'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -958,13 +727,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:42:45 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/utcontainer21831965/blob21831965
+    uri: https://storagename.blob.core.windows.net/utcontainer21831965/Hot21831965
   response:
     body:
       string: ''
@@ -972,13 +741,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:42:44 GMT
+      - Sat, 26 Mar 2022 22:04:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_blob_storage_account_async.test_standard_blob_tier_set_tier_api.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_blob_storage_account_async.test_standard_blob_tier_set_tier_api.yaml
@@ -2,12 +2,14 @@ interactions:
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.blob.core.windows.net/utcontainerc4631be2?restype=container
   response:
@@ -15,25 +17,20 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:43:37 GMT
-      etag: '"0x8D7597B3F9F0E54"'
-      last-modified: Fri, 25 Oct 2019 18:43:37 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758BAA8A85"'
+      last-modified: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2
-        - restype=container
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2?restype=container
 - request:
     body: hello world
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '11'
       Content-Type:
@@ -41,50 +38,45 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
   response:
     body:
       string: ''
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Fri, 25 Oct 2019 18:43:37 GMT
-      etag: '"0x8D7597B3FA82F7C"'
-      last-modified: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758BB3DE9C"'
+      last-modified: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
   response:
     body:
       string: ''
@@ -93,111 +85,63 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:43:37 GMT
-      etag: '"0x8D7597B3FA82F7C"'
-      last-modified: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758BB3DE9C"'
+      last-modified: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary: Origin
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:43:38 GMT
+      x-ms-creation-time: Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainerc4631be2\"><Blobs><Blob><Name>blobc4631be2</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:43:38 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:43:38
-        GMT</Last-Modified><Etag>0x8D7597B3FA82F7C</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type: application/xml
-      date: Fri, 25 Oct 2019 18:43:37 GMT
-      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding: chunked
-      x-ms-version: '2019-02-02'
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2
-        - restype=container&comp=list
-        - ''
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - Archive
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2?comp=tier
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2?comp=tier
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:43:37 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - comp=tier
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2?comp=tier
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
   response:
     body:
       string: ''
@@ -206,103 +150,54 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:43:37 GMT
-      etag: '"0x8D7597B3FA82F7C"'
-      last-modified: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758BB3DE9C"'
+      last-modified: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary: Origin
       x-ms-access-tier: Archive
-      x-ms-access-tier-change-time: Fri, 25 Oct 2019 18:43:38 GMT
+      x-ms-access-tier-change-time: Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:43:38 GMT
+      x-ms-creation-time: Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainerc4631be2\"><Blobs><Blob><Name>blobc4631be2</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:43:38 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:43:38
-        GMT</Last-Modified><Etag>0x8D7597B3FA82F7C</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Archive</AccessTier><AccessTierChangeTime>Fri,
-        25 Oct 2019 18:43:38 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type: application/xml
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding: chunked
-      x-ms-version: '2019-02-02'
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2
-        - restype=container&comp=list
-        - ''
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
-      x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-delete-type-permanent: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 202
       message: Accepted
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Archivec4631be2
 - request:
     body: hello world
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '11'
       Content-Type:
@@ -310,50 +205,45 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
   response:
     body:
       string: ''
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      etag: '"0x8D7597B3FFCEEBD"'
-      last-modified: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758BE45D72"'
+      last-modified: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
   response:
     body:
       string: ''
@@ -362,111 +252,63 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      etag: '"0x8D7597B3FFCEEBD"'
-      last-modified: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758BE45D72"'
+      last-modified: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary: Origin
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:43:38 GMT
+      x-ms-creation-time: Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:43:38 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainerc4631be2\"><Blobs><Blob><Name>blobc4631be2</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:43:38 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:43:38
-        GMT</Last-Modified><Etag>0x8D7597B3FFCEEBD</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type: application/xml
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding: chunked
-      x-ms-version: '2019-02-02'
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2
-        - restype=container&comp=list
-        - ''
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - Cool
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2?comp=tier
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2?comp=tier
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - comp=tier
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2?comp=tier
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
   response:
     body:
       string: ''
@@ -475,103 +317,54 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      etag: '"0x8D7597B3FFCEEBD"'
-      last-modified: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758BE45D72"'
+      last-modified: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary: Origin
       x-ms-access-tier: Cool
-      x-ms-access-tier-change-time: Fri, 25 Oct 2019 18:43:38 GMT
+      x-ms-access-tier-change-time: Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:43:38 GMT
+      x-ms-creation-time: Sat, 26 Mar 2022 22:11:15 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainerc4631be2\"><Blobs><Blob><Name>blobc4631be2</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:43:38 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:43:38
-        GMT</Last-Modified><Etag>0x8D7597B3FFCEEBD</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Fri,
-        25 Oct 2019 18:43:38 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type: application/xml
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding: chunked
-      x-ms-version: '2019-02-02'
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2
-        - restype=container&comp=list
-        - ''
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
-      x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-delete-type-permanent: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 202
       message: Accepted
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Coolc4631be2
 - request:
     body: hello world
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '11'
       Content-Type:
@@ -579,50 +372,45 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
   response:
     body:
       string: ''
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      etag: '"0x8D7597B4051D511"'
-      last-modified: Fri, 25 Oct 2019 18:43:39 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758C0C790D"'
+      last-modified: Sat, 26 Mar 2022 22:11:16 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
   response:
     body:
       string: ''
@@ -631,111 +419,63 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      etag: '"0x8D7597B4051D511"'
-      last-modified: Fri, 25 Oct 2019 18:43:39 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758C0C790D"'
+      last-modified: Sat, 26 Mar 2022 22:11:16 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary: Origin
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:43:39 GMT
+      x-ms-creation-time: Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
-      x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainerc4631be2\"><Blobs><Blob><Name>blobc4631be2</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:43:39 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:43:39
-        GMT</Last-Modified><Etag>0x8D7597B4051D511</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type: application/xml
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding: chunked
-      x-ms-version: '2019-02-02'
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2
-        - restype=container&comp=list
-        - ''
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - Hot
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2?comp=tier
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2?comp=tier
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:43:38 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - comp=tier
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2?comp=tier
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: HEAD
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
   response:
     body:
       string: ''
@@ -744,98 +484,47 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:43:38 GMT
-      etag: '"0x8D7597B4051D511"'
-      last-modified: Fri, 25 Oct 2019 18:43:39 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
+      etag: '"0x8DA0F758C0C790D"'
+      last-modified: Sat, 26 Mar 2022 22:11:16 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary: Origin
       x-ms-access-tier: Hot
-      x-ms-access-tier-change-time: Fri, 25 Oct 2019 18:43:39 GMT
+      x-ms-access-tier-change-time: Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:43:39 GMT
+      x-ms-creation-time: Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.10.1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
+      - Sat, 26 Mar 2022 22:11:16 GMT
       x-ms-version:
-      - '2019-02-02'
-    method: GET
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2?restype=container&comp=list
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"utcontainerc4631be2\"><Blobs><Blob><Name>blobc4631be2</Name><Properties><Creation-Time>Fri,
-        25 Oct 2019 18:43:39 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 18:43:39
-        GMT</Last-Modified><Etag>0x8D7597B4051D511</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
-        /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
-        /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierChangeTime>Fri,
-        25 Oct 2019 18:43:39 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker
-        /></EnumerationResults>"
-    headers:
-      content-type: application/xml
-      date: Fri, 25 Oct 2019 18:43:39 GMT
-      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding: chunked
-      x-ms-version: '2019-02-02'
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2
-        - restype=container&comp=list
-        - ''
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
-      x-ms-date:
-      - Fri, 25 Oct 2019 18:43:39 GMT
-      x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/blobc4631be2
+    uri: https://storagename.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:43:39 GMT
+      date: Sat, 26 Mar 2022 22:11:15 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-delete-type-permanent: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-04-10'
     status:
       code: 202
       message: Accepted
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragewzo2a3il3cqj.blob.core.windows.net
-        - /utcontainerc4631be2/blobc4631be2
-        - ''
-        - ''
+    url: https://jalauzoncanary.blob.core.windows.net/utcontainerc4631be2/Hotc4631be2
 version: 1

--- a/sdk/storage/azure-storage-blob/tests/test_blob_storage_account.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_storage_account.py
@@ -5,25 +5,16 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import pytest
-
-import unittest
-
 from azure.storage.blob import (
     BlobServiceClient,
-    ContainerClient,
-    BlobClient,
     StandardBlobTier
 )
-from devtools_testutils import ResourceGroupPreparer, StorageAccountPreparer
 from azure.storage.blob._generated.models import RehydratePriority
 from settings.testcase import BlobPreparer
 from devtools_testutils.storage import StorageTestCase
 
 # ------------------------------------------------------------------------------
 TEST_BLOB_PREFIX = 'blob'
-
-
 # ------------------------------------------------------------------------------
 
 
@@ -31,9 +22,11 @@ class BlobStorageAccountTest(StorageTestCase):
 
     def _setup(self, bsc):
         self.container_name = self.get_resource_name('utcontainer')
-
         if self.is_live:
-            bsc.create_container(self.container_name)
+            try:
+                bsc.create_container(self.container_name)
+            except:
+                pass
 
     # --Helpers-----------------------------------------------------------------
     def _get_blob_reference(self, bsc):
@@ -49,55 +42,33 @@ class BlobStorageAccountTest(StorageTestCase):
         blob = bsc.get_blob_client(container_name, blob_name)
         actual_data = blob.download_blob().readall()
         self.assertEqual(actual_data, expected_data)
-
-    # --Tests specific to Blob Storage Accounts (not general purpose)------------
+    # --------------------------------------------------------------------------
 
     @BlobPreparer()
     def test_standard_blob_tier_set_tier_api(self, storage_account_name, storage_account_key):
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=storage_account_key)
+
         self._setup(bsc)
-        container = bsc.get_container_client(self.container_name)
         tiers = [StandardBlobTier.Archive, StandardBlobTier.Cool, StandardBlobTier.Hot]
 
         for tier in tiers:
-            blob = self._get_blob_reference(bsc)
-            data = b'hello world'
-            blob.upload_blob(data)
+            blob_name = self.get_resource_name(tier.value)
+            blob = bsc.get_blob_client(self.container_name, blob_name)
+            blob.upload_blob(b'hello world')
 
             blob_ref = blob.get_blob_properties()
             self.assertIsNotNone(blob_ref.blob_tier)
-            # TODO The service is flaky about sending back this property
-            # self.assertTrue(blob_ref.blob_tier_inferred)
+            self.assertTrue(blob_ref.blob_tier_inferred)
             self.assertIsNone(blob_ref.blob_tier_change_time)
 
-            blobs = list(container.list_blobs())
-
-            # Assert
-            self.assertIsNotNone(blobs)
-            self.assertGreaterEqual(len(blobs), 1)
-            self.assertIsNotNone(blobs[0])
-            self.assertNamedItemInContainer(blobs, blob.blob_name)
-            self.assertIsNotNone(blobs[0].blob_tier)
-            self.assertTrue(blobs[0].blob_tier_inferred)
-            self.assertIsNone(blobs[0].blob_tier_change_time)
-
+            # Act
             blob.set_standard_blob_tier(tier)
 
+            # Assert
             blob_ref2 = blob.get_blob_properties()
             self.assertEqual(tier, blob_ref2.blob_tier)
             self.assertFalse(blob_ref2.blob_tier_inferred)
             self.assertIsNotNone(blob_ref2.blob_tier_change_time)
-
-            blobs = list(container.list_blobs())
-
-            # Assert
-            self.assertIsNotNone(blobs)
-            self.assertGreaterEqual(len(blobs), 1)
-            self.assertIsNotNone(blobs[0])
-            self.assertNamedItemInContainer(blobs, blob.blob_name)
-            self.assertEqual(blobs[0].blob_tier, tier)
-            self.assertFalse(blobs[0].blob_tier_inferred)
-            self.assertIsNotNone(blobs[0].blob_tier_change_time)
 
             blob.delete_blob()
 
@@ -169,6 +140,3 @@ class BlobStorageAccountTest(StorageTestCase):
         self.assertEqual(StandardBlobTier.Archive, blobs[0].blob_tier)
         self.assertEqual("rehydrate-pending-to-hot", blobs[0].archive_status)
         self.assertFalse(blobs[0].blob_tier_inferred)
-
-
-# ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_storage_account_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_storage_account_async.py
@@ -5,30 +5,21 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import pytest
-import asyncio
-import unittest
-
 from azure.core.pipeline.transport import AioHttpTransport
 from multidict import CIMultiDict, CIMultiDictProxy
 
 from azure.storage.blob.aio import (
-    BlobServiceClient,
-    ContainerClient,
-    BlobClient,
+    BlobServiceClient
 )
-
 from azure.storage.blob import (
     StandardBlobTier
 )
-from devtools_testutils import ResourceGroupPreparer, StorageAccountPreparer
 from azure.storage.blob._generated.models import RehydratePriority
 from settings.testcase import BlobPreparer
 from devtools_testutils.storage.aio import AsyncStorageTestCase
+
 # ------------------------------------------------------------------------------
 TEST_BLOB_PREFIX = 'blob'
-
-
 # ------------------------------------------------------------------------------
 
 
@@ -66,60 +57,34 @@ class BlobStorageAccountTestAsync(AsyncStorageTestCase):
         blob = bsc.get_blob_client(container_name, blob_name)
         actual_data = await blob.download_blob().readall()
         self.assertEqual(actual_data, expected_data)
+    # --------------------------------------------------------------------------
 
-    # --Tests specific to Blob Storage Accounts (not general purpose)------------
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_standard_blob_tier_set_tier_api(self, storage_account_name, storage_account_key):
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=storage_account_key, transport=AiohttpTestTransport())
 
         await self._setup(bsc)
-        container = bsc.get_container_client(self.container_name)
         tiers = [StandardBlobTier.Archive, StandardBlobTier.Cool, StandardBlobTier.Hot]
 
         for tier in tiers:
-            blob = self._get_blob_reference(bsc)
-            data = b'hello world'
-            await blob.upload_blob(data)
+            blob_name = self.get_resource_name(tier.value)
+            blob = bsc.get_blob_client(self.container_name, blob_name)
+            await blob.upload_blob(b'hello world')
 
             blob_ref = await blob.get_blob_properties()
             self.assertIsNotNone(blob_ref.blob_tier)
-            # TODO The service is flaky about sending back this property
-            # self.assertTrue(blob_ref.blob_tier_inferred)
+            self.assertTrue(blob_ref.blob_tier_inferred)
             self.assertIsNone(blob_ref.blob_tier_change_time)
 
-            blobs = []
-            async for b in container.list_blobs():
-                blobs.append(b)
-
-            # Assert
-            self.assertIsNotNone(blobs)
-            self.assertGreaterEqual(len(blobs), 1)
-            self.assertIsNotNone(blobs[0])
-            self.assertNamedItemInContainer(blobs, blob.blob_name)
-            self.assertIsNotNone(blobs[0].blob_tier)
-            self.assertTrue(blobs[0].blob_tier_inferred)
-            self.assertIsNone(blobs[0].blob_tier_change_time)
-
+            # Act
             await blob.set_standard_blob_tier(tier)
 
+            # Assert
             blob_ref2 = await blob.get_blob_properties()
             self.assertEqual(tier, blob_ref2.blob_tier)
             self.assertFalse(blob_ref2.blob_tier_inferred)
             self.assertIsNotNone(blob_ref2.blob_tier_change_time)
-
-            blobs = []
-            async for b in container.list_blobs():
-                blobs.append(b)
-
-            # Assert
-            self.assertIsNotNone(blobs)
-            self.assertGreaterEqual(len(blobs), 1)
-            self.assertIsNotNone(blobs[0])
-            self.assertNamedItemInContainer(blobs, blob.blob_name)
-            self.assertEqual(blobs[0].blob_tier, tier)
-            self.assertFalse(blobs[0].blob_tier_inferred)
-            self.assertIsNotNone(blobs[0].blob_tier_change_time)
 
             await blob.delete_blob()
 
@@ -198,5 +163,3 @@ class BlobStorageAccountTestAsync(AsyncStorageTestCase):
         self.assertEqual(StandardBlobTier.Archive, blobs[0].blob_tier)
         self.assertEqual("rehydrate-pending-to-hot", blobs[0].archive_status)
         self.assertFalse(blobs[0].blob_tier_inferred)
-
-# ------------------------------------------------------------------------------


### PR DESCRIPTION
The `test_standard_blob_tier_set_tier_api` test has been flaky in our Live test pipeline with previous attempts to fix it not working. This change refactors the test a little to hopefully eliminate flakiness. Also took the opportunity to clean up the tests and test files as well.