### PR TITLE
[Storage] Fix Empty Headers in File Share and Data Lake

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_serialize.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_serialize.py
@@ -45,6 +45,8 @@ def convert_datetime_to_rfc1123(date):
 
 def add_metadata_headers(metadata=None):
     # type: (Optional[Dict[str, str]]) -> str
+    if not metadata:
+        return None
     headers = list()
     if metadata:
         for key, value in metadata.items():

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,35 +11,29 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.0.0b1 Python/3.7.3 (Windows-10-10.0.18362-SP0)
-      x-ms-client-request-id:
-      - d4973a7a-ff4f-11e9-b0b3-001a7dda7113
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 04 Nov 2019 22:09:54 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:28:41 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-10-02'
     method: PUT
-    uri: https://storagename.dfs.core.windows.net/filesystem8e670a80/directory8e670a80?resource=directory
+    uri: https://storagename.blob.core.windows.net/filesystem8e670a80?restype=container&timeout=5
   response:
     body:
       string: ''
     headers:
-      Content-Length:
+      content-length:
       - '0'
-      Date:
-      - Mon, 04 Nov 2019 22:09:54 GMT
-      ETag:
-      - '"0x8D76173B8F086E9"'
-      Last-Modified:
-      - Mon, 04 Nov 2019 22:09:54 GMT
-      Server:
-      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id:
-      - 5e64d340-701f-0005-0f5c-939f4f000000
+      date:
+      - Fri, 01 Apr 2022 21:28:40 GMT
+      etag:
+      - '"0x8DA142697785900"'
+      last-modified:
+      - Fri, 01 Apr 2022 21:28:40 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2020-10-02'
     status:
       code: 201
       message: Created
@@ -47,7 +41,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -55,36 +49,106 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.0.0b1 Python/3.7.3 (Windows-10-10.0.18362-SP0)
-      x-ms-client-request-id:
-      - d4c4e086-ff4f-11e9-aa83-001a7dda7113
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 04 Nov 2019 22:09:54 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:28:41 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-10-02'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesystem8e670a80/directory8e670a80?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 01 Apr 2022 21:28:41 GMT
+      etag:
+      - '"0x8DA142697EE3285"'
+      last-modified:
+      - Fri, 01 Apr 2022 21:28:41 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 01 Apr 2022 21:28:42 GMT
+      x-ms-version:
+      - '2020-10-02'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem8e670a80/directory8e670a80%2Ffilename?resource=file
   response:
     body:
       string: ''
     headers:
-      Content-Length:
+      content-length:
       - '0'
-      Date:
-      - Mon, 04 Nov 2019 22:09:54 GMT
-      ETag:
-      - '"0x8D76173B900C670"'
-      Last-Modified:
-      - Mon, 04 Nov 2019 22:09:54 GMT
-      Server:
+      date:
+      - Fri, 01 Apr 2022 21:28:41 GMT
+      etag:
+      - '"0x8DA142697FBEC26"'
+      last-modified:
+      - Fri, 01 Apr 2022 21:28:41 GMT
+      server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id:
-      - 5e64d341-701f-0005-105c-939f4f000000
+      x-ms-request-server-encrypted:
+      - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2020-10-02'
     status:
       code: 201
       message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 01 Apr 2022 21:28:42 GMT
+      x-ms-version:
+      - '2020-10-02'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystem8e670a80?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 01 Apr 2022 21:28:41 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 202
+      message: Accepted
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_file_exists.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_file_exists.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,35 +11,29 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - 8b3c6806-6d94-11eb-8ce0-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:29:04 GMT
       x-ms-version:
-      - '2020-02-10'
+      - '2020-10-02'
     method: PUT
-    uri: https://storagename.dfs.core.windows.net/filesystem8ebf0aac/directory8ebf0aac?resource=directory
+    uri: https://storagename.blob.core.windows.net/filesystem8ebf0aac?restype=container&timeout=5
   response:
     body:
       string: ''
     headers:
-      Content-Length:
+      content-length:
       - '0'
-      Date:
-      - Sat, 13 Feb 2021 00:43:51 GMT
-      ETag:
-      - '"0x8D8CFB86FA2ADD0"'
-      Last-Modified:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      Server:
-      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id:
-      - a55bcdb1-901f-00db-42a1-010c61000000
+      date:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      etag:
+      - '"0x8DA1426A564EB68"'
+      last-modified:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2020-02-10'
+      - '2020-10-02'
     status:
       code: 201
       message: Created
@@ -55,35 +49,71 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - 8b6e509d-6d94-11eb-a8ab-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:29:04 GMT
       x-ms-version:
-      - '2020-02-10'
+      - '2020-10-02'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesystem8ebf0aac/directory8ebf0aac?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      etag:
+      - '"0x8DA1426A5C0D7FA"'
+      last-modified:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 01 Apr 2022 21:29:05 GMT
+      x-ms-version:
+      - '2020-10-02'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem8ebf0aac/directory8ebf0aac%2Ffilename?resource=file
   response:
     body:
       string: ''
     headers:
-      Content-Length:
+      content-length:
       - '0'
-      Date:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      ETag:
-      - '"0x8D8CFB86FAF6634"'
-      Last-Modified:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      Server:
+      date:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      etag:
+      - '"0x8DA1426A5CF7BDC"'
+      last-modified:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id:
-      - a55bcdb9-901f-00db-4aa1-010c61000000
+      x-ms-request-server-encrypted:
+      - 'true'
       x-ms-version:
-      - '2020-02-10'
+      - '2020-10-02'
     status:
       code: 201
       message: Created
@@ -97,34 +127,30 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - 8b7afa0e-6d94-11eb-b96b-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      x-ms-encryption-algorithm:
-      - AES256
+      - Fri, 01 Apr 2022 21:29:05 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystem8ebf0aac/directory8ebf0aac/filename
   response:
     body:
       string: ''
     headers:
-      Accept-Ranges:
+      accept-ranges:
       - bytes
-      Content-Length:
+      content-length:
       - '0'
-      Content-Type:
+      content-type:
       - application/octet-stream
-      Date:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      ETag:
-      - '"0x8D8CFB86FAF6634"'
-      Last-Modified:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      Server:
+      date:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      etag:
+      - '"0x8DA1426A5CF7BDC"'
+      last-modified:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
       - Hot
@@ -133,23 +159,15 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      x-ms-group:
-      - $superuser
+      - Fri, 01 Apr 2022 21:29:04 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
-      x-ms-owner:
-      - $superuser
-      x-ms-permissions:
-      - rw-r-----
-      x-ms-request-id:
-      - 430eeb87-701e-008e-3ba1-011cea000000
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     status:
       code: 200
       message: OK
@@ -163,34 +181,62 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - 8ba2cd58-6d94-11eb-8c8b-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:43:53 GMT
-      x-ms-encryption-algorithm:
-      - AES256
+      - Fri, 01 Apr 2022 21:29:05 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystem8ebf0aac/directory8ebf0aac/nonexistentfile
   response:
     body:
       string: ''
     headers:
-      Date:
-      - Sat, 13 Feb 2021 00:43:52 GMT
-      Server:
+      date:
+      - Fri, 01 Apr 2022 21:29:04 GMT
+      server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
       x-ms-error-code:
       - BlobNotFound
-      x-ms-request-id:
-      - 430eebc7-701e-008e-73a1-011cea000000
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     status:
       code: 404
       message: The specified blob does not exist.
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 01 Apr 2022 21:29:05 GMT
+      x-ms-version:
+      - '2020-10-02'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystem8ebf0aac?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 01 Apr 2022 21:29:05 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 202
+      message: Accepted
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_async.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_async.yaml
@@ -2,189 +2,109 @@ interactions:
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.0.0b7 Python/3.7.3 (Windows-10-10.0.18362-SP0)
-      x-ms-client-request-id:
-      - 417f25f4-3cb9-11ea-adf4-001a7dda7113
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 22 Jan 2020 01:48:15 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:29:16 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-10-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystem2e5b0f7a?restype=container&timeout=5
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:15 GMT
+      etag: '"0x8DA1426AC962F7A"'
+      last-modified: Fri, 01 Apr 2022 21:29:16 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2020-10-02'
+    status:
+      code: 201
+      message: Created
+    url: https://vincenttrancanary.blob.core.windows.net/filesystem2e5b0f7a?restype=container&timeout=5
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 01 Apr 2022 21:29:17 GMT
+      x-ms-version:
+      - '2020-10-02'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem2e5b0f7a/directory2e5b0f7a?resource=directory
   response:
     body:
       string: ''
     headers:
-      ? !!python/object/new:multidict._multidict.istr
-      - Content-Length
-      : '0'
-      ? !!python/object/new:multidict._multidict.istr
-      - Date
-      : Wed, 22 Jan 2020 01:48:15 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Etag
-      : '"0x8D79EDD25C35352"'
-      ? !!python/object/new:multidict._multidict.istr
-      - Last-Modified
-      : Wed, 22 Jan 2020 01:48:15 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Server
-      : Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id: 4fcc3549-b01f-0035-3ac6-d02180000000
-      x-ms-version: '2019-02-02'
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:16 GMT
+      etag: '"0x8DA1426ACC10AC8"'
+      last-modified: Fri, 01 Apr 2022 21:29:16 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2020-10-02'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - xiafuhns.dfs.core.windows.net
-        - /filesystem2e5b0f7a/directory2e5b0f7a
-        - resource=directory
-        - ''
+    url: https://vincenttrancanary.dfs.core.windows.net/filesystem2e5b0f7a/directory2e5b0f7a?resource=directory
 - request:
     body: null
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.0.0b7 Python/3.7.3 (Windows-10-10.0.18362-SP0)
-      x-ms-client-request-id:
-      - 419e9eae-3cb9-11ea-bd72-001a7dda7113
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 22 Jan 2020 01:48:15 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:29:17 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2020-10-02'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem2e5b0f7a/directory2e5b0f7a%2Ffilename?resource=file
   response:
     body:
       string: ''
     headers:
-      ? !!python/object/new:multidict._multidict.istr
-      - Content-Length
-      : '0'
-      ? !!python/object/new:multidict._multidict.istr
-      - Date
-      : Wed, 22 Jan 2020 01:48:15 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Etag
-      : '"0x8D79EDD25CD0634"'
-      ? !!python/object/new:multidict._multidict.istr
-      - Last-Modified
-      : Wed, 22 Jan 2020 01:48:15 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Server
-      : Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id: 4fcc354a-b01f-0035-3bc6-d02180000000
-      x-ms-version: '2019-02-02'
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:16 GMT
+      etag: '"0x8DA1426ACCCC8E2"'
+      last-modified: Fri, 01 Apr 2022 21:29:16 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2020-10-02'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - xiafuhns.dfs.core.windows.net
-        - /filesystem2e5b0f7a/directory2e5b0f7a%2Ffilename
-        - resource=file
-        - ''
+    url: https://vincenttrancanary.dfs.core.windows.net/filesystem2e5b0f7a/directory2e5b0f7a%2Ffilename?resource=file
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.0.1 Python/3.7.3 (Windows-10-10.0.18362-SP0)
-      x-ms-client-request-id:
-      - e7b356ae-7926-11ea-b205-001a7dda7113
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 07 Apr 2020 23:24:19 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:29:17 GMT
       x-ms-version:
-      - '2019-02-02'
-    method: PUT
-    uri: https://storagename.dfs.core.windows.net/filesystem2e5b0f7a/directory2e5b0f7a?resource=directory
+      - '2020-10-02'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystem2e5b0f7a?restype=container
   response:
     body:
       string: ''
     headers:
-      ? !!python/object/new:multidict._multidict.istr
-      - Content-Length
-      : '0'
-      ? !!python/object/new:multidict._multidict.istr
-      - Date
-      : Tue, 07 Apr 2020 23:24:18 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Etag
-      : '"0x8D7DB4ACBF989BF"'
-      ? !!python/object/new:multidict._multidict.istr
-      - Last-Modified
-      : Tue, 07 Apr 2020 23:24:19 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Server
-      : Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id: 0ef746d7-101f-004e-4733-0d631c000000
-      x-ms-version: '2019-02-02'
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:16 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2020-10-02'
     status:
-      code: 201
-      message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - xiafuhns.dfs.core.windows.net
-        - /filesystem2e5b0f7a/directory2e5b0f7a
-        - resource=directory
-        - ''
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-storage-dfs/12.0.1 Python/3.7.3 (Windows-10-10.0.18362-SP0)
-      x-ms-client-request-id:
-      - e7d0b486-7926-11ea-84d2-001a7dda7113
-      x-ms-date:
-      - Tue, 07 Apr 2020 23:24:19 GMT
-      x-ms-properties:
-      - ''
-      x-ms-version:
-      - '2019-02-02'
-    method: PUT
-    uri: https://storagename.dfs.core.windows.net/filesystem2e5b0f7a/directory2e5b0f7a%2Ffilename?resource=file
-  response:
-    body:
-      string: ''
-    headers:
-      ? !!python/object/new:multidict._multidict.istr
-      - Content-Length
-      : '0'
-      ? !!python/object/new:multidict._multidict.istr
-      - Date
-      : Tue, 07 Apr 2020 23:24:18 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Etag
-      : '"0x8D7DB4ACC01D5DB"'
-      ? !!python/object/new:multidict._multidict.istr
-      - Last-Modified
-      : Tue, 07 Apr 2020 23:24:19 GMT
-      ? !!python/object/new:multidict._multidict.istr
-      - Server
-      : Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id: 0ef746d8-101f-004e-4833-0d631c000000
-      x-ms-version: '2019-02-02'
-    status:
-      code: 201
-      message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - xiafuhns.dfs.core.windows.net
-        - /filesystem2e5b0f7a/directory2e5b0f7a%2Ffilename
-        - resource=file
-        - ''
+      code: 202
+      message: Accepted
+    url: https://vincenttrancanary.blob.core.windows.net/filesystem2e5b0f7a?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_file_exists.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_file_exists.yaml
@@ -3,139 +3,170 @@ interactions:
     body: null
     headers:
       Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 01 Apr 2022 21:29:25 GMT
+      x-ms-version:
+      - '2020-10-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystemd8210d29?restype=container&timeout=5
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:44 GMT
+      etag: '"0x8DA1426BDB5608A"'
+      last-modified: Fri, 01 Apr 2022 21:29:45 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2020-10-02'
+    status:
+      code: 201
+      message: Created
+    url: https://vincenttrancanary.blob.core.windows.net/filesystemd8210d29?restype=container&timeout=5
+- request:
+    body: null
+    headers:
+      Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - efaedac6-6d95-11eb-9bc1-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:53:50 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:29:45 GMT
       x-ms-version:
-      - '2020-02-10'
+      - '2020-10-02'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystemd8210d29/directoryd8210d29?resource=directory
   response:
     body:
       string: ''
     headers:
-      Content-Length: '0'
-      Date: Sat, 13 Feb 2021 00:53:49 GMT
-      ETag: '"0x8D8CFB9D41CFDA5"'
-      Last-Modified: Sat, 13 Feb 2021 00:53:50 GMT
-      Server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id: 55a13272-a01f-009d-80a2-0138e6000000
-      x-ms-version: '2020-02-10'
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:45 GMT
+      etag: '"0x8DA1426BDF2D8E5"'
+      last-modified: Fri, 01 Apr 2022 21:29:45 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2020-10-02'
     status:
       code: 201
       message: Created
-    url: https://seanprodhierarchical.dfs.core.windows.net/filesystemd8210d29/directoryd8210d29?resource=directory
+    url: https://vincenttrancanary.dfs.core.windows.net/filesystemd8210d29/directoryd8210d29?resource=directory
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - efe889a0-6d95-11eb-bda1-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:53:50 GMT
-      x-ms-properties:
-      - ''
+      - Fri, 01 Apr 2022 21:29:46 GMT
       x-ms-version:
-      - '2020-02-10'
+      - '2020-10-02'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystemd8210d29/directoryd8210d29%2Ffilename?resource=file
   response:
     body:
       string: ''
     headers:
-      Content-Length: '0'
-      Date: Sat, 13 Feb 2021 00:53:49 GMT
-      ETag: '"0x8D8CFB9D420F58B"'
-      Last-Modified: Sat, 13 Feb 2021 00:53:50 GMT
-      Server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-id: 55a13276-a01f-009d-04a2-0138e6000000
-      x-ms-version: '2020-02-10'
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:45 GMT
+      etag: '"0x8DA1426BDFDFADA"'
+      last-modified: Fri, 01 Apr 2022 21:29:45 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2020-10-02'
     status:
       code: 201
       message: Created
-    url: https://seanprodhierarchical.dfs.core.windows.net/filesystemd8210d29/directoryd8210d29%2Ffilename?resource=file
+    url: https://vincenttrancanary.dfs.core.windows.net/filesystemd8210d29/directoryd8210d29%2Ffilename?resource=file
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - efec3311-6d95-11eb-968f-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:53:50 GMT
-      x-ms-encryption-algorithm:
-      - AES256
+      - Fri, 01 Apr 2022 21:29:46 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystemd8210d29/directoryd8210d29/filename
   response:
     body:
       string: ''
     headers:
-      Accept-Ranges: bytes
-      Content-Length: '0'
-      Content-Type: application/octet-stream
-      Date: Sat, 13 Feb 2021 00:53:50 GMT
-      ETag: '"0x8D8CFB9D420F58B"'
-      Last-Modified: Sat, 13 Feb 2021 00:53:50 GMT
-      Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      accept-ranges: bytes
+      content-length: '0'
+      content-type: application/octet-stream
+      date: Fri, 01 Apr 2022 21:29:45 GMT
+      etag: '"0x8DA1426BDFDFADA"'
+      last-modified: Fri, 01 Apr 2022 21:29:45 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Sat, 13 Feb 2021 00:53:50 GMT
-      x-ms-group: $superuser
+      x-ms-creation-time: Fri, 01 Apr 2022 21:29:45 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
-      x-ms-owner: $superuser
-      x-ms-permissions: rw-r-----
-      x-ms-request-id: 266f3dd6-a01e-00a2-34a2-01f045000000
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-06-12'
+      x-ms-version: '2020-10-02'
     status:
       code: 200
       message: OK
-    url: https://seanprodhierarchical.blob.core.windows.net/filesystemd8210d29/directoryd8210d29/filename
+    url: https://vincenttrancanary.blob.core.windows.net/filesystemd8210d29/directoryd8210d29/filename
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.3.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-client-request-id:
-      - efef6773-6d95-11eb-8bf7-c8348e5fffbf
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 13 Feb 2021 00:53:50 GMT
-      x-ms-encryption-algorithm:
-      - AES256
+      - Fri, 01 Apr 2022 21:29:46 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystemd8210d29/directoryd8210d29/nonexistentfile
   response:
     body:
       string: ''
     headers:
-      Date: Sat, 13 Feb 2021 00:53:50 GMT
-      Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      Transfer-Encoding: chunked
+      date: Fri, 01 Apr 2022 21:29:45 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
       x-ms-error-code: BlobNotFound
-      x-ms-request-id: 266f3dda-a01e-00a2-38a2-01f045000000
-      x-ms-version: '2020-06-12'
+      x-ms-version: '2020-10-02'
     status:
       code: 404
       message: The specified blob does not exist.
-    url: https://seanprodhierarchical.blob.core.windows.net/filesystemd8210d29/directoryd8210d29/nonexistentfile
+    url: https://vincenttrancanary.blob.core.windows.net/filesystemd8210d29/directoryd8210d29/nonexistentfile
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 01 Apr 2022 21:29:46 GMT
+      x-ms-version:
+      - '2020-10-02'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystemd8210d29?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Fri, 01 Apr 2022 21:29:45 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2020-10-02'
+    status:
+      code: 202
+      message: Accepted
+    url: https://vincenttrancanary.blob.core.windows.net/filesystemd8210d29?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
@@ -39,4 +39,6 @@ def _parse_datetime_from_str(string_datetime):
 
 
 def _datetime_to_str(datetime_obj):
+    if not datetime_obj:
+        return None
     return datetime_obj if isinstance(datetime_obj, str) else datetime_obj.isoformat() + '0Z'

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
@@ -102,8 +102,8 @@ def get_smb_properties(kwargs):
     file_permission = kwargs.pop('file_permission', None)
     file_permission_key = kwargs.pop('permission_key', None)
     file_attributes = kwargs.pop('file_attributes', None)
-    file_creation_time = kwargs.pop('file_creation_time', None) or ""
-    file_last_write_time = kwargs.pop('file_last_write_time', None) or ""
+    file_creation_time = kwargs.pop('file_creation_time', None)
+    file_last_write_time = kwargs.pop('file_last_write_time', None)
 
     file_permission_copy_mode = None
     file_permission = _get_file_permission(file_permission, file_permission_key, None)

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_existing_file_with_lease.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_existing_file_with_lease.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:12 GMT
+      - Fri, 01 Apr 2022 02:17:19 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare969c1215?restype=share
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:14:12 GMT
+      - Fri, 01 Apr 2022 02:17:18 GMT
       etag:
-      - '"0x8D7A3B0E9FC314D"'
+      - '"0x8DA1385BFC6278F"'
       last-modified:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:19 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:19 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -65,7 +65,7 @@ interactions:
       x-ms-type:
       - file
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare969c1215/file969c1215
   response:
@@ -75,31 +75,31 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:18 GMT
       etag:
-      - '"0x8D7A3B0EA151B79"'
+      - '"0x8DA1385BFD9504A"'
       last-modified:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:19 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:14:13.3037945Z'
+      - '2022-04-01T02:17:19.6614730Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:14:13.3037945Z'
+      - '2022-04-01T02:17:19.6614730Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:14:13.3037945Z'
+      - '2022-04-01T02:17:19.6614730Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -107,7 +107,7 @@ interactions:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -117,13 +117,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:19 GMT
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
       x-ms-write:
       - update
     method: PUT
@@ -137,17 +137,17 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:18 GMT
       etag:
-      - '"0x8D7A3B0EA2C03B8"'
+      - '"0x8DA1385BFE61FA4"'
       last-modified:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:19 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -155,7 +155,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -163,11 +163,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:20 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -179,7 +179,7 @@ interactions:
       x-ms-type:
       - file
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare969c1215/file1copy
   response:
@@ -189,31 +189,31 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:14:13 GMT
+      - Fri, 01 Apr 2022 02:17:19 GMT
       etag:
-      - '"0x8D7A3B0EA91E1E0"'
+      - '"0x8DA1385C018C0E6"'
       last-modified:
-      - Tue, 28 Jan 2020 05:14:14 GMT
+      - Fri, 01 Apr 2022 02:17:20 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:14:14.1215200Z'
+      - '2022-04-01T02:17:20.0772326Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:14:14.1215200Z'
+      - '2022-04-01T02:17:20.0772326Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:14:14.1215200Z'
+      - '2022-04-01T02:17:20.0772326Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -221,7 +221,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -229,17 +229,17 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:14 GMT
+      - Fri, 01 Apr 2022 02:17:20 GMT
       x-ms-lease-action:
       - acquire
       x-ms-lease-duration:
       - '-1'
       x-ms-proposed-lease-id:
-      - 6c2262e1-52a3-45f2-9470-821a469722b4
+      - b7e1f71a-0335-4a57-a93f-a3d604f96b09
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare969c1215/file1copy?comp=lease
   response:
@@ -247,19 +247,19 @@ interactions:
       string: ''
     headers:
       date:
-      - Tue, 28 Jan 2020 05:14:14 GMT
+      - Fri, 01 Apr 2022 02:17:20 GMT
       etag:
-      - '"0x8D7A3B0EA91E1E0"'
+      - '"0x8DA1385C018C0E6"'
       last-modified:
-      - Tue, 28 Jan 2020 05:14:14 GMT
+      - Fri, 01 Apr 2022 02:17:20 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-lease-id:
-      - 6c2262e1-52a3-45f2-9470-821a469722b4
+      - b7e1f71a-0335-4a57-a93f-a3d604f96b09
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -267,7 +267,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -275,36 +275,32 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utshare969c1215/file969c1215
+      - https://vincenttrancanary.file.core.windows.net/utshare969c1215/file969c1215
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:14 GMT
-      x-ms-file-creation-time:
-      - ''
-      x-ms-file-last-write-time:
-      - ''
+      - Fri, 01 Apr 2022 02:17:20 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare969c1215/file1copy
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>LeaseIdMissing</Code><Message>There
-        is currently a lease on the file and no lease ID was specified in the request.\nRequestId:8429d098-a01a-000f-7f99-d5e457000000\nTime:2020-01-28T05:14:14.8870479Z</Message></Error>"
+        is currently a lease on the file and no lease ID was specified in the request.\nRequestId:2951facd-601a-008b-4b6e-45deaf000000\nTime:2022-04-01T02:17:21.1107750Z</Message></Error>"
     headers:
       content-length:
       - '267'
       content-type:
       - application/xml
       date:
-      - Tue, 28 Jan 2020 05:14:14 GMT
+      - Fri, 01 Apr 2022 02:17:20 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
       - LeaseIdMissing
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 412
       message: There is currently a lease on the file and no lease ID was specified
@@ -313,7 +309,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -321,19 +317,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utshare969c1215/file969c1215
+      - https://vincenttrancanary.file.core.windows.net/utshare969c1215/file969c1215
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:14 GMT
-      x-ms-file-creation-time:
-      - ''
-      x-ms-file-last-write-time:
-      - ''
+      - Fri, 01 Apr 2022 02:17:21 GMT
       x-ms-lease-id:
-      - 6c2262e1-52a3-45f2-9470-821a469722b4
+      - b7e1f71a-0335-4a57-a93f-a3d604f96b09
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare969c1215/file1copy
   response:
@@ -343,19 +335,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:14:14 GMT
+      - Fri, 01 Apr 2022 02:17:21 GMT
       etag:
-      - '"0x8D7A3B0EB1ED9CE"'
+      - '"0x8DA1385C0C4ECE5"'
       last-modified:
-      - Tue, 28 Jan 2020 05:14:15 GMT
+      - Fri, 01 Apr 2022 02:17:21 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-id:
-      - bd1020b3-1da1-4674-9d61-82e70852b3f5
+      - 17edbd66-4f7c-491b-a7a9-fe8592cc58eb
       x-ms-copy-status:
       - success
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 202
       message: Accepted
@@ -369,13 +361,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:14:15 GMT
+      - Fri, 01 Apr 2022 02:17:21 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: GET
     uri: https://storagename.file.core.windows.net/utshare969c1215/file1copy
   response:
@@ -391,37 +383,37 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 28 Jan 2020 05:14:14 GMT
+      - Fri, 01 Apr 2022 02:17:21 GMT
       etag:
-      - '"0x8D7A3B0EB1ED9CE"'
+      - '"0x8DA1385C0C4ECE5"'
       last-modified:
-      - Tue, 28 Jan 2020 05:14:15 GMT
+      - Fri, 01 Apr 2022 02:17:21 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Tue, 28 Jan 2020 05:14:15 GMT
+      - Fri, 01 Apr 2022 02:17:21 GMT
       x-ms-copy-id:
-      - bd1020b3-1da1-4674-9d61-82e70852b3f5
+      - 17edbd66-4f7c-491b-a7a9-fe8592cc58eb
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utshare969c1215/file969c1215
+      - https://vincenttrancanary.file.core.windows.net/utshare969c1215/file969c1215
       x-ms-copy-status:
       - success
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:14:15.0453710Z'
+      - '2022-04-01T02:17:21.2055781Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:14:15.0453710Z'
+      - '2022-04-01T02:17:21.2055781Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:14:15.0453710Z'
+      - '2022-04-01T02:17:21.2055781Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-lease-duration:
       - infinite
       x-ms-lease-state:
@@ -433,7 +425,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_ignore_readonly.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_ignore_readonly.yaml
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.0b2 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Feb 2022 21:12:43 GMT
+      - Fri, 01 Apr 2022 02:17:31 GMT
       etag:
-      - '"0x8D9F3236821DF7F"'
+      - '"0x8DA1385C772D0B8"'
       last-modified:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.0b2 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -75,27 +75,27 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:31 GMT
       etag:
-      - '"0x8D9F323682E433E"'
+      - '"0x8DA1385C782750D"'
       last-modified:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2022-02-18T21:12:44.6903102Z'
+      - '2022-04-01T02:17:32.5140237Z'
       x-ms-file-creation-time:
-      - '2022-02-18T21:12:44.6903102Z'
+      - '2022-04-01T02:17:32.5140237Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2022-02-18T21:12:44.6903102Z'
+      - '2022-04-01T02:17:32.5140237Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 8725144154719613152*15111010650564761710
+      - 8723072292820393796*15109150453380773834
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -117,9 +117,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.0b2 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
@@ -137,11 +137,11 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:31 GMT
       etag:
-      - '"0x8D9F3236839DA48"'
+      - '"0x8DA1385C7900798"'
       last-modified:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
@@ -163,11 +163,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.0b2 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       x-ms-file-attributes:
       - ReadOnly
       x-ms-file-creation-time:
@@ -189,27 +189,27 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       etag:
-      - '"0x8D9F32368663AF3"'
+      - '"0x8DA1385C7BC4126"'
       last-modified:
-      - Fri, 18 Feb 2022 21:12:45 GMT
+      - Fri, 01 Apr 2022 02:17:32 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - ReadOnly | Archive
       x-ms-file-change-time:
-      - '2022-02-18T21:12:45.0570995Z'
+      - '2022-04-01T02:17:32.8928038Z'
       x-ms-file-creation-time:
-      - '2022-02-18T21:12:45.0570995Z'
+      - '2022-04-01T02:17:32.8928038Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2022-02-18T21:12:45.0570995Z'
+      - '2022-04-01T02:17:32.8928038Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 8725144154719613152*15111010650564761710
+      - 8723072292820393796*15109150453380773834
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -229,15 +229,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.0b2 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-copy-source:
-      - https://storagename.file.core.windows.net/utshare4e671067/file4e671067
+      - https://vincenttrancanary.file.core.windows.net/utshare4e671067/file4e671067
       x-ms-date:
-      - Fri, 18 Feb 2022 21:12:45 GMT
-      x-ms-file-creation-time:
-      - ''
-      x-ms-file-last-write-time:
-      - ''
+      - Fri, 01 Apr 2022 02:17:33 GMT
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -245,14 +241,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ReadOnlyAttribute</Code><Message>The
-        specified resource is read-only and cannot be modified at this time.\nRequestId:1a0261dc-c01a-0082-620c-259b7c000000\nTime:2022-02-18T21:12:45.2389390Z</Message></Error>"
+        specified resource is read-only and cannot be modified at this time.\nRequestId:67ad6c4e-e01a-0061-406e-45f981000000\nTime:2022-04-01T02:17:34.4064080Z</Message></Error>"
     headers:
       content-length:
       - '258'
       content-type:
       - application/xml
       date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
@@ -275,17 +271,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.0b2 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-copy-source:
-      - https://storagename.file.core.windows.net/utshare4e671067/file4e671067
+      - https://vincenttrancanary.file.core.windows.net/utshare4e671067/file4e671067
       x-ms-date:
-      - Fri, 18 Feb 2022 21:12:45 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       x-ms-file-copy-ignore-readonly:
       - 'true'
-      x-ms-file-creation-time:
-      - ''
-      x-ms-file-last-write-time:
-      - ''
       x-ms-version:
       - '2021-04-10'
     method: PUT
@@ -297,15 +289,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       etag:
-      - '"0x8D9F323688CF720"'
+      - '"0x8DA1385C8B15241"'
       last-modified:
-      - Fri, 18 Feb 2022 21:12:45 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-id:
-      - b1ac2a5d-fd4b-41d2-a6fa-3aa175ed4d10
+      - 2f8435ed-a622-4e44-a024-b78bb8e25cc3
       x-ms-copy-status:
       - success
       x-ms-version:
@@ -323,9 +315,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.7.0b2 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 18 Feb 2022 21:12:45 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -345,37 +337,37 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 18 Feb 2022 21:12:44 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       etag:
-      - '"0x8D9F323688CF720"'
+      - '"0x8DA1385C8B15241"'
       last-modified:
-      - Fri, 18 Feb 2022 21:12:45 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Fri, 18 Feb 2022 21:12:45 GMT
+      - Fri, 01 Apr 2022 02:17:34 GMT
       x-ms-copy-id:
-      - b1ac2a5d-fd4b-41d2-a6fa-3aa175ed4d10
+      - 2f8435ed-a622-4e44-a024-b78bb8e25cc3
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
-      - https://storagename.file.core.windows.net/utshare4e671067/file4e671067
+      - https://vincenttrancanary.file.core.windows.net/utshare4e671067/file4e671067
       x-ms-copy-status:
       - success
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2022-02-18T21:12:45.3109536Z'
+      - '2022-04-01T02:17:34.4988737Z'
       x-ms-file-creation-time:
-      - '2022-02-18T21:12:45.3109536Z'
+      - '2022-04-01T02:17:34.4988737Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2022-02-18T21:12:45.3109536Z'
+      - '2022-04-01T02:17:34.4988737Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 8725144154719613152*15111010650564761710
+      - 8723072292820393796*15109150453380773834
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_existing_file.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_existing_file.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.0.1 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 15 Jan 2020 23:46:47 GMT
+      - Fri, 01 Apr 2022 02:13:45 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare838911ab?restype=share
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 15 Jan 2020 23:46:47 GMT
+      - Fri, 01 Apr 2022 02:13:45 GMT
       etag:
-      - '"0x8D79A152F91034B"'
+      - '"0x8DA13854087366D"'
       last-modified:
-      - Wed, 15 Jan 2020 23:46:47 GMT
+      - Fri, 01 Apr 2022 02:13:46 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.0.1 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Wed, 15 Jan 2020 23:46:47 GMT
+      - Fri, 01 Apr 2022 02:13:46 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -65,7 +65,7 @@ interactions:
       x-ms-type:
       - file
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare838911ab/file838911ab
   response:
@@ -75,31 +75,31 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 15 Jan 2020 23:46:47 GMT
+      - Fri, 01 Apr 2022 02:13:45 GMT
       etag:
-      - '"0x8D79A152FA8F205"'
+      - '"0x8DA1385409C5AF0"'
       last-modified:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:46 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-15T23:46:48.0806405Z'
+      - '2022-04-01T02:13:46.1913328Z'
       x-ms-file-creation-time:
-      - '2020-01-15T23:46:48.0806405Z'
+      - '2022-04-01T02:13:46.1913328Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2020-01-15T23:46:48.0806405Z'
+      - '2022-04-01T02:13:46.1913328Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 5724850820508509333*16704459309046467611
+      - 8723072292820393796*15109150453380773834
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -107,7 +107,7 @@ interactions:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -117,13 +117,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-file-share/12.0.1 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:46 GMT
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
       x-ms-write:
       - update
     method: PUT
@@ -137,17 +137,17 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Wed, 15 Jan 2020 23:46:47 GMT
+      - Fri, 01 Apr 2022 02:13:45 GMT
       etag:
-      - '"0x8D79A152FB92175"'
+      - '"0x8DA138540AA148C"'
       last-modified:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:46 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -155,7 +155,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -163,13 +163,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.0.1 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-copy-source:
-      - https://pyacrstorage43x4qoc3y4bx.file.core.windows.net/utshare838911ab/file838911ab
+      - https://vincenttrancanary.file.core.windows.net/utshare838911ab/file838911ab
       x-ms-date:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:46 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare838911ab/file1copy
   response:
@@ -179,19 +179,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:48 GMT
       etag:
-      - '"0x8D79A15301A652D"'
+      - '"0x8DA1385422E09D4"'
       last-modified:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:48 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-id:
-      - 8daea581-e5ec-4336-b56e-f9ef7f06a1c0
+      - 8a5f8287-1636-4572-8c5d-98f9bc4aecb1
       x-ms-copy-status:
       - success
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 202
       message: Accepted
@@ -205,13 +205,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.0.1 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:49 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     method: GET
     uri: https://storagename.file.core.windows.net/utshare838911ab/file1copy
   response:
@@ -227,37 +227,37 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:48 GMT
       etag:
-      - '"0x8D79A15301A652D"'
+      - '"0x8DA1385422E09D4"'
       last-modified:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:48 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Wed, 15 Jan 2020 23:46:48 GMT
+      - Fri, 01 Apr 2022 02:13:48 GMT
       x-ms-copy-id:
-      - 8daea581-e5ec-4336-b56e-f9ef7f06a1c0
+      - 8a5f8287-1636-4572-8c5d-98f9bc4aecb1
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
-      - https://pyacrstorage43x4qoc3y4bx.file.core.windows.net/utshare838911ab/file838911ab
+      - https://vincenttrancanary.file.core.windows.net/utshare838911ab/file838911ab
       x-ms-copy-status:
       - success
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-15T23:46:48.0806405Z'
+      - '2022-04-01T02:13:48.8238036Z'
       x-ms-file-creation-time:
-      - '2020-01-15T23:46:48.8241453Z'
+      - '2022-04-01T02:13:48.8238036Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2020-01-15T23:46:48.0806405Z'
+      - '2022-04-01T02:13:48.8238036Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 5724850820508509333*16704459309046467611
+      - 8723072292820393796*15109150453380773834
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -267,7 +267,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-02-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_specifying_acl_and_attributes_from_source.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_specifying_acl_and_attributes_from_source.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:12:23 GMT
+      - Fri, 01 Apr 2022 02:17:53 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare16fa1d3c?restype=share
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:53 GMT
       etag:
-      - '"0x8D7A3B0A8EE9D97"'
+      - '"0x8DA1385D444B942"'
       last-modified:
-      - Tue, 28 Jan 2020 05:12:23 GMT
+      - Fri, 01 Apr 2022 02:17:53 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -65,7 +65,7 @@ interactions:
       x-ms-type:
       - file
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
   response:
@@ -75,31 +75,31 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:53 GMT
       etag:
-      - '"0x8D7A3B0A9463D7E"'
+      - '"0x8DA1385D4580F21"'
       last-modified:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:12:24.5738878Z'
+      - '2022-04-01T02:17:54.0465441Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:12:24.5738878Z'
+      - '2022-04-01T02:17:54.0465441Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:12:24.5738878Z'
+      - '2022-04-01T02:17:54.0465441Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -107,7 +107,7 @@ interactions:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -117,13 +117,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
       x-ms-write:
       - update
     method: PUT
@@ -137,17 +137,17 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:53 GMT
       etag:
-      - '"0x8D7A3B0A97B1534"'
+      - '"0x8DA1385D4649060"'
       last-modified:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -155,17 +155,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:12:25 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: HEAD
     uri: https://storagename.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
   response:
@@ -177,27 +177,27 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 28 Jan 2020 05:12:25 GMT
+      - Fri, 01 Apr 2022 02:17:53 GMT
       etag:
-      - '"0x8D7A3B0A97B1534"'
+      - '"0x8DA1385D4649060"'
       last-modified:
-      - Tue, 28 Jan 2020 05:12:24 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:12:24.5738878Z'
+      - '2022-04-01T02:17:54.1284960Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:12:24.5738878Z'
+      - '2022-04-01T02:17:54.0465441Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:12:24.5738878Z'
+      - '2022-04-01T02:17:54.1284960Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -207,7 +207,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -223,19 +223,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
+      - https://vincenttrancanary.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
       x-ms-date:
-      - Tue, 28 Jan 2020 05:12:25 GMT
-      x-ms-file-creation-time:
-      - ''
-      x-ms-file-last-write-time:
-      - ''
+      - Fri, 01 Apr 2022 02:17:54 GMT
       x-ms-file-permission-copy-mode:
       - source
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utshare16fa1d3c/file1copy
   response:
@@ -245,19 +241,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:12:25 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       etag:
-      - '"0x8D7A3B0AA9EC9CA"'
+      - '"0x8DA1385D4E5E233"'
       last-modified:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-id:
-      - e82be15f-b62b-41c3-b004-44bd60e8ec41
+      - 9920eb37-9a10-4df4-ad52-b1ddc63b80f2
       x-ms-copy-status:
       - success
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 202
       message: Accepted
@@ -265,17 +261,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:55 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: HEAD
     uri: https://storagename.file.core.windows.net/utshare16fa1d3c/file1copy
   response:
@@ -287,37 +283,37 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       etag:
-      - '"0x8D7A3B0AA9EC9CA"'
+      - '"0x8DA1385D4E5E233"'
       last-modified:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       x-ms-copy-id:
-      - e82be15f-b62b-41c3-b004-44bd60e8ec41
+      - 9920eb37-9a10-4df4-ad52-b1ddc63b80f2
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
+      - https://vincenttrancanary.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
       x-ms-copy-status:
       - success
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:12:26.8319178Z'
+      - '2022-04-01T02:17:54.9760051Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:12:26.8319178Z'
+      - '2022-04-01T02:17:54.9760051Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:12:26.8319178Z'
+      - '2022-04-01T02:17:54.9760051Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -327,7 +323,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -341,13 +337,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:12:27 GMT
+      - Fri, 01 Apr 2022 02:17:55 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: GET
     uri: https://storagename.file.core.windows.net/utshare16fa1d3c/file1copy
   response:
@@ -363,37 +359,37 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       etag:
-      - '"0x8D7A3B0AA9EC9CA"'
+      - '"0x8DA1385D4E5E233"'
       last-modified:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Tue, 28 Jan 2020 05:12:26 GMT
+      - Fri, 01 Apr 2022 02:17:54 GMT
       x-ms-copy-id:
-      - e82be15f-b62b-41c3-b004-44bd60e8ec41
+      - 9920eb37-9a10-4df4-ad52-b1ddc63b80f2
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
+      - https://vincenttrancanary.file.core.windows.net/utshare16fa1d3c/file16fa1d3c
       x-ms-copy-status:
       - success
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:12:26.8319178Z'
+      - '2022-04-01T02:17:54.9760051Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:12:26.8319178Z'
+      - '2022-04-01T02:17:54.9760051Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:12:26.8319178Z'
+      - '2022-04-01T02:17:54.9760051Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -403,7 +399,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_specifying_acl_copy_behavior_attributes.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_specifying_acl_copy_behavior_attributes.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:13:21 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utsharedd3c1c70?restype=share
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:42 GMT
       etag:
-      - '"0x8D7A3B0CBA8DB56"'
+      - '"0x8DA1385CE06A8E7"'
       last-modified:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -65,7 +65,7 @@ interactions:
       x-ms-type:
       - file
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
   response:
@@ -75,31 +75,31 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:42 GMT
       etag:
-      - '"0x8D7A3B0CBBF041D"'
+      - '"0x8DA1385CE17E1B3"'
       last-modified:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2020-01-28T05:13:22.4079389Z'
+      - '2022-04-01T02:17:43.5596211Z'
       x-ms-file-creation-time:
-      - '2020-01-28T05:13:22.4079389Z'
+      - '2022-04-01T02:17:43.5596211Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:13:22.4079389Z'
+      - '2022-04-01T02:17:43.5596211Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 16864655153240182536*4804112389554988934
+      - 8723072292820393796*15109150453380773834
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -107,7 +107,7 @@ interactions:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -117,13 +117,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
       x-ms-write:
       - update
     method: PUT
@@ -137,17 +137,17 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:42 GMT
       etag:
-      - '"0x8D7A3B0CBD74C93"'
+      - '"0x8DA1385CE26AC91"'
       last-modified:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -155,7 +155,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -163,25 +163,23 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
+      - https://vincenttrancanary.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
       x-ms-date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       x-ms-file-attributes:
       - Temporary|NoScrubData
-      x-ms-file-copy-ignore-read-only:
+      x-ms-file-copy-ignore-readonly:
       - 'true'
       x-ms-file-creation-time:
       - '2017-05-10T17:52:33.9551860Z'
-      x-ms-file-last-write-time:
-      - ''
       x-ms-file-permission:
       - O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)
       x-ms-file-permission-copy-mode:
       - override
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: PUT
     uri: https://storagename.file.core.windows.net/utsharedd3c1c70/file1copy
   response:
@@ -191,19 +189,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       etag:
-      - '"0x8D7A3B0CC3DEE93"'
+      - '"0x8DA1385CE7842ED"'
       last-modified:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:44 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-id:
-      - 58e63231-58eb-4f5e-8fbe-8774948ffbc2
+      - e95bb5e2-a62e-444c-8c34-87959344cb53
       x-ms-copy-status:
       - success
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 202
       message: Accepted
@@ -211,17 +209,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:44 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: HEAD
     uri: https://storagename.file.core.windows.net/utsharedd3c1c70/file1copy
   response:
@@ -233,37 +231,37 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 28 Jan 2020 05:13:22 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       etag:
-      - '"0x8D7A3B0CC3DEE93"'
+      - '"0x8DA1385CE7842ED"'
       last-modified:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:44 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:44 GMT
       x-ms-copy-id:
-      - 58e63231-58eb-4f5e-8fbe-8774948ffbc2
+      - e95bb5e2-a62e-444c-8c34-87959344cb53
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
+      - https://vincenttrancanary.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
       x-ms-copy-status:
       - success
       x-ms-file-attributes:
       - Archive | Temporary | NoScrubData
       x-ms-file-change-time:
-      - '2020-01-28T05:13:23.2396947Z'
+      - '2022-04-01T02:17:44.1912557Z'
       x-ms-file-creation-time:
       - '2017-05-10T17:52:33.9551860Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:13:23.2396947Z'
+      - '2022-04-01T02:17:44.1912557Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 11567002431961314099*4804112389554988934
+      - 3712058902937412479*15109150453380773834
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -273,7 +271,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -287,13 +285,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-file-share/12.1.0 Python/3.7.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:44 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     method: GET
     uri: https://storagename.file.core.windows.net/utsharedd3c1c70/file1copy
   response:
@@ -309,37 +307,37 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:43 GMT
       etag:
-      - '"0x8D7A3B0CC3DEE93"'
+      - '"0x8DA1385CE7842ED"'
       last-modified:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:44 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Tue, 28 Jan 2020 05:13:23 GMT
+      - Fri, 01 Apr 2022 02:17:44 GMT
       x-ms-copy-id:
-      - 58e63231-58eb-4f5e-8fbe-8774948ffbc2
+      - e95bb5e2-a62e-444c-8c34-87959344cb53
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
-      - https://emilystageaccount.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
+      - https://vincenttrancanary.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
       x-ms-copy-status:
       - success
       x-ms-file-attributes:
       - Archive | Temporary | NoScrubData
       x-ms-file-change-time:
-      - '2020-01-28T05:13:23.2396947Z'
+      - '2022-04-01T02:17:44.1912557Z'
       x-ms-file-creation-time:
       - '2017-05-10T17:52:33.9551860Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2020-01-28T05:13:23.2396947Z'
+      - '2022-04-01T02:17:44.1912557Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 11567002431961314099*4804112389554988934
+      - 3712058902937412479*15109150453380773834
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -349,7 +347,7 @@ interactions:
       x-ms-type:
       - File
       x-ms-version:
-      - '2019-07-07'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content


### PR DESCRIPTION
As raised in #23543, this PR aims to fix the empty headers being sent on certain requests in both `file-share` and `file-datalake`. Some tests were re-recorded to verify non-breaking.

Follows-ups:

1. Change the name of `add_metadata_headers()` to better represent what the method is doing
2. in .NET, the closest thing we have to `properties` in Python's SDK library is `httpHeaders`, so possibly rename to allow for more seamless transitioning between .NET and Python workflows
3. While empty headers issue was eliminated, `_datetime_to_str()` should be refactored once new library is introduced