### PR TITLE
[Storage] Add settable file-change-time to share file copy

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -608,6 +608,12 @@ class ShareFileClient(StorageAccountHostsMixin):
                 This parameter was introduced in API version '2019-07-07'.
 
         :paramtype file_last_write_time: str or ~datetime.datetime
+        :keyword ~datetime.datetime file_change_time
+            Change time for the file. If not specified, change time will be set to the current date/time.
+
+            .. versionadded:: 12.9.0
+                This parameter was introduced in API version '2021-06-08'.
+
         :keyword bool ignore_read_only:
             Specifies the option to overwrite the target file if it already exists and has read-only attribute set.
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=no-self-use
+from typing import Any, Dict, Optional, Tuple, TypeVar, TYPE_CHECKING
 
 from azure.core import MatchConditions
 
@@ -14,6 +15,9 @@ from ._generated.models import (
     SourceLeaseAccessConditions,
     DestinationLeaseAccessConditions,
     CopyFileSmbInfo)
+
+if TYPE_CHECKING:
+    ShareLeaseClient = TypeVar("ShareLeaseClient")
 
 
 _SUPPORTED_API_VERSIONS = [
@@ -105,6 +109,7 @@ def get_smb_properties(kwargs):
     file_attributes = kwargs.pop('file_attributes', None)
     file_creation_time = kwargs.pop('file_creation_time', None)
     file_last_write_time = kwargs.pop('file_last_write_time', None)
+    file_change_time = kwargs.pop('file_change_time', None)
 
     file_permission_copy_mode = None
     file_permission = _get_file_permission(file_permission, file_permission_key, None)
@@ -130,6 +135,7 @@ def get_smb_properties(kwargs):
             file_attributes=file_attributes,
             file_creation_time=_datetime_to_str(file_creation_time),
             file_last_write_time=_datetime_to_str(file_last_write_time),
+            file_change_time=_datetime_to_str(file_change_time),
             set_archive_attribute=set_archive_attribute
         )
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -478,6 +478,12 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
                 This parameter was introduced in API version '2019-07-07'.
 
         :paramtype file_last_write_time: str or ~datetime.datetime
+        :keyword ~datetime.datetime file_change_time
+            Change time for the file. If not specified, change time will be set to the current date/time.
+
+            .. versionadded:: 12.9.0
+                This parameter was introduced in API version '2021-06-08'.
+
         :keyword bool ignore_read_only:
             Specifies the option to overwrite the target file if it already exists and has read-only attribute set.
 

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_specifying_acl_copy_behavior_attributes.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file.test_copy_file_with_specifying_acl_copy_behavior_attributes.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -25,11 +25,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       etag:
-      - '"0x8DA18EBE5D12B49"'
+      - '"0x8DA2178D8E8E6E6"'
       last-modified:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -53,7 +53,7 @@ interactions:
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -75,23 +75,23 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       etag:
-      - '"0x8DA18EBE5DFE61F"'
+      - '"0x8DA2178D8F68973"'
       last-modified:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2022-04-07T23:11:07.9383583Z'
+      - '2022-04-18T20:20:14.6174323Z'
       x-ms-file-creation-time:
-      - '2022-04-07T23:11:07.9383583Z'
+      - '2022-04-18T20:20:14.6174323Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2022-04-07T23:11:07.9383583Z'
+      - '2022-04-18T20:20:14.6174323Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
@@ -119,7 +119,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
@@ -137,15 +137,15 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       etag:
-      - '"0x8DA18EBE5EED815"'
+      - '"0x8DA2178D90295A8"'
       last-modified:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-last-write-time:
-      - '2022-04-07T23:11:08.0363029Z'
+      - '2022-04-18T20:20:14.6963880Z'
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -165,7 +165,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       x-ms-version:
       - '2021-06-08'
     method: HEAD
@@ -179,23 +179,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Thu, 07 Apr 2022 23:11:07 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       etag:
-      - '"0x8DA18EBE5EED815"'
+      - '"0x8DA2178D90295A8"'
       last-modified:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2022-04-07T23:11:08.0363029Z'
+      - '2022-04-18T20:20:14.6963880Z'
       x-ms-file-creation-time:
-      - '2022-04-07T23:11:07.9383583Z'
+      - '2022-04-18T20:20:14.6174323Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2022-04-07T23:11:08.0363029Z'
+      - '2022-04-18T20:20:14.6963880Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
@@ -229,15 +229,17 @@ interactions:
       x-ms-copy-source:
       - https://storagename.file.core.windows.net/utsharedd3c1c70/filedd3c1c70
       x-ms-date:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:14 GMT
       x-ms-file-attributes:
       - Temporary|NoScrubData
+      x-ms-file-change-time:
+      - '2022-04-18T19:20:14.6963880Z'
       x-ms-file-copy-ignore-readonly:
       - 'true'
       x-ms-file-creation-time:
-      - '2022-04-07T22:11:07.9383580Z'
+      - '2022-04-18T19:20:14.6174320Z'
       x-ms-file-last-write-time:
-      - '2022-04-07T22:11:08.0363020Z'
+      - '2022-04-18T19:20:14.6963880Z'
       x-ms-file-permission:
       - O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)
       x-ms-file-permission-copy-mode:
@@ -253,15 +255,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       etag:
-      - '"0x8DA18EBE6666796"'
+      - '"0x8DA2178DB89F3F7"'
       last-modified:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-id:
-      - 9e5f509f-f3bb-4bb8-a4c9-c8e486896423
+      - ba7091cf-2a3c-48e0-9d18-587449b239ec
       x-ms-copy-status:
       - success
       x-ms-version:
@@ -281,7 +283,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       x-ms-version:
       - '2021-06-08'
     method: HEAD
@@ -295,17 +297,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       etag:
-      - '"0x8DA18EBE6666796"'
+      - '"0x8DA2178DB89F3F7"'
       last-modified:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       x-ms-copy-id:
-      - 9e5f509f-f3bb-4bb8-a4c9-c8e486896423
+      - ba7091cf-2a3c-48e0-9d18-587449b239ec
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
@@ -315,13 +317,13 @@ interactions:
       x-ms-file-attributes:
       - Archive | Temporary | NoScrubData
       x-ms-file-change-time:
-      - '2022-04-07T23:11:08.8198550Z'
+      - '2022-04-18T19:20:14.6963880Z'
       x-ms-file-creation-time:
-      - '2022-04-07T22:11:07.9383580Z'
+      - '2022-04-18T19:20:14.6174320Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2022-04-07T22:11:08.0363020Z'
+      - '2022-04-18T19:20:14.6963880Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
@@ -351,7 +353,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:19 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -371,17 +373,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       etag:
-      - '"0x8DA18EBE6666796"'
+      - '"0x8DA2178DB89F3F7"'
       last-modified:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-copy-completion-time:
-      - Thu, 07 Apr 2022 23:11:08 GMT
+      - Mon, 18 Apr 2022 20:20:18 GMT
       x-ms-copy-id:
-      - 9e5f509f-f3bb-4bb8-a4c9-c8e486896423
+      - ba7091cf-2a3c-48e0-9d18-587449b239ec
       x-ms-copy-progress:
       - 1024/1024
       x-ms-copy-source:
@@ -391,13 +393,13 @@ interactions:
       x-ms-file-attributes:
       - Archive | Temporary | NoScrubData
       x-ms-file-change-time:
-      - '2022-04-07T23:11:08.8198550Z'
+      - '2022-04-18T19:20:14.6963880Z'
       x-ms-file-creation-time:
-      - '2022-04-07T22:11:07.9383580Z'
+      - '2022-04-18T19:20:14.6174320Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2022-04-07T22:11:08.0363020Z'
+      - '2022-04-18T19:20:14.6963880Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:

--- a/sdk/storage/azure-storage-file-share/tests/recordings/test_file_async.test_copy_file_with_specifying_acl_copy_behavior_attributes_async.yaml
+++ b/sdk/storage/azure-storage-file-share/tests/recordings/test_file_async.test_copy_file_with_specifying_acl_copy_behavior_attributes_async.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Tue, 15 Mar 2022 18:46:19 GMT
+      - Mon, 18 Apr 2022 20:23:12 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -17,9 +17,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Tue, 15 Mar 2022 18:46:19 GMT
-      etag: '"0x8DA06B4181F00B9"'
-      last-modified: Tue, 15 Mar 2022 18:46:19 GMT
+      date: Mon, 18 Apr 2022 20:23:11 GMT
+      etag: '"0x8DA217942D987FA"'
+      last-modified: Mon, 18 Apr 2022 20:23:12 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-06-08'
     status:
@@ -32,11 +32,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-content-length:
       - '1024'
       x-ms-date:
-      - Tue, 15 Mar 2022 18:46:19 GMT
+      - Mon, 18 Apr 2022 20:23:12 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -56,15 +56,15 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Tue, 15 Mar 2022 18:46:19 GMT
-      etag: '"0x8DA06B4183F4238"'
-      last-modified: Tue, 15 Mar 2022 18:46:19 GMT
+      date: Mon, 18 Apr 2022 20:23:12 GMT
+      etag: '"0x8DA217942FB5D35"'
+      last-modified: Mon, 18 Apr 2022 20:23:12 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes: Archive
-      x-ms-file-change-time: '2022-03-15T18:46:19.7025336Z'
-      x-ms-file-creation-time: '2022-03-15T18:46:19.7025336Z'
+      x-ms-file-change-time: '2022-04-18T20:23:12.4875573Z'
+      x-ms-file-creation-time: '2022-04-18T20:23:12.4875573Z'
       x-ms-file-id: '13835128424026341376'
-      x-ms-file-last-write-time: '2022-03-15T18:46:19.7025336Z'
+      x-ms-file-last-write-time: '2022-04-18T20:23:12.4875573Z'
       x-ms-file-parent-id: '0'
       x-ms-file-permission-key: 8725144154719613152*15111010650564761710
       x-ms-request-server-encrypted: 'true'
@@ -83,9 +83,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Tue, 15 Mar 2022 18:46:19 GMT
+      - Mon, 18 Apr 2022 20:23:12 GMT
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
@@ -100,11 +100,11 @@ interactions:
     headers:
       content-length: '0'
       content-md5: yaNM/IXZgmmMasifdgcavQ==
-      date: Tue, 15 Mar 2022 18:46:19 GMT
-      etag: '"0x8DA06B418488FAF"'
-      last-modified: Tue, 15 Mar 2022 18:46:19 GMT
+      date: Mon, 18 Apr 2022 20:23:12 GMT
+      etag: '"0x8DA21794303C06D"'
+      last-modified: Mon, 18 Apr 2022 20:23:12 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-file-last-write-time: '2022-03-15T18:46:19.7634991Z'
+      x-ms-file-last-write-time: '2022-04-18T20:23:12.5425261Z'
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-06-08'
     status:
@@ -117,9 +117,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Tue, 15 Mar 2022 18:46:19 GMT
+      - Mon, 18 Apr 2022 20:23:12 GMT
       x-ms-version:
       - '2021-06-08'
     method: HEAD
@@ -130,15 +130,15 @@ interactions:
     headers:
       content-length: '1024'
       content-type: application/octet-stream
-      date: Tue, 15 Mar 2022 18:46:19 GMT
-      etag: '"0x8DA06B418488FAF"'
-      last-modified: Tue, 15 Mar 2022 18:46:19 GMT
+      date: Mon, 18 Apr 2022 20:23:12 GMT
+      etag: '"0x8DA21794303C06D"'
+      last-modified: Mon, 18 Apr 2022 20:23:12 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes: Archive
-      x-ms-file-change-time: '2022-03-15T18:46:19.7634991Z'
-      x-ms-file-creation-time: '2022-03-15T18:46:19.7025336Z'
+      x-ms-file-change-time: '2022-04-18T20:23:12.5425261Z'
+      x-ms-file-creation-time: '2022-04-18T20:23:12.4875573Z'
       x-ms-file-id: '13835128424026341376'
-      x-ms-file-last-write-time: '2022-03-15T18:46:19.7634991Z'
+      x-ms-file-last-write-time: '2022-04-18T20:23:12.5425261Z'
       x-ms-file-parent-id: '0'
       x-ms-file-permission-key: 8725144154719613152*15111010650564761710
       x-ms-lease-state: available
@@ -156,19 +156,21 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-copy-source:
       - https://storagename.file.core.windows.net/utshare53de216a/file53de216a
       x-ms-date:
-      - Tue, 15 Mar 2022 18:46:19 GMT
+      - Mon, 18 Apr 2022 20:23:12 GMT
       x-ms-file-attributes:
       - Temporary|NoScrubData
+      x-ms-file-change-time:
+      - '2022-04-18T19:23:12.5425260Z'
       x-ms-file-copy-ignore-readonly:
       - 'true'
       x-ms-file-creation-time:
-      - '2022-03-15T17:46:19.7025330Z'
+      - '2022-04-18T19:23:12.4875570Z'
       x-ms-file-last-write-time:
-      - '2022-03-15T17:46:19.7634990Z'
+      - '2022-04-18T19:23:12.5425260Z'
       x-ms-file-permission:
       - O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)
       x-ms-file-permission-copy-mode:
@@ -182,11 +184,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Tue, 15 Mar 2022 18:46:22 GMT
-      etag: '"0x8DA06B41A5A0BC9"'
-      last-modified: Tue, 15 Mar 2022 18:46:23 GMT
+      date: Mon, 18 Apr 2022 20:23:13 GMT
+      etag: '"0x8DA21794388E2AD"'
+      last-modified: Mon, 18 Apr 2022 20:23:13 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-copy-id: 2579aaa9-b834-4c6e-b7df-9966cb90cdb2
+      x-ms-copy-id: 9cc7472e-7408-41b1-a617-9925978e55ce
       x-ms-copy-status: success
       x-ms-version: '2021-06-08'
     status:
@@ -199,9 +201,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Tue, 15 Mar 2022 18:46:23 GMT
+      - Mon, 18 Apr 2022 20:23:13 GMT
       x-ms-version:
       - '2021-06-08'
     method: HEAD
@@ -212,20 +214,20 @@ interactions:
     headers:
       content-length: '1024'
       content-type: application/octet-stream
-      date: Tue, 15 Mar 2022 18:46:22 GMT
-      etag: '"0x8DA06B41A5A0BC9"'
-      last-modified: Tue, 15 Mar 2022 18:46:23 GMT
+      date: Mon, 18 Apr 2022 20:23:13 GMT
+      etag: '"0x8DA21794388E2AD"'
+      last-modified: Mon, 18 Apr 2022 20:23:13 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-copy-completion-time: Tue, 15 Mar 2022 18:46:21 GMT
-      x-ms-copy-id: 2579aaa9-b834-4c6e-b7df-9966cb90cdb2
+      x-ms-copy-completion-time: Mon, 18 Apr 2022 20:23:13 GMT
+      x-ms-copy-id: 9cc7472e-7408-41b1-a617-9925978e55ce
       x-ms-copy-progress: 1024/1024
       x-ms-copy-source: https://storagename.file.core.windows.net/utshare53de216a/file53de216a
       x-ms-copy-status: success
       x-ms-file-attributes: Archive | Temporary | NoScrubData
-      x-ms-file-change-time: '2022-03-15T18:46:23.2335305Z'
-      x-ms-file-creation-time: '2022-03-15T17:46:19.7025330Z'
+      x-ms-file-change-time: '2022-04-18T19:23:12.5425260Z'
+      x-ms-file-creation-time: '2022-04-18T19:23:12.4875570Z'
       x-ms-file-id: '13835093239654252544'
-      x-ms-file-last-write-time: '2022-03-15T17:46:19.7634990Z'
+      x-ms-file-last-write-time: '2022-04-18T19:23:12.5425260Z'
       x-ms-file-parent-id: '0'
       x-ms-file-permission-key: 3717868340301450459*15111010650564761710
       x-ms-lease-state: available
@@ -243,9 +245,9 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.1 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-storage-file-share/12.8.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Tue, 15 Mar 2022 18:46:23 GMT
+      - Mon, 18 Apr 2022 20:23:13 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -260,20 +262,20 @@ interactions:
       content-length: '1024'
       content-range: bytes 0-1023/1024
       content-type: application/octet-stream
-      date: Tue, 15 Mar 2022 18:46:22 GMT
-      etag: '"0x8DA06B41A5A0BC9"'
-      last-modified: Tue, 15 Mar 2022 18:46:23 GMT
+      date: Mon, 18 Apr 2022 20:23:13 GMT
+      etag: '"0x8DA21794388E2AD"'
+      last-modified: Mon, 18 Apr 2022 20:23:13 GMT
       server: Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-copy-completion-time: Tue, 15 Mar 2022 18:46:21 GMT
-      x-ms-copy-id: 2579aaa9-b834-4c6e-b7df-9966cb90cdb2
+      x-ms-copy-completion-time: Mon, 18 Apr 2022 20:23:13 GMT
+      x-ms-copy-id: 9cc7472e-7408-41b1-a617-9925978e55ce
       x-ms-copy-progress: 1024/1024
       x-ms-copy-source: https://storagename.file.core.windows.net/utshare53de216a/file53de216a
       x-ms-copy-status: success
       x-ms-file-attributes: Archive | Temporary | NoScrubData
-      x-ms-file-change-time: '2022-03-15T18:46:23.2335305Z'
-      x-ms-file-creation-time: '2022-03-15T17:46:19.7025330Z'
+      x-ms-file-change-time: '2022-04-18T19:23:12.5425260Z'
+      x-ms-file-creation-time: '2022-04-18T19:23:12.4875570Z'
       x-ms-file-id: '13835093239654252544'
-      x-ms-file-last-write-time: '2022-03-15T17:46:19.7634990Z'
+      x-ms-file-last-write-time: '2022-04-18T19:23:12.5425260Z'
       x-ms-file-parent-id: '0'
       x-ms-file-permission-key: 3717868340301450459*15111010650564761710
       x-ms-lease-state: available

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -1331,7 +1331,7 @@ class StorageFileTest(StorageTestCase):
         # to make sure the attributes are the same as the set ones
         self.assertEqual(file_creation_time, dest_prop['creation_time'])
         self.assertEqual(file_last_write_time, dest_prop['last_write_time'])
-        self.assertEqual(file_last_write_time, dest_prop['change_time'])
+        self.assertEqual(file_change_time, dest_prop['change_time'])
         self.assertIn('Temporary', dest_prop['file_attributes'])
         self.assertIn('NoScrubData', dest_prop['file_attributes'])
 

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -1312,6 +1312,7 @@ class StorageFileTest(StorageTestCase):
 
         file_creation_time = source_props.creation_time - timedelta(hours=1)
         file_last_write_time = source_props.last_write_time - timedelta(hours=1)
+        file_change_time = source_props.change_time - timedelta(hours=1)
         file_attributes = "Temporary|NoScrubData"
 
         # Act
@@ -1322,6 +1323,7 @@ class StorageFileTest(StorageTestCase):
             file_attributes=file_attributes,
             file_creation_time=file_creation_time,
             file_last_write_time=file_last_write_time,
+            file_change_time=file_change_time,
         )
 
         # Assert
@@ -1329,6 +1331,7 @@ class StorageFileTest(StorageTestCase):
         # to make sure the attributes are the same as the set ones
         self.assertEqual(file_creation_time, dest_prop['creation_time'])
         self.assertEqual(file_last_write_time, dest_prop['last_write_time'])
+        self.assertEqual(file_last_write_time, dest_prop['change_time'])
         self.assertIn('Temporary', dest_prop['file_attributes'])
         self.assertIn('NoScrubData', dest_prop['file_attributes'])
 

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -1416,6 +1416,7 @@ class StorageFileAsyncTest(AsyncStorageTestCase):
 
         file_creation_time = source_props.creation_time - timedelta(hours=1)
         file_last_write_time = source_props.last_write_time - timedelta(hours=1)
+        file_change_time = source_props.change_time - timedelta(hours=1)
         file_attributes = "Temporary|NoScrubData"
 
         # Act
@@ -1426,6 +1427,7 @@ class StorageFileAsyncTest(AsyncStorageTestCase):
             file_attributes=file_attributes,
             file_creation_time=file_creation_time,
             file_last_write_time=file_last_write_time,
+            file_change_time=file_change_time,
         )
 
         # Assert
@@ -1433,6 +1435,7 @@ class StorageFileAsyncTest(AsyncStorageTestCase):
         # to make sure the attributes are the same as the set ones
         self.assertEqual(file_creation_time, dest_prop['creation_time'])
         self.assertEqual(file_last_write_time, dest_prop['last_write_time'])
+        self.assertEqual(file_last_write_time, dest_prop['change_time'])
         self.assertIn('Temporary', dest_prop['file_attributes'])
         self.assertIn('NoScrubData', dest_prop['file_attributes'])
 

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -1435,7 +1435,7 @@ class StorageFileAsyncTest(AsyncStorageTestCase):
         # to make sure the attributes are the same as the set ones
         self.assertEqual(file_creation_time, dest_prop['creation_time'])
         self.assertEqual(file_last_write_time, dest_prop['last_write_time'])
-        self.assertEqual(file_last_write_time, dest_prop['change_time'])
+        self.assertEqual(file_change_time, dest_prop['change_time'])
         self.assertIn('Temporary', dest_prop['file_attributes'])
         self.assertIn('NoScrubData', dest_prop['file_attributes'])
 


### PR DESCRIPTION
Add the ability to optionally set file-change-time on `start_copy_from_url` in file share.