### PR TITLE
[Storage] Fix Queue account SAS generation with latest service version

### DIFF
--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added support for `max_messages` in `receive_messages()` to specify the maximum number of messages to receive from the queue.
 
 ### Other Changes
+- Updated SAS token generation to use the latest supported service version by default. Moving to the latest version
+also included a change to how account SAS is generated to reflect a change made to the service in SAS generation for
+service version 2020-12-06.
 - Updated documentation for `receive_messages()` to explain iterator behavior and life-cycle.
 - Added a sample to `queue_samples_message.py` (and async-equivalent) showcasing the use of `max_messages` in `receive_messages()`. 
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -211,7 +211,9 @@ class _SharedAccessHelper(object):
              get_value_to_append(QueryStringConstants.SIGNED_EXPIRY) +
              get_value_to_append(QueryStringConstants.SIGNED_IP) +
              get_value_to_append(QueryStringConstants.SIGNED_PROTOCOL) +
-             get_value_to_append(QueryStringConstants.SIGNED_VERSION))
+             get_value_to_append(QueryStringConstants.SIGNED_VERSION) +
+             '\n'   # Signed Encryption Scope - always empty for queue
+             )
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key, string_to_sign))

--- a/sdk/storage/azure-storage-queue/tests/test_queue_api_version.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_api_version.py
@@ -10,7 +10,7 @@ from azure.storage.queue import (
     QueueServiceClient,
     QueueClient
 )
-from azure.storage.queue._serialize import _SUPPORTED_API_VERSIONS
+from azure.storage.queue._shared.constants import X_MS_VERSION
 from devtools_testutils.storage import StorageTestCase
 
 # ------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ class StorageClientTest(StorageTestCase):
     def setUp(self):
         super(StorageClientTest, self).setUp()
         self.api_version_1 = "2019-02-02"
-        self.api_version_2 = _SUPPORTED_API_VERSIONS[-1]
+        self.api_version_2 = X_MS_VERSION
 
     # --Test Cases--------------------------------------------------------------
 

--- a/sdk/storage/azure-storage-queue/tests/test_queue_api_version_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_api_version_async.py
@@ -13,7 +13,7 @@ from azure.storage.queue.aio import (
     QueueServiceClient,
     QueueClient
 )
-from azure.storage.queue._serialize import _SUPPORTED_API_VERSIONS
+from azure.storage.queue._shared.constants import X_MS_VERSION
 from devtools_testutils.storage.aio import AsyncStorageTestCase
 
 # ------------------------------------------------------------------------------
@@ -22,7 +22,7 @@ class StorageClientTest(AsyncStorageTestCase):
     def setUp(self):
         super(StorageClientTest, self).setUp()
         self.api_version_1 = "2019-02-02"
-        self.api_version_2 = _SUPPORTED_API_VERSIONS[-1]
+        self.api_version_2 = X_MS_VERSION
 
     # --Test Cases--------------------------------------------------------------
 


### PR DESCRIPTION
In a previous change the value of `X_MS_VERSION` was updated to use the latest supported service version rather than the version from the generated code (this was done to reflect what our clients do by default). This also updated the version used for SAS generation by default and therefore broke account SAS generation due to the not including the recent change to account SAS generation that only affects later service versions.

This change adds that required change to SAS generation as well as updates our version tests to use the `X_MS_VERSION` constant.