### PR TITLE
containerregistry: Fixing issue where list_tag_properties and list_manifest_properties raise TypeError: NoneType is not iterable if there are no images in the repository

### DIFF
--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
@@ -243,7 +243,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
                     x, repository_name=repository, registry=self._endpoint
                 )
                 for x in objs
-            ],
+            ] if objs is not None else [],
         )
 
         error_map = {401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError}
@@ -452,7 +452,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             lambda objs: [
                 ArtifactTagProperties._from_generated(o, repository=repository)  # pylint: disable=protected-access
                 for o in objs
-            ],
+            ] if objs is not None else [],
         )
 
         error_map = {401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError}


### PR DESCRIPTION
# Description

Calling list_tag_properties or list_manifest_properties on a repository with no images in it currently raises TypeError. This change fixes that problem.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
