### PR TITLE
[Key Vault] Prepare patch release for keys

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 4.5.1 (Unreleased)
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
-
-### Other Changes
+- Fixed error that could occur when fetching a key rotation policy that has no defined
+  `lifetime_actions`.
 
 ## 4.5.0 (2022-03-28)
 

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.5.1 (Unreleased)
+## 4.5.1 (2022-04-19)
 
 ### Bugs Fixed
 - Fixed error that could occur when fetching a key rotation policy that has no defined

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -341,7 +341,11 @@ class KeyRotationPolicy(object):
 
     @classmethod
     def _from_generated(cls, policy):
-        lifetime_actions = [KeyRotationLifetimeAction._from_generated(action) for action in policy.lifetime_actions]  # pylint:disable=protected-access
+        lifetime_actions = (
+            None
+            if policy.lifetime_actions is None
+            else [KeyRotationLifetimeAction._from_generated(action) for action in policy.lifetime_actions]  # pylint:disable=protected-access
+        )
         if policy.attributes:
             return cls(
                 policy_id=policy.id,


### PR DESCRIPTION
# Description

Context: when testing a preview of the new CLI package using `azure-keyvault-keys` 4.5.0, the Managed HSM team found that they would get an error when fetching a key rotation policy for a key without a policy. Specifically, there would be an error when iterating over the `lifetime_actions` of an empty policy because we didn't account for this attribute being `None` on a generated object.

This didn't come up for Key Vault because KV keys have a default lifetime action to notify a user 30 days before key expiry -- MHSM keys don't have a default lifetime action, hence why we would get `None` in responses for the field. This adds logic to adjust to that case, but doesn't add tests for MHSM since key rotation isn't supported formally by the service yet.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
