### PR TITLE
[pylint] fixing enum checker

### DIFF
--- a/scripts/pylint_custom_plugin/pylint_guidelines_checker.py
+++ b/scripts/pylint_custom_plugin/pylint_guidelines_checker.py
@@ -1763,7 +1763,7 @@ class CheckEnum(BaseChecker):
                     self._enum_uppercase(node)   
             # Else if it does not have a metaclass, but it is an enum class
             # Check both capitalization and throw pylint error for metaclass
-            elif node.bases[1].name == "Enum":
+             elif node.bases[0].name == "str" and node.bases[1].name == "Enum":
                 self.add_message(
                     "enum-must-inherit-case-insensitive-enum-meta", node=node, confidence=None
                 )

--- a/scripts/pylint_custom_plugin/pylint_guidelines_checker.py
+++ b/scripts/pylint_custom_plugin/pylint_guidelines_checker.py
@@ -1763,7 +1763,7 @@ class CheckEnum(BaseChecker):
                     self._enum_uppercase(node)   
             # Else if it does not have a metaclass, but it is an enum class
             # Check both capitalization and throw pylint error for metaclass
-             elif node.bases[0].name == "str" and node.bases[1].name == "Enum":
+            elif node.bases[0].name == "str" and node.bases[1].name == "Enum":
                 self.add_message(
                     "enum-must-inherit-case-insensitive-enum-meta", node=node, confidence=None
                 )


### PR DESCRIPTION
Only str enum classes inherit metaclass