### PR TITLE
[Search] Enable tests after search service regression fixes

### DIFF
--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_skillset_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_skillset_live_async.py
@@ -34,13 +34,10 @@ class TestSearchClientSkillsets(AzureRecordedTestCase):
             await self._test_create_skillset(client)
             await self._test_get_skillset(client)
             await self._test_get_skillsets(client)
-            # TODO: Disabled due to service regression. See #22769
-            #await self._test_create_or_update_skillset(client)
+            await self._test_create_or_update_skillset(client)
             await self._test_create_or_update_skillset_if_unchanged(client)
-            # TODO: Disabled due to service regression. See #22769
-            #await self._test_create_or_update_skillset_inplace(client)
-            # TODO: Disabled due to service regression. See #22769
-            #await self._test_delete_skillset_if_unchanged(client)
+            await self._test_create_or_update_skillset_inplace(client)
+            await self._test_delete_skillset_if_unchanged(client)
             await self._test_delete_skillset(client)
 
     async def _test_create_skillset(self, client):
@@ -170,12 +167,11 @@ class TestSearchClientSkillsets(AzureRecordedTestCase):
 
         skillset1 = SearchIndexerSkillset(name=name, skills=list([s]), description="desc1")
         ss = await client.create_or_update_skillset(skillset1)
-        etag = ss.e_tag
-
-        updated = SearchIndexerSkillset(name=name, skills=[s], description="desc2", skillset=ss)
-        updated.e_tag = etag
+        
+        ss.e_tag = 'changed_etag'
+        
         with pytest.raises(HttpResponseError):
-            await client.create_or_update_skillset(updated, match_condition=MatchConditions.IfNotModified)
+            await client.create_or_update_skillset(ss, match_condition=MatchConditions.IfNotModified)
 
     async def _test_delete_skillset_if_unchanged(self, client):
         name = "test-ss-deleted-unchanged"

--- a/sdk/search/azure-search-documents/tests/recordings/async_tests/test_search_index_client_skillset_live_async.pyTestSearchClientSkillsetstest_skillset_crud.json
+++ b/sdk/search/azure-search-documents/tests/recordings/async_tests/test_search_index_client_skillset_live_async.pyTestSearchClientSkillsetstest_skillset_crud.json
@@ -8,8 +8,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "1218",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6aa87b75-7fc3-11ec-9f80-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-create",
@@ -106,20 +105,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1925",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:41 GMT",
-        "elapsed-time": "46",
-        "ETag": "W/\u00220x8D9E1E74F05D2EC\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:50 GMT",
+        "elapsed-time": "51",
+        "ETag": "W/\u00220x8DA1291A0F24DF4\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6aa87b75-7fc3-11ec-9f80-74c63bed1137",
+        "request-id": "bcfb6358-b06d-11ec-bc7f-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E74F05D2EC\u0022",
+        "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
         "name": "test-ss-create",
         "description": "desc",
         "skills": [
@@ -250,8 +249,7 @@
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6b10352b-7fc3-11ec-b483-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -260,13 +258,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "2179",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:43 GMT",
-        "elapsed-time": "26",
+        "Date": "Wed, 30 Mar 2022 21:09:50 GMT",
+        "elapsed-time": "23",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6b10352b-7fc3-11ec-b483-74c63bed1137",
+        "request-id": "bd428d4e-b06d-11ec-82e3-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -274,7 +272,7 @@
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
         "value": [
           {
-            "@odata.etag": "\u00220x8D9E1E74F05D2EC\u0022",
+            "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
             "name": "test-ss-create",
             "description": "desc",
             "skills": [
@@ -432,8 +430,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6b2720e9-7fc3-11ec-b19b-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "skillNames": [
@@ -447,11 +444,11 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:49:43 GMT",
+        "Date": "Wed, 30 Mar 2022 21:09:50 GMT",
         "elapsed-time": "20",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "6b2720e9-7fc3-11ec-b19b-74c63bed1137",
+        "request-id": "bd53e946-b06d-11ec-b745-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -464,8 +461,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "256",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6b3b94b8-7fc3-11ec-a431-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-get",
@@ -493,20 +489,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "616",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:43 GMT",
-        "elapsed-time": "39",
-        "ETag": "W/\u00220x8D9E1E74F4EDF28\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:50 GMT",
+        "elapsed-time": "44",
+        "ETag": "W/\u00220x8DA1291A129827C\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-get\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6b3b94b8-7fc3-11ec-a431-74c63bed1137",
+        "request-id": "bd6466dc-b06d-11ec-bcb4-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E74F4EDF28\u0022",
+        "@odata.etag": "\u00220x8DA1291A129827C\u0022",
         "name": "test-ss-get",
         "description": "desc",
         "skills": [
@@ -546,8 +542,7 @@
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6b526468-7fc3-11ec-95f4-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -556,20 +551,20 @@
         "Content-Encoding": "gzip",
         "Content-Length": "693",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:43 GMT",
-        "elapsed-time": "13",
-        "ETag": "W/\u00220x8D9E1E74F4EDF28\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:50 GMT",
+        "elapsed-time": "11",
+        "ETag": "W/\u00220x8DA1291A129827C\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6b526468-7fc3-11ec-95f4-74c63bed1137",
+        "request-id": "bd774f79-b06d-11ec-8f42-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E74F4EDF28\u0022",
+        "@odata.etag": "\u00220x8DA1291A129827C\u0022",
         "name": "test-ss-get",
         "description": "desc",
         "skills": [
@@ -619,8 +614,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "260",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6b65e8f9-7fc3-11ec-9c40-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-list-1",
@@ -648,20 +642,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "620",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:43 GMT",
-        "elapsed-time": "39",
-        "ETag": "W/\u00220x8D9E1E74F79444D\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "37",
+        "ETag": "W/\u00220x8DA1291A14B8471\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-list-1\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6b65e8f9-7fc3-11ec-9c40-74c63bed1137",
+        "request-id": "bd86dd2b-b06d-11ec-80db-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E74F79444D\u0022",
+        "@odata.etag": "\u00220x8DA1291A14B8471\u0022",
         "name": "test-ss-list-1",
         "description": "desc1",
         "skills": [
@@ -703,8 +697,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "260",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6b7c8065-7fc3-11ec-b64b-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-list-2",
@@ -732,20 +725,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "620",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:43 GMT",
-        "elapsed-time": "39",
-        "ETag": "W/\u00220x8D9E1E74F8F611F\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "38",
+        "ETag": "W/\u00220x8DA1291A15CBFFC\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-list-2\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6b7c8065-7fc3-11ec-b64b-74c63bed1137",
+        "request-id": "bd98ce33-b06d-11ec-b340-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E74F8F611F\u0022",
+        "@odata.etag": "\u00220x8DA1291A15CBFFC\u0022",
         "name": "test-ss-list-2",
         "description": "desc2",
         "skills": [
@@ -785,8 +778,7 @@
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6b92c50c-7fc3-11ec-9416-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -795,13 +787,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "3990",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:43 GMT",
-        "elapsed-time": "42",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "24",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6b92c50c-7fc3-11ec-9416-74c63bed1137",
+        "request-id": "bdabaf62-b06d-11ec-a957-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -809,7 +801,7 @@
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
         "value": [
           {
-            "@odata.etag": "\u00220x8D9E1E74F05D2EC\u0022",
+            "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
             "name": "test-ss-create",
             "description": "desc",
             "skills": [
@@ -957,7 +949,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E74F4EDF28\u0022",
+            "@odata.etag": "\u00220x8DA1291A129827C\u0022",
             "name": "test-ss-get",
             "description": "desc",
             "skills": [
@@ -999,7 +991,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E74F79444D\u0022",
+            "@odata.etag": "\u00220x8DA1291A14B8471\u0022",
             "name": "test-ss-list-1",
             "description": "desc1",
             "skills": [
@@ -1041,7 +1033,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E74F8F611F\u0022",
+            "@odata.etag": "\u00220x8DA1291A15CBFFC\u0022",
             "name": "test-ss-list-2",
             "description": "desc2",
             "skills": [
@@ -1086,6 +1078,939 @@
       }
     },
     {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "270",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-create-or-update",
+        "description": "desc1",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "630",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "49",
+        "ETag": "W/\u00220x8DA1291A1821CDB\u0022",
+        "Expires": "-1",
+        "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "bdbc4d14-b06d-11ec-9616-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A1821CDB\u0022",
+        "name": "test-ss-create-or-update",
+        "description": "desc1",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "4605",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "25",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "bdcf4590-b06d-11ec-adc6-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA1291A1821CDB\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A129827C\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A14B8471\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A15CBFFC\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "270",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-create-or-update",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "630",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "39",
+        "ETag": "W/\u00220x8DA1291A1A41ECE\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "bddfdf55-b06d-11ec-bd5f-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A1A41ECE\u0022",
+        "name": "test-ss-create-or-update",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "4605",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "30",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "bdf23029-b06d-11ec-b82d-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA1291A1A41ECE\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A129827C\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A14B8471\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A15CBFFC\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "707",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "12",
+        "ETag": "W/\u00220x8DA1291A1A41ECE\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "be0532d6-b06d-11ec-9ea3-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A1A41ECE\u0022",
+        "name": "test-ss-create-or-update",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": "#1",
+            "description": null,
+            "context": "/document",
+            "categories": [
+              "Person",
+              "Quantity",
+              "Organization",
+              "URL",
+              "Email",
+              "Location",
+              "DateTime"
+            ],
+            "defaultLanguageCode": "en",
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
       "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
@@ -1094,8 +2019,7 @@
         "Content-Length": "280",
         "Content-Type": "application/json",
         "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6bab08ad-7fc3-11ec-81f5-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-create-or-update-unchanged",
@@ -1123,20 +2047,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "640",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:44 GMT",
-        "elapsed-time": "38",
-        "ETag": "W/\u00220x8D9E1E74FBECE92\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:51 GMT",
+        "elapsed-time": "44",
+        "ETag": "W/\u00220x8DA1291A1D89496\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6bab08ad-7fc3-11ec-81f5-74c63bed1137",
+        "request-id": "be130a0d-b06d-11ec-94e7-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E74FBECE92\u0022",
+        "@odata.etag": "\u00220x8DA1291A1D89496\u0022",
         "name": "test-ss-create-or-update-unchanged",
         "description": "desc1",
         "skills": [
@@ -1176,23 +2100,23 @@
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "320",
+        "Content-Length": "343",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E74FBECE92\u0022",
+        "If-Match": "\u0022changed_etag\u0022",
         "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
+        "description": "desc1",
         "skills": [
           {
             "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
             "inputs": [
               {
                 "name": "text",
-                "source": "/document/content"
+                "source": "/document/content",
+                "inputs": []
               }
             ],
             "outputs": [
@@ -1200,49 +2124,48 @@
                 "name": "organizations",
                 "targetName": "organizations"
               }
-            ]
+            ],
+            "categories": []
           }
         ],
-        "@odata.etag": "\u00220x8D9E1E74FBECE92\u0022"
+        "@odata.etag": "changed_etag"
       },
-      "StatusCode": 500,
+      "StatusCode": 412,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Language": "en",
-        "Content-Length": "56",
+        "Content-Length": "160",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:44 GMT",
-        "elapsed-time": "14",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137",
+        "request-id": "be25b9c0-b06d-11ec-a18d-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "error": {
           "code": "",
-          "message": "An error has occurred."
+          "message": "The precondition given in one of the request headers evaluated to false. No change was made to the resource from this request."
         }
       }
     },
     {
-      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "320",
+        "Content-Length": "278",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E74FBECE92\u0022",
         "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
-        "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc1",
         "skills": [
           {
             "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
@@ -1259,54 +2182,45 @@
               }
             ]
           }
-        ],
-        "@odata.etag": "\u00220x8D9E1E74FBECE92\u0022"
+        ]
       },
-      "StatusCode": 500,
+      "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Language": "en",
-        "Content-Length": "56",
+        "Content-Length": "638",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:44 GMT",
-        "elapsed-time": "13",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "37",
+        "ETag": "W/\u00220x8DA1291A1F7D7CB\u0022",
         "Expires": "-1",
+        "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137",
+        "request-id": "be32fad5-b06d-11ec-a270-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "error": {
-          "code": "",
-          "message": "An error has occurred."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json;odata.metadata=minimal",
-        "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "320",
-        "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E74FBECE92\u0022",
-        "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137"
-      },
-      "RequestBody": {
-        "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A1F7D7CB\u0022",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc1",
         "skills": [
           {
             "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
             "inputs": [
               {
                 "name": "text",
-                "source": "/document/content"
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
               }
             ],
             "outputs": [
@@ -1317,85 +2231,9 @@
             ]
           }
         ],
-        "@odata.etag": "\u00220x8D9E1E74FBECE92\u0022"
-      },
-      "StatusCode": 500,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Language": "en",
-        "Content-Length": "56",
-        "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:46 GMT",
-        "elapsed-time": "17",
-        "Expires": "-1",
-        "OData-Version": "4.0",
-        "Pragma": "no-cache",
-        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "",
-          "message": "An error has occurred."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json;odata.metadata=minimal",
-        "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "320",
-        "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E74FBECE92\u0022",
-        "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137"
-      },
-      "RequestBody": {
-        "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
-        "skills": [
-          {
-            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
-            "inputs": [
-              {
-                "name": "text",
-                "source": "/document/content"
-              }
-            ],
-            "outputs": [
-              {
-                "name": "organizations",
-                "targetName": "organizations"
-              }
-            ]
-          }
-        ],
-        "@odata.etag": "\u00220x8D9E1E74FBECE92\u0022"
-      },
-      "StatusCode": 500,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Language": "en",
-        "Content-Length": "56",
-        "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:49 GMT",
-        "elapsed-time": "14",
-        "Expires": "-1",
-        "OData-Version": "4.0",
-        "Pragma": "no-cache",
-        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6bc26633-7fc3-11ec-bfd7-74c63bed1137",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "",
-          "message": "An error has occurred."
-        }
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
       }
     },
     {
@@ -1404,23 +2242,22 @@
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6eed1241-7fc3-11ec-9fd8-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
-        "Content-Length": "4615",
+        "Content-Length": "5853",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:49:49 GMT",
-        "elapsed-time": "37",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "30",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6eed1241-7fc3-11ec-9fd8-74c63bed1137",
+        "request-id": "be45be12-b06d-11ec-92e9-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -1428,7 +2265,49 @@
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
         "value": [
           {
-            "@odata.etag": "\u00220x8D9E1E74FBECE92\u0022",
+            "@odata.etag": "\u00220x8DA1291A1F7D7CB\u0022",
+            "name": "test-ss-create-or-update-inplace",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A1D89496\u0022",
             "name": "test-ss-create-or-update-unchanged",
             "description": "desc1",
             "skills": [
@@ -1470,7 +2349,49 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E74F05D2EC\u0022",
+            "@odata.etag": "\u00220x8DA1291A1A41ECE\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
             "name": "test-ss-create",
             "description": "desc",
             "skills": [
@@ -1618,7 +2539,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E74F4EDF28\u0022",
+            "@odata.etag": "\u00220x8DA1291A129827C\u0022",
             "name": "test-ss-get",
             "description": "desc",
             "skills": [
@@ -1660,7 +2581,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E74F79444D\u0022",
+            "@odata.etag": "\u00220x8DA1291A14B8471\u0022",
             "name": "test-ss-list-1",
             "description": "desc1",
             "skills": [
@@ -1702,7 +2623,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E74F8F611F\u0022",
+            "@odata.etag": "\u00220x8DA1291A15CBFFC\u0022",
             "name": "test-ss-list-2",
             "description": "desc2",
             "skills": [
@@ -1747,24 +2668,1327 @@
       }
     },
     {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "278",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "638",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "38",
+        "ETag": "W/\u00220x8DA1291A21BFC4F\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "be5778f1-b06d-11ec-81a7-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A21BFC4F\u0022",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "5853",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "39",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "be69aac0-b06d-11ec-a1c1-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA1291A21BFC4F\u0022",
+            "name": "test-ss-create-or-update-inplace",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A1D89496\u0022",
+            "name": "test-ss-create-or-update-unchanged",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A1A41ECE\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A129827C\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A14B8471\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A15CBFFC\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "715",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "13",
+        "ETag": "W/\u00220x8DA1291A21BFC4F\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "be7cbbcb-b06d-11ec-ba12-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A21BFC4F\u0022",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": "#1",
+            "description": null,
+            "context": "/document",
+            "categories": [
+              "Person",
+              "Quantity",
+              "Organization",
+              "URL",
+              "Email",
+              "Location",
+              "DateTime"
+            ],
+            "defaultLanguageCode": "en",
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "270",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-deleted-unchanged",
+        "description": "desc",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "630",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "36",
+        "ETag": "W/\u00220x8DA1291A24FFD02\u0022",
+        "Expires": "-1",
+        "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "be8b837a-b06d-11ec-ba63-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A24FFD02\u0022",
+        "name": "test-ss-deleted-unchanged",
+        "description": "desc",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "273",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-deleted-unchanged",
+        "description": "updated",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "633",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "38",
+        "ETag": "W/\u00220x8DA1291A26297E9\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "be9dd059-b06d-11ec-9d4e-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA1291A26297E9\u0022",
+        "name": "test-ss-deleted-unchanged",
+        "description": "updated",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DA1291A24FFD02\u0022",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 412,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Language": "en",
+        "Content-Length": "160",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:52 GMT",
+        "elapsed-time": "7",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "beb05cef-b06d-11ec-aebb-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "",
+          "message": "The precondition given in one of the request headers evaluated to false. No change was made to the resource from this request."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "6471",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
+        "elapsed-time": "28",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "bebe4fe4-b06d-11ec-8d17-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA1291A21BFC4F\u0022",
+            "name": "test-ss-create-or-update-inplace",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A1D89496\u0022",
+            "name": "test-ss-create-or-update-unchanged",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A1A41ECE\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A0F24DF4\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A26297E9\u0022",
+            "name": "test-ss-deleted-unchanged",
+            "description": "updated",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A129827C\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A14B8471\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA1291A15CBFFC\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
+        "elapsed-time": "25",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "bed10809-b06d-11ec-863d-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": null
+    },
+    {
       "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6f03cccb-7fc3-11ec-8f41-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:49:49 GMT",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
+        "elapsed-time": "33",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "bee2ad76-b06d-11ec-80f7-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
         "elapsed-time": "26",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "6f03cccb-7fc3-11ec-8f41-74c63bed1137",
+        "request-id": "bef5d5f8-b06d-11ec-8dec-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1776,18 +4000,39 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6f187242-7fc3-11ec-adeb-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:49:49 GMT",
-        "elapsed-time": "31",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
+        "elapsed-time": "29",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "6f187242-7fc3-11ec-adeb-74c63bed1137",
+        "request-id": "bf07722a-b06d-11ec-abc9-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
+        "elapsed-time": "27",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "bf19895a-b06d-11ec-8347-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1799,18 +4044,17 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6f2dd324-7fc3-11ec-8faa-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:49:49 GMT",
-        "elapsed-time": "28",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
+        "elapsed-time": "27",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "6f2dd324-7fc3-11ec-8faa-74c63bed1137",
+        "request-id": "bf2b7453-b06d-11ec-8688-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1822,18 +4066,17 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6f42352f-7fc3-11ec-a2a6-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:49:49 GMT",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
         "elapsed-time": "28",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "6f42352f-7fc3-11ec-a2a6-74c63bed1137",
+        "request-id": "bf3c8418-b06d-11ec-ac4a-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1845,18 +4088,17 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "6f5789a4-7fc3-11ec-a4c5-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:49:49 GMT",
-        "elapsed-time": "25",
+        "Date": "Wed, 30 Mar 2022 21:09:53 GMT",
+        "elapsed-time": "27",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "6f5789a4-7fc3-11ec-a4c5-74c63bed1137",
+        "request-id": "bf4e1988-b06d-11ec-a498-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null

--- a/sdk/search/azure-search-documents/tests/recordings/test_search_index_client_skillset_live.pyTestSearchSkillsettest_skillset_crud.json
+++ b/sdk/search/azure-search-documents/tests/recordings/test_search_index_client_skillset_live.pyTestSearchSkillsettest_skillset_crud.json
@@ -9,8 +9,7 @@
         "Connection": "keep-alive",
         "Content-Length": "1348",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1a2109d1-7fc2-11ec-b40a-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-create",
@@ -111,20 +110,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1971",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:18 GMT",
-        "elapsed-time": "75",
-        "ETag": "W/\u00220x8D9E1E5FE8AEC9F\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "2128",
+        "ETag": "W/\u00220x8DA129189EAC966\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1a2109d1-7fc2-11ec-b40a-74c63bed1137",
+        "request-id": "a4a74d28-b06d-11ec-a736-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E5FE8AEC9F\u0022",
+        "@odata.etag": "\u00220x8DA129189EAC966\u0022",
         "name": "test-ss-create",
         "description": "desc",
         "skills": [
@@ -256,8 +255,7 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1a95e834-7fc2-11ec-8de5-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -266,13 +264,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "2225",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:18 GMT",
-        "elapsed-time": "22",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "65",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1a95e834-7fc2-11ec-8de5-74c63bed1137",
+        "request-id": "a63c597b-b06d-11ec-97c4-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -280,7 +278,7 @@
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
         "value": [
           {
-            "@odata.etag": "\u00220x8D9E1E5FE8AEC9F\u0022",
+            "@odata.etag": "\u00220x8DA129189EAC966\u0022",
             "name": "test-ss-create",
             "description": "desc",
             "skills": [
@@ -439,8 +437,7 @@
         "Connection": "keep-alive",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1aae8e1e-7fc2-11ec-a670-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "skillNames": [
@@ -454,11 +451,11 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:40:18 GMT",
-        "elapsed-time": "21",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "37",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "1aae8e1e-7fc2-11ec-a670-74c63bed1137",
+        "request-id": "a654e749-b06d-11ec-a8dc-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -472,8 +469,7 @@
         "Connection": "keep-alive",
         "Content-Length": "256",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1ac3750a-7fc2-11ec-856b-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-get",
@@ -501,20 +497,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "616",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:18 GMT",
-        "elapsed-time": "38",
-        "ETag": "W/\u00220x8D9E1E5FED9763E\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "50",
+        "ETag": "W/\u00220x8DA12918A2D46E3\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-get\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1ac3750a-7fc2-11ec-856b-74c63bed1137",
+        "request-id": "a6685ff7-b06d-11ec-ab2f-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E5FED9763E\u0022",
+        "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
         "name": "test-ss-get",
         "description": "desc",
         "skills": [
@@ -555,8 +551,7 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1ada8728-7fc2-11ec-b482-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -565,20 +560,20 @@
         "Content-Encoding": "gzip",
         "Content-Length": "693",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:18 GMT",
-        "elapsed-time": "13",
-        "ETag": "W/\u00220x8D9E1E5FED9763E\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "17",
+        "ETag": "W/\u00220x8DA12918A2D46E3\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1ada8728-7fc2-11ec-b482-74c63bed1137",
+        "request-id": "a67cdbf2-b06d-11ec-9471-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E5FED9763E\u0022",
+        "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
         "name": "test-ss-get",
         "description": "desc",
         "skills": [
@@ -629,8 +624,7 @@
         "Connection": "keep-alive",
         "Content-Length": "260",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1aee2eec-7fc2-11ec-821f-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-list-1",
@@ -658,20 +652,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "620",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:18 GMT",
-        "elapsed-time": "38",
-        "ETag": "W/\u00220x8D9E1E5FF03B458\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "46",
+        "ETag": "W/\u00220x8DA12918A50A834\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-list-1\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1aee2eec-7fc2-11ec-821f-74c63bed1137",
+        "request-id": "a68bf596-b06d-11ec-8e63-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E5FF03B458\u0022",
+        "@odata.etag": "\u00220x8DA12918A50A834\u0022",
         "name": "test-ss-list-1",
         "description": "desc1",
         "skills": [
@@ -714,8 +708,7 @@
         "Connection": "keep-alive",
         "Content-Length": "260",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1b04e261-7fc2-11ec-9c76-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-list-2",
@@ -743,20 +736,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "620",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:18 GMT",
-        "elapsed-time": "38",
-        "ETag": "W/\u00220x8D9E1E5FF1A4649\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "40",
+        "ETag": "W/\u00220x8DA12918A63B838\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-list-2\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1b04e261-7fc2-11ec-9c76-74c63bed1137",
+        "request-id": "a69f56e1-b06d-11ec-92c1-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E5FF1A4649\u0022",
+        "@odata.etag": "\u00220x8DA12918A63B838\u0022",
         "name": "test-ss-list-2",
         "description": "desc2",
         "skills": [
@@ -797,8 +790,7 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1b1b193f-7fc2-11ec-895f-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -807,13 +799,13 @@
         "Content-Encoding": "gzip",
         "Content-Length": "4036",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:19 GMT",
-        "elapsed-time": "25",
+        "Date": "Wed, 30 Mar 2022 21:09:11 GMT",
+        "elapsed-time": "41",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1b1b193f-7fc2-11ec-895f-74c63bed1137",
+        "request-id": "a6b19f42-b06d-11ec-a31c-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -821,7 +813,7 @@
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
         "value": [
           {
-            "@odata.etag": "\u00220x8D9E1E5FE8AEC9F\u0022",
+            "@odata.etag": "\u00220x8DA129189EAC966\u0022",
             "name": "test-ss-create",
             "description": "desc",
             "skills": [
@@ -969,7 +961,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E5FED9763E\u0022",
+            "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
             "name": "test-ss-get",
             "description": "desc",
             "skills": [
@@ -1011,7 +1003,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E5FF03B458\u0022",
+            "@odata.etag": "\u00220x8DA12918A50A834\u0022",
             "name": "test-ss-list-1",
             "description": "desc1",
             "skills": [
@@ -1053,7 +1045,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E5FF1A4649\u0022",
+            "@odata.etag": "\u00220x8DA12918A63B838\u0022",
             "name": "test-ss-list-2",
             "description": "desc2",
             "skills": [
@@ -1098,6 +1090,944 @@
       }
     },
     {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "270",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-create-or-update",
+        "description": "desc1",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "630",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "41",
+        "ETag": "W/\u00220x8DA12918A898A2C\u0022",
+        "Expires": "-1",
+        "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a6c4b74f-b06d-11ec-8a46-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918A898A2C\u0022",
+        "name": "test-ss-create-or-update",
+        "description": "desc1",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "4651",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "35",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a6d71990-b06d-11ec-8905-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA12918A898A2C\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA129189EAC966\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": "Skill Version 1",
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": "Skill Version 3",
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": "Sentiment V1",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": "Sentiment V3",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A50A834\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A63B838\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "270",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-create-or-update",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "630",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "79",
+        "ETag": "W/\u00220x8DA12918AAF8329\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a6ea21a2-b06d-11ec-9d2e-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918AAF8329\u0022",
+        "name": "test-ss-create-or-update",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "4651",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "36",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a7030183-b06d-11ec-90e2-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA12918AAF8329\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA129189EAC966\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": "Skill Version 1",
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": "Skill Version 3",
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": "Sentiment V1",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": "Sentiment V3",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A50A834\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A63B838\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "707",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "12",
+        "ETag": "W/\u00220x8DA12918AAF8329\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a7177abb-b06d-11ec-a3b8-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918AAF8329\u0022",
+        "name": "test-ss-create-or-update",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": "#1",
+            "description": null,
+            "context": "/document",
+            "categories": [
+              "Person",
+              "Quantity",
+              "Organization",
+              "URL",
+              "Email",
+              "Location",
+              "DateTime"
+            ],
+            "defaultLanguageCode": "en",
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
       "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
@@ -1107,8 +2037,7 @@
         "Content-Length": "280",
         "Content-Type": "application/json",
         "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1b30e92e-7fc2-11ec-8b23-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-create-or-update-unchanged",
@@ -1136,20 +2065,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "640",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:19 GMT",
-        "elapsed-time": "42",
-        "ETag": "W/\u00220x8D9E1E5FF467FEE\u0022",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "38",
+        "ETag": "W/\u00220x8DA12918AEC3523\u0022",
         "Expires": "-1",
         "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1b30e92e-7fc2-11ec-8b23-74c63bed1137",
+        "request-id": "a7272fa7-b06d-11ec-9edf-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9E1E5FF467FEE\u0022",
+        "@odata.etag": "\u00220x8DA12918AEC3523\u0022",
         "name": "test-ss-create-or-update-unchanged",
         "description": "desc1",
         "skills": [
@@ -1190,23 +2119,23 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "320",
+        "Content-Length": "343",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E5FF467FEE\u0022",
+        "If-Match": "\u0022changed_etag\u0022",
         "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
+        "description": "desc1",
         "skills": [
           {
             "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
             "inputs": [
               {
                 "name": "text",
-                "source": "/document/content"
+                "source": "/document/content",
+                "inputs": []
               }
             ],
             "outputs": [
@@ -1214,50 +2143,49 @@
                 "name": "organizations",
                 "targetName": "organizations"
               }
-            ]
+            ],
+            "categories": []
           }
         ],
-        "@odata.etag": "\u00220x8D9E1E5FF467FEE\u0022"
+        "@odata.etag": "changed_etag"
       },
-      "StatusCode": 500,
+      "StatusCode": 412,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Language": "en",
-        "Content-Length": "56",
+        "Content-Length": "160",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:19 GMT",
-        "elapsed-time": "15",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137",
+        "request-id": "a73a0e88-b06d-11ec-ac82-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
         "error": {
           "code": "",
-          "message": "An error has occurred."
+          "message": "The precondition given in one of the request headers evaluated to false. No change was made to the resource from this request."
         }
       }
     },
     {
-      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "320",
+        "Content-Length": "278",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E5FF467FEE\u0022",
         "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
-        "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc1",
         "skills": [
           {
             "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
@@ -1274,55 +2202,45 @@
               }
             ]
           }
-        ],
-        "@odata.etag": "\u00220x8D9E1E5FF467FEE\u0022"
+        ]
       },
-      "StatusCode": 500,
+      "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Language": "en",
-        "Content-Length": "56",
+        "Content-Length": "638",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:19 GMT",
-        "elapsed-time": "20",
+        "Date": "Wed, 30 Mar 2022 21:09:13 GMT",
+        "elapsed-time": "37",
+        "ETag": "W/\u00220x8DA12918B190AF3\u0022",
         "Expires": "-1",
+        "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137",
+        "request-id": "a754ac0f-b06d-11ec-9d4f-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "error": {
-          "code": "",
-          "message": "An error has occurred."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json;odata.metadata=minimal",
-        "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
-        "Content-Length": "320",
-        "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E5FF467FEE\u0022",
-        "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137"
-      },
-      "RequestBody": {
-        "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918B190AF3\u0022",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc1",
         "skills": [
           {
             "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
             "inputs": [
               {
                 "name": "text",
-                "source": "/document/content"
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
               }
             ],
             "outputs": [
@@ -1333,86 +2251,9 @@
             ]
           }
         ],
-        "@odata.etag": "\u00220x8D9E1E5FF467FEE\u0022"
-      },
-      "StatusCode": 500,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Language": "en",
-        "Content-Length": "56",
-        "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:21 GMT",
-        "elapsed-time": "41",
-        "Expires": "-1",
-        "OData-Version": "4.0",
-        "Pragma": "no-cache",
-        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "",
-          "message": "An error has occurred."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json;odata.metadata=minimal",
-        "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
-        "Content-Length": "320",
-        "Content-Type": "application/json",
-        "If-Match": "\u00220x8D9E1E5FF467FEE\u0022",
-        "Prefer": "return=representation",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137"
-      },
-      "RequestBody": {
-        "name": "test-ss-create-or-update-unchanged",
-        "description": "desc2",
-        "skills": [
-          {
-            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
-            "inputs": [
-              {
-                "name": "text",
-                "source": "/document/content"
-              }
-            ],
-            "outputs": [
-              {
-                "name": "organizations",
-                "targetName": "organizations"
-              }
-            ]
-          }
-        ],
-        "@odata.etag": "\u00220x8D9E1E5FF467FEE\u0022"
-      },
-      "StatusCode": 500,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Language": "en",
-        "Content-Length": "56",
-        "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:25 GMT",
-        "elapsed-time": "18",
-        "Expires": "-1",
-        "OData-Version": "4.0",
-        "Pragma": "no-cache",
-        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1b485fd7-7fc2-11ec-b831-74c63bed1137",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "",
-          "message": "An error has occurred."
-        }
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
       }
     },
     {
@@ -1422,23 +2263,22 @@
         "Accept": "application/json;odata.metadata=minimal",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1ea81da7-7fc2-11ec-bf9d-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Encoding": "gzip",
-        "Content-Length": "4661",
+        "Content-Length": "5899",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 27 Jan 2022 22:40:25 GMT",
-        "elapsed-time": "88",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "37",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1ea81da7-7fc2-11ec-bf9d-74c63bed1137",
+        "request-id": "a76724a5-b06d-11ec-a6fb-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding"
       },
@@ -1446,7 +2286,49 @@
         "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
         "value": [
           {
-            "@odata.etag": "\u00220x8D9E1E5FF467FEE\u0022",
+            "@odata.etag": "\u00220x8DA12918B190AF3\u0022",
+            "name": "test-ss-create-or-update-inplace",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918AEC3523\u0022",
             "name": "test-ss-create-or-update-unchanged",
             "description": "desc1",
             "skills": [
@@ -1488,7 +2370,49 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E5FE8AEC9F\u0022",
+            "@odata.etag": "\u00220x8DA12918AAF8329\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA129189EAC966\u0022",
             "name": "test-ss-create",
             "description": "desc",
             "skills": [
@@ -1636,7 +2560,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E5FED9763E\u0022",
+            "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
             "name": "test-ss-get",
             "description": "desc",
             "skills": [
@@ -1678,7 +2602,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E5FF03B458\u0022",
+            "@odata.etag": "\u00220x8DA12918A50A834\u0022",
             "name": "test-ss-list-1",
             "description": "desc1",
             "skills": [
@@ -1720,7 +2644,7 @@
             "encryptionKey": null
           },
           {
-            "@odata.etag": "\u00220x8D9E1E5FF1A4649\u0022",
+            "@odata.etag": "\u00220x8DA12918A63B838\u0022",
             "name": "test-ss-list-2",
             "description": "desc2",
             "skills": [
@@ -1765,6 +2689,1296 @@
       }
     },
     {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "278",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "638",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "38",
+        "ETag": "W/\u00220x8DA12918B3EB5DB\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a77a8550-b06d-11ec-bca2-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918B3EB5DB\u0022",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "5899",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "40",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a78c92f9-b06d-11ec-bf74-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA12918B3EB5DB\u0022",
+            "name": "test-ss-create-or-update-inplace",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918AEC3523\u0022",
+            "name": "test-ss-create-or-update-unchanged",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918AAF8329\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA129189EAC966\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": "Skill Version 1",
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": "Skill Version 3",
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": "Sentiment V1",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": "Sentiment V3",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A50A834\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A63B838\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "715",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "13",
+        "ETag": "W/\u00220x8DA12918B3EB5DB\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a7a030f4-b06d-11ec-8194-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918B3EB5DB\u0022",
+        "name": "test-ss-create-or-update-inplace",
+        "description": "desc2",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": "#1",
+            "description": null,
+            "context": "/document",
+            "categories": [
+              "Person",
+              "Quantity",
+              "Organization",
+              "URL",
+              "Email",
+              "Location",
+              "DateTime"
+            ],
+            "defaultLanguageCode": "en",
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "270",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-deleted-unchanged",
+        "description": "desc",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "630",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "41",
+        "ETag": "W/\u00220x8DA12918B73C7CE\u0022",
+        "Expires": "-1",
+        "Location": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a7aee44b-b06d-11ec-bfc1-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918B73C7CE\u0022",
+        "name": "test-ss-deleted-unchanged",
+        "description": "desc",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "273",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "name": "test-ss-deleted-unchanged",
+        "description": "updated",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "633",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "42",
+        "ETag": "W/\u00220x8DA12918B874CF0\u0022",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a7c1fdd9-b06d-11ec-895a-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DA12918B874CF0\u0022",
+        "name": "test-ss-deleted-unchanged",
+        "description": "updated",
+        "skills": [
+          {
+            "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+            "name": null,
+            "description": null,
+            "context": null,
+            "categories": [],
+            "defaultLanguageCode": null,
+            "minimumPrecision": null,
+            "includeTypelessEntities": null,
+            "inputs": [
+              {
+                "name": "text",
+                "source": "/document/content",
+                "sourceContext": null,
+                "inputs": []
+              }
+            ],
+            "outputs": [
+              {
+                "name": "organizations",
+                "targetName": "organizations"
+              }
+            ]
+          }
+        ],
+        "cognitiveServices": null,
+        "knowledgeStore": null,
+        "encryptionKey": null
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DA12918B73C7CE\u0022",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 412,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Language": "en",
+        "Content-Length": "160",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "12",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a7d5a8ea-b06d-11ec-80ad-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "",
+          "message": "The precondition given in one of the request headers evaluated to false. No change was made to the resource from this request."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets?api-version=2021-04-30-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Length": "6517",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "42",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "a7e5b8cf-b06d-11ec-ac0e-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://fakesearchendpoint.search.windows.net/$metadata#skillsets",
+        "value": [
+          {
+            "@odata.etag": "\u00220x8DA12918B3EB5DB\u0022",
+            "name": "test-ss-create-or-update-inplace",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918AEC3523\u0022",
+            "name": "test-ss-create-or-update-unchanged",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918AAF8329\u0022",
+            "name": "test-ss-create-or-update",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA129189EAC966\u0022",
+            "name": "test-ss-create",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "skill1",
+                "description": "Skill Version 1",
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS1"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+                "name": "skill2",
+                "description": "Skill Version 3",
+                "context": "/document",
+                "categories": [
+                  "Product",
+                  "PhoneNumber",
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "IPAddress",
+                  "URL",
+                  "Email",
+                  "Event",
+                  "Skill",
+                  "Location",
+                  "PersonType",
+                  "Address",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "modelVersion": "3",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizationsS2"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.SentimentSkill",
+                "name": "skill3",
+                "description": "Sentiment V1",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "score",
+                    "targetName": "scoreS3"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.SentimentSkill",
+                "name": "skill4",
+                "description": "Sentiment V3",
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "modelVersion": null,
+                "includeOpinionMining": true,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "confidenceScores",
+                    "targetName": "scoreS4"
+                  }
+                ]
+              },
+              {
+                "@odata.type": "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+                "name": "skill5",
+                "description": null,
+                "context": "/document",
+                "defaultLanguageCode": "en",
+                "minimumPrecision": 0.5,
+                "modelVersion": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "entities",
+                    "targetName": "entitiesS5"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918B874CF0\u0022",
+            "name": "test-ss-deleted-unchanged",
+            "description": "updated",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A2D46E3\u0022",
+            "name": "test-ss-get",
+            "description": "desc",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A50A834\u0022",
+            "name": "test-ss-list-1",
+            "description": "desc1",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          },
+          {
+            "@odata.etag": "\u00220x8DA12918A63B838\u0022",
+            "name": "test-ss-list-2",
+            "description": "desc2",
+            "skills": [
+              {
+                "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
+                "name": "#1",
+                "description": null,
+                "context": "/document",
+                "categories": [
+                  "Person",
+                  "Quantity",
+                  "Organization",
+                  "URL",
+                  "Email",
+                  "Location",
+                  "DateTime"
+                ],
+                "defaultLanguageCode": "en",
+                "minimumPrecision": null,
+                "includeTypelessEntities": null,
+                "inputs": [
+                  {
+                    "name": "text",
+                    "source": "/document/content",
+                    "sourceContext": null,
+                    "inputs": []
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "organizations",
+                    "targetName": "organizations"
+                  }
+                ]
+              }
+            ],
+            "cognitiveServices": null,
+            "knowledgeStore": null,
+            "encryptionKey": null
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-inplace\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Wed, 30 Mar 2022 21:09:14 GMT",
+        "elapsed-time": "39",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "a7fa5307-b06d-11ec-89fd-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": null
+    },
+    {
       "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update-unchanged\u0027)?api-version=2021-04-30-Preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
@@ -1772,18 +3986,40 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1ec7af81-7fc2-11ec-ab6f-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:40:25 GMT",
-        "elapsed-time": "28",
+        "Date": "Wed, 30 Mar 2022 21:09:15 GMT",
+        "elapsed-time": "25",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "1ec7af81-7fc2-11ec-ab6f-74c63bed1137",
+        "request-id": "a80c79d7-b06d-11ec-b8b0-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-create-or-update\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Wed, 30 Mar 2022 21:09:15 GMT",
+        "elapsed-time": "26",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "a81c8f14-b06d-11ec-af6f-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1796,18 +4032,40 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1f070653-7fc2-11ec-8a1a-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:40:25 GMT",
-        "elapsed-time": "32",
+        "Date": "Wed, 30 Mar 2022 21:09:15 GMT",
+        "elapsed-time": "31",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "1f070653-7fc2-11ec-8a1a-74c63bed1137",
+        "request-id": "a82c7082-b06d-11ec-bcac-a04a5ed0778b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakesearchendpoint.search.windows.net/skillsets(\u0027test-ss-deleted-unchanged\u0027)?api-version=2021-04-30-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json;odata.metadata=minimal",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Wed, 30 Mar 2022 21:09:15 GMT",
+        "elapsed-time": "25",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "a83cb36a-b06d-11ec-b0b5-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1820,18 +4078,17 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1f1dce03-7fc2-11ec-85e3-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:40:25 GMT",
-        "elapsed-time": "26",
+        "Date": "Wed, 30 Mar 2022 21:09:15 GMT",
+        "elapsed-time": "25",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "1f1dce03-7fc2-11ec-85e3-74c63bed1137",
+        "request-id": "a84c68c7-b06d-11ec-9e61-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1844,18 +4101,17 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1f320808-7fc2-11ec-9ad4-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:40:26 GMT",
-        "elapsed-time": "28",
+        "Date": "Wed, 30 Mar 2022 21:09:15 GMT",
+        "elapsed-time": "26",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "1f320808-7fc2-11ec-9ad4-74c63bed1137",
+        "request-id": "a85e3aa0-b06d-11ec-83dd-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null
@@ -1868,18 +4124,17 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-search-documents/11.3.0b7 Python/3.9.2 (Windows-10-10.0.19041-SP0)",
-        "x-ms-client-request-id": "1f47376c-7fc2-11ec-a0c1-74c63bed1137"
+        "User-Agent": "azsdk-python-search-documents/11.3.0b9 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Thu, 27 Jan 2022 22:40:26 GMT",
-        "elapsed-time": "235",
+        "Date": "Wed, 30 Mar 2022 21:09:15 GMT",
+        "elapsed-time": "26",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "1f47376c-7fc2-11ec-a0c1-74c63bed1137",
+        "request-id": "a86e12b6-b06d-11ec-9049-a04a5ed0778b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": null

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_skillset_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_skillset_live.py
@@ -34,13 +34,10 @@ class TestSearchSkillset(AzureRecordedTestCase):
         self._test_create_skillset(client)
         self._test_get_skillset(client)
         self._test_get_skillsets(client)
-        # TODO: Disabled due to service regression. See #22769
-        #self._test_create_or_update_skillset(client)
+        self._test_create_or_update_skillset(client)
         self._test_create_or_update_skillset_if_unchanged(client)
-        # TODO: Disabled due to service regression. See #22769
-        #self._test_create_or_update_skillset_inplace(client)
-        # TODO: Disabled due to service regression. See #22769
-        #self._test_delete_skillset_if_unchanged(client)
+        self._test_create_or_update_skillset_inplace(client)
+        self._test_delete_skillset_if_unchanged(client)
         self._test_delete_skillset(client)
 
     def _test_create_skillset_validation(self):
@@ -199,12 +196,11 @@ class TestSearchSkillset(AzureRecordedTestCase):
 
         skillset1 = SearchIndexerSkillset(name=name, skills=list([s]), description="desc1")
         ss = client.create_or_update_skillset(skillset1)
-        etag = ss.e_tag
+        
+        ss.e_tag = 'changed_etag'
 
-        updated = SearchIndexerSkillset(name=name, skills=[s], description="desc2", skillset=ss)
-        updated.e_tag = etag
         with pytest.raises(HttpResponseError):
-            client.create_or_update_skillset(updated, match_condition=MatchConditions.IfNotModified)
+            client.create_or_update_skillset(ss, match_condition=MatchConditions.IfNotModified)
 
     def _test_delete_skillset_if_unchanged(self, client):
         name = "test-ss-deleted-unchanged"


### PR DESCRIPTION
closes #22769 

The following tests were disabled due to a regression on the search service. They have now been enabled and the tests are passing with the expected behavior

test_search_index_client_skillset_live
- _test_create_or_update_skillset
- _test_create_or_update_skillset_inplace
- _test_delete_skillset_if_unchanged

* _test_create_or_update_skillset_if_unchanged - Is now returning a proper error when a modified e_tag is sent in for an existing skillset (with no other changes )