### PR TITLE
[Storage] Update documentation for socket timeouts

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/README.md
+++ b/sdk/storage/azure-storage-blob-changefeed/README.md
@@ -1,6 +1,3 @@
-## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
 # Azure Storage Blob ChangeFeed client library for Python
 
 This preview package for Python enables users to get blob change feed events. These events can be lazily generated, iterated by page, retrieved for a specific time interval, or iterated from a specific continuation token.

--- a/sdk/storage/azure-storage-blob/README.md
+++ b/sdk/storage/azure-storage-blob/README.md
@@ -1,6 +1,3 @@
-## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
 # Azure Storage Blobs client library for Python
 Azure Blob storage is Microsoft's object storage solution for the cloud. Blob storage is optimized for storing massive amounts of unstructured data, such as text or binary data.
 
@@ -347,7 +344,8 @@ Other optional configuration keyword arguments that can be specified on the clie
 
 **Client keyword arguments:**
 
-* __connection_timeout__ (int): Optionally sets the connect and read timeout value, in seconds.
+* __connection_timeout__ (int): The number of seconds the client will wait to establish a connection to the server.
+* __read_timeout__ (int): The number of seconds the client will wait, after the connections has been established, for the server to send a response.
 * __transport__ (Any): User-provided transport to send the HTTP request.
 
 **Per-operation keyword arguments:**

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/constants.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/constants.py
@@ -4,23 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import sys
 from .._serialize import _SUPPORTED_API_VERSIONS
 
 
 X_MS_VERSION = _SUPPORTED_API_VERSIONS[-1]
 
-# Socket timeout in seconds
+# Default socket timeouts, in seconds
 CONNECTION_TIMEOUT = 20
-READ_TIMEOUT = 20
-
-# for python 3.5+, there was a change to the definition of the socket timeout (as far as socket.sendall is concerned)
-# The socket timeout is now the maximum total duration to send all data.
-if sys.version_info >= (3, 5):
-    # the timeout to connect is 20 seconds, and the read timeout is 80000 seconds
-    # the 80000 seconds was calculated with:
-    # 4000MB (max block size)/ 50KB/s (an arbitrarily chosen minimum upload speed)
-    READ_TIMEOUT = 80000
+READ_TIMEOUT = 80000  # 4000MB (max block size) / 50KB/s (an arbitrarily chosen minimum upload speed)
 
 DEFAULT_OAUTH_SCOPE = "/.default"
 STORAGE_OAUTH_SCOPE = "https://storage.azure.com/.default"

--- a/sdk/storage/azure-storage-file-datalake/README.md
+++ b/sdk/storage/azure-storage-file-datalake/README.md
@@ -1,6 +1,3 @@
-## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
 # Azure DataLake service client library for Python
 Overview
 
@@ -195,7 +192,8 @@ Other optional configuration keyword arguments that can be specified on the clie
 
 **Client keyword arguments:**
 
-* __connection_timeout__ (int): Optionally sets the connect and read timeout value, in seconds.
+* __connection_timeout__ (int): The number of seconds the client will wait to establish a connection to the server.
+* __read_timeout__ (int): The number of seconds the client will wait, after the connections has been established, for the server to send a response.
 * __transport__ (Any): User-provided transport to send the HTTP request.
 
 **Per-operation keyword arguments:**

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/constants.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/constants.py
@@ -4,22 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import sys
 from .._serialize import _SUPPORTED_API_VERSIONS
 
 
 X_MS_VERSION = _SUPPORTED_API_VERSIONS[-1]
 
-# Socket timeout in seconds
+# Default socket timeouts, in seconds
 CONNECTION_TIMEOUT = 20
-READ_TIMEOUT = 20
-
-# for python 3.5+, there was a change to the definition of the socket timeout (as far as socket.sendall is concerned)
-# The socket timeout is now the maximum total duration to send all data.
-if sys.version_info >= (3, 5):
-    # the timeout to connect is 20 seconds, and the read timeout is 2000 seconds
-    # the 2000 seconds was calculated with: 100MB (max block size)/ 50KB/s (an arbitrarily chosen minimum upload speed)
-    READ_TIMEOUT = 2000
+READ_TIMEOUT = 2000  # 100MB (max block size) / 50KB/s (an arbitrarily chosen minimum upload speed)
 
 STORAGE_OAUTH_SCOPE = "https://storage.azure.com/.default"
 

--- a/sdk/storage/azure-storage-file-share/README.md
+++ b/sdk/storage/azure-storage-file-share/README.md
@@ -1,6 +1,3 @@
-## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
 # Azure Storage File Share client library for Python
 Azure File Share storage offers fully managed file shares in the cloud that are accessible via the industry standard [Server Message Block (SMB) protocol](https://docs.microsoft.com/windows/desktop/FileIO/microsoft-smb-protocol-and-cifs-protocol-overview). Azure file shares can be mounted concurrently by cloud or on-premises deployments of Windows, Linux, and macOS. Additionally, Azure file shares can be cached on Windows Servers with Azure File Sync for fast access near where the data is being used.
 
@@ -284,7 +281,8 @@ Other optional configuration keyword arguments that can be specified on the clie
 
 **Client keyword arguments:**
 
-* __connection_timeout__ (int): Optionally sets the connect and read timeout value, in seconds.
+* __connection_timeout__ (int): The number of seconds the client will wait to establish a connection to the server.
+* __read_timeout__ (int): The number of seconds the client will wait, after the connections has been established, for the server to send a response.
 * __transport__ (Any): User-provided transport to send the HTTP request.
 
 **Per-operation keyword arguments:**

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/constants.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/constants.py
@@ -4,22 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import sys
 from .._serialize import _SUPPORTED_API_VERSIONS
 
 
 X_MS_VERSION = _SUPPORTED_API_VERSIONS[-1]
 
-# Socket timeout in seconds
+# Default socket timeouts, in seconds
 CONNECTION_TIMEOUT = 20
-READ_TIMEOUT = 20
-
-# for python 3.5+, there was a change to the definition of the socket timeout (as far as socket.sendall is concerned)
-# The socket timeout is now the maximum total duration to send all data.
-if sys.version_info >= (3, 5):
-    # the timeout to connect is 20 seconds, and the read timeout is 2000 seconds
-    # the 2000 seconds was calculated with: 100MB (max block size)/ 50KB/s (an arbitrarily chosen minimum upload speed)
-    READ_TIMEOUT = 2000
+READ_TIMEOUT = 2000  # 100MB (max block size) / 50KB/s (an arbitrarily chosen minimum upload speed)
 
 STORAGE_OAUTH_SCOPE = "https://storage.azure.com/.default"
 

--- a/sdk/storage/azure-storage-queue/README.md
+++ b/sdk/storage/azure-storage-queue/README.md
@@ -1,6 +1,3 @@
-## _Disclaimer_
-_Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
 # Azure Storage Queues client library for Python
 
 Azure Queue storage is a service for storing large numbers of messages that can be accessed from anywhere in the world via authenticated calls using HTTP or HTTPS. A single queue message can be up to 64 KiB in size, and a queue can contain millions of messages, up to the total capacity limit of a storage account.
@@ -301,7 +298,8 @@ Other optional configuration keyword arguments that can be specified on the clie
 
 **Client keyword arguments:**
 
-* __connection_timeout__ (int): Optionally sets the connect and read timeout value, in seconds.
+* __connection_timeout__ (int): The number of seconds the client will wait to establish a connection to the server.
+* __read_timeout__ (int): The number of seconds the client will wait, after the connections has been established, for the server to send a response.
 * __transport__ (Any): User-provided transport to send the HTTP request.
 
 **Per-operation keyword arguments:**

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/constants.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/constants.py
@@ -4,22 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import sys
 from .._serialize import _SUPPORTED_API_VERSIONS
 
 
 X_MS_VERSION = _SUPPORTED_API_VERSIONS[-1]
 
-# Socket timeout in seconds
+# Default socket timeouts, in seconds
 CONNECTION_TIMEOUT = 20
-READ_TIMEOUT = 20
-
-# for python 3.5+, there was a change to the definition of the socket timeout (as far as socket.sendall is concerned)
-# The socket timeout is now the maximum total duration to send all data.
-if sys.version_info >= (3, 5):
-    # the timeout to connect is 20 seconds, and the read timeout is 2000 seconds
-    # the 2000 seconds was calculated with: 100MB (max block size)/ 50KB/s (an arbitrarily chosen minimum upload speed)
-    READ_TIMEOUT = 2000
+READ_TIMEOUT = 2000  # 100MB (max block size) / 50KB/s (an arbitrarily chosen minimum upload speed)
 
 STORAGE_OAUTH_SCOPE = "https://storage.azure.com/.default"
 


### PR DESCRIPTION
Resolves #23049.

Updating documentation for different socket timeouts. Also took the opportunity to remove Python 2 disclaimer and update timeout constants since we no longer support Python 3.5.