### PR TITLE
azure-core: ignore Connection header in tests, make tests pass with recent Flask + Werkzeug

### DIFF
--- a/sdk/core/azure-core/tests/async_tests/test_rest_headers_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_headers_async.py
@@ -12,6 +12,7 @@ from azure.core.rest._aiohttp import RestAioHttpTransportResponse
 
 # flask returns these response headers, which we don't really need for these following tests
 RESPONSE_HEADERS_TO_IGNORE = [
+    "Connection",
     "Content-Type",
     "Content-Length",
     "Server",
@@ -24,7 +25,7 @@ def get_response_headers(client):
         response = await client.send_request(request)
         response.raise_for_status
         for header in RESPONSE_HEADERS_TO_IGNORE:
-            response.headers.pop(header)
+            response.headers.pop(header, None)
         return response.headers
     return _get_response_headers
 

--- a/sdk/core/azure-core/tests/test_rest_headers.py
+++ b/sdk/core/azure-core/tests/test_rest_headers.py
@@ -21,6 +21,7 @@ def get_request_headers():
 
 # flask returns these response headers, which we don't really need for these following tests
 RESPONSE_HEADERS_TO_IGNORE = [
+    "Connection",
     "Content-Type",
     "Content-Length",
     "Server",
@@ -33,7 +34,7 @@ def get_response_headers(client):
         response = client.send_request(request)
         response.raise_for_status
         for header in RESPONSE_HEADERS_TO_IGNORE:
-            response.headers.pop(header)
+            response.headers.pop(header, None)
         return response.headers
     return _get_response_headers
 


### PR DESCRIPTION
# Description

Flask includes that since https://github.com/pallets/werkzeug/pull/2399, so tests fail on newest Flask versions.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
