### PR TITLE
[Key Vault] Remove azure-keyvault from artifacts after release

### DIFF
--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -47,5 +47,3 @@ extends:
       safeName: azurekeyvaultsecrets
     - name: azure-mgmt-keyvault
       safeName: azuremgmtkeyvault
-    - name: azure-keyvault
-      safeName: azurekeyvault


### PR DESCRIPTION
# Description

Now that `azure-keyvault` 4.2.0 has been released to drop Python 2 support, this removes the package from our `Artifacts` list since we can once again go back to pretending the package doesn't exist 🙂

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
