### PR TITLE
[pylint] removing ignore-paths

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -4,7 +4,7 @@ reports=no
 
 # PYLINT DIRECTORY BLACKLIST.
 ignore=_vendor,_generated,samples,examples,test,tests,doc,.tox
-ignore-paths=azure\\mixedreality\\remoterendering\\_api_version.py,azure/mixedreality/remoterendering/_api_version.py,azure/cosmos/aio/cosmos_client.py,azure\\cosmos\\aio\\cosmos_client.py,azure/cosmos/cosmos_client.py,azure\\cosmos\\cosmos_client.py 
+ignore-paths=azure\\mixedreality\\remoterendering\\_api_version.py,azure/mixedreality/remoterendering/_api_version.py
 
 load-plugins=pylint_guidelines_checker
 


### PR DESCRIPTION
removing the ignore-path from the pylintrc file as they have bypassed api keyword for now