### PR TITLE
[Storage] Adjust connection string parser test cases

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file_extra_backslashes.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file_extra_backslashes.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:26 GMT
+      - Fri, 06 May 2022 21:52:51 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/filesystem916811e6?restype=container&timeout=5
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 06 Apr 2022 22:36:25 GMT
+      - Fri, 06 May 2022 21:52:51 GMT
       etag:
-      - '"0x8DA181DE2E5EAE8"'
+      - '"0x8DA2FAAC44170F0"'
       last-modified:
-      - Wed, 06 Apr 2022 22:36:26 GMT
+      - Fri, 06 May 2022 21:52:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     status:
       code: 201
       message: Created
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:26 GMT
+      - Fri, 06 May 2022 21:52:51 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem916811e6/file916811e6?resource=file
   response:
@@ -63,17 +63,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 06 Apr 2022 22:36:26 GMT
+      - Fri, 06 May 2022 21:52:50 GMT
       etag:
-      - '"0x8DA181DE33191DD"'
+      - '"0x8DA2FAAC4A5E1DF"'
       last-modified:
-      - Wed, 06 Apr 2022 22:36:27 GMT
+      - Fri, 06 May 2022 21:52:51 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     status:
       code: 201
       message: Created
@@ -89,11 +89,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:27 GMT
+      - Fri, 06 May 2022 21:52:52 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem916811e6/file916811e6?resource=file
   response:
@@ -103,17 +103,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 06 Apr 2022 22:36:26 GMT
+      - Fri, 06 May 2022 21:52:51 GMT
       etag:
-      - '"0x8DA181DE33D9E10"'
+      - '"0x8DA2FAAC4DB61F5"'
       last-modified:
-      - Wed, 06 Apr 2022 22:36:27 GMT
+      - Fri, 06 May 2022 21:52:52 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     status:
       code: 201
       message: Created
@@ -129,11 +129,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:27 GMT
+      - Fri, 06 May 2022 21:52:52 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/filesystem916811e6?restype=container
   response:
@@ -143,11 +143,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 06 Apr 2022 22:36:26 GMT
+      - Fri, 06 May 2022 21:52:52 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_extra_backslashes_async.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_extra_backslashes_async.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:34 GMT
+      - Fri, 06 May 2022 21:53:20 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/filesystem8a8a16e0?restype=container&timeout=5
   response:
@@ -17,11 +17,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 06 Apr 2022 22:36:34 GMT
-      etag: '"0x8DA181DE7C7C166"'
-      last-modified: Wed, 06 Apr 2022 22:36:34 GMT
+      date: Fri, 06 May 2022 21:53:19 GMT
+      etag: '"0x8DA2FAAD5D0883E"'
+      last-modified: Fri, 06 May 2022 21:53:20 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2020-10-02'
+      x-ms-version: '2021-06-08'
     status:
       code: 201
       message: Created
@@ -32,11 +32,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:35 GMT
+      - Fri, 06 May 2022 21:53:21 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem8a8a16e0/file8a8a16e0?resource=file
   response:
@@ -44,12 +44,12 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 06 Apr 2022 22:36:34 GMT
-      etag: '"0x8DA181DE7F67F66"'
-      last-modified: Wed, 06 Apr 2022 22:36:35 GMT
+      date: Fri, 06 May 2022 21:53:20 GMT
+      etag: '"0x8DA2FAAD61AC7F1"'
+      last-modified: Fri, 06 May 2022 21:53:20 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-10-02'
+      x-ms-version: '2021-06-08'
     status:
       code: 201
       message: Created
@@ -60,11 +60,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:35 GMT
+      - Fri, 06 May 2022 21:53:21 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem8a8a16e0/file8a8a16e0?resource=file
   response:
@@ -72,12 +72,12 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 06 Apr 2022 22:36:34 GMT
-      etag: '"0x8DA181DE80068FD"'
-      last-modified: Wed, 06 Apr 2022 22:36:35 GMT
+      date: Fri, 06 May 2022 21:53:21 GMT
+      etag: '"0x8DA2FAAD64D6C9E"'
+      last-modified: Fri, 06 May 2022 21:53:21 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-10-02'
+      x-ms-version: '2021-06-08'
     status:
       code: 201
       message: Created
@@ -88,11 +88,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 06 Apr 2022 22:36:35 GMT
+      - Fri, 06 May 2022 21:53:22 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-06-08'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/filesystem8a8a16e0?restype=container
   response:
@@ -100,9 +100,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 06 Apr 2022 22:36:34 GMT
+      date: Fri, 06 May 2022 21:53:20 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2020-10-02'
+      x-ms-version: '2021-06-08'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -108,7 +108,7 @@ class FileTest(StorageTestCase):
                                              file_client.file_system_name + '/',
                                              '/' + file_client.path_name,
                                              credential=datalake_storage_account_key, logging_enable=True)
-        response = file_client.create_file()
+        response = new_file_client.create_file()
 
         # Assert
         self.assertIsNotNone(response)

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
@@ -115,7 +115,7 @@ class FileTest(StorageTestCase):
                                              file_client.file_system_name + '/',
                                              '/' + file_client.path_name,
                                              credential=datalake_storage_account_key, logging_enable=True)
-        response = await file_client.create_file()
+        response = await new_file_client.create_file()
 
         # Assert
         self.assertIsNotNone(response)


### PR DESCRIPTION
This PR adjusts the test cases added in #23854
While the original test cases were also sufficient as a failed request would result in:
 `ErrorCode:AuthenticationFailed` , `authenticationerrordetail:Invalid resource path` on the creation of a `DataLakeFileClient` object

The intended logic was to create a `file_client` using the test information prepared in `self._setUp` which shows that that `file_system_name` and `path_name` are valid, and then to create a `new_file_client` while appending extraneous `/` symbols to test the parser.

The current logic creates a `new_file_client` and functionality is tested as intended, but the final assert is whether operations are valid on the original `file_client` and not the `new_file_client`. 
