### PR TITLE
[ServiceBus] improve release message test stability

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -450,7 +450,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
         async with ServiceBusClient.from_connection_string(
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                     for i in range(10):
@@ -700,7 +700,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
 
             deferred_messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                     for i in range(3):
@@ -716,7 +716,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
 
             assert count == 3
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
                 with pytest.raises(ServiceBusError):
                     deferred = await receiver.receive_deferred_messages([3, 4])
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -2334,6 +2334,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     assert message.state == ServiceBusMessageState.ACTIVE
                     deferred_messages.append(message.sequence_number)
                     await receiver.defer_message(message)
+                await asyncio.sleep(5)
                 if deferred_messages:
                     received_deferred_msg = await receiver.receive_deferred_messages(
                         sequence_numbers=deferred_messages

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -128,7 +128,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    def test_async_queue_by_queue_client_conn_str_receive_handler_release_messages(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_release_messages(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
         async with ServiceBusClient.from_connection_string(
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -147,7 +147,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     while len(received_msgs) < 5:
                         # issue link credits more than 5, client should consume 5 msgs from the service in total,
                         # leaving the extra credits on the wire
-                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=5)):
+                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
                             await receiver.complete_message(msg)
                             received_msgs.append(received_msgs)
                     assert len(received_msgs) == 5
@@ -161,7 +161,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     while len(received_msgs) < target_msgs_count:
                         # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
                         for msg in (await receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
-                                                             max_wait_time=5)):
+                                                             max_wait_time=10)):
                             assert msg.delivery_count == 0  # release would not increase delivery count
                             await receiver.complete_message(msg)
                             received_msgs.append(msg)
@@ -187,7 +187,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
 
                             while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
                                 # we issue 10 link credits, leaving more credits on the wire
-                                for sub_msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=5)):
+                                for sub_msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
                                     assert sub_msg.delivery_count == 0
                                     await receiver.complete_message(sub_msg)
                                     received_msgs.append(sub_msg)
@@ -249,7 +249,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     while len(received_msgs) < 5:
                         # issue 10 link credits, client should consume 5 msgs from the service
                         # leaving 5 credits on the wire
-                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=5)):
+                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
                             await receiver.complete_message(msg)
                             received_msgs.append(msg)
                     assert len(received_msgs) == 5
@@ -262,7 +262,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     target_msgs_count = 5
                     received_msgs = []
                     while len(received_msgs) < target_msgs_count:
-                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=5)))
+                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
                     assert len(received_msgs) == 5
                     for msg in received_msgs:
                         assert msg.delivery_count == 0
@@ -273,7 +273,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     target_msgs_count = 5
                     received_msgs = []
                     while len(received_msgs) < target_msgs_count:
-                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=5)))
+                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
                     assert len(received_msgs) == 5
                     for msg in received_msgs:
                         assert msg.delivery_count > 0

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -481,7 +481,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
         async with ServiceBusClient.from_connection_string(
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                     for i in range(10):
@@ -500,7 +500,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
 
             assert count == 10
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
                 count = 0
                 async for message in receiver:
                     print_message(_logger, message)
@@ -518,7 +518,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
 
             deferred_messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                     for i in range(10):
@@ -533,7 +533,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     await receiver.defer_message(message)
 
             assert count == 10
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
                 count = 0
                 async for message in receiver:
                     print_message(_logger, message)
@@ -672,7 +672,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     results = await sender.send_messages(message)
 
             count = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
                 async for message in receiver:
                     deferred_messages.append(message.sequence_number)
                     print_message(_logger, message)
@@ -680,7 +680,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     await receiver.defer_message(message)
 
             assert count == 10
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value) as receiver:
                 deferred = await receiver.receive_deferred_messages(deferred_messages)
                 assert len(deferred) == 10
                 for message in deferred:

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -123,62 +123,91 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
             with pytest.raises(ValueError):
                 await receiver.peek_messages()
 
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    def test_async_queue_by_queue_client_conn_str_receive_handler_release_messages(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+        async with ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, logging_enable=False) as sb_client:
+
             async def sub_test_releasing_messages():
                 # test releasing messages when prefetch is 1 and link credits are issue dynamically
                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
                 sender = sb_client.get_queue_sender(servicebus_queue.name)
                 async with sender, receiver:
                     # send 10 msgs to queue first
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
 
-                    # issue 30 link credits, client should consume 10 msgs from the service
-                    # leaving 20 credits on the wire
-                    received_msgs = await receiver.receive_messages(max_message_count=30, max_wait_time=5)
-                    for msg in received_msgs:
-                        await receiver.complete_message(msg)
-                    assert len(received_msgs) == 10
+                    received_msgs = []
+                    # the amount of messages returned by receive call is not stable, especially in live tests
+                    # of different os platforms, this is why a while loop is used here to receive the specific
+                    # amount of message we want to receive
+                    while len(received_msgs) < 5:
+                        # issue link credits more than 5, client should consume 5 msgs from the service in total,
+                        # leaving the extra credits on the wire
+                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=5)):
+                            await receiver.complete_message(msg)
+                            received_msgs.append(received_msgs)
+                    assert len(received_msgs) == 5
 
-                    # send 20 more messages, those messages would arrive at the client while the program is sleeping
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(20)])
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     await asyncio.sleep(15)  # sleep > message expiration time
 
-                    # issue 20 link credits, client should consume 20 msgs from the service, leaving no link credits
-                    received_msgs = await receiver.receive_messages(max_message_count=30, max_wait_time=5)
-                    for msg in received_msgs:
-                        assert msg.delivery_count == 0  # release would not increase delivery count
-                        await receiver.complete_message(msg)
-                    assert len(received_msgs) == 20
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
+                        for msg in (await receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
+                                                             max_wait_time=5)):
+                            assert msg.delivery_count == 0  # release would not increase delivery count
+                            await receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
 
             async def sub_test_releasing_messages_iterator():
                 # test nested iterator scenario
                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
                 sender = sb_client.get_queue_sender(servicebus_queue.name)
                 async with sender, receiver:
-                    # send 10 msgs to queue first
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    # send 5 msgs to queue first
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     first_time = True
                     iterator_recv_cnt = 0
-                    # iterator + receive batch
+
+                    # case: iterator + receive batch
                     async for msg in receiver:
                         assert msg.delivery_count == 0  # release would not increase delivery count
                         await receiver.complete_message(msg)
                         iterator_recv_cnt += 1
-                        if first_time:
-                            received_msgs = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
-                            for sub_msg in received_msgs:
-                                assert sub_msg.delivery_count == 0
-                                await receiver.complete_message(sub_msg)
-                            assert len(received_msgs) == 9
-                            await sender.send_messages([ServiceBusMessage('test') for _ in range(20)])
+                        if first_time:  # for the first time, we call nested receive message call
+                            received_msgs = []
+
+                            while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
+                                # we issue 10 link credits, leaving more credits on the wire
+                                for sub_msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=5)):
+                                    assert sub_msg.delivery_count == 0
+                                    await receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == 4
+                            await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
                             await asyncio.sleep(15)  # sleep > message expiration time
-                            received_msgs = await receiver.receive_messages(max_message_count=5, max_wait_time=5)
-                            for sub_msg in received_msgs:
-                                assert sub_msg.delivery_count == 0  # release would not increase delivery count
-                                await receiver.complete_message(sub_msg)
-                            assert len(received_msgs) == 5
+
+                            received_msgs = []
+                            target_msgs_count = 5  # we want to receive 5 with the receive message call
+                            while len(received_msgs) < target_msgs_count:
+                                for sub_msg in (await receiver.receive_messages(
+                                        max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5)):
+                                    assert sub_msg.delivery_count == 0  # release would not increase delivery count
+                                    await receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == target_msgs_count
                             first_time = False
-                    assert iterator_recv_cnt == 16  # 1 + 15
-                    # iterator + iterator
+                    assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
+
+                    # case: iterator + iterator case
                     await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
                     outter_recv_cnt = 0
                     inner_recv_cnt = 0
@@ -191,7 +220,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                             inner_recv_cnt += 1
                             await receiver.complete_message(sub_msg)
                             if inner_recv_cnt == 5:
-                                time.sleep(15)
+                                await asyncio.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
                                 break
                     assert outter_recv_cnt == 1
                     outter_recv_cnt = 0
@@ -212,34 +241,43 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                     self._handler._received_messages.put(message)
 
                 async with sender, receiver:
-                    # send 10 msgs to queue first
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    # send 5 msgs to queue first
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     receiver._handler.message_handler.on_message_received = types.MethodType(
                         _hack_disable_receive_context_message_received, receiver)
-                    # issue 30 link credits, client should consume 10 msgs from the service
-                    # leaving 20 credits on the wire
-                    received_msgs = await receiver.receive_messages(max_message_count=30, max_wait_time=5)
-                    for msg in received_msgs:
-                        await receiver.complete_message(msg)
+                    received_msgs = []
+                    while len(received_msgs) < 5:
+                        # issue 10 link credits, client should consume 5 msgs from the service
+                        # leaving 5 credits on the wire
+                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=5)):
+                            await receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
 
-                    # send 20 more messages, those messages would arrive at the client while the program is sleeping
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(20)])
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     await asyncio.sleep(15)  # sleep > message expiration time
 
-                    # issue 20 link credits, client should consume 20 msgs from the service, leaving no link credits
-                    received_msgs = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
-                    assert len(received_msgs) == 20
+                    # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=5)))
+                    assert len(received_msgs) == 5
                     for msg in received_msgs:
                         assert msg.delivery_count == 0
                         with pytest.raises(ServiceBusError):
                             await receiver.complete_message(msg)
 
                     # re-received message with delivery count increased
-                    received_msgs = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=5)))
+                    assert len(received_msgs) == 5
                     for msg in received_msgs:
-                        assert msg.delivery_count == 1
+                        assert msg.delivery_count > 0
                         await receiver.complete_message(msg)
-                    assert len(received_msgs) == 20
 
             await sub_test_releasing_messages()
             await sub_test_releasing_messages_iterator()

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -732,7 +732,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
         async with ServiceBusClient.from_connection_string(
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
 
                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                     for i in range(10):
@@ -750,7 +750,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
 
             assert count == 10
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
                 count = 0
                 async for message in receiver:
                     print_message(_logger, message)
@@ -761,7 +761,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
             async with sb_client.get_queue_receiver(
                     servicebus_queue.name,
                     sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
-                    max_wait_time=5,
+                    max_wait_time=10,
                     mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
                 count = 0
                 async for message in dl_receiver:

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -103,7 +103,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
     @pytest.mark.live_test_only
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
     async def test_async_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
         async with ServiceBusClient.from_connection_string(
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
@@ -115,7 +115,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
                     await sender.send_messages(message)
 
             messages = []
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10)
             async for message in receiver:
                 messages.append(message)
                 assert session_id == receiver.session.session_id
@@ -128,10 +128,10 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
 
             assert not receiver._running
             assert len(messages) == 10
-            time.sleep(5)
+            time.sleep(10)
 
             messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10) as receiver:
                 async for message in receiver:
                     messages.append(message)
             assert len(messages) == 0
@@ -865,7 +865,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
                     await sender.send_messages(message)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
                 assert await receiver.session.get_state(timeout=5) == None
                 await receiver.session.set_state("first_state", timeout=5)
                 count = 0

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -64,9 +64,9 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
                     await sender.send_messages(message)
 
             with pytest.raises(ServiceBusError):
-                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
+                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
             count = 0
             async for message in receiver:
                 print_message(_logger, message)
@@ -85,9 +85,9 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
                     await sender.send_messages(message)
 
             with pytest.raises(ServiceBusError):
-                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
+                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
             count = 0
             async for message in receiver:
                 print_message(_logger, message)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -476,7 +476,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
                 messages.extend(await receiver.receive_messages())
                 recv = True
                 while recv:
-                    recv = await receiver.receive_messages(max_wait_time=5)
+                    recv = await receiver.receive_messages(max_wait_time=10)
                     messages.extend(recv)
 
                 try:
@@ -566,7 +566,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
     @pytest.mark.live_test_only
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
     async def test_async_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
         async with ServiceBusClient.from_connection_string(
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
@@ -585,7 +585,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
             messages = []
             async with sb_client.get_queue_receiver(servicebus_queue.name,
                                                     session_id=session_id,
-                                                    max_wait_time=5,
+                                                    max_wait_time=10,
                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
                                                     prefetch_count=20,
                                                     auto_lock_renewer=renewer) as session:
@@ -624,7 +624,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
 
             async with sb_client.get_queue_receiver(servicebus_queue.name,
                                                     session_id=session_id,
-                                                    max_wait_time=5,
+                                                    max_wait_time=10,
                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
                                                     prefetch_count=10,
                                                     auto_lock_renewer=renewer) as receiver:
@@ -643,12 +643,12 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
         renewer = AutoLockRenewer(max_lock_renewal_duration=100)
         receiver = sb_client.get_queue_receiver(servicebus_queue.name,
                                             session_id=session_id,
-                                            max_wait_time=5,
+                                            max_wait_time=10,
                                             prefetch_count=10,
                                             auto_lock_renewer=renewer)
 
         async with receiver:
-            received_msgs = await receiver.receive_messages(max_wait_time=5)
+            received_msgs = await receiver.receive_messages(max_wait_time=10)
             for msg in received_msgs:
                 await receiver.complete_message(msg)
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
@@ -57,7 +57,7 @@ class ServiceBusSubscriptionAsyncTests(AzureMgmtTestCase):
             async with sb_client.get_subscription_receiver(
                     topic_name=servicebus_topic.name,
                     subscription_name=servicebus_subscription.name,
-                    max_wait_time=5
+                    max_wait_time=10
             ) as receiver:
 
                 with pytest.raises(ValueError):

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -497,7 +497,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     sender.send_messages(message)
     
             messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
                 for message in receiver:
                     messages.append(message)
                     receiver.complete_message(message)
@@ -527,7 +527,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             servicebus_namespace_connection_string, logging_enable=False) as sb_client:
     
             with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              max_wait_time=5, 
+                                              max_wait_time=10,
                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
@@ -1131,7 +1131,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             renewer = AutoLockRenewer()
             messages = []
             with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=5, 
+                                                 max_wait_time=10,
                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
                                                  prefetch_count=10) as receiver:
                 for message in receiver:
@@ -1173,7 +1173,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     sender.send_messages(message)
 
             with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=5,
+                                                 max_wait_time=10,
                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
                                                  prefetch_count=10) as receiver:
                 received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=5)
@@ -1194,10 +1194,10 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     sender.send_messages(message)
 
             with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=5,
+                                                 max_wait_time=10,
                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
                                                  prefetch_count=3) as receiver:
-                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=5)
+                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
                 for msg in received_msgs:
                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
                 time.sleep(10)
@@ -1216,10 +1216,10 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     sender.send_messages(message)
 
             with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=5,
+                                                 max_wait_time=10,
                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
                                                  prefetch_count=3) as receiver:
-                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=5)
+                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
                 for msg in received_msgs:
                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
                 time.sleep(10)
@@ -2322,7 +2322,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
             with sender, receiver:
                 # negative settlement via receiver link
-                sender.send_messages(ServiceBusMessage("body"), timeout=5)
+                sender.send_messages(ServiceBusMessage("body"), timeout=10)
                 message = receiver.receive_messages()[0]
                 message.message.accept = types.MethodType(_hack_amqp_message_complete, message.message)
                 receiver.complete_message(message)  # settle via mgmt link
@@ -2335,7 +2335,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 finally:
                     uamqp.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
 
-                sender.send_messages(ServiceBusMessage("body"), timeout=5)
+                sender.send_messages(ServiceBusMessage("body"), timeout=10)
 
                 message = receiver.receive_messages()[0]
 

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -205,62 +205,91 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
 
             assert count == 10
 
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    def test_queue_by_queue_client_conn_str_receive_handler_release_messages(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+        with ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, logging_enable=False) as sb_client:
+
             def sub_test_releasing_messages():
                 # test releasing messages when prefetch is 1 and link credits are issue dynamically
                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
                 sender = sb_client.get_queue_sender(servicebus_queue.name)
                 with sender, receiver:
                     # send 10 msgs to queue first
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
 
-                    # issue 30 link credits, client should consume 10 msgs from the service
-                    # leaving 20 credits on the wire
-                    received_msgs = receiver.receive_messages(max_message_count=30, max_wait_time=5)
-                    for msg in received_msgs:
-                        receiver.complete_message(msg)
-                    assert len(received_msgs) == 10
+                    received_msgs = []
+                    # the amount of messages returned by receive call is not stable, especially in live tests
+                    # of different os platforms, this is why a while loop is used here to receive the specific
+                    # amount of message we want to receive
+                    while len(received_msgs) < 5:
+                        # issue link credits more than 5, client should consume 5 msgs from the service in total,
+                        # leaving the extra credits on the wire
+                        for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+                            receiver.complete_message(msg)
+                            received_msgs.append(received_msgs)
+                    assert len(received_msgs) == 5
 
-                    # send 20 more messages, those messages would arrive at the client while the program is sleeping
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(20)])
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     time.sleep(15)  # sleep > message expiration time
 
-                    # issue 20 link credits, client should consume 20 msgs from the service, leaving no link credits
-                    received_msgs = receiver.receive_messages(max_message_count=30, max_wait_time=5)
-                    for msg in received_msgs:
-                        assert msg.delivery_count == 0  # release would not increase delivery count
-                        receiver.complete_message(msg)
-                    assert len(received_msgs) == 20
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
+                        for msg in receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
+                                                             max_wait_time=5):
+                            assert msg.delivery_count == 0  # release would not increase delivery count
+                            receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
 
             def sub_test_releasing_messages_iterator():
                 # test nested iterator scenario
                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
                 sender = sb_client.get_queue_sender(servicebus_queue.name)
                 with sender, receiver:
-                    # send 10 msgs to queue first
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    # send 5 msgs to queue first
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     first_time = True
                     iterator_recv_cnt = 0
-                    # iterator + receive batch
+
+                    # case: iterator + receive batch
                     for msg in receiver:
                         assert msg.delivery_count == 0  # release would not increase delivery count
                         receiver.complete_message(msg)
                         iterator_recv_cnt += 1
-                        if first_time:
-                            received_msgs = receiver.receive_messages(max_message_count=20, max_wait_time=5)
-                            for sub_msg in received_msgs:
-                                assert sub_msg.delivery_count == 0
-                                receiver.complete_message(sub_msg)
-                            assert len(received_msgs) == 9
-                            sender.send_messages([ServiceBusMessage('test') for _ in range(20)])
+                        if first_time:  # for the first time, we call nested receive message call
+                            received_msgs = []
+
+                            while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
+                                # we issue 10 link credits, leaving more credits on the wire
+                                for sub_msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+                                    assert sub_msg.delivery_count == 0
+                                    receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == 4
+                            sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
                             time.sleep(15)  # sleep > message expiration time
-                            received_msgs = receiver.receive_messages(max_message_count=5, max_wait_time=5)
-                            for sub_msg in received_msgs:
-                                assert sub_msg.delivery_count == 0  # release would not increase delivery count
-                                receiver.complete_message(sub_msg)
-                            assert len(received_msgs) == 5
+
+                            received_msgs = []
+                            target_msgs_count = 5  # we want to receive 5 with the receive message call
+                            while len(received_msgs) < target_msgs_count:
+                                for sub_msg in receiver.receive_messages(
+                                        max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5):
+                                    assert sub_msg.delivery_count == 0  # release would not increase delivery count
+                                    receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == target_msgs_count
                             first_time = False
-                    assert iterator_recv_cnt == 16  # 1 + 15
-                    # iterator + iterator
+                    assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
+
+                    # case: iterator + iterator case
                     sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
                     outter_recv_cnt = 0
                     inner_recv_cnt = 0
@@ -273,7 +302,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                             inner_recv_cnt += 1
                             receiver.complete_message(sub_msg)
                             if inner_recv_cnt == 5:
-                                time.sleep(15)
+                                time.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
                                 break
                     assert outter_recv_cnt == 1
                     outter_recv_cnt = 0
@@ -294,34 +323,43 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     self._handler._received_messages.put(message)
 
                 with sender, receiver:
-                    # send 10 msgs to queue first
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    # send 5 msgs to queue first
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     receiver._handler.message_handler.on_message_received = types.MethodType(
                         _hack_disable_receive_context_message_received, receiver)
-                    # issue 30 link credits, client should consume 10 msgs from the service
-                    # leaving 20 credits on the wire
-                    received_msgs = receiver.receive_messages(max_message_count=30, max_wait_time=5)
-                    for msg in received_msgs:
-                        receiver.complete_message(msg)
+                    received_msgs = []
+                    while len(received_msgs) < 5:
+                        # issue 10 link credits, client should consume 5 msgs from the service
+                        # leaving 5 credits on the wire
+                        for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+                            receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
 
-                    # send 20 more messages, those messages would arrive at the client while the program is sleeping
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(20)])
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
                     time.sleep(15)  # sleep > message expiration time
 
-                    # issue 20 link credits, client should consume 20 msgs from the service, leaving no link credits
-                    received_msgs = receiver.receive_messages(max_message_count=20, max_wait_time=5)
-                    assert len(received_msgs) == 20
+                    # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
+                    assert len(received_msgs) == 5
                     for msg in received_msgs:
                         assert msg.delivery_count == 0
                         with pytest.raises(ServiceBusError):
                             receiver.complete_message(msg)
 
                     # re-received message with delivery count increased
-                    received_msgs = receiver.receive_messages(max_message_count=20, max_wait_time=5)
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
+                    assert len(received_msgs) == 5
                     for msg in received_msgs:
-                        assert msg.delivery_count == 1
+                        assert msg.delivery_count > 0
                         receiver.complete_message(msg)
-                    assert len(received_msgs) == 20
 
             sub_test_releasing_messages()
             sub_test_releasing_messages_iterator()

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1249,7 +1249,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             renewer = AutoLockRenewer(max_lock_renewal_duration=10)
             messages = []
             with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=5, 
+                                                 max_wait_time=10,
                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
                                                  prefetch_count=10,
                                                  auto_lock_renewer=renewer) as receiver:

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -159,7 +159,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             with pytest.raises(ValueError):
                 sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
 
             assert len(receiver.receive_deferred_messages([])) == 0
             with pytest.raises(ValueError):

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1117,7 +1117,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
     @pytest.mark.live_test_only
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
     def test_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
         
         with ServiceBusClient.from_connection_string(
@@ -1234,7 +1234,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
     @pytest.mark.live_test_only
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
     def test_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
         
         with ServiceBusClient.from_connection_string(
@@ -1945,7 +1945,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 message_2nd_received_cnt = 0
                 while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
                     messages = []
-                    for message in receiver._get_streaming_message_iter(max_wait_time=5):
+                    for message in receiver._get_streaming_message_iter(max_wait_time=10):
                         messages.append(message)
                     if not messages:
                         break

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -719,7 +719,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     sender.send_messages(message)
     
             with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              max_wait_time=5, 
+                                              max_wait_time=10,
                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
                 count = 0
                 for message in receiver:
@@ -731,7 +731,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             assert count == 10
     
             with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                        max_wait_time=5) as receiver:
+                                        max_wait_time=10) as receiver:
                 deferred = receiver.receive_deferred_messages(deferred_messages)
                 assert len(deferred) == 10
                 for message in deferred:
@@ -741,7 +741,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             count = 0
             with sb_client.get_queue_receiver(servicebus_queue.name,
                                               sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                                              max_wait_time=5) as receiver:
+                                              max_wait_time=10) as receiver:
                 for message in receiver:
                     count += 1
                     print_message(_logger, message)

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -2035,7 +2035,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 servicebus_namespace_connection_string, logging_enable=False) as sb_client:
 
             sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
 
             with sender, receiver:
                 sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -641,7 +641,7 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
     @pytest.mark.live_test_only
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
     def test_session_by_conn_str_receive_handler_with_autolockrenew(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
 
         session_id = str(uuid.uuid4())
@@ -659,7 +659,7 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
 
             renewer = AutoLockRenewer()
             messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
                 renewer.register(receiver,
                                  receiver.session,
                                  max_lock_renewal_duration=10,
@@ -700,11 +700,11 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
             renewer._renew_period = 1
             session = None
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
                 session = receiver.session
                 renewer.register(receiver,
                                  session,
-                                 max_lock_renewal_duration=5,
+                                 max_lock_renewal_duration=10,
                                  on_lock_renew_failure=lock_lost_callback)
             sleep_until_expired(receiver.session)
             assert not results

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -716,7 +716,7 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
     @pytest.mark.live_test_only
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
     def test_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
 
         session_id = str(uuid.uuid4())
@@ -736,7 +736,7 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
             messages = []
             with sb_client.get_queue_receiver(servicebus_queue.name,
                                               session_id=session_id,
-                                              max_wait_time=5,
+                                              max_wait_time=10,
                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
                                               prefetch_count=10,
                                               auto_lock_renewer=renewer) as receiver:
@@ -778,7 +778,7 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
 
             with sb_client.get_queue_receiver(servicebus_queue.name,
                                               session_id=session_id,
-                                              max_wait_time=5,
+                                              max_wait_time=10,
                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
                                               prefetch_count=10,
                                               auto_lock_renewer=renewer) as receiver:
@@ -798,7 +798,7 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
         renewer = AutoLockRenewer(max_lock_renewal_duration=100)
         receiver = sb_client.get_queue_receiver(servicebus_queue.name,
                                             session_id=session_id,
-                                            max_wait_time=5,
+                                            max_wait_time=10,
                                             prefetch_count=10,
                                             auto_lock_renewer=renewer)
 


### PR DESCRIPTION
context:

`receive_message` call is unstable from the perspective of receiving exact amount of messages.
to improve the stability of release message test which requires the `receive_message` call, we need to control/monitor the amount received by introducing a while loop