### PR TITLE
[Storage] Fix some datalake cpk Live tests

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk.test_file_download_cpk.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk.test_file_download_cpk.yaml
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 18:30:36 GMT
+      - Thu, 14 Apr 2022 20:13:57 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 18:30:35 GMT
+      - Thu, 14 Apr 2022 20:13:57 GMT
       etag:
-      - '"0x8DA077B1086B58B"'
+      - '"0x8DA1E534EE9B8F3"'
       last-modified:
-      - Wed, 16 Mar 2022 18:30:36 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -49,17 +49,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 18:30:36 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -71,11 +69,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 18:30:36 GMT
+      - Thu, 14 Apr 2022 20:13:57 GMT
       etag:
-      - '"0x8DA077B10C77E4E"'
+      - '"0x8DA1E534F19BC41"'
       last-modified:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:
@@ -99,17 +97,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -121,11 +117,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 18:30:36 GMT
+      - Thu, 14 Apr 2022 20:13:57 GMT
       etag:
-      - '"0x8DA077B10D33C6F"'
+      - '"0x8DA1E534F285CBC"'
       last-modified:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:
@@ -151,9 +147,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -171,7 +167,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:57 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:
@@ -194,12 +190,12 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      If-None-Match:
-      - '*'
+      If-Match:
+      - '"0x8DA1E534F285CBC"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -217,11 +213,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:57 GMT
       etag:
-      - '"0x8DA077B10FD0589"'
+      - '"0x8DA1E534F474F0F"'
       last-modified:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:
@@ -243,9 +239,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -271,23 +267,31 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 16 Mar 2022 18:30:36 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       etag:
-      - '"0x8DA077B10FD0589"'
+      - '"0x8DA1E534F474F0F"'
       last-modified:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 16 Mar 2022 18:30:37 GMT
+      - Thu, 14 Apr 2022 20:13:58 GMT
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
+      x-ms-group:
+      - $superuser
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk.test_file_upload_data_file_cpk.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk.test_file_upload_data_file_cpk.yaml
@@ -11,9 +11,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 01:27:30 GMT
+      - Thu, 14 Apr 2022 20:13:49 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 01:27:29 GMT
+      - Thu, 14 Apr 2022 20:13:49 GMT
       etag:
-      - '"0x8DA06EC239D0DD5"'
+      - '"0x8DA1E534A2666E2"'
       last-modified:
-      - Wed, 16 Mar 2022 01:27:30 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -49,17 +49,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 01:27:30 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -71,11 +69,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 01:27:30 GMT
+      - Thu, 14 Apr 2022 20:13:49 GMT
       etag:
-      - '"0x8DA06EC24504D16"'
+      - '"0x8DA1E534A6A4D21"'
       last-modified:
-      - Wed, 16 Mar 2022 01:27:31 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:
@@ -99,17 +97,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 01:27:31 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -121,11 +117,59 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 01:27:30 GMT
+      - Thu, 14 Apr 2022 20:13:49 GMT
       etag:
-      - '"0x8DA06EC245CA752"'
+      - '"0x8DA1E534A78984E"'
       last-modified:
-      - Wed, 16 Mar 2022 01:27:31 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-encryption-key-sha256:
+      - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Thu, 14 Apr 2022 20:13:50 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-encryption-key:
+      - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
+      x-ms-encryption-key-sha256:
+      - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/utfilesystem3c940fc4/directory3c940fc4%2Ffile3c940fc4?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 14 Apr 2022 20:13:49 GMT
+      etag:
+      - '"0x8DA1E534A843288"'
+      last-modified:
+      - Thu, 14 Apr 2022 20:13:50 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:
@@ -151,9 +195,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 01:27:31 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -171,7 +215,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 01:27:31 GMT
+      - Thu, 14 Apr 2022 20:13:49 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:
@@ -194,12 +238,12 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      If-None-Match:
-      - '*'
+      If-Match:
+      - '"0x8DA1E534A843288"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 01:27:31 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -217,11 +261,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 16 Mar 2022 01:27:31 GMT
+      - Thu, 14 Apr 2022 20:13:50 GMT
       etag:
-      - '"0x8DA06EC2474E6BB"'
+      - '"0x8DA1E534AADE94C"'
       last-modified:
-      - Wed, 16 Mar 2022 01:27:32 GMT
+      - Thu, 14 Apr 2022 20:13:51 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk_async.test_file_download_cpk.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk_async.test_file_download_cpk.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:33:08 GMT
+      - Thu, 14 Apr 2022 20:16:05 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -17,32 +17,30 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:33:08 GMT
-      etag: '"0x8DA0794909CC998"'
-      last-modified: Wed, 16 Mar 2022 21:33:08 GMT
+      date: Thu, 14 Apr 2022 20:16:04 GMT
+      etag: '"0x8DA1E539B0A96B4"'
+      last-modified: Thu, 14 Apr 2022 20:16:05 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-06-08'
     status:
       code: 201
       message: Created
-    url: https://jalauzoncanary.blob.core.windows.net/utfilesystem200e0f1c?restype=container&timeout=5
+    url: https://jalauzoncanaryadls.blob.core.windows.net/utfilesystem200e0f1c?restype=container&timeout=5
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:33:08 GMT
+      - Thu, 14 Apr 2022 20:16:05 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -52,9 +50,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:33:08 GMT
-      etag: '"0x8DA079490CB1B28"'
-      last-modified: Wed, 16 Mar 2022 21:33:09 GMT
+      date: Thu, 14 Apr 2022 20:16:05 GMT
+      etag: '"0x8DA1E539B315333"'
+      last-modified: Thu, 14 Apr 2022 20:16:06 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -62,24 +60,22 @@ interactions:
     status:
       code: 201
       message: Created
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c?resource=directory
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c?resource=directory
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:33:09 GMT
+      - Thu, 14 Apr 2022 20:16:06 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -89,9 +85,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:33:08 GMT
-      etag: '"0x8DA079490D3F37F"'
-      last-modified: Wed, 16 Mar 2022 21:33:09 GMT
+      date: Thu, 14 Apr 2022 20:16:05 GMT
+      etag: '"0x8DA1E539B3C8458"'
+      last-modified: Thu, 14 Apr 2022 20:16:06 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -99,7 +95,7 @@ interactions:
     status:
       code: 201
       message: Created
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c%2Ffile200e0f1c?resource=file
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c%2Ffile200e0f1c?resource=file
 - request:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
@@ -110,9 +106,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:33:09 GMT
+      - Thu, 14 Apr 2022 20:16:06 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -128,7 +124,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:33:09 GMT
+      date: Thu, 14 Apr 2022 20:16:05 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -136,18 +132,18 @@ interactions:
     status:
       code: 202
       message: Accepted
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c%2Ffile200e0f1c?action=append&position=0
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c%2Ffile200e0f1c?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
-      If-None-Match:
-      - '*'
+      If-Match:
+      - '"0x8DA1E539B3C8458"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:33:09 GMT
+      - Thu, 14 Apr 2022 20:16:06 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -163,9 +159,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:33:09 GMT
-      etag: '"0x8DA079491251507"'
-      last-modified: Wed, 16 Mar 2022 21:33:09 GMT
+      date: Thu, 14 Apr 2022 20:16:05 GMT
+      etag: '"0x8DA1E539B512615"'
+      last-modified: Thu, 14 Apr 2022 20:16:06 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -173,16 +169,16 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c%2Ffile200e0f1c?action=flush&position=1024&close=true
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystem200e0f1c/directory200e0f1c%2Ffile200e0f1c?action=flush&position=1024&close=true
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:33:09 GMT
+      - Thu, 14 Apr 2022 20:16:06 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -203,19 +199,23 @@ interactions:
       content-length: '1024'
       content-range: bytes 0-1023/1024
       content-type: application/octet-stream
-      date: Wed, 16 Mar 2022 21:33:09 GMT
-      etag: '"0x8DA079491251507"'
-      last-modified: Wed, 16 Mar 2022 21:33:09 GMT
+      date: Thu, 14 Apr 2022 20:16:05 GMT
+      etag: '"0x8DA1E539B512615"'
+      last-modified: Thu, 14 Apr 2022 20:16:06 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 16 Mar 2022 21:33:09 GMT
+      x-ms-creation-time: Thu, 14 Apr 2022 20:16:06 GMT
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
+      x-ms-group: $superuser
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
       x-ms-server-encrypted: 'true'
       x-ms-version: '2021-06-08'
     status:
       code: 206
       message: Partial Content
-    url: https://jalauzoncanary.blob.core.windows.net/utfilesystem200e0f1c/directory200e0f1c/file200e0f1c
+    url: https://jalauzoncanaryadls.blob.core.windows.net/utfilesystem200e0f1c/directory200e0f1c/file200e0f1c
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk_async.test_file_upload_data_file_cpk.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_cpk_async.test_file_upload_data_file_cpk.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:29:12 GMT
+      - Thu, 14 Apr 2022 20:15:58 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -17,32 +17,30 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:29:12 GMT
-      etag: '"0x8DA07940398292C"'
-      last-modified: Wed, 16 Mar 2022 21:29:12 GMT
+      date: Thu, 14 Apr 2022 20:15:58 GMT
+      etag: '"0x8DA1E539683AA88"'
+      last-modified: Thu, 14 Apr 2022 20:15:58 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-06-08'
     status:
       code: 201
       message: Created
-    url: https://jalauzoncanary.blob.core.windows.net/utfilesystema6801241?restype=container&timeout=5
+    url: https://jalauzoncanaryadls.blob.core.windows.net/utfilesystema6801241?restype=container&timeout=5
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:29:12 GMT
+      - Thu, 14 Apr 2022 20:15:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -52,9 +50,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:29:12 GMT
-      etag: '"0x8DA079403B8EB5C"'
-      last-modified: Wed, 16 Mar 2022 21:29:12 GMT
+      date: Thu, 14 Apr 2022 20:15:57 GMT
+      etag: '"0x8DA1E5396BB1C7E"'
+      last-modified: Thu, 14 Apr 2022 20:15:58 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -62,24 +60,22 @@ interactions:
     status:
       code: 201
       message: Created
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystema6801241/directorya6801241?resource=directory
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystema6801241/directorya6801241?resource=directory
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:29:12 GMT
+      - Thu, 14 Apr 2022 20:15:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
       - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
       x-ms-encryption-key-sha256:
       - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
-      x-ms-properties:
-      - ''
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -89,9 +85,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:29:12 GMT
-      etag: '"0x8DA079403C1EABC"'
-      last-modified: Wed, 16 Mar 2022 21:29:12 GMT
+      date: Thu, 14 Apr 2022 20:15:57 GMT
+      etag: '"0x8DA1E5396C8234F"'
+      last-modified: Thu, 14 Apr 2022 20:15:58 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -99,7 +95,42 @@ interactions:
     status:
       code: 201
       message: Created
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?resource=file
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?resource=file
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
+      x-ms-date:
+      - Thu, 14 Apr 2022 20:15:58 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-encryption-key:
+      - MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=
+      x-ms-encryption-key-sha256:
+      - 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Thu, 14 Apr 2022 20:15:57 GMT
+      etag: '"0x8DA1E5396D12FC6"'
+      last-modified: Thu, 14 Apr 2022 20:15:58 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2021-06-08'
+    status:
+      code: 201
+      message: Created
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?resource=file
 - request:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
@@ -110,9 +141,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:29:12 GMT
+      - Thu, 14 Apr 2022 20:15:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -128,7 +159,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:29:12 GMT
+      date: Thu, 14 Apr 2022 20:15:58 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -136,18 +167,18 @@ interactions:
     status:
       code: 202
       message: Accepted
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?action=append&position=0
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
-      If-None-Match:
-      - '*'
+      If-Match:
+      - '"0x8DA1E5396D12FC6"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.6.1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Wed, 16 Mar 2022 21:29:12 GMT
+      - Thu, 14 Apr 2022 20:15:59 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-encryption-key:
@@ -163,9 +194,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 16 Mar 2022 21:29:12 GMT
-      etag: '"0x8DA079403D4ACB5"'
-      last-modified: Wed, 16 Mar 2022 21:29:12 GMT
+      date: Thu, 14 Apr 2022 20:15:58 GMT
+      etag: '"0x8DA1E539703E40E"'
+      last-modified: Thu, 14 Apr 2022 20:15:59 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-encryption-key-sha256: 3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=
       x-ms-request-server-encrypted: 'true'
@@ -173,5 +204,5 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://jalauzoncanary.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?action=flush&position=1024&close=true
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/utfilesystema6801241/directorya6801241%2Ffilea6801241?action=flush&position=1024&close=true
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/test_cpk.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_cpk.py
@@ -174,7 +174,7 @@ class DatalakeCpkTest(StorageTestCase):
         data = self.get_random_bytes(1024)
 
         # Act
-        response = file_client.upload_data(data, cpk=TEST_ENCRYPTION_KEY)
+        response = file_client.upload_data(data, overwrite=True, cpk=TEST_ENCRYPTION_KEY)
 
         # Assert
         self.assertIsNotNone(response)
@@ -202,10 +202,12 @@ class DatalakeCpkTest(StorageTestCase):
     def test_file_download_cpk(self, datalake_storage_account_name, datalake_storage_account_key):
         # Arrange
         self._setup(datalake_storage_account_name, datalake_storage_account_key)
-        directory_name = self._get_directory_reference()
-        file_client = self._create_file(directory_name=directory_name, cpk=TEST_ENCRYPTION_KEY)
+        directory_client = self._create_directory(cpk=TEST_ENCRYPTION_KEY)
+        file_name = self._get_file_reference()
+        file_client = directory_client.get_file_client(file_name)
+
         data = self.get_random_bytes(1024)
-        file_client.upload_data(data, cpk=TEST_ENCRYPTION_KEY)
+        file_client.upload_data(data, overwrite=True, cpk=TEST_ENCRYPTION_KEY)
 
         # Act
         file = file_client.download_file(cpk=TEST_ENCRYPTION_KEY).readall()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_cpk_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_cpk_async.py
@@ -177,7 +177,7 @@ class DatalakeCpkTest(StorageTestCase):
         data = self.get_random_bytes(1024)
 
         # Act
-        response = await file_client.upload_data(data, cpk=TEST_ENCRYPTION_KEY)
+        response = await file_client.upload_data(data, overwrite=True, cpk=TEST_ENCRYPTION_KEY)
 
         # Assert
         self.assertIsNotNone(response)
@@ -205,10 +205,12 @@ class DatalakeCpkTest(StorageTestCase):
     async def test_file_download_cpk(self, datalake_storage_account_name, datalake_storage_account_key):
         # Arrange
         await self._setup(datalake_storage_account_name, datalake_storage_account_key)
-        directory_name = self._get_directory_reference()
-        file_client = await self._create_file(directory_name=directory_name, cpk=TEST_ENCRYPTION_KEY)
+        directory_client = await self._create_directory(cpk=TEST_ENCRYPTION_KEY)
+        file_name = self._get_file_reference()
+        file_client = directory_client.get_file_client(file_name)
+
         data = self.get_random_bytes(1024)
-        await file_client.upload_data(data, cpk=TEST_ENCRYPTION_KEY)
+        await file_client.upload_data(data, overwrite=True, cpk=TEST_ENCRYPTION_KEY)
 
         # Act
         download = await file_client.download_file(cpk=TEST_ENCRYPTION_KEY)


### PR DESCRIPTION
Some new datalake cpk tests started to fail in the Live test pipeline due to improper conditions when uploading data to files. I believe these tests passed during development of the feature since I was not using an HNS enabled account to run the tests.