### PR TITLE
[Key Vault] Update default value of lifetime_actions

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.5.1 (2022-04-19)
+## 4.5.1 (2022-04-18)
 
 ### Bugs Fixed
 - Fixed error that could occur when fetching a key rotation policy that has no defined

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -291,12 +291,14 @@ class KeyRotationLifetimeAction(object):
     :param action: The action that will be executed.
     :type action: ~azure.keyvault.keys.KeyRotationPolicyAction or str
 
-    :keyword str time_after_create: Time after creation to attempt the specified action, as an ISO 8601 duration.
+    :keyword time_after_create: Time after creation to attempt the specified action, as an ISO 8601 duration.
         For example, 90 days is "P90D". See `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_ for more
         information on ISO 8601 durations.
-    :keyword str time_before_expiry: Time before expiry to attempt the specified action, as an ISO 8601 duration.
+    :paramtype time_after_create: Optional[str]
+    :keyword time_before_expiry: Time before expiry to attempt the specified action, as an ISO 8601 duration.
         For example, 90 days is "P90D". See `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_ for more
         information on ISO 8601 durations.
+    :paramtype time_before_expiry: Optional[str]
     """
 
     def __init__(self, action, **kwargs):
@@ -319,22 +321,24 @@ class KeyRotationLifetimeAction(object):
 class KeyRotationPolicy(object):
     """The key rotation policy that belongs to a key.
 
-    :ivar str id: The identifier of the key rotation policy.
+    :ivar id: The identifier of the key rotation policy.
+    :vartype id: Optional[str]
     :ivar lifetime_actions: Actions that will be performed by Key Vault over the lifetime of a key.
     :vartype lifetime_actions: List[~azure.keyvault.keys.KeyRotationLifetimeAction]
-    :ivar str expires_in: The expiry time of the policy that will be applied on new key versions, defined as an ISO 8601
+    :ivar expires_in: The expiry time of the policy that will be applied on new key versions, defined as an ISO 8601
         duration. For example, 90 days is "P90D".  See `Wikipedia <https://wikipedia.org/wiki/ISO_8601#Durations>`_ for
         more information on ISO 8601 durations.
+    :vartype expires_in: Optional[str]
     :ivar created_on: When the policy was created, in UTC
-    :vartype created_on: ~datetime.datetime
+    :vartype created_on: Optional[~datetime.datetime]
     :ivar updated_on: When the policy was last updated, in UTC
-    :vartype updated_on: ~datetime.datetime
+    :vartype updated_on: Optional[~datetime.datetime]
     """
 
     def __init__(self, **kwargs):
         # type: (**Any) -> None
         self.id = kwargs.get("policy_id", None)
-        self.lifetime_actions = kwargs.get("lifetime_actions", None)
+        self.lifetime_actions = kwargs.get("lifetime_actions", [])
         self.expires_in = kwargs.get("expires_in", None)
         self.created_on = kwargs.get("created_on", None)
         self.updated_on = kwargs.get("updated_on", None)
@@ -342,7 +346,7 @@ class KeyRotationPolicy(object):
     @classmethod
     def _from_generated(cls, policy):
         lifetime_actions = (
-            None
+            []
             if policy.lifetime_actions is None
             else [KeyRotationLifetimeAction._from_generated(action) for action in policy.lifetime_actions]  # pylint:disable=protected-access
         )

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -21,6 +21,7 @@ from azure.keyvault.keys import (
     KeyRotationPolicyAction,
     KeyType,
 )
+from azure.keyvault.keys._generated.v7_3.models import KeyRotationPolicy as _KeyRotationPolicy
 import pytest
 from six import byte2int
 
@@ -754,3 +755,11 @@ def test_case_insensitive_key_type():
     assert KeyType("OCT") == KeyType.oct
     # KeyType with mixed-case value
     assert KeyType("oct-hsm") == KeyType.oct_hsm
+
+
+def test_empty_rotation_policy_actions():
+    """Regression test: make sure a KeyRotationPolicy can be created with a response that has None properties"""
+    generated_policy = _KeyRotationPolicy()
+    assert generated_policy.lifetime_actions is None
+    policy = KeyRotationPolicy._from_generated(generated_policy)
+    assert policy.lifetime_actions == []


### PR DESCRIPTION
# Description

Context for supporting a value of `None` for `lifetime_actions` is described in https://github.com/Azure/azure-sdk-for-python/pull/24059. After looking over Managed HSM responses and discussing with Laurent, we decided that using an empty list instead of `None` makes the most sense for `KeyRotationPolicy.lifetime_actions`, since the assumption in the regular case is that this attribute is iterable, even if empty. Other attributes have had their type hints updated, since we can't rely on the values we _expect_ to get back from Key Vault.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - No tests for Managed HSM since this feature isn't in preview yet for the service, and the changes here aren't relevant for Key Vault.