### PR TITLE
include py.typed in azure-template

### DIFF
--- a/sdk/template/azure-template/MANIFEST.in
+++ b/sdk/template/azure-template/MANIFEST.in
@@ -3,3 +3,4 @@ include *.md
 include azure/__init__.py
 recursive-include tests *.py
 recursive-include samples *.py
+include azure/template/py.typed


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/23735

This helps mypy recognize the type hints in a package. Adding to template package so anyone copying this will get it for free.