### PR TITLE
[Storage] Fix changefeed import for local testing

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/tests/test_change_feed.py
+++ b/sdk/storage/azure-storage-blob-changefeed/tests/test_change_feed.py
@@ -6,16 +6,19 @@
 # license information.
 # --------------------------------------------------------------------------
 import json
-from time import sleep
-
 import pytest
 from datetime import datetime, timedelta
-
 from math import ceil
+from time import sleep
 
-from azure.storage.blob.changefeed import (
-    ChangeFeedClient,
-)
+try:
+    # Hack to run ChangeFeed tests locally due to conflicting namespace and dependency with blob.
+    # To run locally, set each library folder in ChangeFeed package as "Sources Root" in PyCharm
+    # (i.e. azure, storage, blob, changefeed).
+    from changefeed import ChangeFeedClient
+except ImportError:
+    from azure.storage.blob.changefeed import ChangeFeedClient
+
 from devtools_testutils.storage import StorageTestCase
 from settings.testcase import ChangeFeedPreparer
 


### PR DESCRIPTION
There is an issue with running ChangeFeed tests locally due to the direct dependency on blob package which has a conflicting namespace. This change adds a workaround for this by importing from the `changefeed` folder directly rather than `azure-storage-blob-changefeed` and explains how to set up sources root in PyCharm for this to work. The original import is left as-is in an `except` block for pipelines.