### PR TITLE
azure-monitor-opentelemetry-exporter update examples in readme to reuse LogEmitterProvider 

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -160,7 +160,7 @@ from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 log_emitter_provider = LogEmitterProvider()
-set_log_emitter_provider(LogEmitterProvider())
+set_log_emitter_provider(log_emitter_provider)
 
 exporter = AzureMonitorLogExporter.from_connection_string(
     os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
@@ -197,7 +197,7 @@ from opentelemetry.sdk._logs.export import BatchLogProcessor
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 
 log_emitter_provider = LogEmitterProvider()
-set_log_emitter_provider(LogEmitterProvider())
+set_log_emitter_provider(log_emitter_provider)
 
 exporter = AzureMonitorLogExporter.from_connection_string(
     os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]


### PR DESCRIPTION
# Description

Update two examples in the readme to reuse LogEmitterProvider in two examples
rather than creating a new one. This matches other examples in
the readme as well as samples

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
