### PR TITLE
[Storage] Fix service operations with account SAS

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Bugs Fixed:
 - Fixed a bug in `BlobClient.from_blob_url()` such that users will receive a more helpful error
 message if they pass an incorrect URL without a full `/container/blob` path.
+- Fixed a bug, introduced in the previous beta release, that caused Authentication errors when attempting to use
+an Account SAS with certain service level operations.
 
 ## 12.12.0b1 (2022-04-14)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/operations/_service_operations.py
@@ -86,6 +86,7 @@ class ServiceOperations:
         _content = self._serialize.body(storage_service_properties, 'StorageServiceProperties', is_xml=True)
 
         request = build_set_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -119,7 +120,7 @@ class ServiceOperations:
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    set_properties.metadata = {'url': "/"}  # type: ignore
+    set_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -163,6 +164,7 @@ class ServiceOperations:
 
         
         request = build_get_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -197,7 +199,7 @@ class ServiceOperations:
 
         return deserialized
 
-    get_properties.metadata = {'url': "/"}  # type: ignore
+    get_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -242,6 +244,7 @@ class ServiceOperations:
 
         
         request = build_get_statistics_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -277,7 +280,7 @@ class ServiceOperations:
 
         return deserialized
 
-    get_statistics.metadata = {'url': "/"}  # type: ignore
+    get_statistics.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -341,6 +344,7 @@ class ServiceOperations:
 
         
         request = build_list_containers_segment_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             prefix=prefix,
@@ -378,7 +382,7 @@ class ServiceOperations:
 
         return deserialized
 
-    list_containers_segment.metadata = {'url': "/"}  # type: ignore
+    list_containers_segment.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -427,6 +431,7 @@ class ServiceOperations:
         _content = self._serialize.body(key_info, 'KeyInfo', is_xml=True)
 
         request = build_get_user_delegation_key_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -464,7 +469,7 @@ class ServiceOperations:
 
         return deserialized
 
-    get_user_delegation_key.metadata = {'url': "/"}  # type: ignore
+    get_user_delegation_key.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -496,6 +501,7 @@ class ServiceOperations:
 
         
         request = build_get_account_info_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -529,7 +535,7 @@ class ServiceOperations:
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    get_account_info.metadata = {'url': "/"}  # type: ignore
+    get_account_info.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -579,6 +585,7 @@ class ServiceOperations:
         _content = self._serialize.body(body, 'IO')
 
         request = build_submit_batch_request(
+            url=self._config.url,
             multipart_content_type=multipart_content_type,
             comp=comp,
             version=self._config.version,
@@ -615,7 +622,7 @@ class ServiceOperations:
 
         return deserialized
 
-    submit_batch.metadata = {'url': "/"}  # type: ignore
+    submit_batch.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -676,6 +683,7 @@ class ServiceOperations:
 
         
         request = build_filter_blobs_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             timeout=timeout,
@@ -713,5 +721,5 @@ class ServiceOperations:
 
         return deserialized
 
-    filter_blobs.metadata = {'url': "/"}  # type: ignore
+    filter_blobs.metadata = {'url': "{url}"}  # type: ignore
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/operations/_service_operations.py
@@ -17,7 +17,7 @@ from azure.core.rest import HttpRequest
 from azure.core.tracing.decorator import distributed_trace
 
 from .. import models as _models
-from .._vendor import _convert_request
+from .._vendor import _convert_request, _format_url_section
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -30,6 +30,7 @@ _SERIALIZER.client_side_validation = False
 # fmt: off
 
 def build_set_properties_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -42,7 +43,12 @@ def build_set_properties_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -70,6 +76,7 @@ def build_set_properties_request(
 
 
 def build_get_properties_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -81,7 +88,12 @@ def build_get_properties_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -107,6 +119,7 @@ def build_get_properties_request(
 
 
 def build_get_statistics_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -118,7 +131,12 @@ def build_get_statistics_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -144,6 +162,7 @@ def build_get_statistics_request(
 
 
 def build_list_containers_segment_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -158,7 +177,12 @@ def build_list_containers_segment_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -191,6 +215,7 @@ def build_list_containers_segment_request(
 
 
 def build_get_user_delegation_key_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -203,7 +228,12 @@ def build_get_user_delegation_key_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -231,6 +261,7 @@ def build_get_user_delegation_key_request(
 
 
 def build_get_account_info_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -240,7 +271,12 @@ def build_get_account_info_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -262,6 +298,7 @@ def build_get_account_info_request(
 
 
 def build_submit_batch_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -274,7 +311,12 @@ def build_submit_batch_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -301,6 +343,7 @@ def build_submit_batch_request(
 
 
 def build_filter_blobs_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -314,7 +357,12 @@ def build_filter_blobs_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -411,6 +459,7 @@ class ServiceOperations(object):
         _content = self._serialize.body(storage_service_properties, 'StorageServiceProperties', is_xml=True)
 
         request = build_set_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -444,7 +493,7 @@ class ServiceOperations(object):
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    set_properties.metadata = {'url': "/"}  # type: ignore
+    set_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -489,6 +538,7 @@ class ServiceOperations(object):
 
         
         request = build_get_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -523,7 +573,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    get_properties.metadata = {'url': "/"}  # type: ignore
+    get_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -569,6 +619,7 @@ class ServiceOperations(object):
 
         
         request = build_get_statistics_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -604,7 +655,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    get_statistics.metadata = {'url': "/"}  # type: ignore
+    get_statistics.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -669,6 +720,7 @@ class ServiceOperations(object):
 
         
         request = build_list_containers_segment_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             prefix=prefix,
@@ -706,7 +758,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    list_containers_segment.metadata = {'url': "/"}  # type: ignore
+    list_containers_segment.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -756,6 +808,7 @@ class ServiceOperations(object):
         _content = self._serialize.body(key_info, 'KeyInfo', is_xml=True)
 
         request = build_get_user_delegation_key_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -793,7 +846,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    get_user_delegation_key.metadata = {'url': "/"}  # type: ignore
+    get_user_delegation_key.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -826,6 +879,7 @@ class ServiceOperations(object):
 
         
         request = build_get_account_info_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -859,7 +913,7 @@ class ServiceOperations(object):
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    get_account_info.metadata = {'url': "/"}  # type: ignore
+    get_account_info.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -910,6 +964,7 @@ class ServiceOperations(object):
         _content = self._serialize.body(body, 'IO')
 
         request = build_submit_batch_request(
+            url=self._config.url,
             multipart_content_type=multipart_content_type,
             comp=comp,
             version=self._config.version,
@@ -946,7 +1001,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    submit_batch.metadata = {'url': "/"}  # type: ignore
+    submit_batch.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -1008,6 +1063,7 @@ class ServiceOperations(object):
 
         
         request = build_filter_blobs_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             timeout=timeout,
@@ -1045,5 +1101,5 @@ class ServiceOperations(object):
 
         return deserialized
 
-    filter_blobs.metadata = {'url': "/"}  # type: ignore
+    filter_blobs.metadata = {'url': "{url}"}  # type: ignore
 

--- a/sdk/storage/azure-storage-blob/swagger/README.md
+++ b/sdk/storage/azure-storage-blob/swagger/README.md
@@ -150,7 +150,7 @@ directive:
     $["x-ms-parameterized-host"] = undefined;
 ```
 
-### Add url parameter to each operation and add url to path
+### Add url parameter to each operation and add url to the path
 ``` yaml
 directive:
 - from: swagger-document

--- a/sdk/storage/azure-storage-blob/swagger/README.md
+++ b/sdk/storage/azure-storage-blob/swagger/README.md
@@ -150,7 +150,7 @@ directive:
     $["x-ms-parameterized-host"] = undefined;
 ```
 
-### Add url parameter to each operation and add it to the url
+### Add url parameter to each operation and add url to path
 ``` yaml
 directive:
 - from: swagger-document
@@ -158,14 +158,21 @@ directive:
   transform: >
     for (const property in $)
     {
-        // Don't apply to service operations (where path is just '/')
-        if (property !== '/' && !property.startsWith('/?')) {
-            $[property]["parameters"].push({"$ref": "#/parameters/Url"});
-    
-            var oldName = property;
-            var newName = '{url}' + property;
-            $[newName] = $[oldName];
-            delete $[oldName];
+        $[property]["parameters"].push({"$ref": "#/parameters/Url"});
+
+        var oldName = property;
+        // For service operations (where the path is just '/') we need to
+        // remove the '/' at the begining to avoid having an extra '/' in
+        // the final URL.
+        if (property === '/' || property.startsWith('/?'))
+        {
+            var newName = '{url}' + property.substring(1);
         }
+        else
+        {
+            var newName = '{url}' + property;
+        }
+        $[newName] = $[oldName];
+        delete $[oldName];
     }
 ```

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_properties.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_properties.py
@@ -385,7 +385,7 @@ class ServicePropertiesTest(StorageTestCase):
 
     @pytest.mark.live_test_only
     @BlobPreparer()
-    def test_get_service_properties_sas(self, storage_account_name, storage_account_key):
+    def test_get_service_properties_account_sas(self, storage_account_name, storage_account_key):
         # Arrange
         sas_token = generate_account_sas(
             account_name=storage_account_name,

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_properties.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_properties.py
@@ -5,20 +5,20 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import unittest
+import pytest
+from datetime import datetime, timedelta
 
-from msrest.exceptions import ValidationError  # TODO This should be an azure-core error.
 from azure.core.exceptions import HttpResponseError
-from devtools_testutils import ResourceGroupPreparer, StorageAccountPreparer
 from azure.storage.blob import (
-    BlobServiceClient,
-    ContainerClient,
-    BlobClient,
+    AccountSasPermissions,
     BlobAnalyticsLogging,
-    Metrics,
+    BlobServiceClient,
     CorsRule,
+    Metrics,
+    ResourceTypes,
     RetentionPolicy,
     StaticWebsite,
+    generate_account_sas,
 )
 
 from settings.testcase import BlobPreparer
@@ -382,6 +382,25 @@ class ServicePropertiesTest(StorageTestCase):
         # Assert
         received_props = bsc.get_service_properties()
         self._assert_cors_equal(received_props['cors'], cors)
+
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    def test_get_service_properties_sas(self, storage_account_name, storage_account_key):
+        # Arrange
+        sas_token = generate_account_sas(
+            account_name=storage_account_name,
+            account_key=storage_account_key,
+            resource_types=ResourceTypes(service=True),
+            permission=AccountSasPermissions(read=True),
+            expiry=datetime.utcnow() + timedelta(hours=3)
+        )
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=sas_token)
+
+        # Act
+        props = bsc.get_service_properties()
+
+        # Assert
+        self.assertIsNotNone(props)
 
     # --Test cases for errors ---------------------------------------
     @BlobPreparer()

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_properties_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_properties_async.py
@@ -5,28 +5,25 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import unittest
 import pytest
-import asyncio
+from datetime import datetime, timedelta
 
-from msrest.exceptions import ValidationError  # TODO This should be an azure-core error.
 from azure.core.exceptions import HttpResponseError
-from devtools_testutils import ResourceGroupPreparer, StorageAccountPreparer
-from azure.storage.blob.aio import (
-    BlobServiceClient,
-    ContainerClient,
-    BlobClient,
-)
-
 from azure.core.pipeline.transport import AioHttpTransport
 from multidict import CIMultiDict, CIMultiDictProxy
 
+from azure.storage.blob.aio import (
+    BlobServiceClient,
+)
 from azure.storage.blob import (
+    AccountSasPermissions,
     BlobAnalyticsLogging,
-    Metrics,
     CorsRule,
+    Metrics,
+    ResourceTypes,
     RetentionPolicy,
     StaticWebsite,
+    generate_account_sas,
 )
 from settings.testcase import BlobPreparer
 from devtools_testutils.storage.aio import AsyncStorageTestCase
@@ -414,6 +411,26 @@ class ServicePropertiesTestAsync(AsyncStorageTestCase):
         # Assert
         received_props = await bsc.get_service_properties()
         self._assert_cors_equal(received_props['cors'], cors)
+
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    @AsyncStorageTestCase.await_prepared_test
+    async def test_get_service_properties_sas(self, storage_account_name, storage_account_key):
+        # Arrange
+        sas_token = generate_account_sas(
+            account_name=storage_account_name,
+            account_key=storage_account_key,
+            resource_types=ResourceTypes(service=True),
+            permission=AccountSasPermissions(read=True),
+            expiry=datetime.utcnow() + timedelta(hours=3)
+        )
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=sas_token)
+
+        # Act
+        props = await bsc.get_service_properties()
+
+        # Assert
+        self.assertIsNotNone(props)
 
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_properties_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_properties_async.py
@@ -415,7 +415,7 @@ class ServicePropertiesTestAsync(AsyncStorageTestCase):
     @pytest.mark.live_test_only
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test
-    async def test_get_service_properties_sas(self, storage_account_name, storage_account_key):
+    async def test_get_service_properties_account_sas(self, storage_account_name, storage_account_key):
         # Arrange
         sas_token = generate_account_sas(
             account_name=storage_account_name,

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -327,6 +327,31 @@ class StorageContainerTest(StorageTestCase):
         self.assertNamedItemInContainer(containers2, container_names[2])
         self.assertNamedItemInContainer(containers2, container_names[3])
 
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    def test_list_containers_with_account_sas(self, storage_account_name, storage_account_key):
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key)
+        container = self._create_container(bsc)
+
+        sas_token = generate_account_sas(
+            account_name=storage_account_name,
+            account_key=storage_account_key,
+            resource_types=ResourceTypes(service=True),
+            permission=AccountSasPermissions(list=True),
+            expiry=datetime.utcnow() + timedelta(hours=3)
+        )
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=sas_token)
+
+        # Act
+        containers = list(bsc.list_containers(name_starts_with=container.container_name))
+
+        # Assert
+        self.assertIsNotNone(containers)
+        self.assertEqual(len(containers), 1)
+        self.assertIsNotNone(containers[0])
+        self.assertEqual(containers[0].name, container.container_name)
+        self.assertIsNone(containers[0].metadata)
+
     @BlobPreparer()
     def test_set_container_metadata(self, storage_account_name, storage_account_key):
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key)

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -329,7 +329,7 @@ class StorageContainerTest(StorageTestCase):
 
     @pytest.mark.live_test_only
     @BlobPreparer()
-    def test_list_containers_with_account_sas(self, storage_account_name, storage_account_key):
+    def test_list_containers_account_sas(self, storage_account_name, storage_account_key):
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key)
         container = self._create_container(bsc)
 

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -418,7 +418,7 @@ class StorageContainerAsyncTest(AsyncStorageTestCase):
     @pytest.mark.live_test_only
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test
-    async def test_list_containers_with_account_sas(self, storage_account_name, storage_account_key):
+    async def test_list_containers_account_sas(self, storage_account_name, storage_account_key):
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key)
         container = await self._create_container(bsc)
 

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -415,6 +415,34 @@ class StorageContainerAsyncTest(AsyncStorageTestCase):
         self.assertNamedItemInContainer(containers2, container_names[2])
         self.assertNamedItemInContainer(containers2, container_names[3])
 
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    @AsyncStorageTestCase.await_prepared_test
+    async def test_list_containers_with_account_sas(self, storage_account_name, storage_account_key):
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key)
+        container = await self._create_container(bsc)
+
+        sas_token = generate_account_sas(
+            account_name=storage_account_name,
+            account_key=storage_account_key,
+            resource_types=ResourceTypes(service=True),
+            permission=AccountSasPermissions(list=True),
+            expiry=datetime.utcnow() + timedelta(hours=3)
+        )
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=sas_token)
+
+        # Act
+        containers = []
+        async for c in bsc.list_containers(name_starts_with=container.container_name):
+            containers.append(c)
+
+        # Assert
+        self.assertIsNotNone(containers)
+        self.assertEqual(len(containers), 1)
+        self.assertIsNotNone(containers[0])
+        self.assertEqual(containers[0].name, container.container_name)
+        self.assertIsNone(containers[0].metadata)
+
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_set_container_metadata(self, storage_account_name, storage_account_key):

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Bugs Fixed
+- Fixed a bug, introduced in the previous beta release, that caused Authentication errors when attempting to use
+an Account SAS with certain service level operations.
 
 ## 12.7.0b1 (2022-04-14)
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_generated/aio/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_generated/aio/operations/_service_operations.py
@@ -97,6 +97,7 @@ class ServiceOperations:
             if not next_link:
                 
                 request = build_list_file_systems_request(
+                    url=self._config.url,
                     resource=resource,
                     version=self._config.version,
                     prefix=prefix,
@@ -112,6 +113,7 @@ class ServiceOperations:
             else:
                 
                 request = build_list_file_systems_request(
+                    url=self._config.url,
                     resource=resource,
                     version=self._config.version,
                     prefix=prefix,
@@ -154,4 +156,4 @@ class ServiceOperations:
         return AsyncItemPaged(
             get_next, extract_data
         )
-    list_file_systems.metadata = {'url': "/"}  # type: ignore
+    list_file_systems.metadata = {'url': "{url}"}  # type: ignore

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_generated/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_generated/operations/_service_operations.py
@@ -18,7 +18,7 @@ from azure.core.rest import HttpRequest
 from azure.core.tracing.decorator import distributed_trace
 
 from .. import models as _models
-from .._vendor import _convert_request
+from .._vendor import _convert_request, _format_url_section
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -31,6 +31,7 @@ _SERIALIZER.client_side_validation = False
 # fmt: off
 
 def build_list_file_systems_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -44,7 +45,12 @@ def build_list_file_systems_request(
 
     accept = "application/json"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -150,6 +156,7 @@ class ServiceOperations(object):
             if not next_link:
                 
                 request = build_list_file_systems_request(
+                    url=self._config.url,
                     resource=resource,
                     version=self._config.version,
                     prefix=prefix,
@@ -165,6 +172,7 @@ class ServiceOperations(object):
             else:
                 
                 request = build_list_file_systems_request(
+                    url=self._config.url,
                     resource=resource,
                     version=self._config.version,
                     prefix=prefix,
@@ -207,4 +215,4 @@ class ServiceOperations(object):
         return ItemPaged(
             get_next, extract_data
         )
-    list_file_systems.metadata = {'url': "/"}  # type: ignore
+    list_file_systems.metadata = {'url': "{url}"}  # type: ignore

--- a/sdk/storage/azure-storage-file-datalake/swagger/README.md
+++ b/sdk/storage/azure-storage-file-datalake/swagger/README.md
@@ -83,18 +83,25 @@ directive:
   transform: >
     for (const property in $)
     {
-        // Don't apply to service operations (where path is just '/')
-        if (property !== '/' && !property.startsWith('/?')) {
-            if ($[property]["parameters"] === undefined)
-            {
-                $[property]["parameters"] = []
-            }
-            $[property]["parameters"].push({"$ref": "#/parameters/Url"});
-    
-            var oldName = property;
-            var newName = '{url}' + property;
-            $[newName] = $[oldName];
-            delete $[oldName];
+        if ($[property]["parameters"] === undefined)
+        {
+            $[property]["parameters"] = []
         }
+        $[property]["parameters"].push({"$ref": "#/parameters/Url"});
+
+        var oldName = property;
+        // For service operations (where the path is just '/') we need to
+        // remove the '/' at the begining to avoid having an extra '/' in
+        // the final URL.
+        if (property === '/' || property.startsWith('/?'))
+        {
+            var newName = '{url}' + property.substring(1);
+        }
+        else
+        {
+            var newName = '{url}' + property;
+        }
+        $[newName] = $[oldName];
+        delete $[oldName];
     }
 ```

--- a/sdk/storage/azure-storage-file-datalake/swagger/README.md
+++ b/sdk/storage/azure-storage-file-datalake/swagger/README.md
@@ -75,7 +75,7 @@ directive:
     $["x-ms-parameterized-host"] = undefined;
 ```
 
-### Add url parameter to each operation and add it to the url
+### Add url parameter to each operation and add url to the path
 ``` yaml
 directive:
 - from: swagger-document

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -158,6 +158,31 @@ class FileSystemTest(StorageTestCase):
         self.assertIsNotNone(file_systems[0].has_immutability_policy)
         self.assertIsNotNone(file_systems[0].has_legal_hold)
 
+    @pytest.mark.live_test_only
+    @DataLakePreparer()
+    def test_list_file_systems_sas(self, datalake_storage_account_name, datalake_storage_account_key):
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+        # Arrange
+        file_system_name = self._get_file_system_reference()
+        file_system = self.dsc.create_file_system(file_system_name)
+        sas_token = generate_account_sas(
+            datalake_storage_account_name,
+            datalake_storage_account_key,
+            ResourceTypes(service=True),
+            AccountSasPermissions(list=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        # Act
+        dsc = DataLakeServiceClient(self.account_url(datalake_storage_account_name, 'dfs'), credential=sas_token)
+        file_systems = list(dsc.list_file_systems())
+
+        # Assert
+        self.assertIsNotNone(file_systems)
+        self.assertGreaterEqual(len(file_systems), 1)
+        self.assertIsNotNone(file_systems[0])
+        self.assertNamedItemInContainer(file_systems, file_system.file_system_name)
+
     @DataLakePreparer()
     def test_rename_file_system(self, datalake_storage_account_name, datalake_storage_account_key):
         if not self.is_playback():

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -160,7 +160,7 @@ class FileSystemTest(StorageTestCase):
 
     @pytest.mark.live_test_only
     @DataLakePreparer()
-    def test_list_file_systems_sas(self, datalake_storage_account_name, datalake_storage_account_key):
+    def test_list_file_systems_account_sas(self, datalake_storage_account_name, datalake_storage_account_key):
         self._setUp(datalake_storage_account_name, datalake_storage_account_key)
         # Arrange
         file_system_name = self._get_file_system_reference()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
@@ -161,7 +161,7 @@ class FileSystemTest(StorageTestCase):
 
     @pytest.mark.live_test_only
     @DataLakePreparer()
-    async def test_list_file_systems_sas(self, datalake_storage_account_name, datalake_storage_account_key):
+    async def test_list_file_systems_account_sas(self, datalake_storage_account_name, datalake_storage_account_key):
         self._setUp(datalake_storage_account_name, datalake_storage_account_key)
         # Arrange
         file_system_name = self._get_file_system_reference()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
@@ -159,6 +159,33 @@ class FileSystemTest(StorageTestCase):
         self.assertIsNotNone(file_systems[0].has_immutability_policy)
         self.assertIsNotNone(file_systems[0].has_legal_hold)
 
+    @pytest.mark.live_test_only
+    @DataLakePreparer()
+    async def test_list_file_systems_sas(self, datalake_storage_account_name, datalake_storage_account_key):
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+        # Arrange
+        file_system_name = self._get_file_system_reference()
+        file_system = await self.dsc.create_file_system(file_system_name)
+        sas_token = generate_account_sas(
+            datalake_storage_account_name,
+            datalake_storage_account_key,
+            ResourceTypes(service=True),
+            AccountSasPermissions(list=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        # Act
+        dsc = DataLakeServiceClient(self.account_url(datalake_storage_account_name, 'dfs'), credential=sas_token)
+        file_systems = []
+        async for filesystem in dsc.list_file_systems():
+            file_systems.append(filesystem)
+
+        # Assert
+        self.assertIsNotNone(file_systems)
+        self.assertGreaterEqual(len(file_systems), 1)
+        self.assertIsNotNone(file_systems[0])
+        self.assertNamedItemInContainer(file_systems, file_system.file_system_name)
+
     @DataLakePreparer()
     async def test_delete_file_system_with_existing_file_system_async(
             self, datalake_storage_account_name, datalake_storage_account_key):

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Bugs Fixed
+- Fixed a bug, introduced in the previous beta release, that caused Authentication errors when attempting to use
+an Account SAS with certain service level operations.
 
 ## 12.8.0b1 (2022-04-14)
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_service_operations.py
@@ -81,6 +81,7 @@ class ServiceOperations:
         _content = self._serialize.body(storage_service_properties, 'StorageServiceProperties', is_xml=True)
 
         request = build_set_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -112,7 +113,7 @@ class ServiceOperations:
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    set_properties.metadata = {'url': "/"}  # type: ignore
+    set_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -151,6 +152,7 @@ class ServiceOperations:
 
         
         request = build_get_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -183,7 +185,7 @@ class ServiceOperations:
 
         return deserialized
 
-    get_properties.metadata = {'url': "/"}  # type: ignore
+    get_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -237,6 +239,7 @@ class ServiceOperations:
 
         
         request = build_list_shares_segment_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             prefix=prefix,
@@ -272,5 +275,5 @@ class ServiceOperations:
 
         return deserialized
 
-    list_shares_segment.metadata = {'url': "/"}  # type: ignore
+    list_shares_segment.metadata = {'url': "{url}"}  # type: ignore
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_service_operations.py
@@ -17,7 +17,7 @@ from azure.core.rest import HttpRequest
 from azure.core.tracing.decorator import distributed_trace
 
 from .. import models as _models
-from .._vendor import _convert_request
+from .._vendor import _convert_request, _format_url_section
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -30,6 +30,7 @@ _SERIALIZER.client_side_validation = False
 # fmt: off
 
 def build_set_properties_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -41,7 +42,12 @@ def build_set_properties_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -67,6 +73,7 @@ def build_set_properties_request(
 
 
 def build_get_properties_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -77,7 +84,12 @@ def build_get_properties_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -101,6 +113,7 @@ def build_get_properties_request(
 
 
 def build_list_shares_segment_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -114,7 +127,12 @@ def build_list_shares_segment_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -206,6 +224,7 @@ class ServiceOperations(object):
         _content = self._serialize.body(storage_service_properties, 'StorageServiceProperties', is_xml=True)
 
         request = build_set_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -237,7 +256,7 @@ class ServiceOperations(object):
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    set_properties.metadata = {'url': "/"}  # type: ignore
+    set_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -277,6 +296,7 @@ class ServiceOperations(object):
 
         
         request = build_get_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -309,7 +329,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    get_properties.metadata = {'url': "/"}  # type: ignore
+    get_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -364,6 +384,7 @@ class ServiceOperations(object):
 
         
         request = build_list_shares_segment_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             prefix=prefix,
@@ -399,5 +420,5 @@ class ServiceOperations(object):
 
         return deserialized
 
-    list_shares_segment.metadata = {'url': "/"}  # type: ignore
+    list_shares_segment.metadata = {'url': "{url}"}  # type: ignore
 

--- a/sdk/storage/azure-storage-file-share/swagger/README.md
+++ b/sdk/storage/azure-storage-file-share/swagger/README.md
@@ -119,7 +119,7 @@ directive:
     $["x-ms-parameterized-host"] = undefined;
 ```
 
-### Add url parameter to each operation and add it to the url
+### Add url parameter to each operation and add url to the path
 ``` yaml
 directive:
 - from: swagger-document
@@ -127,14 +127,21 @@ directive:
   transform: >
     for (const property in $)
     {
-        // Don't apply to service operations (where path is just '/')
-        if (property !== '/' && !property.startsWith('/?')) {
-            $[property]["parameters"].push({"$ref": "#/parameters/Url"});
-    
-            var oldName = property;
-            var newName = '{url}' + property;
-            $[newName] = $[oldName];
-            delete $[oldName];
+        $[property]["parameters"].push({"$ref": "#/parameters/Url"});
+
+        var oldName = property;
+        // For service operations (where the path is just '/') we need to
+        // remove the '/' at the begining to avoid having an extra '/' in
+        // the final URL.
+        if (property === '/' || property.startsWith('/?'))
+        {
+            var newName = '{url}' + property.substring(1);
         }
+        else
+        {
+            var newName = '{url}' + property;
+        }
+        $[newName] = $[oldName];
+        delete $[oldName];
     }
 ```

--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -5,6 +5,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import os
 import time
 import unittest
 from datetime import datetime, timedelta
@@ -12,29 +13,27 @@ from datetime import datetime, timedelta
 import pytest
 import requests
 from azure.core.pipeline.transport import RequestsTransport
-from azure.core.exceptions import (
-    HttpResponseError,
-    ResourceNotFoundError,
-    ResourceExistsError)
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 
 from azure.storage.fileshare import (
     AccessPolicy,
-    ShareSasPermissions,
+    AccountSasPermissions,
+    ResourceTypes,
     ShareAccessTier,
-    ShareServiceClient,
-    ShareDirectoryClient,
-    ShareFileClient,
     ShareClient,
-    generate_share_sas,
-    ShareRootSquash, ShareProtocols)
+    ShareFileClient,
+    ShareSasPermissions,
+    ShareServiceClient,
+    ShareProtocols,
+    ShareRootSquash,
+    generate_account_sas,
+    generate_share_sas,)
 
 from devtools_testutils.storage import StorageTestCase, LogCaptured
 from settings.testcase import FileSharePreparer
 
 # ------------------------------------------------------------------------------
 TEST_SHARE_PREFIX = 'share'
-
-
 # ------------------------------------------------------------------------------
 
 class StorageShareTest(StorageTestCase):
@@ -736,6 +735,30 @@ class StorageShareTest(StorageTestCase):
         self.assertEqual(len(shares2), 2)
         self.assertNamedItemInContainer(shares2, share_names[2])
         self.assertNamedItemInContainer(shares2, share_names[3])
+        self._delete_shares()
+
+    @pytest.mark.live_test_only
+    @FileSharePreparer()
+    def test_list_shares_account_sas(self, storage_account_name, storage_account_key):
+        self._setup(storage_account_name, storage_account_key)
+        share = self._create_share()
+        sas_token = generate_account_sas(
+            storage_account_name,
+            storage_account_key,
+            ResourceTypes(service=True),
+            AccountSasPermissions(list=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        # Act
+        fsc = ShareServiceClient(self.account_url(storage_account_name, "file"), credential=sas_token)
+        shares = list(fsc.list_shares())
+
+        # Assert
+        self.assertIsNotNone(shares)
+        self.assertGreaterEqual(len(shares), 1)
+        self.assertIsNotNone(shares[0])
+        self.assertNamedItemInContainer(shares, share.share_name)
         self._delete_shares()
 
     @FileSharePreparer()

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -5,30 +5,29 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import os
 import time
-import unittest
 from datetime import datetime, timedelta
-import asyncio
+
 import pytest
 import requests
 from azure.core.pipeline.transport import AioHttpTransport
-from azure.core.pipeline.transport import AsyncioRequestsTransport
 from multidict import CIMultiDict, CIMultiDictProxy
-from azure.core.exceptions import (
-    HttpResponseError,
-    ResourceNotFoundError,
-    ResourceExistsError)
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 
 from azure.storage.fileshare import (
     AccessPolicy,
-    ShareSasPermissions,
+    AccountSasPermissions,
+    ResourceTypes,
     ShareAccessTier,
+    ShareProtocols,
+    ShareRootSquash,
+    ShareSasPermissions,
+    generate_account_sas,
     generate_share_sas,
-    ShareRootSquash, ShareProtocols
 )
 from azure.storage.fileshare.aio import (
     ShareServiceClient,
-    ShareDirectoryClient,
     ShareFileClient,
     ShareClient,
 )
@@ -37,8 +36,6 @@ from devtools_testutils.storage.aio import AsyncStorageTestCase
 from devtools_testutils.storage import LogCaptured
 # ------------------------------------------------------------------------------
 TEST_SHARE_PREFIX = 'share'
-
-
 # ------------------------------------------------------------------------------
 
 
@@ -806,6 +803,33 @@ class StorageShareTest(AsyncStorageTestCase):
         self.assertNamedItemInContainer(shares2, share_names[2])
         self.assertNamedItemInContainer(shares2, share_names[3])
         await self._delete_shares(prefix)
+
+    @pytest.mark.live_test_only
+    @FileSharePreparer()
+    @AsyncStorageTestCase.await_prepared_test
+    async def test_list_shares_account_sas(self, storage_account_name, storage_account_key):
+        self._setup(storage_account_name, storage_account_key)
+        share = await self._create_share()
+        sas_token = generate_account_sas(
+            storage_account_name,
+            storage_account_key,
+            ResourceTypes(service=True),
+            AccountSasPermissions(list=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        # Act
+        fsc = ShareServiceClient(self.account_url(storage_account_name, "file"), credential=sas_token)
+        shares = []
+        async for s in fsc.list_shares():
+            shares.append(s)
+
+        # Assert
+        self.assertIsNotNone(shares)
+        self.assertGreaterEqual(len(shares), 1)
+        self.assertIsNotNone(shares[0])
+        self.assertNamedItemInContainer(shares, share.share_name)
+        await self._delete_shares()
 
 
     @FileSharePreparer()

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Bugs Fixed
+- Fixed a bug, introduced in the previous beta release, that caused Authentication errors when attempting to use
+an Account SAS with certain service level operations.
 
 ## 12.3.0b1 (2022-04-14)
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/aio/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/aio/operations/_service_operations.py
@@ -85,6 +85,7 @@ class ServiceOperations:
         _content = self._serialize.body(storage_service_properties, 'StorageServiceProperties', is_xml=True)
 
         request = build_set_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -117,7 +118,7 @@ class ServiceOperations:
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    set_properties.metadata = {'url': "/"}  # type: ignore
+    set_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -160,6 +161,7 @@ class ServiceOperations:
 
         
         request = build_get_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -193,7 +195,7 @@ class ServiceOperations:
 
         return deserialized
 
-    get_properties.metadata = {'url': "/"}  # type: ignore
+    get_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -237,6 +239,7 @@ class ServiceOperations:
 
         
         request = build_get_statistics_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -271,7 +274,7 @@ class ServiceOperations:
 
         return deserialized
 
-    get_statistics.metadata = {'url': "/"}  # type: ignore
+    get_statistics.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace_async
@@ -333,6 +336,7 @@ class ServiceOperations:
 
         
         request = build_list_queues_segment_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             prefix=prefix,
@@ -370,5 +374,5 @@ class ServiceOperations:
 
         return deserialized
 
-    list_queues_segment.metadata = {'url': "/"}  # type: ignore
+    list_queues_segment.metadata = {'url': "{url}"}  # type: ignore
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/operations/_service_operations.py
@@ -17,7 +17,7 @@ from azure.core.rest import HttpRequest
 from azure.core.tracing.decorator import distributed_trace
 
 from .. import models as _models
-from .._vendor import _convert_request
+from .._vendor import _convert_request, _format_url_section
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -30,6 +30,7 @@ _SERIALIZER.client_side_validation = False
 # fmt: off
 
 def build_set_properties_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -42,7 +43,12 @@ def build_set_properties_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -70,6 +76,7 @@ def build_set_properties_request(
 
 
 def build_get_properties_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -81,7 +88,12 @@ def build_get_properties_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -107,6 +119,7 @@ def build_get_properties_request(
 
 
 def build_get_statistics_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -118,7 +131,12 @@ def build_get_statistics_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -144,6 +162,7 @@ def build_get_statistics_request(
 
 
 def build_list_queues_segment_request(
+    url,  # type: str
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -158,7 +177,12 @@ def build_list_queues_segment_request(
 
     accept = "application/xml"
     # Construct URL
-    _url = kwargs.pop("template_url", "/")
+    _url = kwargs.pop("template_url", "{url}")
+    path_format_arguments = {
+        "url": _SERIALIZER.url("url", url, 'str', skip_quote=True),
+    }
+
+    _url = _format_url_section(_url, **path_format_arguments)
 
     # Construct parameters
     _query_parameters = kwargs.pop("params", {})  # type: Dict[str, Any]
@@ -256,6 +280,7 @@ class ServiceOperations(object):
         _content = self._serialize.body(storage_service_properties, 'StorageServiceProperties', is_xml=True)
 
         request = build_set_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -288,7 +313,7 @@ class ServiceOperations(object):
         if cls:
             return cls(pipeline_response, None, response_headers)
 
-    set_properties.metadata = {'url': "/"}  # type: ignore
+    set_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -332,6 +357,7 @@ class ServiceOperations(object):
 
         
         request = build_get_properties_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -365,7 +391,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    get_properties.metadata = {'url': "/"}  # type: ignore
+    get_properties.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -410,6 +436,7 @@ class ServiceOperations(object):
 
         
         request = build_get_statistics_request(
+            url=self._config.url,
             restype=restype,
             comp=comp,
             version=self._config.version,
@@ -444,7 +471,7 @@ class ServiceOperations(object):
 
         return deserialized
 
-    get_statistics.metadata = {'url': "/"}  # type: ignore
+    get_statistics.metadata = {'url': "{url}"}  # type: ignore
 
 
     @distributed_trace
@@ -507,6 +534,7 @@ class ServiceOperations(object):
 
         
         request = build_list_queues_segment_request(
+            url=self._config.url,
             comp=comp,
             version=self._config.version,
             prefix=prefix,
@@ -544,5 +572,5 @@ class ServiceOperations(object):
 
         return deserialized
 
-    list_queues_segment.metadata = {'url': "/"}  # type: ignore
+    list_queues_segment.metadata = {'url': "{url}"}  # type: ignore
 

--- a/sdk/storage/azure-storage-queue/swagger/README.md
+++ b/sdk/storage/azure-storage-queue/swagger/README.md
@@ -96,7 +96,7 @@ directive:
     $["x-ms-parameterized-host"] = undefined;
 ```
 
-### Add url parameter to each operation and add it to the url
+### Add url parameter to each operation and add url to the path
 ``` yaml
 directive:
 - from: swagger-document
@@ -104,14 +104,21 @@ directive:
   transform: >
     for (const property in $)
     {
-        // Don't apply to service operations (where path is just '/')
-        if (property !== '/' && !property.startsWith('/?')) {
-            $[property]["parameters"].push({"$ref": "#/parameters/Url"});
-    
-            var oldName = property;
-            var newName = '{url}' + property;
-            $[newName] = $[oldName];
-            delete $[oldName];
+        $[property]["parameters"].push({"$ref": "#/parameters/Url"});
+
+        var oldName = property;
+        // For service operations (where the path is just '/') we need to
+        // remove the '/' at the begining to avoid having an extra '/' in
+        // the final URL.
+        if (property === '/' || property.startsWith('/?'))
+        {
+            var newName = '{url}' + property.substring(1);
         }
+        else
+        {
+            var newName = '{url}' + property;
+        }
+        $[newName] = $[oldName];
+        delete $[oldName];
     }
 ```

--- a/sdk/storage/azure-storage-queue/tests/test_queue.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue.py
@@ -6,20 +6,15 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from collections import namedtuple
-import unittest
 import pytest
-import sys
-
-from azure.core.credentials import AzureSasCredential
-from dateutil.tz import tzutc
+import unittest
 from datetime import (
     datetime,
     timedelta,
     date,
 )
-from devtools_testutils.storage import StorageTestCase
-from azure.mgmt.storage.models import Endpoints
+
+from azure.core.credentials import AzureSasCredential
 from azure.core.pipeline.transport import RequestsTransport
 from azure.core.exceptions import (
     HttpResponseError,
@@ -28,16 +23,17 @@ from azure.core.exceptions import (
     ClientAuthenticationError)
 
 from azure.storage.queue import (
-    QueueServiceClient,
+    AccessPolicy,
+    AccountSasPermissions,
+    ResourceTypes,
     QueueClient,
     QueueSasPermissions,
-    AccessPolicy,
-    ResourceTypes,
-    AccountSasPermissions,
+    QueueServiceClient,
     generate_account_sas,
     generate_queue_sas
 )
 
+from devtools_testutils.storage import StorageTestCase
 from settings.testcase import QueuePreparer
 
 # ------------------------------------------------------------------------------
@@ -197,6 +193,28 @@ class StorageQueueTest(StorageTestCase):
         self.assertIsNotNone(listed_queue.metadata)
         self.assertEqual(len(listed_queue.metadata), 2)
         self.assertEqual(listed_queue.metadata['val1'], 'test')
+
+    @QueuePreparer()
+    def test_list_queues_account_sas(self, storage_account_name, storage_account_key):
+        # Action
+        qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key)
+        queue_client = self._get_queue_reference(qsc)
+        queue_client.create_queue()
+        sas_token = generate_account_sas(
+            storage_account_name,
+            storage_account_key,
+            ResourceTypes(service=True),
+            AccountSasPermissions(list=True),
+            datetime.utcnow() + timedelta(hours=1)
+        )
+
+        # Act
+        qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), credential=sas_token)
+        queues = list(qsc.list_queues())
+
+        # Assert
+        self.assertIsNotNone(queues)
+        assert len(queues) >= 1
 
     @QueuePreparer()
     def test_set_queue_metadata(self, storage_account_name, storage_account_key):

--- a/sdk/storage/azure-storage-queue/tests/test_queue.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue.py
@@ -194,6 +194,7 @@ class StorageQueueTest(StorageTestCase):
         self.assertEqual(len(listed_queue.metadata), 2)
         self.assertEqual(listed_queue.metadata['val1'], 'test')
 
+    @pytest.mark.live_test_only
     @QueuePreparer()
     def test_list_queues_account_sas(self, storage_account_name, storage_account_key):
         # Action

--- a/sdk/storage/azure-storage-queue/tests/test_queue_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_async.py
@@ -356,6 +356,7 @@ class StorageQueueTestAsync(AsyncStorageTestCase):
         self.assertEqual(len(listed_queue.metadata), 2)
         self.assertEqual(listed_queue.metadata['val1'], 'test')
 
+    @pytest.mark.live_test_only
     @QueuePreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_list_queues_account_sas(self, storage_account_name, storage_account_key):

--- a/sdk/storage/azure-storage-queue/tests/test_queue_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_async.py
@@ -5,41 +5,39 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import unittest
-import pytest
-import asyncio
 
-from azure.core.credentials import AzureSasCredential
-from dateutil.tz import tzutc
+import pytest
+import unittest
 from datetime import (
     datetime,
     timedelta,
     date,
 )
-from multidict import CIMultiDict, CIMultiDictProxy
-from devtools_testutils.storage.aio import AsyncStorageTestCase
+
+from azure.core.credentials import AzureSasCredential
+from azure.core.pipeline.transport import AioHttpTransport
 from azure.core.exceptions import (
     HttpResponseError,
     ResourceNotFoundError,
     ResourceExistsError,
     ClientAuthenticationError)
+from multidict import CIMultiDict, CIMultiDictProxy
 
-from azure.core.pipeline.transport import AioHttpTransport
 from azure.storage.queue import (
-    QueueSasPermissions,
     AccessPolicy,
-    ResourceTypes,
     AccountSasPermissions,
+    ResourceTypes,
+    QueueSasPermissions,
     generate_account_sas,
     generate_queue_sas
 )
 from azure.storage.queue.aio import QueueServiceClient, QueueClient
 
+from devtools_testutils.storage.aio import AsyncStorageTestCase
 from settings.testcase import QueuePreparer
 
 # ------------------------------------------------------------------------------
 TEST_QUEUE_PREFIX = 'pyqueueasync'
-
 # ------------------------------------------------------------------------------
 
 
@@ -357,6 +355,31 @@ class StorageQueueTestAsync(AsyncStorageTestCase):
         self.assertIsNotNone(listed_queue.metadata)
         self.assertEqual(len(listed_queue.metadata), 2)
         self.assertEqual(listed_queue.metadata['val1'], 'test')
+
+    @QueuePreparer()
+    @AsyncStorageTestCase.await_prepared_test
+    async def test_list_queues_account_sas(self, storage_account_name, storage_account_key):
+        # Action
+        qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key)
+        queue_client = self._get_queue_reference(qsc)
+        await queue_client.create_queue()
+        sas_token = generate_account_sas(
+            storage_account_name,
+            storage_account_key,
+            ResourceTypes(service=True),
+            AccountSasPermissions(list=True),
+            datetime.utcnow() + timedelta(hours=1)
+        )
+
+        # Act
+        qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), credential=sas_token)
+        queues = []
+        async for q in qsc.list_queues():
+            queues.append(q)
+
+        # Assert
+        self.assertIsNotNone(queues)
+        assert len(queues) >= 1
 
     @QueuePreparer()
     @AsyncStorageTestCase.await_prepared_test


### PR DESCRIPTION
Resolves #24156

As part of the latest beta release, we introduced a regression that caused certain service operations (e.g., `list_containers()`) to fail when using an account SAS as the authentication method. This was due to the modifications that were made to the generated code as part of the move to the latest version of `autorest/python`. One of the custom directives we added wasn't fully correct and caused URLs to be malformed with certain service operations using account SAS.

This change modifies the custom directive and re-generates the service operations code to address the issue. This change also introduces a series of tests that would have helped to catch this issue before release and can help prevent future, similar regressions.