### PR TITLE
Update Azure monitor OpenTelemetry exporter example

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -114,7 +114,7 @@ import logging
 
 from opentelemetry.sdk._logs import (
     LogEmitterProvider,
-    OTLPHandler,
+    LoggingHandler,
     set_log_emitter_provider,
 )
 from opentelemetry.sdk._logs.export import BatchLogProcessor
@@ -129,9 +129,9 @@ exporter = AzureMonitorLogExporter.from_connection_string(
 )
 
 log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
-handler = OTLPHandler()
+handler = LoggingHandler()
 
-# Attach OTLPhandler to root logger
+# Attach LoggingHandler to root logger
 logging.getLogger().addHandler(handler)
 logging.getLogger().setLevel(logging.NOTSET)
 
@@ -149,7 +149,7 @@ import logging
 from opentelemetry import trace
 from opentelemetry.sdk._logs import (
     LogEmitterProvider,
-    OTLPHandler,
+    LoggingHandler,
     set_log_emitter_provider,
 )
 from opentelemetry.sdk._logs.export import BatchLogProcessor
@@ -167,9 +167,9 @@ exporter = AzureMonitorLogExporter.from_connection_string(
 )
 
 log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
-handler = OTLPHandler()
+handler = LoggingHandler()
 
-# Attach OTel handler to root logger
+# Attach LoggingHandler to root logger
 logging.getLogger().addHandler(handler)
 logging.getLogger().setLevel(logging.NOTSET)
 
@@ -189,7 +189,7 @@ import logging
 
 from opentelemetry.sdk._logs import (
     LogEmitterProvider,
-    OTLPHandler,
+    LoggingHandler,
     set_log_emitter_provider,
 )
 from opentelemetry.sdk._logs.export import BatchLogProcessor
@@ -204,9 +204,9 @@ exporter = AzureMonitorLogExporter.from_connection_string(
 )
 
 log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
-handler = OTLPHandler()
+handler = LoggingHandler()
 
-# Attach OTel handler to root logger
+# Attach LoggingHandler to root logger
 logging.getLogger().addHandler(handler)
 logging.getLogger().setLevel(logging.NOTSET)
 
@@ -333,7 +333,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [log_emitter]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogEmitter
 [log_emitter_provider]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogEmitterProvider
 [log_processor]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogProcessor
-[logging_handler]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.OTLPHandler
+[logging_handler]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LoggingHandler
 [log_reference]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py#L30
 [trace_concept]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#tracing-signal
 [span]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html?highlight=TracerProvider#opentelemetry.trace.Span

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_correlate.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_correlate.py
@@ -9,7 +9,7 @@ import logging
 from opentelemetry import trace
 from opentelemetry.sdk._logs import (
     LogEmitterProvider,
-    OTLPHandler,
+    LoggingHandler,
     get_log_emitter_provider,
     set_log_emitter_provider,
 )
@@ -28,7 +28,7 @@ exporter = AzureMonitorLogExporter.from_connection_string(
 get_log_emitter_provider().add_log_processor(BatchLogProcessor(exporter))
 
 # Attach OTel handler to namespaced logger
-handler = OTLPHandler()
+handler = LoggingHandler()
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.NOTSET)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_exception.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_exception.py
@@ -8,7 +8,7 @@ import logging
 
 from opentelemetry.sdk._logs import (
     LogEmitterProvider,
-    OTLPHandler,
+    LoggingHandler,
     get_log_emitter_provider,
     set_log_emitter_provider,
 )
@@ -23,7 +23,7 @@ exporter = AzureMonitorLogExporter.from_connection_string(
 get_log_emitter_provider().add_log_processor(BatchLogProcessor(exporter))
 
 # Attach OTel handler to namespaced logger
-handler = OTLPHandler()
+handler = LoggingHandler()
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.NOTSET)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py
@@ -9,7 +9,7 @@ import logging
 
 from opentelemetry.sdk._logs import (
     LogEmitterProvider,
-    OTLPHandler,
+    LoggingHandler,
     get_log_emitter_provider,
     set_log_emitter_provider,
 )
@@ -24,7 +24,7 @@ exporter = AzureMonitorLogExporter.from_connection_string(
 get_log_emitter_provider().add_log_processor(BatchLogProcessor(exporter))
 
 # Attach OTel handler to namespaced logger
-handler = OTLPHandler()
+handler = LoggingHandler()
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.NOTSET)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_properties.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_properties.py
@@ -8,7 +8,7 @@ import logging
 
 from opentelemetry.sdk._logs import (
     LogEmitterProvider,
-    OTLPHandler,
+    LoggingHandler,
     get_log_emitter_provider,
     set_log_emitter_provider,
 )
@@ -23,7 +23,7 @@ exporter = AzureMonitorLogExporter.from_connection_string(
 get_log_emitter_provider().add_log_processor(BatchLogProcessor(exporter))
 
 # Attach OTel handler to namespaced logger
-handler = OTLPHandler()
+handler = LoggingHandler()
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.NOTSET)


### PR DESCRIPTION
# Description

This updates the examples of using the experimental opentelemetry logging api to export to use 
the latest api from version 1.11 of the open telemetry sdk. See [here](https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LoggingHandler) and [here](https://github.com/open-telemetry/opentelemetry-python/blob/main/CHANGELOG.md#1110-030b0---2022-04-18)

Note that since this only fixes examples of use of an experimental api that is also currently 
not part of a release of this package I don't think there is a need to include this in the changelog. 

The minimum supported version of opentelemetry-sdk is 1.11.1 so I don't see a need to support 
the previous name since the name changed in 1.11.0

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.** 
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
Only examples have changed
