### PR TITLE
FIX: give useful error msg when bad URL passed to BlobClient.from_blob_url()

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.##.## (Unreleased)
+
+### Bugs Fixed:
+- fixes a bug in `BlobClient.from_blob_url()` such that users will receive a more helpful error
+message if they pass an incorrect URL without a full `/container/blob` path.
+
 ## 12.12.0b1 (2022-04-14)
 
 ### Features Added

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -241,23 +241,24 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
         account_path = ""
         if ".core." in parsed_url.netloc:
             # .core. is indicating non-customized url. Blob name with directory info can also be parsed.
-            path_blob = parsed_url.path.lstrip('/').split('/', 1)
+            path_blob = parsed_url.path.lstrip('/').split('/', maxsplit=1)
         elif "localhost" in parsed_url.netloc or "127.0.0.1" in parsed_url.netloc:
-            path_blob = parsed_url.path.lstrip('/').split('/', 2)
+            path_blob = parsed_url.path.lstrip('/').split('/', maxsplit=2)
             account_path += '/' + path_blob[0]
         else:
             # for customized url. blob name that has directory info cannot be parsed.
             path_blob = parsed_url.path.lstrip('/').split('/')
             if len(path_blob) > 2:
                 account_path = "/" + "/".join(path_blob[:-2])
+
         account_url = "{}://{}{}?{}".format(
             parsed_url.scheme,
             parsed_url.netloc.rstrip('/'),
             account_path,
             parsed_url.query)
-        container_name, blob_name = unquote(path_blob[-2]), unquote(path_blob[-1])
-        if not container_name or not blob_name:
+        if len(path_blob) <= 1:
             raise ValueError("Invalid URL. Provide a blob_url with a valid blob and container name.")
+        container_name, blob_name = unquote(path_blob[-2]), unquote(path_blob[-1])
 
         path_snapshot, _ = parse_query(parsed_url.query)
         if snapshot:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -256,9 +256,13 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             parsed_url.netloc.rstrip('/'),
             account_path,
             parsed_url.query)
+
+        msg_invalid_url = "Invalid URL. Provide a blob_url with a valid blob and container name."
         if len(path_blob) <= 1:
-            raise ValueError("Invalid URL. Provide a blob_url with a valid blob and container name.")
+            raise ValueError(msg_invalid_url)
         container_name, blob_name = unquote(path_blob[-2]), unquote(path_blob[-1])
+        if not container_name or not blob_name:
+            raise ValueError(msg_invalid_url)
 
         path_snapshot, _ = parse_query(parsed_url.query)
         if snapshot:

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client.py
@@ -480,6 +480,12 @@ class StorageClientTest(StorageTestCase):
         self.assertEqual(blob_client.blob_name, "dir1/sub000/2010_Unit150_Ivan097_img0003.jpg")
         self.assertEqual(blob_client.url, blob_emulator_url)
 
+    def test_from_blob_url_too_short_url(self):
+        """Test that a useful error message is obtained if user gives incorrect URL"""
+        url = "https://testaccount.blob.core.windows.net/containername/"
+        with pytest.raises(ValueError, match="Invalid URL"):
+            _ = BlobClient.from_blob_url(url)
+
     def test_create_client_for_emulator(self):
         container_client = ContainerClient(
             account_url='http://127.0.0.1:1000/devstoreaccount1',


### PR DESCRIPTION
# Description

**Problem:** A user tries to use `BlobClient.from_blob_url()` with an incorrect URL that does not have a container name and blob path, e.g. `BlobClient.from_blob_url("https://testaccount.blob.core.windows.net/containername/")` - note the missing blobname after the containername
**Current Behaviour:** User gets obscure error message: Because the list `path_blob` only has length of 1, i.e. `["containername"]`.
```
>       container_name, blob_name = unquote(path_blob[-2]), unquote(path_blob[-1])
E       IndexError: list index out of range
```

**Fixed Behaviour**: raises more helpful error: `ValueError("Invalid URL. Provide a blob_url with a valid blob and container name.")`

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
- Test 'test_from_blob_url_too_short_url()` added to `test_blob_client.py`