### PR TITLE
[Storage] Changefeed changes to better support point in time restore

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
+++ b/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
@@ -32,10 +32,10 @@ class ChangeFeedClient(object):  # pylint: disable=too-many-public-methods
     :keyword str secondary_hostname:
         The hostname of the secondary endpoint.
     :keyword int max_single_get_size:
-        The maximum size for an event to be downloaded in a single call,
+        The maximum size for a changefeed blob to be downloaded in a single call,
         the exceeded part will be downloaded in chunks.
     :keyword int max_chunk_get_size:
-        The maximum chunk size used for downloading an event.
+        The maximum chunk size used for downloading a changefeed blob.
     :keyword str api_version:
         The Storage API version to use for requests. Default value is the most recent service version that is
         compatible with the current SDK. Setting to an older version may result in reduced feature compatibility.

--- a/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
+++ b/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
@@ -31,6 +31,11 @@ class ChangeFeedClient(object):  # pylint: disable=too-many-public-methods
         - except in the case of AzureSasCredential, where the conflicting SAS tokens will raise a ValueError.
     :keyword str secondary_hostname:
         The hostname of the secondary endpoint.
+    :keyword int max_single_get_size:
+        The maximum size for an event to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks.
+    :keyword int max_chunk_get_size:
+        The maximum chunk size used for downloading an event.
     :keyword str api_version:
         The Storage API version to use for requests. Default value is the most recent service version that is
         compatible with the current SDK. Setting to an older version may result in reduced feature compatibility.

--- a/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
+++ b/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
@@ -35,7 +35,7 @@ class ChangeFeedClient(object):  # pylint: disable=too-many-public-methods
         The maximum size for a changefeed blob to be downloaded in a single call,
         the exceeded part will be downloaded in chunks.
     :keyword int max_chunk_get_size:
-        The maximum chunk size used for downloading a changefeed blob.
+        The maximum chunk size used for downloading a changefeed blob. 
     :keyword str api_version:
         The Storage API version to use for requests. Default value is the most recent service version that is
         compatible with the current SDK. Setting to an older version may result in reduced feature compatibility.

--- a/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
+++ b/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
@@ -35,7 +35,7 @@ class ChangeFeedClient(object):  # pylint: disable=too-many-public-methods
         The maximum size for a changefeed blob to be downloaded in a single call,
         the exceeded part will be downloaded in chunks.
     :keyword int max_chunk_get_size:
-        The maximum chunk size used for downloading a changefeed blob. 
+        The maximum chunk size used for downloading a changefeed blob.
     :keyword str api_version:
         The Storage API version to use for requests. Default value is the most recent service version that is
         compatible with the current SDK. Setting to an older version may result in reduced feature compatibility.

--- a/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_models.py
+++ b/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_models.py
@@ -389,7 +389,6 @@ class ChangeFeedStreamer(object):
         self.object_position = self._chunk_file_start  # track the most recently read sync marker position
         self.event_index = 0
         self._point = self._chunk_file_start  # file cursor position relative to the whole chunk file, not the buffered
-        self._chunk_size = 4 * 1024 * 1024
         self._buf = b""
         self._buf_start = self._chunk_file_start  # the start position of the chunk file to buffer
         self._chunk_size_snapshot = blob_client.get_blob_properties().size


### PR DESCRIPTION
This PR aims to complete the work outlined in #24167. While typically I would follow best code practices and include checked-in tests, this is more of a plumbing change than any heavyweight implementation and was ad-hoc tested to ensure both requirements have been met as follows:

**Add adjustable chunk size**
- Verified in debugger when looking at variables of the `ChangeFeedClient` object
- Observed the number of `GET` API calls and ensuring it has an inverse relationship with values of `max_single_get_size` and `max_chunk_get_size` (as parameters values increased, number of `GET` API calls decreased)

**Do not return BlobNotFound if the ChangeFeed blob does not exist, instead return and empty list of results.**
- While a change was necessary in .NET, Python already supported this behavior and can be observed in the checked-in test `test_change_feed_does_not_fail_on_empty_event_stream`

Furthermore, the removal of  `self._chunk_size` in `_models.py` is because the value is not used anywhere in the file (and is not used anywhere in all of ChangeFeed) and appears to be a leftover variable from a previous implementation. I have removed it to avoid future confusion (as it confused me initially 😅)