### PR TITLE
Import OS in pylint rcfile.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -5,7 +5,7 @@ reports=no
 # PYLINT DIRECTORY BLACKLIST.
 ignore=_vendor,_generated,samples,examples,test,tests,doc,.tox
 
-init-hook='import sys; sys.path.insert(0, os.path.abspath(os.getcwd().rsplit("azure-sdk-for-python", 1)[0] + "azure-sdk-for-python/scripts/pylint_custom_plugin"))'
+init-hook='import sys; import os; sys.path.insert(0, os.path.abspath(os.getcwd().rsplit("azure-sdk-for-python", 1)[0] + "azure-sdk-for-python/scripts/pylint_custom_plugin"))'
 load-plugins=pylint_guidelines_checker
 
 [MESSAGES CONTROL]


### PR DESCRIPTION
See: https://github.com/Azure/azure-sdk-tools/pull/2933

In order for the above PR to pass, the pylint rcfile needs the `import os` statement. The file in the SDK tools repo and the SDK repo _must_ match or the CI will fail. Thus, updating this repo's copy to match. 