### PR TITLE
[Storage] Update Storage mgmt MANIFESTs to include py.typed

### DIFF
--- a/sdk/storage/azure-mgmt-storage/MANIFEST.in
+++ b/sdk/storage/azure-mgmt-storage/MANIFEST.in
@@ -4,3 +4,4 @@ include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
 include LICENSE
+include azure/mgmt/storage/py.typed

--- a/sdk/storage/azure-mgmt-storagecache/MANIFEST.in
+++ b/sdk/storage/azure-mgmt-storagecache/MANIFEST.in
@@ -4,3 +4,4 @@ include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
 include LICENSE
+include azure/mgmt/storagecache/py.typed

--- a/sdk/storage/azure-mgmt-storageimportexport/MANIFEST.in
+++ b/sdk/storage/azure-mgmt-storageimportexport/MANIFEST.in
@@ -4,3 +4,4 @@ include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
 include LICENSE
+include azure/mgmt/storageimportexport/py.typed

--- a/sdk/storage/azure-mgmt-storagesync/MANIFEST.in
+++ b/sdk/storage/azure-mgmt-storagesync/MANIFEST.in
@@ -3,4 +3,4 @@ recursive-include tests *.py *.yaml
 include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
-
+include azure/mgmt/storagesync/py.typed


### PR DESCRIPTION
The recent enforcement of `py.typed` requires `py.typed` files to exist AND be included in the `MANIFEST` file, the latter of which was missing for Storage mgmt packages. This is causing failures in the release pipeline (of all of Storage). This change includes `py.typed` in the `MANIFEST` for all Storage mgmt packages which should appease the pipeline.