### PR TITLE
[textanalytics] decorator to validate multiapi 

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_check.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_check.py
@@ -11,3 +11,12 @@ def is_language_api(api_version):
     """Language API is date-based
     """
     return re.search(r'\d{4}-\d{2}-\d{2}', api_version)
+
+
+def string_index_type_compatibility(string_index_type):
+    """Language API changed this string_index_type option to plural.
+    Convert singular to plural for language API
+    """
+    if string_index_type == "TextElement_v8":
+        return "TextElements_v8"
+    return string_index_type

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -13,16 +13,7 @@ from ._generated.models import (
 from ._generated.v3_0 import models as _v3_0_models
 from ._generated.v3_1 import models as _v3_1_models
 from ._generated.v2022_03_01_preview import models as _v2022_03_01_preview_models
-from ._check import is_language_api
-
-
-def string_index_type_compatibility(string_index_type):
-    """Language API changed this string_index_type option to plural.
-    Convert singular to plural for language API
-    """
-    if string_index_type == "TextElement_v8":
-        return "TextElements_v8"
-    return string_index_type
+from ._check import is_language_api, string_index_type_compatibility
 
 
 def _get_indices(relation):

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_request_handlers.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_request_handlers.py
@@ -9,7 +9,6 @@ from ._models import (
     TextDocumentInput,
     _AnalyzeActionsType,
 )
-from ._check import is_language_api
 
 
 def _validate_input(documents, hint, whole_input_hint):
@@ -99,25 +98,3 @@ def _determine_action_type(action):  # pylint: disable=too-many-return-statement
     if action.__class__.__name__ == "CustomMultiLabelClassificationLROTask":
         return _AnalyzeActionsType.MULTI_CATEGORY_CLASSIFY
     return _AnalyzeActionsType.EXTRACT_KEY_PHRASES
-
-
-def _check_string_index_type_arg(
-    string_index_type_arg, api_version, string_index_type_default="UnicodeCodePoint"
-):
-    string_index_type = None
-
-    if api_version == "v3.0":
-        if string_index_type_arg is not None:
-            raise ValueError(
-                "'string_index_type' is only available for API version V3_1 and up"
-            )
-    elif is_language_api(api_version) and string_index_type_arg == "TextElement_v8":
-        return "TextElements_v8"
-    else:
-        if string_index_type_arg is None:
-            string_index_type = string_index_type_default
-
-        else:
-            string_index_type = string_index_type_arg
-
-    return string_index_type

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -16,13 +16,13 @@ from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.exceptions import HttpResponseError
 from azure.core.credentials import AzureKeyCredential
-from ._base_client import TextAnalyticsClientBase, TextAnalyticsApiVersion
+from ._base_client import TextAnalyticsClientBase
 from ._lro import AnalyzeActionsLROPoller, AnalyzeHealthcareEntitiesLROPoller
 from ._request_handlers import (
     _validate_input,
     _determine_action_type,
-    _check_string_index_type_arg,
 )
+from ._validate import validate_multiapi_args, check_for_unsupported_actions_types
 from ._version import DEFAULT_API_VERSION
 from ._response_handlers import (
     process_http_response_error,
@@ -67,7 +67,7 @@ from ._models import (
     MultiCategoryClassifyResult,
     _AnalyzeActionsType,
 )
-from ._check import is_language_api
+from ._check import is_language_api, string_index_type_compatibility
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
@@ -132,6 +132,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         )
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["disable_service_logs"]}
+    )
     def detect_language(
         self,
         documents: Union[List[str], List[DetectLanguageInput], List[Dict[str, str]]],
@@ -228,6 +232,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             return process_http_response_error(error)
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["string_index_type", "disable_service_logs"]}
+    )
     def recognize_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -294,11 +302,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_index_type_default,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_index_type_default)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
 
         try:
@@ -310,7 +314,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         parameters=models.EntitiesTaskParameters(
                             logging_opt_out=disable_service_logs,
                             model_version=model_version,
-                            string_index_type=string_index_type
+                            string_index_type=string_index_type_compatibility(string_index_type)
                         )
                     ),
                     show_stats=show_stats,
@@ -332,6 +336,9 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             return process_http_response_error(error)
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.1"
+    )
     def recognize_pii_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -408,11 +415,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         show_stats = kwargs.pop("show_stats", None)
         domain_filter = kwargs.pop("domain_filter", None)
         categories_filter = kwargs.pop("categories_filter", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_index_type_default,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_index_type_default)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
 
         try:
@@ -426,7 +429,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                             model_version=model_version,
                             domain=domain_filter,
                             pii_categories=categories_filter,
-                            string_index_type=string_index_type
+                            string_index_type=string_index_type_compatibility(string_index_type)
                         )
                     ),
                     show_stats=show_stats,
@@ -446,19 +449,14 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 cls=kwargs.pop("cls", pii_entities_result),
                 **kwargs
             )
-        except ValueError as error:
-            if (
-                "API version v3.0 does not have operation 'entities_recognition_pii'"
-                in str(error)
-            ):
-                raise ValueError(
-                    "'recognize_pii_entities' endpoint is only available for API version V3_1 and up"
-                ) from error
-            raise error
         except HttpResponseError as error:
             return process_http_response_error(error)
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["string_index_type", "disable_service_logs"]}
+    )
     def recognize_linked_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -527,11 +525,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", None)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_index_type_default,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_index_type_default)
 
         try:
             if is_language_api(self._api_version):
@@ -542,7 +536,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         parameters=models.EntityLinkingTaskParameters(
                             logging_opt_out=disable_service_logs,
                             model_version=model_version,
-                            string_index_type=string_index_type
+                            string_index_type=string_index_type_compatibility(string_index_type)
                         )
                     ),
                     show_stats=show_stats,
@@ -581,6 +575,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         )
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.1",
+        args_mapping={"2022-03-01-preview": ["display_name"]}
+    )
     def begin_analyze_healthcare_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -658,11 +656,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         show_stats = kwargs.pop("show_stats", None)
         polling_interval = kwargs.pop("polling_interval", 5)
         continuation_token = kwargs.pop("continuation_token", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_index_type_default,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_index_type_default)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
         display_name = kwargs.pop("display_name", None)
 
@@ -710,7 +704,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                                 parameters=models.HealthcareTaskParameters(
                                     model_version=model_version,
                                     logging_opt_out=disable_service_logs,
-                                    string_index_type=string_index_type,
+                                    string_index_type=string_index_type_compatibility(string_index_type)
                                 )
                             )
                         ]
@@ -755,19 +749,14 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 continuation_token=continuation_token,
                 **kwargs
             )
-
-        except ValueError as error:
-            if "API version v3.0 does not have operation 'begin_health'" in str(error):
-                raise ValueError(
-                    "'begin_analyze_healthcare_entities' method is only available for API version \
-                    V3_1 and up."
-                ) from error
-            raise error
-
         except HttpResponseError as error:
             return process_http_response_error(error)
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["disable_service_logs"]}
+    )
     def extract_key_phrases(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -862,6 +851,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             return process_http_response_error(error)
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["show_opinion_mining", "disable_service_logs", "string_index_type"]}
+    )
     def analyze_sentiment(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -936,19 +929,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         show_stats = kwargs.pop("show_stats", None)
         show_opinion_mining = kwargs.pop("show_opinion_mining", None)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_index_type_default,
-        )
-        if show_opinion_mining is not None:
-            if (
-                self._api_version == TextAnalyticsApiVersion.V3_0
-                and show_opinion_mining
-            ):
-                raise ValueError(
-                    "'show_opinion_mining' is only available for API version v3.1 and up"
-                )
+        string_index_type = kwargs.pop("string_index_type", self._string_index_type_default)
 
         try:
             if is_language_api(self._api_version):
@@ -959,7 +940,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         parameters=models.SentimentAnalysisTaskParameters(
                             logging_opt_out=disable_service_logs,
                             model_version=model_version,
-                            string_index_type=string_index_type,
+                            string_index_type=string_index_type_compatibility(string_index_type),
                             opinion_mining=show_opinion_mining,
                         )
                     ),
@@ -1001,6 +982,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         )
 
     @distributed_trace
+    @validate_multiapi_args(
+        version_method_added="v3.1",
+        custom_wrapper=check_for_unsupported_actions_types
+    )
     def begin_analyze_actions(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -1253,13 +1238,5 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 continuation_token=continuation_token,
                 **kwargs
             )
-
-        except ValueError as error:
-            if "API version v3.0 does not have operation 'begin_analyze'" in str(error):
-                raise ValueError(
-                    "'begin_analyze_actions' endpoint is only available for API version V3_1 and up"
-                ) from error
-            raise error
-
         except HttpResponseError as error:
             return process_http_response_error(error)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_validate.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_validate.py
@@ -1,0 +1,97 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+import functools
+from ._version import VERSIONS_SUPPORTED
+
+
+def check_for_unsupported_actions_types(*args, **kwargs):
+
+    client = args[0]
+    # this assumes the client has an _api_version attribute
+    selected_api_version = client._api_version  # pylint: disable=protected-access
+
+    if "actions" not in kwargs:
+        actions = args[2]
+    else:
+        actions = kwargs.get("actions")
+
+    if actions is None:
+        return
+
+    actions_version_mapping = {
+        "2022-03-01-preview":
+        [
+            "ExtractSummaryAction",
+            "RecognizeCustomEntitiesAction",
+            "SingleCategoryClassifyAction",
+            "MultiCategoryClassifyAction"
+        ]
+    }
+
+    unsupported = {
+        arg: version
+        for version, args in actions_version_mapping.items()
+        for arg in args
+        if arg in [action.__class__.__name__ for action in actions]
+           and selected_api_version != version
+           and VERSIONS_SUPPORTED.index(selected_api_version) < VERSIONS_SUPPORTED.index(version)
+    }
+
+    if unsupported:
+        error_strings = [
+            f"'{param}' is only available for API version {version} and up.\n"
+            for param, version in unsupported.items()
+        ]
+        raise ValueError("".join(error_strings))
+
+
+def validate_multiapi_args(**kwargs):
+    args_mapping = kwargs.pop("args_mapping", None)
+    version_method_added = kwargs.pop("version_method_added", None)
+    custom_wrapper = kwargs.pop("custom_wrapper", None)
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                # this assumes the client has an _api_version attribute
+                client = args[0]
+                selected_api_version = client._api_version  # pylint: disable=protected-access
+            except AttributeError:
+                return func(*args, **kwargs)
+
+            # the latest version is selected, we assume all features supported
+            if selected_api_version == VERSIONS_SUPPORTED[-1]:
+                return func(*args, **kwargs)
+
+            if version_method_added and version_method_added != selected_api_version and \
+                    VERSIONS_SUPPORTED.index(selected_api_version) < VERSIONS_SUPPORTED.index(version_method_added):
+                raise ValueError(f"'{func.__name__}' is only available for API version {version_method_added} and up.")
+
+            if args_mapping:
+                unsupported = {
+                    arg: version
+                    for version, args in args_mapping.items()
+                    for arg in args
+                    if arg in kwargs.keys()
+                    and selected_api_version != version
+                    and VERSIONS_SUPPORTED.index(selected_api_version) < VERSIONS_SUPPORTED.index(version)
+                }
+                if unsupported:
+                    error_strings = [
+                        f"'{param}' is only available for API version {version} and up.\n"
+                        for param, version in unsupported.items()
+                    ]
+                    raise ValueError("".join(error_strings))
+
+            if custom_wrapper:
+                custom_wrapper(*args, **kwargs)
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_version.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_version.py
@@ -5,3 +5,4 @@
 
 VERSION = "5.2.0b4"
 DEFAULT_API_VERSION = "2022-03-01-preview"
+VERSIONS_SUPPORTED = ("v3.0", "v3.1", "2022-03-01-preview")

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -10,14 +10,13 @@ from azure.core.async_paging import AsyncItemPaged
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.exceptions import HttpResponseError
 from azure.core.credentials import AzureKeyCredential
-from .._version import DEFAULT_API_VERSION
 from ._base_client_async import AsyncTextAnalyticsClientBase
-from .._base_client import TextAnalyticsApiVersion
 from .._request_handlers import (
     _validate_input,
     _determine_action_type,
-    _check_string_index_type_arg,
 )
+from .._validate import validate_multiapi_args, check_for_unsupported_actions_types
+from .._version import DEFAULT_API_VERSION
 from .._response_handlers import (
     process_http_response_error,
     entities_result,
@@ -54,7 +53,7 @@ from .._models import (
     MultiCategoryClassifyAction,
     MultiCategoryClassifyResult,
 )
-from .._check import is_language_api
+from .._check import is_language_api, string_index_type_compatibility
 from .._lro import TextAnalyticsOperationResourcePolling
 from ._lro_async import (
     AsyncAnalyzeHealthcareEntitiesLROPollingMethod,
@@ -127,6 +126,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         )
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["disable_service_logs"]}
+    )
     async def detect_language(
         self,
         documents: Union[List[str], List[DetectLanguageInput], List[Dict[str, str]]],
@@ -223,6 +226,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             return process_http_response_error(error)
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["string_index_type", "disable_service_logs"]}
+    )
     async def recognize_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -290,11 +297,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", None)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_code_unit,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_code_unit)
 
         try:
             if is_language_api(self._api_version):
@@ -305,7 +308,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         parameters=models.EntitiesTaskParameters(
                             logging_opt_out=disable_service_logs,
                             model_version=model_version,
-                            string_index_type=string_index_type
+                            string_index_type=string_index_type_compatibility(string_index_type),
                         )
                     ),
                     show_stats=show_stats,
@@ -327,6 +330,9 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             return process_http_response_error(error)
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.1"
+    )
     async def recognize_pii_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -403,11 +409,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         show_stats = kwargs.pop("show_stats", None)
         domain_filter = kwargs.pop("domain_filter", None)
         categories_filter = kwargs.pop("categories_filter", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_code_unit,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_code_unit)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
 
         try:
@@ -421,7 +423,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                             model_version=model_version,
                             domain=domain_filter,
                             pii_categories=categories_filter,
-                            string_index_type=string_index_type
+                            string_index_type=string_index_type_compatibility(string_index_type),
                         )
                     ),
                     show_stats=show_stats,
@@ -441,19 +443,14 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 cls=kwargs.pop("cls", pii_entities_result),
                 **kwargs,
             )
-        except ValueError as error:
-            if (
-                "API version v3.0 does not have operation 'entities_recognition_pii'"
-                in str(error)
-            ):
-                raise ValueError(
-                    "'recognize_pii_entities' endpoint is only available for API version V3_1 and up"
-                ) from error
-            raise error
         except HttpResponseError as error:
             return process_http_response_error(error)
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["string_index_type", "disable_service_logs"]}
+    )
     async def recognize_linked_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -522,11 +519,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", None)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_code_unit,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_code_unit)
 
         try:
             if is_language_api(self._api_version):
@@ -537,7 +530,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         parameters=models.EntityLinkingTaskParameters(
                             logging_opt_out=disable_service_logs,
                             model_version=model_version,
-                            string_index_type=string_index_type
+                            string_index_type=string_index_type_compatibility(string_index_type),
                         )
                     ),
                     show_stats=show_stats,
@@ -559,6 +552,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             return process_http_response_error(error)
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["disable_service_logs"]}
+    )
     async def extract_key_phrases(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -653,6 +650,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             return process_http_response_error(error)
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.0",
+        args_mapping={"v3.1": ["show_opinion_mining", "disable_service_logs", "string_index_type"]}
+    )
     async def analyze_sentiment(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -727,19 +728,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         show_stats = kwargs.pop("show_stats", None)
         show_opinion_mining = kwargs.pop("show_opinion_mining", None)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_code_unit,
-        )
-        if show_opinion_mining is not None:
-            if (
-                self._api_version == TextAnalyticsApiVersion.V3_0
-                and show_opinion_mining
-            ):
-                raise ValueError(
-                    "'show_opinion_mining' is only available for API version v3.1 and up"
-                )
+        string_index_type = kwargs.pop("string_index_type", self._string_code_unit)
 
         try:
             if is_language_api(self._api_version):
@@ -750,7 +739,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         parameters=models.SentimentAnalysisTaskParameters(
                             logging_opt_out=disable_service_logs,
                             model_version=model_version,
-                            string_index_type=string_index_type,
+                            string_index_type=string_index_type_compatibility(string_index_type),
                             opinion_mining=show_opinion_mining,
                         )
                     ),
@@ -791,6 +780,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         )
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.1",
+        args_mapping={"2022-03-01-preview": ["display_name"]}
+    )
     async def begin_analyze_healthcare_entities(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -869,11 +862,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         show_stats = kwargs.pop("show_stats", None)
         polling_interval = kwargs.pop("polling_interval", 5)
         continuation_token = kwargs.pop("continuation_token", None)
-        string_index_type = _check_string_index_type_arg(
-            kwargs.pop("string_index_type", None),
-            self._api_version,
-            string_index_type_default=self._string_code_unit,
-        )
+        string_index_type = kwargs.pop("string_index_type", self._string_code_unit)
         disable_service_logs = kwargs.pop("disable_service_logs", None)
         display_name = kwargs.pop("display_name", None)
 
@@ -921,7 +910,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                                 parameters=models.HealthcareTaskParameters(
                                     model_version=model_version,
                                     logging_opt_out=disable_service_logs,
-                                    string_index_type=string_index_type,
+                                    string_index_type=string_index_type_compatibility(string_index_type),
                                 )
                             )
                         ]
@@ -966,14 +955,6 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 continuation_token=continuation_token,
                 **kwargs,
             )
-
-        except ValueError as error:
-            if "API version v3.0 does not have operation 'begin_health'" in str(error):
-                raise ValueError(
-                    "'begin_analyze_healthcare_entities' endpoint is only available for API version V3_1 and up"
-                ) from error
-            raise error
-
         except HttpResponseError as error:
             return process_http_response_error(error)
 
@@ -996,6 +977,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         )
 
     @distributed_trace_async
+    @validate_multiapi_args(
+        version_method_added="v3.1",
+        custom_wrapper=check_for_unsupported_actions_types
+    )
     async def begin_analyze_actions(
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
@@ -1250,13 +1235,5 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 continuation_token=continuation_token,
                 **kwargs,
             )
-
-        except ValueError as error:
-            if "API version v3.0 does not have operation 'begin_analyze'" in str(error):
-                raise ValueError(
-                    "'begin_analyze_actions' endpoint is only available for API version V3_1 and up"
-                ) from error
-            raise error
-
         except HttpResponseError as error:
             return process_http_response_error(error)

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -1728,3 +1728,71 @@ class TestAnalyze(TextAnalyticsTest):
                 assert document_result.id == document_order[doc_idx]
                 assert not document_result.is_error
                 assert self.document_result_to_action_type(document_result) == action_order[action_idx]
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    def test_analyze_multiapi_validate_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+        docs = [{"id": "56", "text": ":)"},
+                {"id": "0", "text": ":("},
+                {"id": "19", "text": ":P"},
+                {"id": "1", "text": ":D"}]
+
+        with pytest.raises(ValueError) as e:
+            response = client.begin_analyze_actions(
+                docs,
+                actions=[
+                    RecognizeEntitiesAction(),
+                    ExtractKeyPhrasesAction(),
+                    RecognizePiiEntitiesAction(),
+                    RecognizeLinkedEntitiesAction(),
+                    AnalyzeSentimentAction()
+                ],
+                polling_interval=self._interval(),
+            ).result()
+        assert str(e.value) == "'begin_analyze_actions' is only available for API version v3.1 and up."
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsCustomPreparer()
+    def test_analyze_multiapi_validate_v3_1(self, **kwargs):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_single_category_classify_project_name = kwargs.pop("textanalytics_single_category_classify_project_name")
+        textanalytics_single_category_classify_deployment_name = kwargs.pop("textanalytics_single_category_classify_deployment_name")
+        textanalytics_multi_category_classify_project_name = kwargs.pop("textanalytics_multi_category_classify_project_name")
+        textanalytics_multi_category_classify_deployment_name = kwargs.pop("textanalytics_multi_category_classify_deployment_name")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
+
+        client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key), api_version="v3.1")
+
+        docs = [{"id": "56", "text": ":)"},
+                {"id": "0", "text": ":("},
+                {"id": "19", "text": ":P"},
+                {"id": "1", "text": ":D"}]
+        version_supported = "2022-03-01-preview"
+        with pytest.raises(ValueError) as e:
+            response = client.begin_analyze_actions(
+                docs,
+                actions=[
+                    SingleCategoryClassifyAction(
+                        project_name=textanalytics_single_category_classify_project_name,
+                        deployment_name=textanalytics_single_category_classify_deployment_name
+                    ),
+                    MultiCategoryClassifyAction(
+                        project_name=textanalytics_multi_category_classify_project_name,
+                        deployment_name=textanalytics_multi_category_classify_deployment_name
+                    ),
+                    RecognizeCustomEntitiesAction(
+                        project_name=textanalytics_custom_entities_project_name,
+                        deployment_name=textanalytics_custom_entities_deployment_name
+                    ),
+                    ExtractSummaryAction()
+                ],
+                polling_interval=self._interval(),
+            ).result()
+        assert str(e.value) == f"'ExtractSummaryAction' is only available for API version {version_supported} and " \
+                               f"up.\n'RecognizeCustomEntitiesAction' is only available for API version " \
+                               f"{version_supported} and up.\n'SingleCategoryClassifyAction' is only available " \
+                               f"for API version {version_supported} and up.\n'MultiCategoryClassifyAction' is " \
+                               f"only available for API version {version_supported} and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -1842,3 +1842,72 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                     assert document_result.id == document_order[doc_idx]
                     assert not document_result.is_error
                     assert self.document_result_to_action_type(document_result) == action_order[action_idx]
+
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_analyze_multiapi_validate_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+        docs = [{"id": "56", "text": ":)"},
+                {"id": "0", "text": ":("},
+                {"id": "19", "text": ":P"},
+                {"id": "1", "text": ":D"}]
+
+        with pytest.raises(ValueError) as e:
+            response = await (await client.begin_analyze_actions(
+                docs,
+                actions=[
+                    RecognizeEntitiesAction(),
+                    ExtractKeyPhrasesAction(),
+                    RecognizePiiEntitiesAction(),
+                    RecognizeLinkedEntitiesAction(),
+                    AnalyzeSentimentAction()
+                ],
+                polling_interval=self._interval(),
+            )).result()
+        assert str(e.value) == "'begin_analyze_actions' is only available for API version v3.1 and up."
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsCustomPreparer()
+    async def test_analyze_multiapi_validate_v3_1(self, **kwargs):
+        textanalytics_custom_text_endpoint = kwargs.pop("textanalytics_custom_text_endpoint")
+        textanalytics_custom_text_key = kwargs.pop("textanalytics_custom_text_key")
+        textanalytics_single_category_classify_project_name = kwargs.pop("textanalytics_single_category_classify_project_name")
+        textanalytics_single_category_classify_deployment_name = kwargs.pop("textanalytics_single_category_classify_deployment_name")
+        textanalytics_multi_category_classify_project_name = kwargs.pop("textanalytics_multi_category_classify_project_name")
+        textanalytics_multi_category_classify_deployment_name = kwargs.pop("textanalytics_multi_category_classify_deployment_name")
+        textanalytics_custom_entities_project_name = kwargs.pop("textanalytics_custom_entities_project_name")
+        textanalytics_custom_entities_deployment_name = kwargs.pop("textanalytics_custom_entities_deployment_name")
+
+        client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key), api_version="v3.1")
+
+        docs = [{"id": "56", "text": ":)"},
+                {"id": "0", "text": ":("},
+                {"id": "19", "text": ":P"},
+                {"id": "1", "text": ":D"}]
+        version_supported = "2022-03-01-preview"
+        with pytest.raises(ValueError) as e:
+            response = await (await client.begin_analyze_actions(
+                docs,
+                actions=[
+                    SingleCategoryClassifyAction(
+                        project_name=textanalytics_single_category_classify_project_name,
+                        deployment_name=textanalytics_single_category_classify_deployment_name
+                    ),
+                    MultiCategoryClassifyAction(
+                        project_name=textanalytics_multi_category_classify_project_name,
+                        deployment_name=textanalytics_multi_category_classify_deployment_name
+                    ),
+                    RecognizeCustomEntitiesAction(
+                        project_name=textanalytics_custom_entities_project_name,
+                        deployment_name=textanalytics_custom_entities_deployment_name
+                    ),
+                    ExtractSummaryAction()
+                ],
+                polling_interval=self._interval(),
+            )).result()
+        assert str(e.value) == f"'ExtractSummaryAction' is only available for API version {version_supported} and " \
+                               f"up.\n'RecognizeCustomEntitiesAction' is only available for API version " \
+                               f"{version_supported} and up.\n'SingleCategoryClassifyAction' is only available " \
+                               f"for API version {version_supported} and up.\n'MultiCategoryClassifyAction' is " \
+                               f"only available for API version {version_supported} and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -549,3 +549,42 @@ class TestHealth(TextAnalyticsTest):
         assert isinstance(poller.expires_on, datetime.datetime)
         assert isinstance(poller.last_modified_on, datetime.datetime)
         assert poller.id
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    def test_healthcare_multiapi_validate_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            poller = client.begin_analyze_healthcare_entities(
+                documents=[
+                    {"id": "1",
+                     "text": "Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."},
+                    {"id": "2", "text": "patients must have histologically confirmed NHL"},
+                    {"id": "3", "text": ""},
+                    {"id": "4", "text": "The patient was diagnosed with Parkinsons Disease (PD)"}
+                ],
+                show_stats=True,
+                polling_interval=self._interval(),
+            )
+        assert str(e.value) == "'begin_analyze_healthcare_entities' is only available for API version v3.1 and up."
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
+    def test_healthcare_multiapi_validate_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            poller = client.begin_analyze_healthcare_entities(
+                documents=[
+                    {"id": "1",
+                     "text": "Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."},
+                    {"id": "2", "text": "patients must have histologically confirmed NHL"},
+                    {"id": "3", "text": ""},
+                    {"id": "4", "text": "The patient was diagnosed with Parkinsons Disease (PD)"}
+                ],
+                display_name="this won't work",
+                show_stats=True,
+                polling_interval=self._interval(),
+            )
+        assert str(e.value) == "'display_name' is only available for API version 2022-03-01-preview and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -578,3 +578,42 @@ class TestHealth(TextAnalyticsTest):
             assert isinstance(poller.expires_on, datetime.datetime)
             assert isinstance(poller.last_modified_on, datetime.datetime)
             assert poller.id
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_healthcare_multiapi_validate_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            poller = await client.begin_analyze_healthcare_entities(
+                documents=[
+                    {"id": "1",
+                     "text": "Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."},
+                    {"id": "2", "text": "patients must have histologically confirmed NHL"},
+                    {"id": "3", "text": ""},
+                    {"id": "4", "text": "The patient was diagnosed with Parkinsons Disease (PD)"}
+                ],
+                show_stats=True,
+                polling_interval=self._interval(),
+            )
+        assert str(e.value) == "'begin_analyze_healthcare_entities' is only available for API version v3.1 and up."
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
+    async def test_healthcare_multiapi_validate_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            poller = await client.begin_analyze_healthcare_entities(
+                documents=[
+                    {"id": "1",
+                     "text": "Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."},
+                    {"id": "2", "text": "patients must have histologically confirmed NHL"},
+                    {"id": "3", "text": ""},
+                    {"id": "4", "text": "The patient was diagnosed with Parkinsons Disease (PD)"}
+                ],
+                display_name="this won't work",
+                show_stats=True,
+                polling_interval=self._interval(),
+            )
+        assert str(e.value) == "'display_name' is only available for API version 2022-03-01-preview and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment.py
@@ -761,22 +761,6 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
         assert sentences[1].offset is None
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_string_index_type_not_fail_v3(self, client):
-        # make sure that the addition of the string_index_type kwarg for v3.1-preview.1 doesn't
-        # cause v3.0 calls to fail
-        client.analyze_sentiment(["please don't fail"])
-
-    @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            client.analyze_sentiment(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
     def test_default_string_index_type_is_UnicodeCodePoint(self, client):
@@ -849,3 +833,24 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    def test_sentiment_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = client.analyze_sentiment(["I'm tired"], string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = client.analyze_sentiment(["I'm tired"], show_opinion_mining=True)
+        assert str(e.value) == "'show_opinion_mining' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = client.analyze_sentiment(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = client.analyze_sentiment(["I'm tired"], show_opinion_mining=True, disable_service_logs=True, string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'show_opinion_mining' is only available for API version v3.1 and up.\n'disable_service_logs' is only available for API version v3.1 and up.\n'string_index_type' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
@@ -772,14 +772,6 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
         await client.analyze_sentiment(["please don't fail"])
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy_async
-    async def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            await client.analyze_sentiment(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
     async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
@@ -852,3 +844,24 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_sentiment_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = await client.analyze_sentiment(["I'm tired"], string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = await client.analyze_sentiment(["I'm tired"], show_opinion_mining=True)
+        assert str(e.value) == "'show_opinion_mining' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = await client.analyze_sentiment(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = await client.analyze_sentiment(["I'm tired"], show_opinion_mining=True, disable_service_logs=True, string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'show_opinion_mining' is only available for API version v3.1 and up.\n'disable_service_logs' is only available for API version v3.1 and up.\n'string_index_type' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language.py
@@ -657,3 +657,12 @@ class TestDetectLanguage(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_language_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = await client.detect_language(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language_async.py
@@ -658,3 +658,12 @@ class TestDetectLanguage(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_language_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = await client.detect_language(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases.py
@@ -571,3 +571,12 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    def test_key_phrases_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = client.extract_key_phrases(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases_async.py
@@ -573,3 +573,12 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_key_phrases_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = await client.extract_key_phrases(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
@@ -599,22 +599,6 @@ class TestRecognizeEntities(TextAnalyticsTest):
         assert entities[2].offset is None
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_string_index_type_not_fail_v3(self, client):
-        # make sure that the addition of the string_index_type kwarg for v3.1-preview doesn't
-        # cause v3.0 calls to fail
-        client.recognize_entities(["please don't fail"])
-
-    @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            client.recognize_entities(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
     def test_default_string_index_type_is_UnicodeCodePoint(self, client):
@@ -687,3 +671,20 @@ class TestRecognizeEntities(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    def test_entities_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = client.recognize_entities(["I'm tired"], string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = client.recognize_entities(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = client.recognize_entities(["I'm tired"], string_index_type="UnicodeCodePoint", disable_service_logs=True)
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
@@ -606,22 +606,6 @@ class TestRecognizeEntities(TextAnalyticsTest):
         assert entities[2].offset is None
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy_async
-    async def test_string_index_type_not_fail_v3(self, client):
-        # make sure that the addition of the string_index_type kwarg for v3.1-preview doesn't
-        # cause v3.0 calls to fail
-        await client.recognize_entities(["please don't fail"])
-
-    @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy_async
-    async def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            await client.recognize_entities(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
     async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
@@ -694,3 +678,20 @@ class TestRecognizeEntities(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_entities_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = await client.recognize_entities(["I'm tired"], string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = await client.recognize_entities(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = await client.recognize_entities(["I'm tired"], string_index_type="UnicodeCodePoint", disable_service_logs=True)
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities.py
@@ -623,14 +623,6 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
                 assert entity.bing_entity_search_api_id  # this checks if it's None and if it's empty
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            client.recognize_linked_entities(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
     def test_default_string_index_type_is_UnicodeCodePoint(self, client):
@@ -703,3 +695,20 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    def test_linked_entities_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = client.recognize_linked_entities(["I'm tired"], string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = client.recognize_linked_entities(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = client.recognize_linked_entities(["I'm tired"], string_index_type="UnicodeCodePoint", disable_service_logs=True)
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities_async.py
@@ -647,14 +647,6 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
                 assert entity.bing_entity_search_api_id  # this checks if it's None and if it's empty
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy_async
-    async def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            await client.recognize_linked_entities(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
     async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
@@ -729,3 +721,22 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_linked_entities_multiapi_validate_args_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            res = await client.recognize_linked_entities(["I'm tired"], string_index_type="UnicodeCodePoint")
+        assert str(e.value) == "'string_index_type' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = await client.recognize_linked_entities(["I'm tired"], disable_service_logs=True)
+        assert str(e.value) == "'disable_service_logs' is only available for API version v3.1 and up.\n"
+
+        with pytest.raises(ValueError) as e:
+            res = await client.recognize_linked_entities(["I'm tired"], string_index_type="UnicodeCodePoint",
+                                                   disable_service_logs=True)
+        assert str(
+            e.value) == "'string_index_type' is only available for API version v3.1 and up.\n'disable_service_logs' is only available for API version v3.1 and up.\n"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities.py
@@ -601,15 +601,6 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
         )
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_recognize_pii_entities_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            client.recognize_pii_entities(["this should fail"])
-
-        assert "'recognize_pii_entities' endpoint is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
     def test_redacted_text(self, client):
@@ -666,14 +657,6 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
         assert len(result[0].entities) == 1
         entity = result[0].entities[0]
         assert entity.category == PiiEntityCategory.US_SOCIAL_SECURITY_NUMBER.value
-
-    @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy
-    def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            client.recognize_pii_entities(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
@@ -748,3 +731,14 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    def test_pii_entities_multiapi_validate_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            client.recognize_pii_entities(
+                documents=["Test"]
+            )
+        assert str(e.value) == "'recognize_pii_entities' is only available for API version v3.1 and up."

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities_async.py
@@ -603,15 +603,6 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
         )
 
     @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy_async
-    async def test_recognize_pii_entities_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            await client.recognize_pii_entities(["this should fail"])
-
-        assert "'recognize_pii_entities' endpoint is only available for API version V3_1 and up" in str(excinfo.value)
-
-    @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
     async def test_redacted_text(self, client):
@@ -667,14 +658,6 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
         assert len(result[0].entities) == 1
         entity = result[0].entities[0]
         assert entity.category == PiiEntityCategory.US_SOCIAL_SECURITY_NUMBER.value
-
-    @TextAnalyticsPreparer()
-    @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
-    @recorded_by_proxy_async
-    async def test_string_index_type_explicit_fails_v3(self, client):
-        with pytest.raises(ValueError) as excinfo:
-            await client.recognize_pii_entities(["this should fail"], string_index_type="UnicodeCodePoint")
-        assert "'string_index_type' is only available for API version V3_1 and up" in str(excinfo.value)
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
@@ -749,3 +732,14 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
             disable_service_logs=True,
             raw_response_hook=callback,
         )
+
+    @TextAnalyticsPreparer()
+    @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.0"})
+    async def test_pii_entities_multiapi_validate_v3_0(self, **kwargs):
+        client = kwargs.pop("client")
+
+        with pytest.raises(ValueError) as e:
+            await client.recognize_pii_entities(
+                documents=["Test"]
+            )
+        assert str(e.value) == "'recognize_pii_entities' is only available for API version v3.1 and up."


### PR DESCRIPTION
This decorator helps... 
- move some of the multiapi param validation out of the client methods
- validate args/action type support between the TA service vs Language... since the input shaped has changed between API versions and many of the args went from query params -> body params, we validate so that users targeting an older API version don't pass unsupported params which get silently ignored. We plan to let the service validate between Language API versions in the future.