### PR TITLE
[Core] Add multi-tenant authentication policy

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
@@ -25,7 +25,12 @@
 # --------------------------------------------------------------------------
 
 from ._base import HTTPPolicy, SansIOHTTPPolicy, RequestHistory
-from ._authentication import BearerTokenCredentialPolicy, AzureKeyCredentialPolicy, AzureSasCredentialPolicy
+from ._authentication import (
+    AzureKeyCredentialPolicy,
+    AzureSasCredentialPolicy,
+    BearerTokenCredentialPolicy,
+    MultitenantTokenCredentialPolicy,
+)
 from ._custom_hook import CustomHookPolicy
 from ._redirect import RedirectPolicy
 from ._retry import RetryPolicy, RetryMode
@@ -43,9 +48,10 @@ from ._universal import (
 __all__ = [
     'HTTPPolicy',
     'SansIOHTTPPolicy',
-    'BearerTokenCredentialPolicy',
     'AzureKeyCredentialPolicy',
     'AzureSasCredentialPolicy',
+    'BearerTokenCredentialPolicy',
+    'MultitenantTokenCredentialPolicy',
     'HeadersPolicy',
     'UserAgentPolicy',
     'NetworkTraceLoggingPolicy',

--- a/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
@@ -29,7 +29,7 @@ from ._authentication import (
     AzureKeyCredentialPolicy,
     AzureSasCredentialPolicy,
     BearerTokenCredentialPolicy,
-    MultitenantCredentialPolicy,
+    BearerTokenChallengePolicy,
 )
 from ._custom_hook import CustomHookPolicy
 from ._redirect import RedirectPolicy
@@ -51,7 +51,7 @@ __all__ = [
     'AzureKeyCredentialPolicy',
     'AzureSasCredentialPolicy',
     'BearerTokenCredentialPolicy',
-    'MultitenantCredentialPolicy',
+    'BearerTokenChallengePolicy',
     'HeadersPolicy',
     'UserAgentPolicy',
     'NetworkTraceLoggingPolicy',
@@ -71,13 +71,13 @@ __all__ = [
 
 try:
     from ._base_async import AsyncHTTPPolicy
-    from ._authentication_async import AsyncBearerTokenCredentialPolicy, AsyncMultitenantCredentialPolicy
+    from ._authentication_async import AsyncBearerTokenCredentialPolicy, AsyncBearerTokenChallengePolicy
     from ._redirect_async import AsyncRedirectPolicy
     from ._retry_async import AsyncRetryPolicy
     __all__.extend([
         'AsyncHTTPPolicy',
         'AsyncBearerTokenCredentialPolicy',
-        'AsyncMultitenantCredentialPolicy',
+        'AsyncBearerTokenChallengePolicy',
         'AsyncRedirectPolicy',
         'AsyncRetryPolicy'
     ])

--- a/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
@@ -29,7 +29,7 @@ from ._authentication import (
     AzureKeyCredentialPolicy,
     AzureSasCredentialPolicy,
     BearerTokenCredentialPolicy,
-    MultitenantTokenCredentialPolicy,
+    MultitenantCredentialPolicy,
 )
 from ._custom_hook import CustomHookPolicy
 from ._redirect import RedirectPolicy
@@ -51,7 +51,7 @@ __all__ = [
     'AzureKeyCredentialPolicy',
     'AzureSasCredentialPolicy',
     'BearerTokenCredentialPolicy',
-    'MultitenantTokenCredentialPolicy',
+    'MultitenantCredentialPolicy',
     'HeadersPolicy',
     'UserAgentPolicy',
     'NetworkTraceLoggingPolicy',
@@ -71,12 +71,13 @@ __all__ = [
 
 try:
     from ._base_async import AsyncHTTPPolicy
-    from ._authentication_async import AsyncBearerTokenCredentialPolicy
+    from ._authentication_async import AsyncBearerTokenCredentialPolicy, AsyncMultitenantCredentialPolicy
     from ._redirect_async import AsyncRedirectPolicy
     from ._retry_async import AsyncRetryPolicy
     __all__.extend([
         'AsyncHTTPPolicy',
         'AsyncBearerTokenCredentialPolicy',
+        'AsyncMultitenantCredentialPolicy',
         'AsyncRedirectPolicy',
         'AsyncRetryPolicy'
     ])

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
-class _HttpChallenge(object):  # pylint:disable=too-few-public-methods
+class HttpChallenge(object):  # pylint:disable=too-few-public-methods
     """Represents a parsed HTTP WWW-Authentication Bearer challenge from a server."""
 
     def __init__(self, challenge):
@@ -255,7 +255,7 @@ class BearerTokenChallengePolicy(BearerTokenCredentialPolicy):
             return False
 
         try:
-            challenge = _HttpChallenge(response.http_response.headers.get("WWW-Authenticate"))
+            challenge = HttpChallenge(response.http_response.headers.get("WWW-Authenticate"))
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             # if no scopes are included in the challenge, challenge.scope and challenge.resource will both be ''
             scope = challenge.scope or challenge.resource + "/.default" if self._discover_scopes else self._scopes

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -4,8 +4,8 @@
 # license information.
 # -------------------------------------------------------------------------
 import time
-import six
 import urllib.parse
+import six
 
 from . import HTTPPolicy, SansIOHTTPPolicy
 from ...exceptions import ServiceRequestError

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -214,7 +214,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
         return
 
 
-class MultitenantCredentialPolicy(BearerTokenCredentialPolicy):
+class BearerTokenChallengePolicy(BearerTokenCredentialPolicy):
     """Adds a bearer token Authorization header to requests, for the tenant provided in authentication challenges.
 
     See https://docs.microsoft.com/azure/active-directory/develop/claims-challenge for documentation on AAD

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -225,7 +225,7 @@ class BearerTokenChallengePolicy(BearerTokenCredentialPolicy):
     :param str scopes: Lets you specify the type of access needed.
     :keyword bool discover_tenant: Determines if tenant discovery should be enabled. Defaults to True.
     :keyword bool discover_scopes: Determines if scopes from authentication challenges should be provided to token
-        requests, instead of the scopes given to the policy's constructor. Defaults to True.
+        requests, instead of the scopes given to the policy's constructor, if any are present. Defaults to True.
     :raises: :class:`~azure.core.exceptions.ServiceRequestError`
     """
 
@@ -257,7 +257,10 @@ class BearerTokenChallengePolicy(BearerTokenCredentialPolicy):
         try:
             challenge = _HttpChallenge(response.http_response.headers.get("WWW-Authenticate"))
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
+            # if no scopes are included in the challenge, challenge.scope and challenge.resource will both be ''
             scope = challenge.scope or challenge.resource + "/.default" if self._discover_scopes else self._scopes
+            if scope == "/.default":
+                scope = self._scopes
         except ValueError:
             return False
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
-class _HttpChallenge(object):
+class _HttpChallenge(object):  # pylint:disable=too-few-public-methods
     """Represents a parsed HTTP WWW-Authentication Bearer challenge from a server."""
 
     def __init__(self, request_uri, challenge):

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -252,7 +252,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
         return
 
 
-class MultitenantTokenCredentialPolicy(BearerTokenCredentialPolicy):
+class MultitenantCredentialPolicy(BearerTokenCredentialPolicy):
     """Adds a bearer token Authorization header to requests, for the tenant provided in authorization challenges.
 
     See https://docs.microsoft.com/azure/active-directory/develop/claims-challenge for documentation on AAD
@@ -280,10 +280,7 @@ class MultitenantTokenCredentialPolicy(BearerTokenCredentialPolicy):
         except ValueError:
             return False
 
-        body = request.context.pop("key_vault_request_data", None)
-        request.http_request.set_text_body(body)  # no-op when text is None
         self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
-
         return True
 
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -167,7 +167,7 @@ class AsyncMultitenantCredentialPolicy(AsyncBearerTokenCredentialPolicy):
         :returns: a bool indicating whether the policy should send the request
         """
         try:
-            challenge = _HttpChallenge(request.http_request.url, response.http_response.headers.get("WWW-Authenticate"))
+            challenge = _HttpChallenge(response.http_response.headers.get("WWW-Authenticate"))
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             scope = challenge.scope or challenge.resource + "/.default"
         except ValueError:

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -8,7 +8,7 @@ import time
 from typing import TYPE_CHECKING
 
 from azure.core.pipeline.policies import AsyncHTTPPolicy
-from azure.core.pipeline.policies._authentication import _BearerTokenCredentialPolicyBase, _HttpChallenge
+from azure.core.pipeline.policies._authentication import _BearerTokenCredentialPolicyBase, HttpChallenge
 
 from .._tools_async import await_result
 
@@ -171,7 +171,7 @@ class AsyncBearerTokenChallengePolicy(AsyncBearerTokenCredentialPolicy):
             return False
 
         try:
-            challenge = _HttpChallenge(response.http_response.headers.get("WWW-Authenticate"))
+            challenge = HttpChallenge(response.http_response.headers.get("WWW-Authenticate"))
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
             # if no scopes are included in the challenge, challenge.scope and challenge.resource will both be ''
             scope = challenge.scope or challenge.resource + "/.default" if self._discover_scopes else self._scopes

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -141,7 +141,7 @@ class AsyncBearerTokenChallengePolicy(AsyncBearerTokenCredentialPolicy):
     :param str scopes: Lets you specify the type of access needed.
     :keyword bool discover_tenant: Determines if tenant discovery should be enabled. Defaults to True.
     :keyword bool discover_scopes: Determines if scopes from authentication challenges should be provided to token
-        requests, instead of the scopes given to the policy's constructor. Defaults to True.
+        requests, instead of the scopes given to the policy's constructor, if any are present. Defaults to True.
     :raises: :class:`~azure.core.exceptions.ServiceRequestError`
     """
 
@@ -173,7 +173,10 @@ class AsyncBearerTokenChallengePolicy(AsyncBearerTokenCredentialPolicy):
         try:
             challenge = _HttpChallenge(response.http_response.headers.get("WWW-Authenticate"))
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
+            # if no scopes are included in the challenge, challenge.scope and challenge.resource will both be ''
             scope = challenge.scope or challenge.resource + "/.default" if self._discover_scopes else self._scopes
+            if scope == "/.default":
+                scope = self._scopes
         except ValueError:
             return False
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -130,7 +130,7 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy):
         return not self._token or self._token.expires_on - time.time() < 300
 
 
-class AsyncMultitenantCredentialPolicy(AsyncBearerTokenCredentialPolicy):
+class AsyncBearerTokenChallengePolicy(AsyncBearerTokenCredentialPolicy):
     """Adds a bearer token Authorization header to requests, for the tenant provided in authentication challenges.
 
     See https://docs.microsoft.com/azure/active-directory/develop/claims-challenge for documentation on AAD

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_http_challenge_cache.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_http_challenge_cache.py
@@ -1,0 +1,79 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import threading
+
+import urllib.parse as parse
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    from typing import Dict
+    from ._authentication import HttpChallenge
+
+
+_cache = {}  # type: Dict[str, HttpChallenge]
+_lock = threading.Lock()
+
+
+def get_challenge_for_url(url):
+    """Gets the challenge for the cached URL.
+
+    :param url: the URL the challenge is cached for.
+    :rtype: HttpBearerChallenge
+    """
+    key = _get_cache_key(url)
+
+    with _lock:
+        return _cache.get(key)
+
+
+def _get_cache_key(url):
+    """Use the URL's netloc as cache key except when the URL specifies the default port for its scheme. In that case
+    use the netloc without the port. That is to say, https://foo.bar and https://foo.bar:443 are considered equivalent.
+
+    This equivalency prevents an unnecessary challenge when using Key Vault's paging API. The Key Vault client doesn't
+    specify ports, but Key Vault's next page links do, so a redundant challenge would otherwise be executed when the
+    client requests the next page.
+    """
+    parsed = parse.urlparse(url)
+    if parsed.scheme == "https" and parsed.port == 443:
+        return parsed.netloc[:-4]
+    return parsed.netloc
+
+
+def remove_challenge_for_url(url):
+    """Removes the cached challenge for the specified URL.
+
+    :param url: the URL for which to remove the cached challenge
+    """
+    url = parse.urlparse(url)
+
+    with _lock:
+        del _cache[url.netloc]
+
+
+def set_challenge_for_url(url, challenge):
+    """Caches the challenge for the specified URL.
+
+    :param url: the URL for which to cache the challenge
+    :param challenge: the challenge to cache
+    """
+    src_url = parse.urlparse(url)
+    if src_url.netloc != challenge.source_authority:
+        raise ValueError("Source URL and Challenge URL do not match")
+
+    with _lock:
+        _cache[src_url.netloc] = challenge
+
+
+def clear():
+    """Clears the cache."""
+    with _lock:
+        _cache.clear()

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -297,6 +297,178 @@ async def test_multitenant_policy_uses_scopes_and_tenant(http_request):
     await test_with_challenge(challenge_with_scope, scope, tenant)
 
 
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_multitenant_policy_disable_tenant_discovery(http_request):
+    """The policy's token requests should exclude the challenge's tenant if requested"""
+
+    async def test_with_challenge(challenge, challenge_scope):
+        bad_token = "bad_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        async def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            elif Requests.count == 2:
+                # second request should still be unauthorized because we didn't authenticate in the correct tenant
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            raise ValueError("unexpected request")
+
+        async def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            elif TokenRequests.count == 2:
+                # second request should use the scope specified in the auth challenge, but not the tenant
+                assert scopes[0] == challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            raise ValueError("unexpected token request")
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = AsyncMultitenantCredentialPolicy(credential, "scope", enable_tenant_discovery=False)
+        pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
+        await pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge separates the authorization server and resource with commas in the WWW-Authenticate header
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
+    )
+    # the request should fail after the challenge because we don't use the correct tenant
+    # after the second 4xx response, the policy should raise the authentication error
+    await test_with_challenge(challenge_with_commas, scope)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_multitenant_policy_disable_scopes_discovery(http_request):
+    """The policy's token requests should exclude the challenge's scope if requested"""
+
+    async def test_with_challenge(challenge, challenge_scope, challenge_tenant):
+        bad_token = "bad_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        async def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            elif Requests.count == 2:
+                # second request should still be unauthorized because we didn't authenticate with the correct scope
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            raise ValueError("unexpected request")
+
+        async def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            elif TokenRequests.count == 2:
+                # second request should use the tenant specified in the auth challenge, but not the scope
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") == challenge_tenant
+                return AccessToken(bad_token, 0)
+            raise ValueError("unexpected token request")
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = AsyncMultitenantCredentialPolicy(credential, "scope", enable_scopes_discovery=False)
+        pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
+        await pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge separates the authorization server and resource with commas in the WWW-Authenticate header
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
+    )
+    # the request should fail after the challenge because we don't use the correct scope
+    # after the second 4xx response, the policy should raise the authentication error
+    await test_with_challenge(challenge_with_commas, scope, tenant)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_multitenant_policy_disable_any_discovery(http_request):
+    """The policy shouldn't respond to the challenge if it can't use the provided scope or tenant"""
+
+    async def test_with_challenge(challenge, challenge_scope, challenge_tenant):
+        bad_token = "bad_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        async def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            raise ValueError("unexpected request")
+
+        async def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            raise ValueError("unexpected token request")
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = AsyncMultitenantCredentialPolicy(
+            credential, "scope", enable_tenant_discovery=False, enable_scopes_discovery=False
+        )
+        pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
+        await pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge separates the authorization server and resource with commas in the WWW-Authenticate header
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
+    )
+    # the policy should only send one request since we can't update our request per the challenge response
+    await test_with_challenge(challenge_with_commas, scope, tenant)
+
+
 def get_completed_future(result=None):
     fut = asyncio.Future()
     fut.set_result(result)

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -227,7 +227,7 @@ async def test_bearer_policy_calls_sansio_methods(http_request):
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_multitenant_policy_uses_scopes_and_tenant(http_request):
+async def test_challenge_policy_uses_scopes_and_tenant(http_request):
     """The policy's token requests should pass the parsed scope and tenant ID from the challenge"""
 
     async def test_with_challenge(challenge, expected_scope, expected_tenant):
@@ -298,7 +298,7 @@ async def test_multitenant_policy_uses_scopes_and_tenant(http_request):
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_multitenant_policy_disable_tenant_discovery(http_request):
+async def test_challenge_policy_disable_tenant_discovery(http_request):
     """The policy's token requests should exclude the challenge's tenant if requested"""
 
     async def test_with_challenge(challenge, challenge_scope):
@@ -358,7 +358,7 @@ async def test_multitenant_policy_disable_tenant_discovery(http_request):
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_multitenant_policy_disable_scopes_discovery(http_request):
+async def test_challenge_policy_disable_scopes_discovery(http_request):
     """The policy's token requests should exclude the challenge's scope if requested"""
 
     async def test_with_challenge(challenge, challenge_scope, challenge_tenant):
@@ -418,7 +418,7 @@ async def test_multitenant_policy_disable_scopes_discovery(http_request):
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_multitenant_policy_disable_any_discovery(http_request):
+async def test_challenge_policy_disable_any_discovery(http_request):
     """The policy shouldn't respond to the challenge if it can't use the provided scope or tenant"""
 
     async def test_with_challenge(challenge, challenge_scope, challenge_tenant):
@@ -466,6 +466,66 @@ async def test_multitenant_policy_disable_any_discovery(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
     )
     # the policy should only send one request since we can't update our request per the challenge response
+    await test_with_challenge(challenge_with_commas, scope, tenant)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_challenge_policy_no_scope_in_challenge(http_request):
+    """The policy's token requests should use constructor scopes if none are in the challenge"""
+
+    async def test_with_challenge(challenge, challenge_scope, challenge_tenant):
+        bad_token = "bad_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        async def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            elif Requests.count == 2:
+                # second request should still be unauthorized because we didn't authenticate with the correct scope
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            raise ValueError("unexpected request")
+
+        async def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            elif TokenRequests.count == 2:
+                # second request should use the tenant specified in the auth challenge, and same scope as before
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") == challenge_tenant
+                return AccessToken(bad_token, 0)
+            raise ValueError("unexpected token request")
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = AsyncBearerTokenChallengePolicy(credential, "scope")
+        pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
+        await pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge has no `resource` or `scope` field
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}"'},
+    )
+    # the request should fail after the challenge because we don't use the correct scope
+    # after the second 4xx response, the policy should raise the authentication error
     await test_with_challenge(challenge_with_commas, scope, tenant)
 
 

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -16,6 +16,7 @@ from azure.core.pipeline.policies import (
     AsyncBearerTokenChallengePolicy,
     SansIOHTTPPolicy,
 )
+from azure.core.pipeline.policies import _http_challenge_cache as ChallengeCache
 import pytest
 
 pytestmark = pytest.mark.asyncio
@@ -281,6 +282,7 @@ async def test_challenge_policy_uses_scopes_and_tenant(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
     )
     await test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
     # this challenge separates the authorization server and resource with only spaces in the WWW-Authenticate header
     challenge_without_commas = Mock(
@@ -288,6 +290,7 @@ async def test_challenge_policy_uses_scopes_and_tenant(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization={endpoint} resource={resource}'},
     )
     await test_with_challenge(challenge_without_commas, scope, tenant)
+    ChallengeCache.clear()
 
     # this challenge gives an AADv2 scope, ending with "/.default", instead of an AADv1 resource
     challenge_with_scope = Mock(
@@ -295,6 +298,7 @@ async def test_challenge_policy_uses_scopes_and_tenant(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization={endpoint} scope={scope}'},
     )
     await test_with_challenge(challenge_with_scope, scope, tenant)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -355,6 +359,7 @@ async def test_challenge_policy_disable_tenant_discovery(http_request):
     # the request should fail after the challenge because we don't use the correct tenant
     # after the second 4xx response, the policy should raise the authentication error
     await test_with_challenge(challenge_with_commas, scope)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -415,6 +420,7 @@ async def test_challenge_policy_disable_scopes_discovery(http_request):
     # the request should fail after the challenge because we don't use the correct scope
     # after the second 4xx response, the policy should raise the authentication error
     await test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -467,6 +473,7 @@ async def test_challenge_policy_disable_any_discovery(http_request):
     )
     # the policy should only send one request since we can't update our request per the challenge response
     await test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -527,6 +534,7 @@ async def test_challenge_policy_no_scope_in_challenge(http_request):
     # the request should fail after the challenge because we don't use the correct scope
     # after the second 4xx response, the policy should raise the authentication error
     await test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
 
 def get_completed_future(result=None):

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -13,7 +13,7 @@ from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import AsyncPipeline
 from azure.core.pipeline.policies import (
     AsyncBearerTokenCredentialPolicy,
-    AsyncMultitenantCredentialPolicy,
+    AsyncBearerTokenChallengePolicy,
     SansIOHTTPPolicy,
 )
 import pytest
@@ -266,7 +266,7 @@ async def test_multitenant_policy_uses_scopes_and_tenant(http_request):
             return AccessToken(expected_token, 0)
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = AsyncMultitenantCredentialPolicy(credential, "scope")
+        policy = AsyncBearerTokenChallengePolicy(credential, "scope")
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
 
@@ -338,7 +338,7 @@ async def test_multitenant_policy_disable_tenant_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = AsyncMultitenantCredentialPolicy(credential, "scope", discover_tenant=False)
+        policy = AsyncBearerTokenChallengePolicy(credential, "scope", discover_tenant=False)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
 
@@ -398,7 +398,7 @@ async def test_multitenant_policy_disable_scopes_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = AsyncMultitenantCredentialPolicy(credential, "scope", discover_scopes=False)
+        policy = AsyncBearerTokenChallengePolicy(credential, "scope", discover_scopes=False)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
 
@@ -449,7 +449,7 @@ async def test_multitenant_policy_disable_any_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = AsyncMultitenantCredentialPolicy(
+        policy = AsyncBearerTokenChallengePolicy(
             credential, "scope", discover_tenant=False, discover_scopes=False
         )
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -11,7 +11,11 @@ from unittest.mock import Mock
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import AsyncPipeline
-from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy, SansIOHTTPPolicy
+from azure.core.pipeline.policies import (
+    AsyncBearerTokenCredentialPolicy,
+    AsyncMultitenantCredentialPolicy,
+    SansIOHTTPPolicy,
+)
 import pytest
 
 pytestmark = pytest.mark.asyncio
@@ -220,6 +224,77 @@ async def test_bearer_policy_calls_sansio_methods(http_request):
     assert transport.send.call_count == 2
     policy.on_challenge.assert_called_once()
     policy.on_exception.assert_called_once_with(policy.request)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_multitenant_policy_uses_scopes_and_tenant(http_request):
+    """The policy's token requests should pass the parsed scope and tenant ID from the challenge"""
+
+    async def test_with_challenge(challenge, expected_scope, expected_tenant):
+        expected_token = "expected_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        async def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                return challenge
+            elif Requests.count == 2:
+                # second request should be authorized according to challenge and have the expected content
+                assert expected_token in request.headers["Authorization"]
+                return Mock(status_code=200)
+            raise ValueError("unexpected request")
+
+        async def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != expected_scope
+                assert kwargs.get("tenant_id") is None
+            elif TokenRequests.count == 2:
+                # second request should use the scope and tenant ID specified in the auth challenge
+                assert scopes[0] == expected_scope
+                assert kwargs.get("tenant_id") == expected_tenant
+            else:
+                raise ValueError("unexpected token request")
+            return AccessToken(expected_token, 0)
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = AsyncMultitenantCredentialPolicy(credential, "scope")
+        pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
+        await pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge separates the authorization server and resource with commas in the WWW-Authenticate header
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
+    )
+    await test_with_challenge(challenge_with_commas, scope, tenant)
+
+    # this challenge separates the authorization server and resource with only spaces in the WWW-Authenticate header
+    challenge_without_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization={endpoint} resource={resource}'},
+    )
+    await test_with_challenge(challenge_without_commas, scope, tenant)
+
+    # this challenge gives an AADv2 scope, ending with "/.default", instead of an AADv1 resource
+    challenge_with_scope = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization={endpoint} scope={scope}'},
+    )
+    await test_with_challenge(challenge_with_scope, scope, tenant)
 
 
 def get_completed_future(result=None):

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -338,7 +338,7 @@ async def test_multitenant_policy_disable_tenant_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = AsyncMultitenantCredentialPolicy(credential, "scope", enable_tenant_discovery=False)
+        policy = AsyncMultitenantCredentialPolicy(credential, "scope", discover_tenant=False)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
 
@@ -398,7 +398,7 @@ async def test_multitenant_policy_disable_scopes_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = AsyncMultitenantCredentialPolicy(credential, "scope", enable_scopes_discovery=False)
+        policy = AsyncMultitenantCredentialPolicy(credential, "scope", discover_scopes=False)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
 
@@ -450,7 +450,7 @@ async def test_multitenant_policy_disable_any_discovery(http_request):
 
         credential = Mock(get_token=Mock(wraps=get_token))
         policy = AsyncMultitenantCredentialPolicy(
-            credential, "scope", enable_tenant_discovery=False, enable_scopes_discovery=False
+            credential, "scope", discover_tenant=False, discover_scopes=False
         )
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -377,7 +377,7 @@ def test_multitenant_policy_disable_tenant_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = MultitenantCredentialPolicy(credential, "scope", enable_tenant_discovery=False)
+        policy = MultitenantCredentialPolicy(credential, "scope", discover_tenant=False)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
 
@@ -437,7 +437,7 @@ def test_multitenant_policy_disable_scopes_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = MultitenantCredentialPolicy(credential, "scope", enable_scopes_discovery=False)
+        policy = MultitenantCredentialPolicy(credential, "scope", discover_scopes=False)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
 
@@ -489,7 +489,7 @@ def test_multitenant_policy_disable_any_discovery(http_request):
 
         credential = Mock(get_token=Mock(wraps=get_token))
         policy = MultitenantCredentialPolicy(
-            credential, "scope", enable_tenant_discovery=False, enable_scopes_discovery=False
+            credential, "scope", discover_tenant=False, discover_scopes=False
         )
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -11,7 +11,7 @@ from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import (
     BearerTokenCredentialPolicy,
-    MultitenantCredentialPolicy,
+    BearerTokenChallengePolicy,
     SansIOHTTPPolicy,
     AzureKeyCredentialPolicy,
     AzureSasCredentialPolicy,
@@ -305,7 +305,7 @@ def test_multitenant_policy_uses_scopes_and_tenant(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = MultitenantCredentialPolicy(credential, "scope")
+        policy = BearerTokenChallengePolicy(credential, "scope")
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
 
@@ -377,7 +377,7 @@ def test_multitenant_policy_disable_tenant_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = MultitenantCredentialPolicy(credential, "scope", discover_tenant=False)
+        policy = BearerTokenChallengePolicy(credential, "scope", discover_tenant=False)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
 
@@ -437,7 +437,7 @@ def test_multitenant_policy_disable_scopes_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = MultitenantCredentialPolicy(credential, "scope", discover_scopes=False)
+        policy = BearerTokenChallengePolicy(credential, "scope", discover_scopes=False)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
 
@@ -488,7 +488,7 @@ def test_multitenant_policy_disable_any_discovery(http_request):
             raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        policy = MultitenantCredentialPolicy(
+        policy = BearerTokenChallengePolicy(
             credential, "scope", discover_tenant=False, discover_scopes=False
         )
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -7,7 +7,7 @@ import time
 from itertools import product
 import azure.core
 from azure.core.credentials import AccessToken, AzureKeyCredential, AzureSasCredential, AzureNamedKeyCredential
-from azure.core.exceptions import ServiceRequestError
+from azure.core.exceptions import ClientAuthenticationError, ServiceRequestError
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import (
     BearerTokenCredentialPolicy,
@@ -31,13 +31,13 @@ except ImportError:
 def test_bearer_policy_adds_header(http_request):
     """The bearer token policy should add a header containing a token from its credential"""
     # 2524608000 == 01/01/2050 @ 12:00am (UTC)
-    expected_token = AccessToken("expected_token", 2524608000)
+    correct_token = AccessToken("correct_token", 2524608000)
 
     def verify_authorization_header(request):
-        assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token.token)
+        assert request.http_request.headers["Authorization"] == "Bearer {}".format(correct_token.token)
         return Mock()
 
-    fake_credential = Mock(get_token=Mock(return_value=expected_token))
+    fake_credential = Mock(get_token=Mock(return_value=correct_token))
     policies = [BearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_authorization_header)]
 
     pipeline = Pipeline(transport=Mock(), policies=policies)
@@ -139,15 +139,15 @@ def test_bearer_policy_preserves_enforce_https_opt_out(http_request):
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_bearer_policy_default_context(http_request):
     """The policy should call get_token with the scopes given at construction, and no keyword arguments, by default"""
-    expected_scope = "scope"
+    challenge_scope = "scope"
     token = AccessToken("", 0)
     credential = Mock(get_token=Mock(return_value=token))
-    policy = BearerTokenCredentialPolicy(credential, expected_scope)
+    policy = BearerTokenCredentialPolicy(credential, challenge_scope)
     pipeline = Pipeline(transport=Mock(), policies=[policy])
 
     pipeline.run(http_request("GET", "https://localhost"))
 
-    credential.get_token.assert_called_once_with(expected_scope)
+    credential.get_token.assert_called_once_with(challenge_scope)
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -191,19 +191,19 @@ def test_bearer_policy_calls_on_challenge(http_request):
 def test_bearer_policy_cannot_complete_challenge(http_request):
     """BearerTokenCredentialPolicy should return the 401 response when it can't complete its challenge"""
 
-    expected_scope = "scope"
-    expected_token = AccessToken("***", int(time.time()) + 3600)
-    credential = Mock(get_token=Mock(return_value=expected_token))
+    challenge_scope = "scope"
+    correct_token = AccessToken("***", int(time.time()) + 3600)
+    credential = Mock(get_token=Mock(return_value=correct_token))
     expected_response = Mock(status_code=401, headers={"WWW-Authenticate": 'Basic realm="localhost"'})
     transport = Mock(send=Mock(return_value=expected_response))
-    policies = [BearerTokenCredentialPolicy(credential, expected_scope)]
+    policies = [BearerTokenCredentialPolicy(credential, challenge_scope)]
 
     pipeline = Pipeline(transport=transport, policies=policies)
     response = pipeline.run(http_request("GET", "https://localhost"))
 
     assert response.http_response is expected_response
     assert transport.send.call_count == 1
-    credential.get_token.assert_called_once_with(expected_scope)
+    credential.get_token.assert_called_once_with(challenge_scope)
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -265,10 +265,11 @@ def test_bearer_policy_calls_sansio_methods(http_request):
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_multitenant_policy_uses_scopes_and_tenant(http_request):
-    """The policy's token requests should pass the parsed scope and tenant ID from the challenge"""
+    """The policy's token requests should pass the parsed scope and tenant ID from the challenge, by default"""
 
-    def test_with_challenge(challenge, expected_scope, expected_tenant):
-        expected_token = "expected_token"
+    def test_with_challenge(challenge, challenge_scope, challenge_tenant):
+        bad_token = "bad_token"
+        correct_token = "correct_token"
 
         class Requests:
             count = 0
@@ -279,11 +280,12 @@ def test_multitenant_policy_uses_scopes_and_tenant(http_request):
         def send(request):
             Requests.count += 1
             if Requests.count == 1:
-                # first request triggers a 401 response w/ auth challenge
+                # first request triggers a 401 response w/ auth challenge -- token is for incorrect scope/tenant
+                assert bad_token in request.headers["Authorization"]
                 return challenge
             elif Requests.count == 2:
                 # second request should be authorized according to challenge and have the expected content
-                assert expected_token in request.headers["Authorization"]
+                assert correct_token in request.headers["Authorization"]
                 return Mock(status_code=200)
             raise ValueError("unexpected request")
 
@@ -292,15 +294,15 @@ def test_multitenant_policy_uses_scopes_and_tenant(http_request):
             TokenRequests.count += 1
             if TokenRequests.count == 1:
                 # first request uses the scope given to the policy, and no tenant ID
-                assert scopes[0] != expected_scope
+                assert scopes[0] != challenge_scope
                 assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
             elif TokenRequests.count == 2:
                 # second request should use the scope and tenant ID specified in the auth challenge
-                assert scopes[0] == expected_scope
-                assert kwargs.get("tenant_id") == expected_tenant
-            else:
-                raise ValueError("unexpected token request")
-            return AccessToken(expected_token, 0)
+                assert scopes[0] == challenge_scope
+                assert kwargs.get("tenant_id") == challenge_tenant
+                return AccessToken(correct_token, 0)
+            raise ValueError("unexpected token request")
 
         credential = Mock(get_token=Mock(wraps=get_token))
         policy = MultitenantCredentialPolicy(credential, "scope")
@@ -332,6 +334,178 @@ def test_multitenant_policy_uses_scopes_and_tenant(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization={endpoint} scope={scope}'},
     )
     test_with_challenge(challenge_with_scope, scope, tenant)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+def test_multitenant_policy_disable_tenant_discovery(http_request):
+    """The policy's token requests should exclude the challenge's tenant if requested"""
+
+    def test_with_challenge(challenge, challenge_scope):
+        bad_token = "bad_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            elif Requests.count == 2:
+                # second request should still be unauthorized because we didn't authenticate in the correct tenant
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            raise ValueError("unexpected request")
+
+        def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            elif TokenRequests.count == 2:
+                # second request should use the scope specified in the auth challenge, but not the tenant
+                assert scopes[0] == challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            raise ValueError("unexpected token request")
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = MultitenantCredentialPolicy(credential, "scope", enable_tenant_discovery=False)
+        pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
+        pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge separates the authorization server and resource with commas in the WWW-Authenticate header
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
+    )
+    # the request should fail after the challenge because we don't use the correct tenant
+    # after the second 4xx response, the policy should raise the authentication error
+    test_with_challenge(challenge_with_commas, scope)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+def test_multitenant_policy_disable_scopes_discovery(http_request):
+    """The policy's token requests should exclude the challenge's scope if requested"""
+
+    def test_with_challenge(challenge, challenge_scope, challenge_tenant):
+        bad_token = "bad_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            elif Requests.count == 2:
+                # second request should still be unauthorized because we didn't authenticate with the correct scope
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            raise ValueError("unexpected request")
+
+        def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            elif TokenRequests.count == 2:
+                # second request should use the tenant specified in the auth challenge, but not the scope
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") == challenge_tenant
+                return AccessToken(bad_token, 0)
+            raise ValueError("unexpected token request")
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = MultitenantCredentialPolicy(credential, "scope", enable_scopes_discovery=False)
+        pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
+        pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge separates the authorization server and resource with commas in the WWW-Authenticate header
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
+    )
+    # the request should fail after the challenge because we don't use the correct scope
+    # after the second 4xx response, the policy should raise the authentication error
+    test_with_challenge(challenge_with_commas, scope, tenant)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+def test_multitenant_policy_disable_any_discovery(http_request):
+    """The policy shouldn't respond to the challenge if it can't use the provided scope or tenant"""
+
+    def test_with_challenge(challenge, challenge_scope, challenge_tenant):
+        bad_token = "bad_token"
+
+        class Requests:
+            count = 0
+
+        class TokenRequests:
+            count = 0
+
+        def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request triggers a 401 response w/ auth challenge
+                assert bad_token in request.headers["Authorization"]
+                return challenge
+            raise ValueError("unexpected request")
+
+        def get_token(*scopes, **kwargs):
+            assert len(scopes) == 1
+            TokenRequests.count += 1
+            if TokenRequests.count == 1:
+                # first request uses the scope given to the policy, and no tenant ID
+                assert scopes[0] != challenge_scope
+                assert kwargs.get("tenant_id") is None
+                return AccessToken(bad_token, 0)
+            raise ValueError("unexpected token request")
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        policy = MultitenantCredentialPolicy(
+            credential, "scope", enable_tenant_discovery=False, enable_scopes_discovery=False
+        )
+        pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
+        pipeline.run(http_request("GET", "https://localhost"))
+
+    tenant = "tenant-id"
+    endpoint = f"https://authority.net/{tenant}/oauth2/authorize"
+    resource = "https://challenge.resource"
+    scope = f"{resource}/.default"
+
+    # this challenge separates the authorization server and resource with commas in the WWW-Authenticate header
+    challenge_with_commas = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
+    )
+    # the policy should only send one request since we can't update our request per the challenge response
+    test_with_challenge(challenge_with_commas, scope, tenant)
 
 
 @pytest.mark.skipif(azure.core.__version__ >= "2", reason="this test applies only to azure-core 1.x")

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -16,6 +16,7 @@ from azure.core.pipeline.policies import (
     AzureKeyCredentialPolicy,
     AzureSasCredentialPolicy,
 )
+from azure.core.pipeline.policies import _http_challenge_cache as ChallengeCache
 from utils import HTTP_REQUESTS
 
 import pytest
@@ -320,6 +321,7 @@ def test_challenge_policy_uses_scopes_and_tenant(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource="{resource}"'},
     )
     test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
     # this challenge separates the authorization server and resource with only spaces in the WWW-Authenticate header
     challenge_without_commas = Mock(
@@ -327,6 +329,7 @@ def test_challenge_policy_uses_scopes_and_tenant(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization={endpoint} resource={resource}'},
     )
     test_with_challenge(challenge_without_commas, scope, tenant)
+    ChallengeCache.clear()
 
     # this challenge gives an AADv2 scope, ending with "/.default", instead of an AADv1 resource
     challenge_with_scope = Mock(
@@ -334,6 +337,7 @@ def test_challenge_policy_uses_scopes_and_tenant(http_request):
         headers={"WWW-Authenticate": f'Bearer authorization={endpoint} scope={scope}'},
     )
     test_with_challenge(challenge_with_scope, scope, tenant)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -394,6 +398,7 @@ def test_challenge_policy_disable_tenant_discovery(http_request):
     # the request should fail after the challenge because we don't use the correct tenant
     # after the second 4xx response, the policy should raise the authentication error
     test_with_challenge(challenge_with_commas, scope)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -454,6 +459,7 @@ def test_challenge_policy_disable_scopes_discovery(http_request):
     # the request should fail after the challenge because we don't use the correct scope
     # after the second 4xx response, the policy should raise the authentication error
     test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -506,6 +512,7 @@ def test_challenge_policy_disable_any_discovery(http_request):
     )
     # the policy should only send one request since we can't update our request per the challenge response
     test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -566,6 +573,7 @@ def test_challenge_policy_no_scope_in_challenge(http_request):
     # the request should fail after the challenge because we don't use the correct scope
     # after the second 4xx response, the policy should raise the authentication error
     test_with_challenge(challenge_with_commas, scope, tenant)
+    ChallengeCache.clear()
 
 
 @pytest.mark.skipif(azure.core.__version__ >= "2", reason="this test applies only to azure-core 1.x")


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/23613. For cross-language reference, [here](https://github.com/Azure/azure-sdk-for-net/blob/1722fc8329bd848d400faf73daeba06d9d718cc1/sdk/tables/Azure.Data.Tables/src/TableBearerTokenChallengeAuthorizationPolicy.cs#L28) is .NET's Tables-internal implementation, [here](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/tables/azure-data-tables/src/main/java/com/azure/data/tables/implementation/TableBearerTokenChallengeAuthorizationPolicy.java) is Java's Tables-internal implementation, and [here](https://github.com/Azure/azure-sdk-for-js/blob/bf7f3c18b6e43272b8a6db0defccd09d551923d9/sdk/core/core-client/src/authorizeRequestOnTenantChallenge.ts) is JavaScript's challenge-handling callback method in Core.

**Context:** AAD supports [authentication claims challenges](https://docs.microsoft.com/azure/active-directory/develop/claims-challenge), which are exposed in service requests as 401 responses when authentication fails. These 401 responses contain a header that includes the tenant ID where the requested resource lives -- this tenant ID can be passed along to token requests in order to get a valid token for the resource, even if the credential we initially provided to the client targeted a different tenant.

For example:

```python
from azure.data.tables import TableServiceClient
from azure.identity import ClientSecretCredential

endpoint = "https://storage-account.table.core.windows.net"
credential = ClientSecretCredential(
    tenant_id=tenant_A,  # our storage account lives in tenant_B
    client_id=...,
    client_secret=...,
)

# Note: Tables only supports auth challenges in API version 2020-12-06 and after (this will require new Tables SDK support)
client = TableServiceClient(credential=credential, endpoint=endpoint, api_version="2020-12-06")
for table in client.list_tables():
    print(table.name)
```

**Current behavior:** we call `client.list_tables()` with a `BearerTokenCredentialPolicy`:
1. We fetch a token for `tenant_A` because of our credential
2. The service rejects this token because our storage resource is in `tenant_B`
3. We return the error response in an exception

**New behavior:** we call `client.list_tables()` with a `BearerTokenChallengePolicy` (from this PR):
1. We fetch a token for `tenant_A` because of our credential
2. The service rejects this token because our storage resource is in `tenant_B`
3. We parse the `WWW-Authenticate` header of the response and fetch a token valid in `tenant_B` (for the scope provided in the same header)
4. We re-send the original request, with the new token for `tenant_B`
5. We get a successful response from the service


This policy is based on the [ChallengeAuthPolicy](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py) used by Key Vault, which currently supports multi-tenant authentication. The most significant change between this policy and KV's is that this policy doesn't use its `ChallengeCache` to remove the request body when a request is expected to prompt an auth challenge. Changing this behavior should reduce the number of requests we make:

1. If the resource we're making a request for exists in our tenant, we already provide a valid token. The request succeeds.
  1a. In KV, we would send an empty request the first time in order to prompt an auth challenge, even though our tenant matches that of the resource. Our second request succeeds.
2. If the resource exists in a different tenant, our request fails and prompts a 401. We make a second request with the correct tenant.
  2a. In KV, we would have initially sent an empty request to prompt a 401. We still send a second request with the correct tenant.
  
For context, Key Vault drops the body of requests made to a new endpoint for security reasons: we want to ensure that the endpoint we're communicating with can accept our auth flow; that it is a correct KV endpoint (at least, that it follows the expected challenge auth flow); and that we don't send sensitive information (like key or secret values) in request bodies until the former conditions are met. Tables doesn't follow these security requirements today, so I decided to leave request bodies in initial requests by default -- KV's use of the policy will just have to be modified. This is prototyped in https://github.com/mccoyp/azure-sdk-for-python/pull/1.
  
  
By default, this policy will fetch tokens after a challenge response that are valid for the tenant and scope we get back in a challenge response (and _only_ the scope provided in the response). There are two toggles to disable either part or all of this behavior: `discover_tenant` and `discover_scopes`. If both of these kwargs are set to `False`, this policy becomes functionally equivalent to the base `BearerTokenCredentialPolicy`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
d