### PR TITLE
[Key Vault] Correctly skip unconfigured tests

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_async_test_case.py
@@ -23,7 +23,7 @@ async def get_attestation_token(attestation_uri):
 def get_decorator(only_hsm=False, only_vault=False, api_versions=None, **kwargs):
     """returns a test decorator for test parameterization"""
     params = [
-        pytest.param(p[0],p[1], id=p[0] + ("_mhsm" if p[1] else "_vault" ))
+        pytest.param(p[0], p[1], id=p[0] + ("_mhsm" if p[1] else "_vault"))
         for p in get_test_parameters(only_hsm, only_vault, api_versions=api_versions)
     ]
     return params
@@ -31,18 +31,8 @@ def get_decorator(only_hsm=False, only_vault=False, api_versions=None, **kwargs)
 
 def get_release_policy(attestation_uri, **kwargs):
     release_policy_json = {
-        "anyOf": [
-            {
-                "anyOf": [
-                    {
-                        "claim": "sdk-test",
-                        "equals": True
-                    }
-                ],
-                "authority": attestation_uri.rstrip("/") + "/"
-            }
-        ],
-        "version": "1.0.0"
+        "anyOf": [{"anyOf": [{"claim": "sdk-test", "equals": True}], "authority": attestation_uri.rstrip("/") + "/"}],
+        "version": "1.0.0",
     }
     policy_string = json.dumps(release_policy_json).encode()
     return KeyReleasePolicy(policy_string, **kwargs)
@@ -63,9 +53,9 @@ def get_test_parameters(only_hsm=False, only_vault=False, api_versions=None):
 
 
 def is_public_cloud():
-    return (".microsoftonline.com" in os.getenv('AZURE_AUTHORITY_HOST', ''))
+    return ".microsoftonline.com" in os.getenv("AZURE_AUTHORITY_HOST", "")
 
-    
+
 class AsyncKeysClientPreparer(AzureRecordedTestCase):
     def __init__(self, *args, **kwargs):
         vault_playback_url = "https://vaultname.vault.azure.net"
@@ -83,25 +73,25 @@ class AsyncKeysClientPreparer(AzureRecordedTestCase):
 
     def __call__(self, fn):
         async def _preparer(test_class, api_version, is_hsm, **kwargs):
-            
+
             self._skip_if_not_configured(api_version, is_hsm)
             if not self.is_logging_enabled:
                 kwargs.update({"logging_enable": False})
             endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
             client = self.create_key_client(endpoint_url, api_version=api_version, **kwargs)
             async with client:
-                await fn(test_class, client, is_hsm=is_hsm, managed_hsm_url = self.managed_hsm_url, vault_url = self.vault_url)
+                await fn(
+                    test_class, client, is_hsm=is_hsm, managed_hsm_url=self.managed_hsm_url, vault_url=self.vault_url
+                )
 
         return _preparer
-        
-
 
     def create_key_client(self, vault_uri, **kwargs):
-       
+
         from azure.keyvault.keys.aio import KeyClient
 
         credential = self.get_credential(KeyClient, is_async=True)
-        
+
         return self.create_client_from_credential(KeyClient, credential=credential, vault_url=vault_uri, **kwargs)
 
     def _set_mgmt_settings_real_values(self):

--- a/sdk/keyvault/azure-keyvault-keys/tests/_keys_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_keys_test_case.py
@@ -1,3 +1,7 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
 import os
 
 import pytest

--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -23,7 +23,7 @@ def get_attestation_token(attestation_uri):
 def get_decorator(only_hsm=False, only_vault=False, api_versions=None, **kwargs):
     """returns a test decorator for test parameterization"""
     params = [
-        pytest.param(p[0],p[1], id=p[0] + ("_mhsm" if p[1] else "_vault" ))
+        pytest.param(p[0], p[1], id=p[0] + ("_mhsm" if p[1] else "_vault"))
         for p in get_test_parameters(only_hsm, only_vault, api_versions=api_versions)
     ]
     return params
@@ -31,18 +31,8 @@ def get_decorator(only_hsm=False, only_vault=False, api_versions=None, **kwargs)
 
 def get_release_policy(attestation_uri, **kwargs):
     release_policy_json = {
-        "anyOf": [
-            {
-                "anyOf": [
-                    {
-                        "claim": "sdk-test",
-                        "equals": True
-                    }
-                ],
-                "authority": attestation_uri.rstrip("/") + "/"
-            }
-        ],
-        "version": "1.0.0"
+        "anyOf": [{"anyOf": [{"claim": "sdk-test", "equals": True}], "authority": attestation_uri.rstrip("/") + "/"}],
+        "version": "1.0.0",
     }
     policy_string = json.dumps(release_policy_json).encode()
     return KeyReleasePolicy(policy_string, **kwargs)
@@ -63,9 +53,9 @@ def get_test_parameters(only_hsm=False, only_vault=False, api_versions=None):
 
 
 def is_public_cloud():
-    return (".microsoftonline.com" in os.getenv('AZURE_AUTHORITY_HOST', ''))
+    return ".microsoftonline.com" in os.getenv("AZURE_AUTHORITY_HOST", "")
 
-    
+
 class KeysClientPreparer(AzureRecordedTestCase):
     def __init__(self, *args, **kwargs):
         vault_playback_url = "https://vaultname.vault.azure.net"
@@ -87,26 +77,24 @@ class KeysClientPreparer(AzureRecordedTestCase):
     def __call__(self, fn):
         def _preparer(test_class, api_version, is_hsm, **kwargs):
 
-            #self._skip_if_not_configured(api_version, is_hsm)
+            self._skip_if_not_configured(api_version, is_hsm)
             if not self.is_logging_enabled:
                 kwargs.update({"logging_enable": False})
             endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
             client = self.create_key_client(endpoint_url, api_version=api_version, **kwargs)
 
             with client:
-                fn(test_class, client, is_hsm=is_hsm, managed_hsm_url = self.managed_hsm_url, vault_url = self.vault_url)
-        return _preparer
-        
+                fn(test_class, client, is_hsm=is_hsm, managed_hsm_url=self.managed_hsm_url, vault_url=self.vault_url)
 
+        return _preparer
 
     def create_key_client(self, vault_uri, **kwargs):
-       
+
         from azure.keyvault.keys import KeyClient
 
         credential = self.get_credential(KeyClient)
-        
-        return self.create_client_from_credential(KeyClient, credential=credential, vault_url=vault_uri, **kwargs)
 
+        return self.create_client_from_credential(KeyClient, credential=credential, vault_url=vault_uri, **kwargs)
 
     def _set_mgmt_settings_real_values(self):
         if self.is_live:


### PR DESCRIPTION
# Description

Tests for `azure-keyvault-keys` are working as expected with the test proxy, but as this morning's [failed pipeline test](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1545203&view=logs&j=5e51fe0c-f9f1-5a38-5eae-c9084b88a2d5&t=0c030fb8-1e23-5645-917e-145a85b016af&l=5386) output shows, there are a number of live test failures for environments that don't use an HSM. This is because a method call was commented out that otherwise skips some tests: HSM tests when there's no HSM available, and live tests when using a non-default API version. This uncomments that method call and cleans up test preparers a bit with `black`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
