### PR TITLE
[perf] NoOpTest.run_async() should yield to avoid blocking event loop

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/system_perfstress/no_op_test.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/system_perfstress/no_op_test.py
@@ -6,6 +6,7 @@
 import asyncio
 from azure_devtools.perfstress_tests import PerfStressTest
 
+
 class NoOpTest(PerfStressTest):
     def run_sync(self):
         pass

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/system_perfstress/no_op_test.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/system_perfstress/no_op_test.py
@@ -3,12 +3,15 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import asyncio
 from azure_devtools.perfstress_tests import PerfStressTest
-
 
 class NoOpTest(PerfStressTest):
     def run_sync(self):
         pass
 
     async def run_async(self):
-        pass
+        # Yield on each call to avoid blocking the event loop.  Also simulates a real call to async IO.
+        # Reduces throughput by almost a factor of 10 (1.3M vs 160k ops/sec), but allows for parallel execution
+        # and should more accurately represent real-world async performance.
+        await asyncio.sleep(0)


### PR DESCRIPTION
- Fixes #23740
- Reduces throughput by almost a factor of 10 (1.3M vs 160k ops/sec), but allows for parallel execution and should more accurately represent real-world async performance.

**Parallel**|**main**|**PR**
-----|-----|-----
1|1,300,000|160,000
2|FAIL|198,000
4|FAIL|226,000
8|FAIL|234,000
16|FAIL|237,000
32|FAIL|263,000
64|FAIL|271,000