### PR TITLE
[textanalytics] fix for 429

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
@@ -70,6 +70,7 @@ class TextAnalyticsClientBase:
                 "$top",
                 "$skip",
                 "opinionMining",
+                "api-version"
             }
         )
         try:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-import json
+from azure.core.pipeline.policies import ContentDecodePolicy
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from ._models import TextDocumentBatchStatistics
 from ._lro import _FINISHED
@@ -25,7 +25,9 @@ class TextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
             # determine LRO based off of initial response. If 202, we say it's an LRO
             self._is_lro = response.http_response.status_code == 202
         if self._response_callback:
-            data = json.loads(response.http_response.text())
+            data = ContentDecodePolicy.deserialize_from_http_generics(
+                response.http_response
+            )
             if self._is_lro and (not data or data.get("status", "").lower() not in _FINISHED):
                 return
             if response.http_response.status_code == 429:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
@@ -57,6 +57,7 @@ class AsyncTextAnalyticsClientBase:
                 "$top",
                 "$skip",
                 "opinionMining",
+                "api-version"
             }
         )
         try:


### PR DESCRIPTION
The language service returns 429 when there are too many requests. We have our strange response hook policy which returns information on the response, but need to let the request get retried and return a 200 before we should call the user-passed callback.