### PR TITLE
[Storage] Fix create_if_not_exists() docstrings and tests

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Added support for service version 2021-06-08.
-- Added support for `create_if_not_exists()` for `BlobContainerClient`
+- Added support for `create_container_if_not_exists()` for `BlobContainerClient`
 
 ## 12.11.0 (2022-03-29)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -304,7 +304,7 @@ class ContainerClient(StorageAccountHostsMixin):    # pylint: disable=too-many-p
             process_storage_error(error)
 
     @distributed_trace
-    def create_if_not_exists(self, **kwargs):
+    def create_container_if_not_exists(self, **kwargs):
         # type: (**Any) -> None
         """
         Creates a new container under the specified account. If the container

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -169,7 +169,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def create_if_not_exists(self, **kwargs):
+    async def create_container_if_not_exists(self, **kwargs):
         # type: (**Any) -> None
         """
         Creates a new container under the specified account. If the container

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_create_container_if_not_exists_with_existing_container.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_create_container_if_not_exists_with_existing_container.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.10.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.12.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:56:41 GMT
+      - Wed, 30 Mar 2022 21:22:44 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/container785a1eaa?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:56:40 GMT
+      - Wed, 30 Mar 2022 21:22:44 GMT
       etag:
-      - '"0x8DA0911096F64AA"'
+      - '"0x8DA12936E6CC3E6"'
       last-modified:
-      - Fri, 18 Mar 2022 18:56:40 GMT
+      - Wed, 30 Mar 2022 21:22:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 201
       message: Created
@@ -49,30 +49,30 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.10.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.12.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:56:42 GMT
+      - Wed, 30 Mar 2022 21:22:45 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/container785a1eaa?restype=container
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:6c8fa979-201e-008a-05f9-3a8173000000\nTime:2022-03-18T18:56:40.4555247Z</Message></Error>"
+        specified container already exists.\nRequestId:be779b14-901e-006b-497c-445d36000000\nTime:2022-03-30T21:22:44.9260314Z</Message></Error>"
     headers:
       content-length:
       - '230'
       content-type:
       - application/xml
       date:
-      - Fri, 18 Mar 2022 18:56:40 GMT
+      - Wed, 30 Mar 2022 21:22:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
       - ContainerAlreadyExists
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 409
       message: The specified container already exists.

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_create_container_if_not_exists_without_existing_container.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_create_container_if_not_exists_without_existing_container.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.10.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.12.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:56:48 GMT
+      - Wed, 30 Mar 2022 21:22:36 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containerd8c72002?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:56:46 GMT
+      - Wed, 30 Mar 2022 21:22:36 GMT
       etag:
-      - '"0x8DA09110D2893BD"'
+      - '"0x8DA129369B4AC8A"'
       last-modified:
-      - Fri, 18 Mar 2022 18:56:46 GMT
+      - Wed, 30 Mar 2022 21:22:36 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 201
       message: Created

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_create_container_if_not_exists_with_existing_container.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_create_container_if_not_exists_with_existing_container.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.10.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.12.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:01:59 GMT
+      - Wed, 30 Mar 2022 21:23:02 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer399c2127?restype=container
   response:
@@ -17,11 +17,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:01:56 GMT
-      etag: '"0x8DA0911C6843F7F"'
-      last-modified: Fri, 18 Mar 2022 19:01:57 GMT
+      date: Wed, 30 Mar 2022 21:23:01 GMT
+      etag: '"0x8DA129378BE5DFF"'
+      last-modified: Wed, 30 Mar 2022 21:23:02 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-04-10'
+      x-ms-version: '2021-06-08'
     status:
       code: 201
       message: Created
@@ -32,24 +32,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.10.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.12.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:01:59 GMT
+      - Wed, 30 Mar 2022 21:23:02 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer399c2127?restype=container
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:6b597129-701e-0001-51fa-3a851e000000\nTime:2022-03-18T19:01:57.6645912Z</Message></Error>"
+        specified container already exists.\nRequestId:397f4f94-a01e-003d-297c-44acd9000000\nTime:2022-03-30T21:23:02.2260400Z</Message></Error>"
     headers:
       content-length: '230'
       content-type: application/xml
-      date: Fri, 18 Mar 2022 19:01:56 GMT
+      date: Wed, 30 Mar 2022 21:23:01 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code: ContainerAlreadyExists
-      x-ms-version: '2021-04-10'
+      x-ms-version: '2021-06-08'
     status:
       code: 409
       message: The specified container already exists.

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_create_container_if_not_exists_without_existing_container.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_create_container_if_not_exists_without_existing_container.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.10.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.12.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:01:52 GMT
+      - Wed, 30 Mar 2022 21:22:56 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainera180227f?restype=container
   response:
@@ -17,11 +17,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:01:50 GMT
-      etag: '"0x8DA0911C28A275B"'
-      last-modified: Fri, 18 Mar 2022 19:01:50 GMT
+      date: Wed, 30 Mar 2022 21:22:56 GMT
+      etag: '"0x8DA1293756D6BAD"'
+      last-modified: Wed, 30 Mar 2022 21:22:56 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-04-10'
+      x-ms-version: '2021-06-08'
     status:
       code: 201
       message: Created

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -87,7 +87,7 @@ class StorageContainerTest(StorageTestCase):
 
         # Act
         container = bsc.get_container_client(container_name)
-        created = container.create_if_not_exists()
+        created = container.create_container_if_not_exists()
 
         # Assert
         self.assertTrue(created)
@@ -100,7 +100,7 @@ class StorageContainerTest(StorageTestCase):
         # Act
         container = bsc.get_container_client(container_name)
         container.create_container()
-        created = container.create_if_not_exists()
+        created = container.create_container_if_not_exists()
 
         # Assert
         self.assertIsNone(created)

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -106,7 +106,7 @@ class StorageContainerAsyncTest(AsyncStorageTestCase):
 
         # Act
         container = bsc.get_container_client(container_name)
-        created = await container.create_if_not_exists()
+        created = await container.create_container_if_not_exists()
 
         # Assert
         self.assertTrue(created)
@@ -120,7 +120,7 @@ class StorageContainerAsyncTest(AsyncStorageTestCase):
         # Act
         container = bsc.get_container_client(container_name)
         await container.create_container()
-        created = await container.create_if_not_exists()
+        created = await container.create_container_if_not_exists()
 
         # Assert
         self.assertIsNone(created)

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 12.7.0b1 (Unreleased)
 
 ### Features Added
-- Added support for `create_if_not_exists()` for `FileSystemClient`
+- Added support for `create_file_system_if_not_exists()` for `FileSystemClient`
 
 ### Bugs Fixed
 - Updated `create_file_system()` docstring to have the correct return-type of `None`

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -274,9 +274,8 @@ class FileSystemClient(StorageAccountHostsMixin):
         :keyword Dict(str,str) metadata:
             A dict with name-value pairs to associate with the
             file system as metadata. Example: `{'Category':'test'}`
-        :keyword public_access:
+        :keyword ~azure.storage.filedatalake.PublicAccess public_access:
             To specify whether data in the file system may be accessed publicly and the level of access.
-        :type public_access: ~azure.storage.filedatalake.PublicAccess
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :rtype: None

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -265,7 +265,7 @@ class FileSystemClient(StorageAccountHostsMixin):
                                                        public_access=public_access,
                                                        **kwargs)
 
-    def create_if_not_exists(self, **kwargs):
+    def create_file_system_if_not_exists(self, **kwargs):
         # type: (Any) -> None
         """Creates a new file system under the specified account.
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -210,7 +210,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
                                                              **kwargs)
 
     @distributed_trace_async
-    async def create_if_not_exists(self, **kwargs):
+    async def create_file_system_if_not_exists(self, **kwargs):
         # type: (Any) -> None
         """Creates a new file system under the specified account.
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -219,9 +219,8 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
         :keyword Dict(str,str) metadata:
             A dict with name-value pairs to associate with the
             file system as metadata. Example: `{'Category':'test'}`
-        :keyword public_access:
+        :keyword ~azure.storage.filedatalake.PublicAccess public_access:
             To specify whether data in the file system may be accessed publicly and the level of access.
-        :type public_access: ~azure.storage.filedatalake.PublicAccess
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :rtype: None

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_create_file_system_if_not_exists_with_existing_file_system.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_create_file_system_if_not_exists_with_existing_file_system.yaml
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:30 GMT
+      - Wed, 30 Mar 2022 21:24:09 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:28 GMT
+      - Wed, 30 Mar 2022 21:24:09 GMT
       etag:
-      - '"0x8DA091126AB3E77"'
+      - '"0x8DA1293A1037E23"'
       last-modified:
-      - Fri, 18 Mar 2022 18:57:29 GMT
+      - Wed, 30 Mar 2022 21:24:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -49,9 +49,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:31 GMT
+      - Wed, 30 Mar 2022 21:24:09 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -59,14 +59,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:adfefe9f-a01e-002d-34fa-3a69b1000000\nTime:2022-03-18T18:57:29.5006906Z</Message></Error>"
+        specified container already exists.\nRequestId:41c5dbaa-101e-0007-137c-44b6a1000000\nTime:2022-03-30T21:24:09.8029177Z</Message></Error>"
     headers:
       content-length:
       - '230'
       content-type:
       - application/xml
       date:
-      - Fri, 18 Mar 2022 18:57:28 GMT
+      - Wed, 30 Mar 2022 21:24:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
@@ -88,9 +88,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:31 GMT
+      - Wed, 30 Mar 2022 21:24:09 GMT
       x-ms-version:
       - '2020-10-02'
     method: DELETE
@@ -102,7 +102,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:28 GMT
+      - Wed, 30 Mar 2022 21:24:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_create_file_system_if_not_exists_without_existing_file_system.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_create_file_system_if_not_exists_without_existing_file_system.yaml
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:25 GMT
+      - Wed, 30 Mar 2022 21:24:04 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:24 GMT
+      - Wed, 30 Mar 2022 21:24:04 GMT
       etag:
-      - '"0x8DA0911238D99C3"'
+      - '"0x8DA12939E2611B1"'
       last-modified:
-      - Fri, 18 Mar 2022 18:57:24 GMT
+      - Wed, 30 Mar 2022 21:24:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -49,9 +49,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:25 GMT
+      - Wed, 30 Mar 2022 21:24:05 GMT
       x-ms-version:
       - '2020-10-02'
     method: DELETE
@@ -63,7 +63,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:24 GMT
+      - Wed, 30 Mar 2022 21:24:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_create_file_system_async_if_not_exists_with_existing_file_system.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_create_file_system_async_if_not_exists_with_existing_file_system.yaml
@@ -5,78 +5,78 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:03:26 GMT
+      - Wed, 30 Mar 2022 21:28:44 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/filesystema0cc2566?restype=container
+    uri: https://storagename.blob.core.windows.net/filesystemeccd2647?restype=container
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:03:24 GMT
-      etag: '"0x8DA0911FA9D0F61"'
-      last-modified: Fri, 18 Mar 2022 19:03:25 GMT
+      date: Wed, 30 Mar 2022 21:28:44 GMT
+      etag: '"0x8DA12944525078B"'
+      last-modified: Wed, 30 Mar 2022 21:28:45 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2020-10-02'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.blob.core.windows.net/filesystema0cc2566?restype=container
+    url: https://vincenttrancanary.blob.core.windows.net/filesystemeccd2647?restype=container
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:03:26 GMT
+      - Wed, 30 Mar 2022 21:28:45 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/filesystema0cc2566?restype=container
+    uri: https://storagename.blob.core.windows.net/filesystemeccd2647?restype=container
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:05890fdf-301e-003f-6ffa-3a1261000000\nTime:2022-03-18T19:03:25.0847129Z</Message></Error>"
+        specified container already exists.\nRequestId:6e0a2c33-e01e-002c-717d-44366d000000\nTime:2022-03-30T21:28:45.1670474Z</Message></Error>"
     headers:
       content-length: '230'
       content-type: application/xml
-      date: Fri, 18 Mar 2022 19:03:24 GMT
+      date: Wed, 30 Mar 2022 21:28:44 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code: ContainerAlreadyExists
       x-ms-version: '2020-10-02'
     status:
       code: 409
       message: The specified container already exists.
-    url: https://vincenttrancanary.blob.core.windows.net/filesystema0cc2566?restype=container
+    url: https://vincenttrancanary.blob.core.windows.net/filesystemeccd2647?restype=container
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:03:26 GMT
+      - Wed, 30 Mar 2022 21:28:45 GMT
       x-ms-version:
       - '2020-10-02'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/filesystema0cc2566?restype=container
+    uri: https://storagename.blob.core.windows.net/filesystemeccd2647?restype=container
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:03:24 GMT
+      date: Wed, 30 Mar 2022 21:28:44 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2020-10-02'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/filesystema0cc2566?restype=container
+    url: https://vincenttrancanary.blob.core.windows.net/filesystemeccd2647?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_create_file_system_async_if_not_exists_without_existing_file_system.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_create_file_system_async_if_not_exists_without_existing_file_system.yaml
@@ -5,50 +5,50 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:03:21 GMT
+      - Wed, 30 Mar 2022 21:28:40 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/filesystem157c26be?restype=container
+    uri: https://storagename.blob.core.windows.net/filesystem642d279f?restype=container
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:03:19 GMT
-      etag: '"0x8DA0911F78DE4E0"'
-      last-modified: Fri, 18 Mar 2022 19:03:19 GMT
+      date: Wed, 30 Mar 2022 21:28:40 GMT
+      etag: '"0x8DA1294428FB33D"'
+      last-modified: Wed, 30 Mar 2022 21:28:40 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2020-10-02'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem157c26be?restype=container
+    url: https://vincenttrancanary.blob.core.windows.net/filesystem642d279f?restype=container
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:03:21 GMT
+      - Wed, 30 Mar 2022 21:28:40 GMT
       x-ms-version:
       - '2020-10-02'
     method: DELETE
-    uri: https://storagename.blob.core.windows.net/filesystem157c26be?restype=container
+    uri: https://storagename.blob.core.windows.net/filesystem642d279f?restype=container
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:03:19 GMT
+      date: Wed, 30 Mar 2022 21:28:40 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2020-10-02'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem157c26be?restype=container
+    url: https://vincenttrancanary.blob.core.windows.net/filesystem642d279f?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -80,7 +80,7 @@ class FileSystemTest(StorageTestCase):
 
         # Act
         file_system_client = self.dsc.get_file_system_client(file_system_name)
-        created = file_system_client.create_if_not_exists()
+        created = file_system_client.create_file_system_if_not_exists()
 
         # Assert
         self.assertTrue(created)
@@ -95,7 +95,7 @@ class FileSystemTest(StorageTestCase):
         # Act
         file_system_client = self.dsc.get_file_system_client(file_system_name)
         file_system_client.create_file_system()
-        created = file_system_client.create_if_not_exists()
+        created = file_system_client.create_file_system_if_not_exists()
 
         # Assert
         self.assertIsNone(created)

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
@@ -97,24 +97,24 @@ class FileSystemTest(StorageTestCase):
         self.assertTrue(created)
 
     @DataLakePreparer()
-    async def test_create_file_system_async_if_not_exists_without_existing_container(self,
-                                                                                     datalake_storage_account_name,
-                                                                                     datalake_storage_account_key):
+    async def test_create_file_system_async_if_not_exists_without_existing_file_system(self,
+                                                                                       datalake_storage_account_name,
+                                                                                       datalake_storage_account_key):
         self._setUp(datalake_storage_account_name, datalake_storage_account_key)
         # Arrange
         file_system_name = self._get_file_system_reference()
 
         # Act
         file_system_client = self.dsc.get_file_system_client(file_system_name)
-        created = await file_system_client.create_if_not_exists()
+        created = await file_system_client.create_file_system_if_not_exists()
 
         # Assert
         self.assertTrue(created)
 
     @DataLakePreparer()
-    async def test_create_file_system_async_if_not_exists_with_existing_container(self,
-                                                                                  datalake_storage_account_name,
-                                                                                  datalake_storage_account_key):
+    async def test_create_file_system_async_if_not_exists_with_existing_file_system(self,
+                                                                                    datalake_storage_account_name,
+                                                                                    datalake_storage_account_key):
         self._setUp(datalake_storage_account_name, datalake_storage_account_key)
         # Arrange
         file_system_name = self._get_file_system_reference()
@@ -122,7 +122,7 @@ class FileSystemTest(StorageTestCase):
         # Act
         file_system_client = self.dsc.get_file_system_client(file_system_name)
         await file_system_client.create_file_system()
-        created = await file_system_client.create_if_not_exists()
+        created = await file_system_client.create_file_system_if_not_exists()
 
         # Assert
         self.assertIsNone(created)

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 12.8.0b1 (Unreleased)
 
 ### Features Added
-- Added support for `create_if_not_exists()` for `FileShareClient`
+- Added support for `create_share_if_not_exists()` for `FileShareClient`
 
 ### Bugs Fixed
 - Updated `create_share()` docstring to have the correct return-type of `None`

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -392,11 +392,11 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             The timeout parameter is expressed in seconds.
         :keyword protocols:
             Protocols to enable on the share. Only one protocol can be enabled on the share.
-        :keyword protocols: str or ~azure.storage.fileshare.ShareProtocols
+        :paramtype protocols: str or ~azure.storage.fileshare.ShareProtocols
         :keyword root_squash:
             Root squash to set on the share.
             Only valid for NFS shares. Possible values include: 'NoRootSquash', 'RootSquash', 'AllSquash'.
-        :keyword root_squash: str or ~azure.storage.fileshare.ShareRootSquash
+        :paramtype root_squash: str or ~azure.storage.fileshare.ShareRootSquash
         :rtype: None
         """
         try:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -372,7 +372,7 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             process_storage_error(error)
 
     @distributed_trace
-    def create_if_not_exists(self, **kwargs):
+    def create_share_if_not_exists(self, **kwargs):
         # type: (Any) -> None
         """Creates a new Share under the account. If a share with the
         same name already exists, it is not changed.
@@ -384,7 +384,7 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         :keyword access_tier:
             Specifies the access tier of the share.
             Possible values: 'TransactionOptimized', 'Hot', 'Cool'
-        :keyword access_tier: str or ~azure.storage.fileshare.models.ShareAccessTier
+        :paramtype access_tier: str or ~azure.storage.fileshare.models.ShareAccessTier
 
             .. versionadded:: 12.4.0
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -253,11 +253,11 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             The timeout parameter is expressed in seconds.
         :keyword protocols:
             Protocols to enable on the share. Only one protocol can be enabled on the share.
-        :keyword protocols: str or ~azure.storage.fileshare.ShareProtocols
+        :paramtype protocols: str or ~azure.storage.fileshare.ShareProtocols
         :keyword root_squash:
             Root squash to set on the share.
             Only valid for NFS shares. Possible values include: 'NoRootSquash', 'RootSquash', 'AllSquash'.
-        :keyword root_squash: str or ~azure.storage.fileshare.ShareRootSquash
+        :paramtype root_squash: str or ~azure.storage.fileshare.ShareRootSquash
         :rtype: None
         """
         try:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -233,7 +233,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def create_if_not_exists(self, **kwargs):
+    async def create_share_if_not_exists(self, **kwargs):
         # type: (Any) -> None
         """Creates a new Share under the account. If a share with the
         same name already exists, it is not changed.
@@ -245,7 +245,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :keyword access_tier:
             Specifies the access tier of the share.
             Possible values: 'TransactionOptimized', 'Hot', 'Cool'
-        :keyword access_tier: str or ~azure.storage.fileshare.models.ShareAccessTier
+        :paramtype access_tier: str or ~azure.storage.fileshare.models.ShareAccessTier
 
             .. versionadded:: 12.4.0
 

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_share.test_create_share_if_not_exists_with_existing_share.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_share.test_create_share_if_not_exists_with_existing_share.yaml
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:14 GMT
+      - Wed, 30 Mar 2022 21:25:22 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:11 GMT
+      - Wed, 30 Mar 2022 21:25:22 GMT
       etag:
-      - '"0x8DA09111CCCB674"'
+      - '"0x8DA1293CC9CCD86"'
       last-modified:
-      - Fri, 18 Mar 2022 18:57:12 GMT
+      - Wed, 30 Mar 2022 21:25:22 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -49,9 +49,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:14 GMT
+      - Wed, 30 Mar 2022 21:25:23 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -59,14 +59,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ShareAlreadyExists</Code><Message>The
-        specified share already exists.\nRequestId:ccd303b7-501a-0016-12f9-3a2c15000000\nTime:2022-03-18T18:57:12.9408162Z</Message></Error>"
+        specified share already exists.\nRequestId:55d51bdb-c01a-0082-477c-449b7c000000\nTime:2022-03-30T21:25:22.9416841Z</Message></Error>"
     headers:
       content-length:
       - '222'
       content-type:
       - application/xml
       date:
-      - Fri, 18 Mar 2022 18:57:11 GMT
+      - Wed, 30 Mar 2022 21:25:22 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
@@ -86,9 +86,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:14 GMT
+      - Wed, 30 Mar 2022 21:25:23 GMT
       x-ms-version:
       - '2021-04-10'
     method: GET
@@ -96,15 +96,15 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>share21b0199a</Name><Properties><Last-Modified>Fri,
-        18 Mar 2022 18:57:12 GMT</Last-Modified><Etag>\"0x8DA09111CCCB674\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Fri,
-        18 Mar 2022 18:57:12 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
+        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>share21b0199a</Name><Properties><Last-Modified>Wed,
+        30 Mar 2022 21:25:22 GMT</Last-Modified><Etag>\"0x8DA1293CC9CCD86\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Wed,
+        30 Mar 2022 21:25:22 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
         /></EnumerationResults>"
     headers:
       content-type:
       - application/xml
       date:
-      - Fri, 18 Mar 2022 18:57:12 GMT
+      - Wed, 30 Mar 2022 21:25:22 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -126,9 +126,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:14 GMT
+      - Wed, 30 Mar 2022 21:25:23 GMT
       x-ms-delete-snapshots:
       - include
       x-ms-version:
@@ -142,7 +142,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:12 GMT
+      - Wed, 30 Mar 2022 21:25:22 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_share.test_create_share_if_not_exists_without_existing_share.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_share.test_create_share_if_not_exists_without_existing_share.yaml
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:08 GMT
+      - Wed, 30 Mar 2022 21:25:16 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:06 GMT
+      - Wed, 30 Mar 2022 21:25:16 GMT
       etag:
-      - '"0x8DA0911192C0325"'
+      - '"0x8DA1293C8F99CAC"'
       last-modified:
-      - Fri, 18 Mar 2022 18:57:06 GMT
+      - Wed, 30 Mar 2022 21:25:16 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -47,9 +47,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:08 GMT
+      - Wed, 30 Mar 2022 21:25:16 GMT
       x-ms-version:
       - '2021-04-10'
     method: GET
@@ -57,15 +57,15 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>share729d1af2</Name><Properties><Last-Modified>Fri,
-        18 Mar 2022 18:57:06 GMT</Last-Modified><Etag>\"0x8DA0911192C0325\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Fri,
-        18 Mar 2022 18:57:06 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
+        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>share729d1af2</Name><Properties><Last-Modified>Wed,
+        30 Mar 2022 21:25:16 GMT</Last-Modified><Etag>\"0x8DA1293C8F99CAC\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Wed,
+        30 Mar 2022 21:25:16 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
         /></EnumerationResults>"
     headers:
       content-type:
       - application/xml
       date:
-      - Fri, 18 Mar 2022 18:57:06 GMT
+      - Wed, 30 Mar 2022 21:25:16 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -87,9 +87,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:08 GMT
+      - Wed, 30 Mar 2022 21:25:17 GMT
       x-ms-delete-snapshots:
       - include
       x-ms-version:
@@ -103,7 +103,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:06 GMT
+      - Wed, 30 Mar 2022 21:25:17 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_share_async.test_create_share_if_not_exists_with_existing_share.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_share_async.test_create_share_if_not_exists_with_existing_share.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 21 Mar 2022 23:19:58 GMT
+      - Wed, 30 Mar 2022 21:25:37 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -17,9 +17,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Mon, 21 Mar 2022 23:19:59 GMT
-      etag: '"0x8DA0B915176C6A4"'
-      last-modified: Mon, 21 Mar 2022 23:19:59 GMT
+      date: Wed, 30 Mar 2022 21:25:37 GMT
+      etag: '"0x8DA1293D585A5A1"'
+      last-modified: Wed, 30 Mar 2022 21:25:37 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-04-10'
     status:
@@ -32,9 +32,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 21 Mar 2022 23:19:59 GMT
+      - Wed, 30 Mar 2022 21:25:37 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -42,11 +42,11 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ShareAlreadyExists</Code><Message>The
-        specified share already exists.\nRequestId:e6ddc3c7-401a-0078-767a-3d793a000000\nTime:2022-03-21T23:19:59.2038085Z</Message></Error>"
+        specified share already exists.\nRequestId:7b92e011-501a-004b-4c7c-442691000000\nTime:2022-03-30T21:25:37.8804296Z</Message></Error>"
     headers:
       content-length: '222'
       content-type: application/xml
-      date: Mon, 21 Mar 2022 23:19:59 GMT
+      date: Wed, 30 Mar 2022 21:25:37 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code: ShareAlreadyExists
       x-ms-version: '2021-04-10'
@@ -60,9 +60,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 21 Mar 2022 23:19:59 GMT
+      - Wed, 30 Mar 2022 21:25:38 GMT
       x-ms-version:
       - '2021-04-10'
     method: GET
@@ -70,13 +70,13 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>sharec4db1c17</Name><Properties><Last-Modified>Mon,
-        21 Mar 2022 23:19:59 GMT</Last-Modified><Etag>\"0x8DA0B915176C6A4\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Mon,
-        21 Mar 2022 23:19:59 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
+        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>sharec4db1c17</Name><Properties><Last-Modified>Wed,
+        30 Mar 2022 21:25:37 GMT</Last-Modified><Etag>\"0x8DA1293D585A5A1\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Wed,
+        30 Mar 2022 21:25:37 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
         /></EnumerationResults>"
     headers:
       content-type: application/xml
-      date: Mon, 21 Mar 2022 23:19:59 GMT
+      date: Wed, 30 Mar 2022 21:25:37 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2021-04-10'
@@ -90,9 +90,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 21 Mar 2022 23:19:59 GMT
+      - Wed, 30 Mar 2022 21:25:38 GMT
       x-ms-delete-snapshots:
       - include
       x-ms-version:
@@ -104,7 +104,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Mon, 21 Mar 2022 23:19:59 GMT
+      date: Wed, 30 Mar 2022 21:25:37 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-04-10'
     status:

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_share_async.test_create_share_if_not_exists_without_existing_share.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_share_async.test_create_share_if_not_exists_without_existing_share.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 21 Mar 2022 23:18:25 GMT
+      - Wed, 30 Mar 2022 21:25:32 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -17,9 +17,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Mon, 21 Mar 2022 23:18:24 GMT
-      etag: '"0x8DA0B9119BCF17B"'
-      last-modified: Mon, 21 Mar 2022 23:18:25 GMT
+      date: Wed, 30 Mar 2022 21:25:31 GMT
+      etag: '"0x8DA1293D22E738B"'
+      last-modified: Wed, 30 Mar 2022 21:25:32 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-04-10'
     status:
@@ -32,9 +32,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 21 Mar 2022 23:18:25 GMT
+      - Wed, 30 Mar 2022 21:25:32 GMT
       x-ms-version:
       - '2021-04-10'
     method: GET
@@ -42,13 +42,13 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>share1d4e1d6f</Name><Properties><Last-Modified>Mon,
-        21 Mar 2022 23:18:25 GMT</Last-Modified><Etag>\"0x8DA0B9119BCF17B\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Mon,
-        21 Mar 2022 23:18:25 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
+        ServiceEndpoint=\"https://storagename.file.core.windows.net/\"><Shares><Share><Name>share1d4e1d6f</Name><Properties><Last-Modified>Wed,
+        30 Mar 2022 21:25:32 GMT</Last-Modified><Etag>\"0x8DA1293D22E738B\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><Quota>5120</Quota><AccessTier>TransactionOptimized</AccessTier><AccessTierChangeTime>Wed,
+        30 Mar 2022 21:25:32 GMT</AccessTierChangeTime><DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope><DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride></Properties></Share></Shares><NextMarker
         /></EnumerationResults>"
     headers:
       content-type: application/xml
-      date: Mon, 21 Mar 2022 23:18:24 GMT
+      date: Wed, 30 Mar 2022 21:25:31 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2021-04-10'
@@ -62,9 +62,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 21 Mar 2022 23:18:25 GMT
+      - Wed, 30 Mar 2022 21:25:32 GMT
       x-ms-delete-snapshots:
       - include
       x-ms-version:
@@ -76,7 +76,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Mon, 21 Mar 2022 23:18:24 GMT
+      date: Wed, 30 Mar 2022 21:25:31 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-04-10'
     status:

--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -65,9 +65,9 @@ class StorageShareTest(StorageTestCase):
             pass
         return share_client
 
-    def _create_if_not_exists(self, prefix=TEST_SHARE_PREFIX, **kwargs):
+    def _create_share_if_not_exists(self, prefix=TEST_SHARE_PREFIX, **kwargs):
         share_client = self._get_share_reference(prefix)
-        return share_client.create_if_not_exists(**kwargs)
+        return share_client.create_share_if_not_exists(**kwargs)
     
     def _delete_shares(self, prefix=TEST_SHARE_PREFIX):
         for l in self.fsc.list_shares(include_snapshots=True):
@@ -104,7 +104,7 @@ class StorageShareTest(StorageTestCase):
         share = self._get_share_reference()
 
         # Act
-        created = self._create_if_not_exists()
+        created = self._create_share_if_not_exists()
 
         # Assert
         self.assertTrue(created)
@@ -117,7 +117,7 @@ class StorageShareTest(StorageTestCase):
 
         # Act
         self._create_share()
-        created = self._create_if_not_exists()
+        created = self._create_share_if_not_exists()
 
         # Assert
         self.assertIsNone(created)

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -109,7 +109,7 @@ class StorageShareTest(AsyncStorageTestCase):
         share = self._get_share_reference()
 
         # Act
-        created = await share.create_if_not_exists()
+        created = await share.create_share_if_not_exists()
 
         # Assert
         self.assertTrue(created)
@@ -123,7 +123,7 @@ class StorageShareTest(AsyncStorageTestCase):
 
         # Act
         await share.create_share()
-        created = await share.create_if_not_exists()
+        created = await share.create_share_if_not_exists()
 
         # Assert
         self.assertIsNone(created)

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 12.3.0b1 (Unreleased)
 
 ### Features Added
-- Added support for `create_if_not_exists()` for `QueueClient`
+- Added support for `create_queue_if_not_exists()` for `QueueClient`
 
 ## 12.2.0 (2022-03-08)
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -243,7 +243,7 @@ class QueueClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def create_if_not_exists(self, **kwargs):
+    def create_queue_if_not_exists(self, **kwargs):
         # type: (Any) -> None
         """Creates a new queue in the storage account.
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -155,7 +155,7 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def create_if_not_exists(self, **kwargs):
+    async def create_queue_if_not_exists(self, **kwargs):
         # type: (Any) -> None
         """Creates a new queue in the storage account.
 

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_create_queue_if_not_exists_with_existing_queue.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_create_queue_if_not_exists_with_existing_queue.yaml
@@ -11,13 +11,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-queue/12.2.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-queue/12.3.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:02 GMT
+      - Wed, 30 Mar 2022 21:29:34 GMT
       x-ms-version:
       - '2021-02-12'
     method: PUT
-    uri: https://storagename.queue.core.windows.net/pyqueuesync93511b6e
+    uri: https://storagename.queue.core.windows.net/pyqueuesync287019d0
   response:
     body:
       string: ''
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:00 GMT
+      - Wed, 30 Mar 2022 21:29:34 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -45,13 +45,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-queue/12.2.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-queue/12.3.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:57:02 GMT
+      - Wed, 30 Mar 2022 21:29:35 GMT
       x-ms-version:
       - '2021-02-12'
     method: PUT
-    uri: https://storagename.queue.core.windows.net/pyqueuesync93511b6e
+    uri: https://storagename.queue.core.windows.net/pyqueuesync287019d0
   response:
     body:
       string: ''
@@ -59,7 +59,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:57:00 GMT
+      - Wed, 30 Mar 2022 21:29:34 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_create_queue_if_not_exists_without_existing_queue.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_create_queue_if_not_exists_without_existing_queue.yaml
@@ -11,13 +11,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-queue/12.2.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-queue/12.3.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 18:56:55 GMT
+      - Wed, 30 Mar 2022 21:29:30 GMT
       x-ms-version:
       - '2021-02-12'
     method: PUT
-    uri: https://storagename.queue.core.windows.net/pyqueuesyncea0a1cc6
+    uri: https://storagename.queue.core.windows.net/pyqueuesync79c91b28
   response:
     body:
       string: ''
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Mar 2022 18:56:53 GMT
+      - Wed, 30 Mar 2022 21:29:30 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_create_queue_if_not_exists_with_existing_queue.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_create_queue_if_not_exists_with_existing_queue.yaml
@@ -5,48 +5,48 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-queue/12.2.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-queue/12.3.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:02:39 GMT
+      - Wed, 30 Mar 2022 21:30:20 GMT
       x-ms-version:
       - '2021-02-12'
     method: PUT
-    uri: https://storagename.queue.core.windows.net/pyqueueasync40eb1deb
+    uri: https://storagename.queue.core.windows.net/pyqueueasynccc071c4d
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:02:37 GMT
+      date: Wed, 30 Mar 2022 21:30:20 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-02-12'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.queue.core.windows.net/pyqueueasync40eb1deb
+    url: https://vincenttrancanary.queue.core.windows.net/pyqueueasynccc071c4d
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-queue/12.2.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-queue/12.3.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:02:39 GMT
+      - Wed, 30 Mar 2022 21:30:20 GMT
       x-ms-version:
       - '2021-02-12'
     method: PUT
-    uri: https://storagename.queue.core.windows.net/pyqueueasync40eb1deb
+    uri: https://storagename.queue.core.windows.net/pyqueueasynccc071c4d
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:02:38 GMT
+      date: Wed, 30 Mar 2022 21:30:20 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-02-12'
     status:
       code: 204
       message: No Content
-    url: https://vincenttrancanary.queue.core.windows.net/pyqueueasync40eb1deb
+    url: https://vincenttrancanary.queue.core.windows.net/pyqueueasynccc071c4d
 version: 1

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_create_queue_if_not_exists_without_existing_queue.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_create_queue_if_not_exists_without_existing_queue.yaml
@@ -5,23 +5,23 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-queue/12.2.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-queue/12.3.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Mar 2022 19:02:39 GMT
+      - Wed, 30 Mar 2022 21:30:20 GMT
       x-ms-version:
       - '2021-02-12'
     method: PUT
-    uri: https://storagename.queue.core.windows.net/pyqueueasync9f1b1f43
+    uri: https://storagename.queue.core.windows.net/pyqueueasync24e61da5
   response:
     body:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 18 Mar 2022 19:02:38 GMT
+      date: Wed, 30 Mar 2022 21:30:20 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-02-12'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.queue.core.windows.net/pyqueueasync9f1b1f43
+    url: https://vincenttrancanary.queue.core.windows.net/pyqueueasync24e61da5
 version: 1

--- a/sdk/storage/azure-storage-queue/tests/test_queue.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue.py
@@ -71,22 +71,22 @@ class StorageQueueTest(StorageTestCase):
         self.assertTrue(created)
 
     @QueuePreparer()
-    def test_create_queue_if_not_exists_without_existing_container(self, storage_account_name, storage_account_key):
+    def test_create_queue_if_not_exists_without_existing_queue(self, storage_account_name, storage_account_key):
         # Action
         qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key)
         queue_client = self._get_queue_reference(qsc)
-        created = queue_client.create_if_not_exists()
+        created = queue_client.create_queue_if_not_exists()
 
         # Asserts
         self.assertTrue(created)
 
     @QueuePreparer()
-    def test_create_queue_if_not_exists_with_existing_container(self, storage_account_name, storage_account_key):
+    def test_create_queue_if_not_exists_with_existing_queue(self, storage_account_name, storage_account_key):
         # Action
         qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key)
         queue_client = self._get_queue_reference(qsc)
         queue_client.create_queue()
-        created = queue_client.create_if_not_exists()
+        created = queue_client.create_queue_if_not_exists()
 
         # Asserts
         self.assertIsNone(created)

--- a/sdk/storage/azure-storage-queue/tests/test_queue_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_async.py
@@ -82,23 +82,23 @@ class StorageQueueTestAsync(AsyncStorageTestCase):
 
     @QueuePreparer()
     @AsyncStorageTestCase.await_prepared_test
-    async def test_create_queue_if_not_exists_without_existing_container(self, storage_account_name, storage_account_key):
+    async def test_create_queue_if_not_exists_without_existing_queue(self, storage_account_name, storage_account_key):
         # Action
         qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key, transport=AiohttpTestTransport())
         queue_client = self._get_queue_reference(qsc)
-        created = await queue_client.create_if_not_exists()
+        created = await queue_client.create_queue_if_not_exists()
 
         # Asserts
         self.assertTrue(created)
 
     @QueuePreparer()
     @AsyncStorageTestCase.await_prepared_test
-    async def test_create_queue_if_not_exists_with_existing_container(self, storage_account_name, storage_account_key):
+    async def test_create_queue_if_not_exists_with_existing_queue(self, storage_account_name, storage_account_key):
         # Action
         qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key, transport=AiohttpTestTransport())
         queue_client = self._get_queue_reference(qsc)
         await queue_client.create_queue()
-        created = await queue_client.create_if_not_exists()
+        created = await queue_client.create_queue_if_not_exists()
 
         # Asserts
         self.assertIsNone(created)


### PR DESCRIPTION
This PR aims to address the following that was introduced in a previous PR #23574.

1. View API unable to generate some paramtypes properly
2. Change naming of `create_if_not_exists()` method to `create_<lib_object>_if_not_exists()` to increase clarity