### PR TITLE
Update network loss schema

### DIFF
--- a/sdk/servicebus/azure-servicebus/stress/Chart.lock
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
-  repository: file:///Git\azure-sdk-tools\tools\stress-cluster\cluster\kubernetes\stress-test-addons
+  repository: https://stresstestcharts.blob.core.windows.net/helm/
   version: 0.1.14
-digest: sha256:af99a5b1fb84886cc2a3ac78486268fddc72461f3dfaeb1a87edb371c8831d8b
-generated: "2022-04-14T12:07:21.7659195-07:00"
+digest: sha256:3e3330d3c01b26d1ca93e1490a9f2fee49eace7ae43fbd3ad284160f79d5b150
+generated: "2022-04-14T14:13:21.9911421-07:00"

--- a/sdk/servicebus/azure-servicebus/stress/Chart.lock
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.14
-digest: sha256:3e3330d3c01b26d1ca93e1490a9f2fee49eace7ae43fbd3ad284160f79d5b150
-generated: "2022-04-14T14:13:21.9911421-07:00"
+  version: 0.1.16
+digest: sha256:75061792fdbebe57c664322579af6dc240ce8f464280ac5e192de72a29d4f63f
+generated: "2022-04-21T12:02:33.1615633-07:00"

--- a/sdk/servicebus/azure-servicebus/stress/Chart.lock
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
-  repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.13
-digest: sha256:007ec9983233e0f8c8ad8aa7f1df5f57b1b4c127d223d59d233b3c5366bd5173
-generated: "2021-12-02T16:05:20.2152434-05:00"
+  repository: file:///Git\azure-sdk-tools\tools\stress-cluster\cluster\kubernetes\stress-test-addons
+  version: 0.1.14
+digest: sha256:af99a5b1fb84886cc2a3ac78486268fddc72461f3dfaeb1a87edb371c8831d8b
+generated: "2022-04-14T12:07:21.7659195-07:00"

--- a/sdk/servicebus/azure-servicebus/stress/Chart.yaml
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.yaml
@@ -9,5 +9,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.14
+  version: 0.1.16
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/servicebus/azure-servicebus/stress/Chart.yaml
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.yaml
@@ -10,4 +10,4 @@ annotations:
 dependencies:
 - name: stress-test-addons
   version: 0.1.14
-  repository: file:///Git\azure-sdk-tools\tools\stress-cluster\cluster\kubernetes\stress-test-addons #https://stresstestcharts.blob.core.windows.net/helm/
+  repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/servicebus/azure-servicebus/stress/Chart.yaml
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.yaml
@@ -9,5 +9,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.13
-  repository: https://stresstestcharts.blob.core.windows.net/helm/
+  version: 0.1.14
+  repository: file:///Git\azure-sdk-tools\tools\stress-cluster\cluster\kubernetes\stress-test-addons #https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/servicebus/azure-servicebus/stress/templates/network_loss.yaml
+++ b/sdk/servicebus/azure-servicebus/stress/templates/network_loss.yaml
@@ -1,14 +1,7 @@
+{{- include "stress-test-addons.chaos-wrapper.tpl" (list . "stress.python-sb-network") -}}
+{{- define "stress.python-sb-network" -}}
 apiVersion: chaos-mesh.org/v1alpha1
 kind: Schedule
-metadata:
-  name: '{{ .Release.Name }}-{{ .Release.Revision }}'
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    experiment.chaos-mesh.org/pause: 'true'
-  labels:
-    scenario: 'stress'
-    release: '{{ .Release.Name }}'
-    revision: '{{ .Release.Revision }}'
 spec:
   schedule: '@every 30s'
   type: 'NetworkChaos'
@@ -30,3 +23,4 @@ spec:
     loss:
       loss: '100'
       correlation: '100'
+{{- end -}}

--- a/sdk/servicebus/azure-servicebus/stress/templates/network_loss.yaml
+++ b/sdk/servicebus/azure-servicebus/stress/templates/network_loss.yaml
@@ -1,5 +1,5 @@
 apiVersion: chaos-mesh.org/v1alpha1
-kind: NetworkChaos
+kind: Schedule
 metadata:
   name: '{{ .Release.Name }}-{{ .Release.Revision }}'
   namespace: {{ .Release.Namespace }}
@@ -10,22 +10,23 @@ metadata:
     release: '{{ .Release.Name }}'
     revision: '{{ .Release.Revision }}'
 spec:
-  scheduler:
-    cron: '@every 30s'
-  duration: '10s'
-  action: loss
-  direction: to
-  externalTargets:
-    - 'servicebus.windows.net'
-  mode: one
-  selector:
-    labelSelectors:
-      testInstance: "servicebus-{{ .Release.Name }}-{{ .Release.Revision }}"
-      chaos: 'true'
-    namespaces:
-      - {{ .Release.Namespace }}
-    podPhaseSelectors:
-      - 'Running'
-  loss:
-    loss: '100'
-    correlation: '100'
+  schedule: '@every 30s'
+  type: 'NetworkChaos'
+  networkChaos:
+    action: loss
+    mode: one
+    selector:
+      labelSelectors:
+        testInstance: "servicebus-{{ .Release.Name }}-{{ .Release.Revision }}"
+        chaos: 'true'
+      namespaces:
+        - {{ .Release.Namespace }}
+      podPhaseSelectors:
+        - 'Running'
+    duration: '10s'
+    direction: to
+    externalTargets:
+      - 'servicebus.windows.net'
+    loss:
+      loss: '100'
+      correlation: '100'

--- a/sdk/servicebus/azure-servicebus/stress/templates/network_loss.yaml
+++ b/sdk/servicebus/azure-servicebus/stress/templates/network_loss.yaml
@@ -19,7 +19,7 @@ spec:
     duration: '10s'
     direction: to
     externalTargets:
-      - 'servicebus.windows.net'
+      - '{{ .Stress.ResourceGroupName }}.servicebus.windows.net'
     loss:
       loss: '100'
       correlation: '100'


### PR DESCRIPTION
Newest Chaos Mesh schema for "scheduler" now called [scheduling rules](https://chaos-mesh.org/docs/2.0.7/define-scheduling-rules/)
