### PR TITLE
Fix CI under `sdk/compute`

### DIFF
--- a/sdk/compute/azure-mgmt-avs/MANIFEST.in
+++ b/sdk/compute/azure-mgmt-avs/MANIFEST.in
@@ -4,3 +4,4 @@ include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
 include LICENSE
+include azure/mgmt/avs/py.typed

--- a/sdk/compute/azure-mgmt-avs/setup.py
+++ b/sdk/compute/azure-mgmt-avs/setup.py
@@ -35,6 +35,7 @@ with open('README.md', encoding='utf-8') as f:
 with open('CHANGELOG.md', encoding='utf-8') as f:
     changelog = f.read()
 
+
 setup(
     name=PACKAGE_NAME,
     version=version,

--- a/sdk/compute/azure-mgmt-avs/setup.py
+++ b/sdk/compute/azure-mgmt-avs/setup.py
@@ -35,7 +35,6 @@ with open('README.md', encoding='utf-8') as f:
 with open('CHANGELOG.md', encoding='utf-8') as f:
     changelog = f.read()
 
-
 setup(
     name=PACKAGE_NAME,
     version=version,
@@ -66,6 +65,10 @@ setup(
         'azure',
         'azure.mgmt',
     ]),
+    include_package_data=True,
+    package_data={
+        'pytyped': ['py.typed'],
+    },
     install_requires=[
         'msrest>=0.6.21',
         'azure-common~=1.1',

--- a/sdk/compute/azure-mgmt-imagebuilder/MANIFEST.in
+++ b/sdk/compute/azure-mgmt-imagebuilder/MANIFEST.in
@@ -4,3 +4,4 @@ include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
 include LICENSE
+include azure/mgmt/imagebuilder/py.typed

--- a/sdk/compute/azure-mgmt-imagebuilder/setup.py
+++ b/sdk/compute/azure-mgmt-imagebuilder/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-
 #-------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for
@@ -66,6 +65,10 @@ setup(
         'azure',
         'azure.mgmt',
     ]),
+    include_package_data=True,
+    package_data={
+        'pytyped': ['py.typed'],
+    },
     install_requires=[
         'msrest>=0.6.21',
         'azure-common~=1.1',

--- a/sdk/compute/azure-mgmt-imagebuilder/setup.py
+++ b/sdk/compute/azure-mgmt-imagebuilder/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+
 #-------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for

--- a/sdk/compute/azure-mgmt-vmwarecloudsimple/MANIFEST.in
+++ b/sdk/compute/azure-mgmt-vmwarecloudsimple/MANIFEST.in
@@ -4,3 +4,4 @@ include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
 include LICENSE
+include azure/mgmt/vmwarecloudsimple/py.typed

--- a/sdk/compute/azure-mgmt-vmwarecloudsimple/setup.py
+++ b/sdk/compute/azure-mgmt-vmwarecloudsimple/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-
 #-------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for
@@ -66,6 +65,10 @@ setup(
         'azure',
         'azure.mgmt',
     ]),
+    include_package_data=True,
+    package_data={
+        'pytyped': ['py.typed'],
+    },
     install_requires=[
         'msrest>=0.6.21',
         'azure-common~=1.1',

--- a/sdk/compute/azure-mgmt-vmwarecloudsimple/setup.py
+++ b/sdk/compute/azure-mgmt-vmwarecloudsimple/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+
 #-------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for


### PR DESCRIPTION
Fix CI under `sdk/compute` to unblock release for `azure-mgmt-compute`: https://github.com/Azure/azure-sdk-for-python/pull/24479