### PR TITLE
Use docker validation for daily onboarding

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -81,6 +81,7 @@ jobs:
           arguments: >-
             -DocRepoLocation $(DocRepoLocation)
             -PackageSourceOverride "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
+            -ImageId '$(DocValidationImageId)'
         displayName: Update Docs Onboarding for Daily branch
 
       - task: Powershell@2


### PR DESCRIPTION
This was previously letting packages through. See this metapackage which got let in: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1472811&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=61cf404c-fb38-582c-ffd7-16eb9e7ec7ac&l=826