### PR TITLE
[EventHubs] Buffered Producer 

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -168,7 +168,8 @@ class BufferedProducer:
             if self._cur_buffered_len > 0:
                 now_time = time.time()
                 _LOGGER.info("Partition %r worker is checking max_wait_time.", self.partition_id)
-                # flush the partition if the producer is running beyond the waiting time or the buffer is at max capacity
+                # flush the partition if the producer is running beyond the waiting time 
+                # or the buffer is at max capacity
                 if (now_time - self._last_send_time > self._max_wait_time) or (
                     self._cur_buffered_len >= self._max_buffer_len
                 ):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -30,7 +30,6 @@ class BufferedProducer:
             executor: ThreadPoolExecutor,
             *,
             max_wait_time: float = 1,
-            max_concurrent_sends: int = 1,
             max_buffer_length: int = 1500
     ):
         self._buffered_queue: queue.Queue = queue.Queue()
@@ -39,7 +38,6 @@ class BufferedProducer:
         self._executor: ThreadPoolExecutor = executor
         self._producer: EventHubProducer = producer
         self._lock = RLock()
-        self._max_concurrent_sends = max_concurrent_sends
         self._max_wait_time = max_wait_time
         self._on_success = self.failsafe_callback(on_success)
         self._on_error = self.failsafe_callback(on_error)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -5,7 +5,7 @@
 import time
 import queue
 import logging
-from threading import RLock, Condition, Semaphore
+from threading import RLock
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Callable, TYPE_CHECKING
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -137,7 +137,6 @@ class BufferedProducer:
             self._cur_batch = EventDataBatch(self._max_message_size_on_link)
         while self._cur_buffered_len:
             remaining_time = timeout_time - time.time() if timeout_time else None
-            # If flush could get the semaphore, perform sending
             if ((remaining_time and remaining_time > 0) or remaining_time is None):
                 batch = self._buffered_queue.get()
                 self._buffered_queue.task_done()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -30,7 +30,7 @@ class BufferedProducer:
             executor: ThreadPoolExecutor,
             *,
             max_wait_time: float = 1,
-            max_buffer_length: int = 1500
+            max_buffer_length: int
     ):
         self._buffered_queue: queue.Queue = queue.Queue()
         self._max_buffer_len = max_buffer_length

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -89,7 +89,7 @@ class BufferedProducer:
             new_events_len = len(events)
         except TypeError:
             new_events_len = 1
-        if self._buffered_queue.maxsize - self._cur_buffered_len < new_events_len:
+        if self._max_buffer_len - self._cur_buffered_len < new_events_len:
             _LOGGER.info(
                 "The buffer for partition %r is full. Attempting to flush before adding %r events.",
                 self.partition_id,
@@ -186,7 +186,6 @@ class BufferedProducer:
                 if (now_time - self._last_send_time > self._max_wait_time) or (self._cur_buffered_len >= self._max_buffer_len):
                     # in the worker, not raising error for flush, users can not handle this
                     self.flush(raise_error=False)
-
             time.sleep(min(self._max_wait_time, 5))
 
     @property

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -185,7 +185,8 @@ class BufferedProducer:
                 #flush the partition if the producer is running beyond the waiting time or the buffer is at max capacity
                 if (now_time - self._last_send_time > self._max_wait_time) or (self._cur_buffered_len >= self._max_buffer_len):
                     # in the worker, not raising error for flush, users can not handle this
-                    self.flush(raise_error=False)
+                    with self._lock:
+                        self.flush(raise_error=False)
             time.sleep(min(self._max_wait_time, 5))
 
     @property

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -50,11 +50,12 @@ class BufferedProducer:
         self.partition_id = partition_id
 
     def start(self):
-        self._cur_batch = EventDataBatch(self._max_message_size_on_link)
-        self._running = True
-        if self._max_wait_time:
-            self._last_send_time = time.time()
-            self._check_max_wait_time_future = self._executor.submit(self.check_max_wait_time_worker)
+        with self._lock:
+            self._cur_batch = EventDataBatch(self._max_message_size_on_link)
+            self._running = True
+            if self._max_wait_time:
+                self._last_send_time = time.time()
+                self._check_max_wait_time_future = self._executor.submit(self.check_max_wait_time_worker)
 
     def stop(self, flush=True, timeout_time=None, raise_error=False):
         self._running = False

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -33,7 +33,8 @@ class BufferedProducer:
             max_concurrent_sends: int = 1,
             max_buffer_length: int = 1500
     ):
-        self._buffered_queue: queue.Queue = queue.Queue(maxsize=max_buffer_length)
+        self._buffered_queue: queue.Queue = queue.Queue()
+        self._max_buffer_len = max_buffer_length
         self._cur_buffered_len = 0
         self._executor: ThreadPoolExecutor = executor
         self._producer: EventHubProducer = producer
@@ -183,7 +184,7 @@ class BufferedProducer:
                 now_time = time.time()
                 _LOGGER.info("Partition %r worker is checking max_wait_time.", self.partition_id)
                 #flush the partition if its beyond the waiting time or the buffer is at max capacity
-                if (now_time - self._last_send_time > self._max_wait_time and self._running) or (self._buffered_queue.qsize == self._buffered_queue.maxsize and self._running):
+                if (now_time - self._last_send_time > self._max_wait_time and self._running) or (self._cur_buffered_len >= self._max_buffer_len and self._running):
                     # in the worker, not raising error for flush, users can not handle this
                     self.flush(raise_error=False)
             time.sleep(min(self._max_wait_time, 5))

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -31,18 +31,14 @@ class BufferedProducer:
             *,
             max_wait_time: float = 1,
             max_concurrent_sends: int = 1,
-            max_buffer_length: int = 10
+            max_buffer_length: int = 1500
     ):
-        self._buffered_queue: queue.Queue = queue.Queue()
+        self._buffered_queue: queue.Queue = queue.Queue(max_buffer_length)
         self._cur_buffered_len = 0
         self._executor: ThreadPoolExecutor = executor
         self._producer: EventHubProducer = producer
         self._lock = RLock()
-        self._not_empty = Condition(self._lock)
-        self._not_full = Condition(self._lock)
-        self._max_buffer_len = max_buffer_length
         self._max_concurrent_sends = max_concurrent_sends
-        self._max_concurrent_sends_semaphore = Semaphore(self._max_concurrent_sends)
         self._max_wait_time = max_wait_time
         self._on_success = self.failsafe_callback(on_success)
         self._on_error = self.failsafe_callback(on_error)
@@ -54,12 +50,11 @@ class BufferedProducer:
         self.partition_id = partition_id
 
     def start(self):
-        with self._lock:
-            self._cur_batch = EventDataBatch(self._max_message_size_on_link)
-            self._running = True
-            if self._max_wait_time:
-                self._last_send_time = time.time()
-                self._check_max_wait_time_future = self._executor.submit(self.check_max_wait_time_worker)
+        self._cur_batch = EventDataBatch(self._max_message_size_on_link)
+        self._running = True
+        if self._max_wait_time:
+            self._last_send_time = time.time()
+            self._check_max_wait_time_future = self._executor.submit(self.check_max_wait_time_worker)
 
     def stop(self, flush=True, timeout_time=None, raise_error=False):
         self._running = False
@@ -75,10 +70,6 @@ class BufferedProducer:
         if self._check_max_wait_time_future:
             remain_timeout = timeout_time - time.time() if timeout_time else None
             try:
-                with self._not_empty:
-                    # in the stop procedure, calling notify to give check_max_wait_time_future a chance to stop
-                    # as it is waiting for Condition self._not_empty
-                    self._not_empty.notify()
                 self._check_max_wait_time_future.result(remain_timeout)
             except Exception as exc:  # pylint: disable=broad-except
                 _LOGGER.warning(
@@ -92,42 +83,36 @@ class BufferedProducer:
         # Put single event or EventDataBatch into the queue.
         # This method would raise OperationTimeout if the queue does not have enough space for the input and
         # flush cannot finish in timeout.
-        with self._not_full:
-            try:
-                new_events_len = len(events)
-            except TypeError:
-                new_events_len = 1
-
-            if self._max_buffer_len - self._cur_buffered_len < new_events_len:
-                _LOGGER.info(
-                    "The buffer for partition %r is full. Attempting to flush before adding %r events.",
-                    self.partition_id,
-                    new_events_len
-                )
-                # flush the buffer
-                self.flush(timeout_time=timeout_time)
-
-            if timeout_time and time.time() > timeout_time:
-                raise OperationTimeoutError("Failed to enqueue events into buffer due to timeout.")
-
-            try:
-                # add single event into current batch
-                self._cur_batch.add(events)
-            except AttributeError:  # if the input events is a EventDataBatch, put the whole into the buffer
-                # if there are events in cur_batch, enqueue cur_batch to the buffer
-                if self._cur_batch:
-                    self._buffered_queue.put(self._cur_batch)
-                self._buffered_queue.put(events)
-                # create a new batch for incoming events
-                self._cur_batch = EventDataBatch(self._max_message_size_on_link)
-            except ValueError:
-                # add single event exceeds the cur batch size, create new batch
+        try:
+            new_events_len = len(events)
+        except TypeError:
+            new_events_len = 1
+        if self._buffered_queue.maxsize - self._cur_buffered_len < new_events_len:
+            _LOGGER.info(
+                "The buffer for partition %r is full. Attempting to flush before adding %r events.",
+                self.partition_id,
+                new_events_len
+            )
+            # flush the buffer
+            self.flush(timeout_time=timeout_time)
+        if timeout_time and time.time() > timeout_time:
+            raise OperationTimeoutError("Failed to enqueue events into buffer due to timeout.")
+        try:
+            # add single event into current batch
+            self._cur_batch.add(events)
+        except AttributeError:  # if the input events is a EventDataBatch, put the whole into the buffer
+            # if there are events in cur_batch, enqueue cur_batch to the buffer
+            if self._cur_batch:
                 self._buffered_queue.put(self._cur_batch)
-                self._cur_batch = EventDataBatch(self._max_message_size_on_link)
-                self._cur_batch.add(events)
-            self._cur_buffered_len += new_events_len
-            # notify the max_wait_time worker
-            self._not_empty.notify()
+            self._buffered_queue.put(events)
+            # create a new batch for incoming events
+            self._cur_batch = EventDataBatch(self._max_message_size_on_link)
+        except ValueError:
+            # add single event exceeds the cur batch size, create new batch
+            self._buffered_queue.put(self._cur_batch)
+            self._cur_batch = EventDataBatch(self._max_message_size_on_link)
+            self._cur_batch.add(events)
+        self._cur_buffered_len += new_events_len
 
     def failsafe_callback(self, callback):
         def wrapper_callback(*args, **kwargs):
@@ -147,50 +132,45 @@ class BufferedProducer:
         # pylint: disable=protected-access
         # try flushing all the buffered batch within given time
         _LOGGER.info("Partition: %r started flushing.", self.partition_id)
-        with self._not_empty:
-            if self._cur_batch:  # if there is batch, enqueue it to the buffer first
-                self._buffered_queue.put(self._cur_batch)
-                self._cur_batch = EventDataBatch(self._max_message_size_on_link)
-            while self._cur_buffered_len:
-                remaining_time = timeout_time - time.time() if timeout_time else None
-                # If flush could get the semaphore, perform sending
-                if ((remaining_time and remaining_time > 0) or remaining_time is None) and \
-                        self._max_concurrent_sends_semaphore.acquire(timeout=remaining_time):
-                    batch = self._buffered_queue.get()
-                    self._buffered_queue.task_done()
-                    try:
-                        _LOGGER.info("Partition %r is sending.", self.partition_id)
-                        self._producer.send(
-                            batch,
-                            timeout=timeout_time - time.time() if timeout_time else None
-                        )
-                        _LOGGER.info(
-                            "Partition %r sending %r events succeeded.",
-                            self.partition_id,
-                            len(batch)
-                        )
-                        self._on_success(batch._internal_events, self.partition_id)
-                    except Exception as exc:  # pylint: disable=broad-except
-                        _LOGGER.info(
-                            "Partition %r sending %r events failed due to exception: %r ",
-                            self.partition_id,
-                            len(batch),
-                            exc
-                        )
-                        self._on_error(batch._internal_events, self.partition_id, exc)
-                    finally:
-                        self._cur_buffered_len -= len(batch)
-                        self._max_concurrent_sends_semaphore.release()
-                        self._not_full.notify()
-                # If flush could not get the semaphore, we log and raise error if wanted
-                else:
-                    _LOGGER.info(
-                        "Partition %r fails to flush due to timeout.",
-                        self.partition_id
+        if self._cur_batch:  # if there is batch, enqueue it to the buffer first
+            self._buffered_queue.put(self._cur_batch)
+            self._cur_batch = EventDataBatch(self._max_message_size_on_link)
+        while self._cur_buffered_len:
+            remaining_time = timeout_time - time.time() if timeout_time else None
+            # If flush could get the semaphore, perform sending
+            if ((remaining_time and remaining_time > 0) or remaining_time is None):
+                batch = self._buffered_queue.get()
+                self._buffered_queue.task_done()
+                try:
+                    _LOGGER.info("Partition %r is sending.", self.partition_id)
+                    self._producer.send(
+                        batch,
+                        timeout=timeout_time - time.time() if timeout_time else None
                     )
-                    if raise_error:
-                        raise OperationTimeoutError("Failed to flush {!r}".format(self.partition_id))
-                    break
+                    _LOGGER.info(
+                        "Partition %r sending %r events succeeded.",
+                        self.partition_id,
+                        len(batch)
+                    )
+                    self._on_success(batch._internal_events, self.partition_id)
+                except Exception as exc:  # pylint: disable=broad-except
+                    _LOGGER.info(
+                        "Partition %r sending %r events failed due to exception: %r ",
+                        self.partition_id,
+                        len(batch),
+                        exc
+                    )
+                    self._on_error(batch._internal_events, self.partition_id, exc)
+                finally:
+                    self._cur_buffered_len -= len(batch)
+            else:
+                _LOGGER.info(
+                    "Partition %r fails to flush due to timeout.",
+                    self.partition_id
+                )
+                if raise_error:
+                    raise OperationTimeoutError("Failed to flush {!r}".format(self.partition_id))
+                break
         # after finishing flushing, reset cur batch and put it into the buffer
         self._last_send_time = time.time()
         self._cur_batch = EventDataBatch(self._max_message_size_on_link)
@@ -198,13 +178,11 @@ class BufferedProducer:
 
     def check_max_wait_time_worker(self):
         while self._running:
-            with self._not_empty:
-                if not self._cur_buffered_len:
-                    _LOGGER.info("Partition %r worker is awaiting data.", self.partition_id)
-                    self._not_empty.wait()
+            if not self._buffered_queue.empty():
                 now_time = time.time()
                 _LOGGER.info("Partition %r worker is checking max_wait_time.", self.partition_id)
-                if now_time - self._last_send_time > self._max_wait_time and self._running:
+                #flush the partition if its beyond the waiting time or the buffer is at max capacity
+                if (now_time - self._last_send_time > self._max_wait_time and self._running) or (self._buffered_queue.qsize == self._buffered_queue.maxsize and self._running):
                     # in the worker, not raising error for flush, users can not handle this
                     self.flush(raise_error=False)
             time.sleep(min(self._max_wait_time, 5))

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -33,7 +33,7 @@ class BufferedProducer:
             max_concurrent_sends: int = 1,
             max_buffer_length: int = 1500
     ):
-        self._buffered_queue: queue.Queue = queue.Queue(max_buffer_length)
+        self._buffered_queue: queue.Queue = queue.Queue(maxsize=max_buffer_length)
         self._cur_buffered_len = 0
         self._executor: ThreadPoolExecutor = executor
         self._producer: EventHubProducer = producer

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
@@ -31,7 +31,6 @@ class BufferedProducerDispatcher:
             *,
             max_buffer_length: int = 1500,
             max_wait_time: float = 1,
-            max_concurrent_sends: int = 1,
             executor: Optional[Union[ThreadPoolExecutor, int]] = None,
             max_worker: Optional[int] = None
     ):
@@ -46,7 +45,6 @@ class BufferedProducerDispatcher:
         self._partition_resolver = PartitionResolver(self._partition_ids)
         self._max_wait_time = max_wait_time
         self._max_buffer_length = max_buffer_length
-        self._max_concurrent_sends = max_concurrent_sends
         self._existing_executor = bool(executor)
 
         if not executor:
@@ -83,7 +81,6 @@ class BufferedProducerDispatcher:
                     self._max_message_size_on_link,
                     executor=self._executor,
                     max_wait_time=self._max_wait_time,
-                    max_concurrent_sends=self._max_concurrent_sends,
                     max_buffer_length=self._max_buffer_length
                 )
                 buffered_producer.start()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
@@ -45,13 +45,14 @@ class BufferedProducerDispatcher:
         self._partition_resolver = PartitionResolver(self._partition_ids)
         self._max_wait_time = max_wait_time
         self._max_buffer_length = max_buffer_length
-        self._existing_executor = bool(executor)
+        self._existing_executor = False
 
         if not executor:
             self._executor = ThreadPoolExecutor(max_worker)
         elif isinstance(executor, ThreadPoolExecutor):
             self._executor = executor
         elif isinstance(executor, int):
+            self._existing_executor = True
             self._executor = ThreadPoolExecutor(executor)
 
     def _get_partition_id(self, partition_id, partition_key):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer_dispatcher.py
@@ -31,8 +31,7 @@ class BufferedProducerDispatcher:
             *,
             max_buffer_length: int = 1500,
             max_wait_time: float = 1,
-            executor: Optional[Union[ThreadPoolExecutor, int]] = None,
-            max_worker: Optional[int] = None
+            executor: Optional[Union[ThreadPoolExecutor, int]] = None
     ):
         self._buffered_producers: Dict[str, BufferedProducer] = {}
         self._partition_ids: List[str] = partitions
@@ -48,11 +47,11 @@ class BufferedProducerDispatcher:
         self._existing_executor = False
 
         if not executor:
-            self._executor = ThreadPoolExecutor(max_worker)
+            self._executor = ThreadPoolExecutor()
         elif isinstance(executor, ThreadPoolExecutor):
+            self._existing_executor = True
             self._executor = executor
         elif isinstance(executor, int):
-            self._existing_executor = True
             self._executor = ThreadPoolExecutor(executor)
 
     def _get_partition_id(self, partition_id, partition_key):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -55,8 +55,9 @@ class EventHubProducerClient(ClientBase):  # pylint: disable=client-accepts-api-
     :keyword bool buffered_mode: If True, the producer client will collect events in a buffer, efficiently batch,
      then publish. Default is False.
     :keyword Union[ThreadPoolExecutor, int] buffer_concurrency: The ThreadPoolExecutor to be used for publishing events
-     or the number of workers for the ThreadPoolExecutor. Default is none and a ThreadPoolExecutor with the default number of workers
-     will be created https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
+     or the number of workers for the ThreadPoolExecutor. 
+     Default is none and a ThreadPoolExecutor with the default number of workers will be created
+     per https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
     :keyword on_success: The callback to be called once a batch has been successfully published.
      The callback takes two parameters:
         - `events`: The list of events that have been successfully published

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -55,8 +55,8 @@ class EventHubProducerClient(ClientBase):   # pylint: disable=client-accepts-api
     :keyword bool buffered_mode: If True, the producer client will collect events in a buffer, efficiently batch,
      then publish. Default is False.
     :keyword Union[ThreadPoolExecutor, int] buffer_concurrency: The ThreadPoolExecutor to be used for publishing events
-    or the number of workers for the ThreadPoolExecutor. Default is none and a ThreadPoolExecutor with the default number of workers
-    will be created https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
+     or the number of workers for the ThreadPoolExecutor. Default is none and a ThreadPoolExecutor with the default number of workers
+     will be created https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
     :keyword on_success: The callback to be called once a batch has been successfully published.
      The callback takes two parameters:
         - `events`: The list of events that have been successfully published

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -191,7 +191,6 @@ class EventHubProducerClient(ClientBase):  # pylint: disable=client-accepts-api-
         self._max_wait_time = max_wait_time
         self._max_buffer_length = max_buffer_length
         self._executor = kwargs.get("buffer_concurrency")
-        self._max_worker = None
 
         if self._buffered_mode:
             setattr(self, "send_batch", self._buffered_send_batch)
@@ -236,9 +235,8 @@ class EventHubProducerClient(ClientBase):  # pylint: disable=client-accepts-api-
                 self._max_message_size_on_link,
                 max_wait_time=self._max_wait_time,
                 max_buffer_length=self._max_buffer_length,
-                executor=self._executor,
-                max_worker=self._max_worker,
-            )
+                executor=self._executor
+                )
             self._buffered_producer_dispatcher.enqueue_events(events, **kwargs)
 
     def _batch_preparer(self, event_data_batch, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -140,7 +140,6 @@ class BufferedProducer:
             self._cur_batch = EventDataBatch(self._max_message_size_on_link)
         while self._cur_buffered_len:
             remaining_time = timeout_time - time.time() if timeout_time else None
-            # If flush could get the semaphore, perform sending
             if ((remaining_time and remaining_time > 0) or remaining_time is None):
                 batch = self._buffered_queue.get()
                 self._buffered_queue.task_done()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -31,15 +31,13 @@ class BufferedProducer:
             max_message_size_on_link: int,
             *,
             max_wait_time: float = 1,
-            max_concurrent_sends: int = 1,
-            max_buffer_length: int = 1500
+            max_buffer_length: int
     ):
         self._buffered_queue: queue.Queue = queue.Queue()
         self._max_buffer_len = max_buffer_length
         self._cur_buffered_len = 0
         self._producer: EventHubProducer = producer
         self._lock = Lock()
-        self._max_concurrent_sends = max_concurrent_sends
         self._max_wait_time = max_wait_time
         self._on_success = self.failsafe_callback(on_success)
         self._on_error = self.failsafe_callback(on_error)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -170,7 +170,8 @@ class BufferedProducer:
                     self._cur_buffered_len >= self._max_buffer_len and self._running
                 ):
                     # in the worker, not raising error for flush, users can not handle this
-                    await self.flush(raise_error=False)
+                    async with self._lock:
+                        await self.flush(raise_error=False)
             await asyncio.sleep(min(self._max_wait_time, 5))
 
     @property

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -172,7 +172,7 @@ class BufferedProducer:
                     self.partition_id
                 )
                 if raise_error:
-                    raise OperationTimeoutError("Failed to flush {!r}".format(self.partition_id))
+                    raise OperationTimeoutError("Failed to flush {!r} within {}".format(self.partition_id, timeout_time))
                 break
         # after finishing flushing, reset cur batch and put it into the buffer
         self._last_send_time = time.time()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -34,7 +34,8 @@ class BufferedProducer:
             max_concurrent_sends: int = 1,
             max_buffer_length: int = 1500
     ):
-        self._buffered_queue: queue.Queue = queue.Queue(maxsize=max_buffer_length)
+        self._buffered_queue: queue.Queue = queue.Queue()
+        self._max_buffer_len = max_buffer_length
         self._cur_buffered_len = 0
         self._producer: EventHubProducer = producer
         self._lock = Lock()
@@ -187,7 +188,7 @@ class BufferedProducer:
                 now_time = time.time()
                 _LOGGER.info("Partition %r worker is checking max_wait_time.", self.partition_id)
                 #flush the partition if its beyond the waiting time or the buffer is at max capacity
-                if (now_time - self._last_send_time > self._max_wait_time and self._running) or (self._buffered_queue.qsize == self._buffered_queue.maxsize and self._running):
+                if (now_time - self._last_send_time > self._max_wait_time and self._running) or (self._cur_buffered_len >= self._max_buffer_len and self._running):
                     # in the worker, not raising error for flush, users can not handle this
                     await self.flush(raise_error=False)
             await asyncio.sleep(min(self._max_wait_time, 5))

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_dispatcher_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_dispatcher_async.py
@@ -31,7 +31,6 @@ class BufferedProducerDispatcher:
             *,
             max_buffer_length: int = 1500,
             max_wait_time: float = 1,
-            max_concurrent_sends: int = 1
     ):
         self._buffered_producers: Dict[str, BufferedProducer] = {}
         self._partition_ids: List[str] = partitions
@@ -44,7 +43,6 @@ class BufferedProducerDispatcher:
         self._partition_resolver = PartitionResolver(self._partition_ids)
         self._max_wait_time = max_wait_time
         self._max_buffer_length = max_buffer_length
-        self._max_concurrent_sends = max_concurrent_sends
 
     async def _get_partition_id(self, partition_id, partition_key):
         if partition_id:
@@ -72,7 +70,6 @@ class BufferedProducerDispatcher:
                     self._on_error,
                     self._max_message_size_on_link,
                     max_wait_time=self._max_wait_time,
-                    max_concurrent_sends=self._max_concurrent_sends,
                     max_buffer_length=self._max_buffer_length
                 )
                 await buffered_producer.start()


### PR DESCRIPTION
This PR is looking to address the following issues:
* Concurrency strategy - #23844
* Back-pressure handling strategy - #23909

How BufferedProducer works and its place within EventHub #23748

After an initial sync with Anna, we agreed on the following changes to BufferedProducer:
* The `ThreadPoolExecutor` would give us the concurrency we needed given the design of n number of `BufferedProducers` per partition. We would expose a `buffer_concurrency` kwarg that would allow a user to send in their own `ThreadPoolExecutor` or maximum number of workers.
* Document the Python specific behavior for how many workers are created by default
* Clean up `BufferedProducer` to not use semaphores & conditions, given that each `Queue` belongs to a particular partition, is independent and is not shared/modified between partitions.
* The background worker `check_max_wait_time_worker` in `BufferedProducer` would proactively flush the queue if it was at max capacity bringing the behavior inline with the documentation.