### PR TITLE
[Key Vault] Keep port number in parsed resource IDs

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Port numbers are now preserved in the `vault_url` property of a `KeyVaultCertificateIdentifier`
+  ([#24446](https://github.com/Azure/azure-sdk-for-python/issues/24446))
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
@@ -64,9 +64,13 @@ def parse_key_vault_id(source_id):
     if len(path) < 2 or len(path) > 3:
         raise ValueError("'{}' is not a valid ID".format(source_id))
 
+    vault_url = "{}://{}".format(parsed_uri.scheme, parsed_uri.hostname)
+    if parsed_uri.port:
+        vault_url += f":{parsed_uri.port}"
+
     return KeyVaultResourceId(
         source_id=source_id,
-        vault_url="{}://{}".format(parsed_uri.scheme, parsed_uri.hostname),
+        vault_url=vault_url,
         name=path[1],
         version=path[2] if len(path) == 3 else None,
     )

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_parse_id.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_parse_id.py
@@ -62,3 +62,15 @@ def test_parse_deleted_certificate_id():
         parsed_certificate_id.source_id
         == "https://keyvault-name.vault.azure.net/deletedcertificates/deleted-certificate"
     )
+
+
+def test_parse_certificate_id_with_port():
+    """Regression test for https://github.com/Azure/azure-sdk-for-python/issues/24446"""
+
+    source_id = "https://localhost:8443/certificates/certificate-name/version"
+    parsed_key_id = KeyVaultCertificateIdentifier(source_id)
+
+    assert parsed_key_id.name == "certificate-name"
+    assert parsed_key_id.vault_url == "https://localhost:8443"
+    assert parsed_key_id.version == "version"
+    assert parsed_key_id.source_id == "https://localhost:8443/certificates/certificate-name/version"

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- If a key's ID contains a port number, this port will now be preserved in the vault URL of a
+  `CryptographyClient` instance created from this key
+  ([#24446](https://github.com/Azure/azure-sdk-for-python/issues/24446))
+  - Port numbers are now preserved in the `vault_url` property of a `KeyVaultKeyIdentifier`
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
@@ -64,9 +64,13 @@ def parse_key_vault_id(source_id):
     if len(path) < 2 or len(path) > 3:
         raise ValueError("'{}' is not a valid ID".format(source_id))
 
+    vault_url = "{}://{}".format(parsed_uri.scheme, parsed_uri.hostname)
+    if parsed_uri.port:
+        vault_url += f":{parsed_uri.port}"
+
     return KeyVaultResourceId(
         source_id=source_id,
-        vault_url="{}://{}".format(parsed_uri.scheme, parsed_uri.hostname),
+        vault_url=vault_url,
         name=path[1],
         version=path[2] if len(path) == 3 else None,
     )

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -878,3 +878,27 @@ def test_decrypt_argument_validation():
     with pytest.raises(ValueError) as ex:
         client.decrypt(EncryptionAlgorithm.a192_cbcpad, b"...")
     assert "iv" in str(ex.value) and "required" in str(ex.value)
+
+
+def test_retain_url_port():
+    """Regression test for https://github.com/Azure/azure-sdk-for-python/issues/24446"""
+
+    mock_client = mock.Mock()
+    key = mock.Mock(spec=KeyVaultKey, id="https://localhost:8443/keys/rsa-2048/2d93f37afada4679b00b528f7238ad5c")
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+    assert client.vault_url == "https://localhost:8443"
+
+    # Make request for locally unsupported operation, prompting a service request
+    supports_nothing = mock.Mock(supports=mock.Mock(return_value=False))
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider", lambda *_: supports_nothing):
+        client.encrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.encrypt.call_count == 1
+
+    # See https://docs.python.org/dev/library/unittest.mock.html#calls-as-tuples for details about this inspection
+    for method_call in mock_client.method_calls:
+        name, args, kwargs = method_call
+        if name == "encrypt":
+            # This check is implementation-dependent, and assumes that the generated client's encrypt method is
+            # called using named arguments
+            assert kwargs.get("vault_base_url") == "https://localhost:8443"

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -925,3 +925,32 @@ async def test_decrypt_argument_validation():
     with pytest.raises(ValueError) as ex:
         await client.decrypt(EncryptionAlgorithm.a192_cbcpad, b"...")
     assert "iv" in str(ex.value) and "required" in str(ex.value)
+
+
+@pytest.mark.asyncio
+async def test_retain_url_port():
+    """Regression test for https://github.com/Azure/azure-sdk-for-python/issues/24446"""
+
+    class _AsyncMock(mock.Mock):
+        async def __call__(self, *args, **kwargs):
+            return super().__call__(*args, **kwargs)
+
+    mock_client = _AsyncMock()
+    key = mock.Mock(spec=KeyVaultKey, id="https://localhost:8443/keys/rsa-2048/2d93f37afada4679b00b528f7238ad5c")
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+    assert client.vault_url == "https://localhost:8443"
+
+    # Make request for locally unsupported operation, prompting a service request
+    supports_nothing = mock.Mock(supports=mock.Mock(return_value=False))
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider", lambda *_: supports_nothing):
+        await client.encrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.encrypt.call_count == 1
+
+    # See https://docs.python.org/dev/library/unittest.mock.html#calls-as-tuples for details about this inspection
+    for method_call in mock_client.method_calls:
+        name, args, kwargs = method_call
+        if name == "encrypt":
+            # This check is implementation-dependent, and assumes that the generated client's encrypt method is
+            # called using named arguments
+            assert kwargs.get("vault_base_url") == "https://localhost:8443"

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_parse_id.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_parse_id.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # -------------------------------------
-import os
-
 import pytest
 
 from azure.keyvault.keys import KeyVaultKeyIdentifier
@@ -58,3 +56,15 @@ def test_parse_deleted_key_id():
     assert parsed_key_id.vault_url == "https://keyvault-name.vault.azure.net"
     assert parsed_key_id.version is None
     assert parsed_key_id.source_id == "https://keyvault-name.vault.azure.net/deletedkeys/deleted-key"
+
+
+def test_parse_key_id_with_port():
+    """Regression test for https://github.com/Azure/azure-sdk-for-python/issues/24446"""
+
+    source_id = "https://localhost:8443/keys/rsa-2048/2d93f37afada4679b00b528f7238ad5c"
+    parsed_key_id = KeyVaultKeyIdentifier(source_id)
+
+    assert parsed_key_id.name == "rsa-2048"
+    assert parsed_key_id.vault_url == "https://localhost:8443"
+    assert parsed_key_id.version == "2d93f37afada4679b00b528f7238ad5c"
+    assert parsed_key_id.source_id == "https://localhost:8443/keys/rsa-2048/2d93f37afada4679b00b528f7238ad5c"

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Port numbers are now preserved in the `vault_url` property of a `KeyVaultSecretIdentifier`
+  ([#24446](https://github.com/Azure/azure-sdk-for-python/issues/24446))
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
@@ -64,9 +64,13 @@ def parse_key_vault_id(source_id):
     if len(path) < 2 or len(path) > 3:
         raise ValueError("'{}' is not a valid ID".format(source_id))
 
+    vault_url = "{}://{}".format(parsed_uri.scheme, parsed_uri.hostname)
+    if parsed_uri.port:
+        vault_url += f":{parsed_uri.port}"
+
     return KeyVaultResourceId(
         source_id=source_id,
-        vault_url="{}://{}".format(parsed_uri.scheme, parsed_uri.hostname),
+        vault_url=vault_url,
         name=path[1],
         version=path[2] if len(path) == 3 else None,
     )

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_parse_id.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_parse_id.py
@@ -55,3 +55,15 @@ def test_parse_deleted_secret_id():
     assert parsed_secret_id.vault_url == "https://keyvault-name.vault.azure.net"
     assert parsed_secret_id.version is None
     assert parsed_secret_id.source_id == "https://keyvault-name.vault.azure.net/deletedsecrets/deleted-secret"
+
+
+def test_parse_secret_id_with_port():
+    """Regression test for https://github.com/Azure/azure-sdk-for-python/issues/24446"""
+
+    source_id = "https://localhost:8443/secrets/secret-name/version"
+    parsed_key_id = KeyVaultSecretIdentifier(source_id)
+
+    assert parsed_key_id.name == "secret-name"
+    assert parsed_key_id.vault_url == "https://localhost:8443"
+    assert parsed_key_id.version == "version"
+    assert parsed_key_id.source_id == "https://localhost:8443/secrets/secret-name/version"


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/24446. Resource IDs that include a port number will now have that port number included in the resulting vault URL. This is particularly noteworthy in the case of `CryptographyClient`, which will have its vault URL set to the parsed vault URL from a key ID. The linked issue has details about how this can pose a problem with the port-omitting implementation.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
