### PR TITLE
[Storage] Arch Board Review Feedback STG83

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -542,14 +542,13 @@ class DataLakeDirectoryClient(PathClient):
             (-1) for a lease that never expires. A non-infinite lease can be
             between 15 and 60 seconds. A lease duration cannot be changed
             using renew or change.
-        :keyword expiry_options:
-            Indicates mode of the expiry time.
-            Possible values include: 'NeverExpire', 'RelativeToNow', 'Absolute'"
-        :paramtype expiry_options: Literal["NeverExpire", "RelativeToNow", "Absolute"]
         :keyword expires_on:
             The time to set the file to expiry.
-            When expiry_options is RelativeTo*, expires_on should be an int in milliseconds.
-            If the type of expires_on is datetime, it should be in UTC time.
+            If the type of expires_on is an int, expiration time will be set
+            as the number of milliseconds elapsed from creation time.
+            If the type of expires_on is datetime, expiration time will be set
+            absolute to the time provided. If no time zone info is provided, this
+            will be interpreted as UTC.
         :paramtype expires_on: datetime or int
         :keyword str permissions:
             Optional and only valid if Hierarchical Namespace

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -190,13 +190,7 @@ class DataLakeDirectoryClient(PathClient):
                 :dedent: 8
                 :caption: Create directory.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        return self._create('directory', lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
+        return self._create('directory', metadata=metadata, **kwargs)
 
     def delete_directory(self, **kwargs):
         # type: (...) -> None
@@ -461,14 +455,8 @@ class DataLakeDirectoryClient(PathClient):
             The timeout parameter is expressed in seconds.
         :return: DataLakeDirectoryClient for the subdirectory.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         subdir = self.get_sub_directory_client(sub_directory)
-        subdir.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
+        subdir.create_directory(metadata=metadata, **kwargs)
         return subdir
 
     def delete_sub_directory(self, sub_directory,  # type: Union[DirectoryProperties, str]
@@ -594,14 +582,8 @@ class DataLakeDirectoryClient(PathClient):
             The timeout parameter is expressed in seconds.
         :return: DataLakeFileClient
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
+        file_client.create_file(**kwargs)
         return file_client
 
     def get_file_client(self, file  # type: Union[FileProperties, str]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -190,7 +190,13 @@ class DataLakeDirectoryClient(PathClient):
                 :dedent: 8
                 :caption: Create directory.
         """
-        return self._create('directory', metadata=metadata, **kwargs)
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        return self._create('directory', lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
 
     def delete_directory(self, **kwargs):
         # type: (...) -> None
@@ -455,8 +461,14 @@ class DataLakeDirectoryClient(PathClient):
             The timeout parameter is expressed in seconds.
         :return: DataLakeDirectoryClient for the subdirectory.
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         subdir = self.get_sub_directory_client(sub_directory)
-        subdir.create_directory(metadata=metadata, **kwargs)
+        subdir.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
         return subdir
 
     def delete_sub_directory(self, sub_directory,  # type: Union[DirectoryProperties, str]
@@ -582,8 +594,14 @@ class DataLakeDirectoryClient(PathClient):
             The timeout parameter is expressed in seconds.
         :return: DataLakeFileClient
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        file_client.create_file(**kwargs)
+        file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
         return file_client
 
     def get_file_client(self, file  # type: Union[FileProperties, str]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -210,7 +210,13 @@ class DataLakeFileClient(PathClient):
                 :dedent: 4
                 :caption: Create file.
         """
-        return self._create('file', content_settings=content_settings, metadata=metadata, **kwargs)
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        return self._create('file', lease_id=lease_id, lease_duration=lease_duration, content_settings=content_settings, metadata=metadata, **kwargs)
 
     def delete_file(self, **kwargs):
         # type: (...) -> None

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -161,14 +161,13 @@ class DataLakeFileClient(PathClient):
             (-1) for a lease that never expires. A non-infinite lease can be
             between 15 and 60 seconds. A lease duration cannot be changed
             using renew or change.
-        :keyword expiry_options:
-            Indicates mode of the expiry time.
-            Possible values include: 'NeverExpire', 'RelativeToNow', 'Absolute'"
-        :paramtype expiry_options: Literal["NeverExpire", "RelativeToNow", "Absolute"]
         :keyword expires_on:
             The time to set the file to expiry.
-            When expiry_options is RelativeTo*, expires_on should be an int in milliseconds.
-            If the type of expires_on is datetime, it should be in UTC time.
+            If the type of expires_on is an int, expiration time will be set
+            as the number of milliseconds elapsed from creation time.
+            If the type of expires_on is datetime, expiration time will be set
+            absolute to the time provided. If no time zone info is provided, this
+            will be interpreted as UTC.
         :paramtype expires_on: datetime or int
         :keyword str permissions:
             Optional and only valid if Hierarchical Namespace

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -210,13 +210,7 @@ class DataLakeFileClient(PathClient):
                 :dedent: 4
                 :caption: Create file.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        return self._create('file', lease_id=lease_id, lease_duration=lease_duration, content_settings=content_settings, metadata=metadata, **kwargs)
+        return self._create('file', content_settings=content_settings, metadata=metadata, **kwargs)
 
     def delete_file(self, **kwargs):
         # type: (...) -> None

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -616,8 +616,14 @@ class FileSystemClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Create directory in the file system.
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         directory_client = self.get_directory_client(directory)
-        directory_client.create_directory(metadata=metadata, **kwargs)
+        directory_client.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
         return directory_client
 
     def delete_directory(self, directory,  # type: Union[DirectoryProperties, str]
@@ -758,8 +764,14 @@ class FileSystemClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Create file in the file system.
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        file_client.create_file(**kwargs)
+        file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
         return file_client
 
     def delete_file(self, file,  # type: Union[FileProperties, str]
@@ -869,6 +881,7 @@ class FileSystemClient(StorageAccountHostsMixin):
     def delete_files(
         self,
         *files: str,
+        raise_on_any_failure=False,
         **kwargs) -> List[Optional[HttpResponseError]]:
         """Marks the specified files or empty directories for deletion.
 
@@ -896,7 +909,7 @@ class FileSystemClient(StorageAccountHostsMixin):
             Specify this header to perform the operation only if
             the resource has not been modified since the specified date/time.
         :keyword bool raise_on_any_failure:
-            This is a boolean param which defaults to True. When this is set, an exception
+            This is a boolean param which defaults to False. When this is set, an exception
             is raised even if there is a single operation failure.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -894,9 +894,6 @@ class FileSystemClient(StorageAccountHostsMixin):
             If a date is passed in without timezone info, it is assumed to be UTC.
             Specify this header to perform the operation only if
             the resource has not been modified since the specified date/time.
-        :keyword bool raise_on_any_failure:
-            This is a boolean param which defaults to True. When this is set, an exception
-            is raised even if there is a single operation failure.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :return: A list containing None for successful operations and
@@ -912,6 +909,7 @@ class FileSystemClient(StorageAccountHostsMixin):
                 :dedent: 4
                 :caption: Deleting multiple files or empty directories.
         """
+        kwargs['raise_on_any_failure'] = False
         results = self._container_client.delete_blobs(*files, **kwargs)
 
         errors = []

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -712,14 +712,13 @@ class FileSystemClient(StorageAccountHostsMixin):
             (-1) for a lease that never expires. A non-infinite lease can be
             between 15 and 60 seconds. A lease duration cannot be changed
             using renew or change.
-        :keyword expiry_options:
-            Indicates mode of the expiry time.
-            Possible values include: 'NeverExpire', 'RelativeToNow', 'Absolute'"
-        :paramtype expiry_options: Literal["NeverExpire", "RelativeToNow", "Absolute"]
         :keyword expires_on:
             The time to set the file to expiry.
-            When expiry_options is RelativeTo*, expires_on should be an int in milliseconds.
-            If the type of expires_on is datetime, it should be in UTC time.
+            If the type of expires_on is an int, expiration time will be set
+            as the number of milliseconds elapsed from creation time.
+            If the type of expires_on is datetime, expiration time will be set
+            absolute to the time provided. If no time zone info is provided, this
+            will be interpreted as UTC.
         :paramtype expires_on: datetime or int
         :keyword str permissions:
             Optional and only valid if Hierarchical Namespace

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -909,8 +909,7 @@ class FileSystemClient(StorageAccountHostsMixin):
                 :dedent: 4
                 :caption: Deleting multiple files or empty directories.
         """
-        kwargs['raise_on_any_failure'] = False
-        results = self._container_client.delete_blobs(*files, **kwargs)
+        results = self._container_client.delete_blobs(raise_on_any_failure=False, *files, **kwargs)
 
         errors = []
         for result in results:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -616,14 +616,8 @@ class FileSystemClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Create directory in the file system.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         directory_client = self.get_directory_client(directory)
-        directory_client.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
+        directory_client.create_directory(metadata=metadata, **kwargs)
         return directory_client
 
     def delete_directory(self, directory,  # type: Union[DirectoryProperties, str]
@@ -764,14 +758,8 @@ class FileSystemClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Create file in the file system.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
+        file_client.create_file(**kwargs)
         return file_client
 
     def delete_file(self, file,  # type: Union[FileProperties, str]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -881,7 +881,6 @@ class FileSystemClient(StorageAccountHostsMixin):
     def delete_files(
         self,
         *files: str,
-        raise_on_any_failure=False,
         **kwargs) -> List[Optional[HttpResponseError]]:
         """Marks the specified files or empty directories for deletion.
 
@@ -909,7 +908,7 @@ class FileSystemClient(StorageAccountHostsMixin):
             Specify this header to perform the operation only if
             the resource has not been modified since the specified date/time.
         :keyword bool raise_on_any_failure:
-            This is a boolean param which defaults to False. When this is set, an exception
+            This is a boolean param which defaults to True. When this is set, an exception
             is raised even if there is a single operation failure.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -167,8 +167,10 @@ class PathClient(StorageAccountHostsMixin):
         if expires_on:
             try:
                 expires_on = convert_datetime_to_rfc1123(expires_on)
+                kwargs['expiry_options'] = 'Absolute'
             except AttributeError:
                 expires_on = str(expires_on)
+                kwargs['expiry_options'] = 'RelativeToNow'
 
         options = {
             'resource': resource_type,
@@ -235,14 +237,13 @@ class PathClient(StorageAccountHostsMixin):
             (-1) for a lease that never expires. A non-infinite lease can be
             between 15 and 60 seconds. A lease duration cannot be changed
             using renew or change.
-        :keyword expiry_options:
-            Indicates mode of the expiry time.
-            Possible values include: 'NeverExpire', 'RelativeToNow', 'Absolute'"
-        :paramtype expiry_options: Literal["NeverExpire", "RelativeToNow", "Absolute"]
         :keyword expires_on:
             The time to set the file to expiry.
-            When expiry_options is RelativeTo*, expires_on should be an int in milliseconds.
-            If the type of expires_on is datetime, it should be in UTC time.
+            If the type of expires_on is an int, expiration time will be set
+            as the number of milliseconds elapsed from creation time.
+            If the type of expires_on is datetime, expiration time will be set
+            absolute to the time provided. If no time zone info is provided, this
+            will be interpreted as UTC.
         :paramtype expires_on: datetime or int
         :keyword permissions:
             Optional and only valid if Hierarchical Namespace
@@ -278,32 +279,15 @@ class PathClient(StorageAccountHostsMixin):
         """
         lease_id = kwargs.get('lease_id', None)
         lease_duration = kwargs.get('lease_duration', None)
-        expires_on = kwargs.get('expires_on', None)
         if lease_id and not lease_duration:
             raise ValueError("Please specify a lease_id and a lease_duration.")
         if lease_duration and not lease_id:
             raise ValueError("Please specify a lease_id and a lease_duration.")
-        if expires_on:
-            if isinstance(expires_on, datetime):
-                options = self._create_path_options(
-                    resource_type,
-                    content_settings=content_settings,
-                    metadata=metadata,
-                    expiry_options='Absolute',
-                    **kwargs)
-            else:
-                options = self._create_path_options(
-                    resource_type,
-                    content_settings=content_settings,
-                    metadata=metadata,
-                    expiry_options='RelativeToNow',
-                    **kwargs)
-        else:
-            options = self._create_path_options(
-                resource_type,
-                content_settings=content_settings,
-                metadata=metadata,
-                **kwargs)
+        options = self._create_path_options(
+            resource_type,
+            content_settings=content_settings,
+            metadata=metadata,
+            **kwargs)
         try:
             return self._client.path.create(**options)
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -276,6 +276,12 @@ class PathClient(StorageAccountHostsMixin):
             The timeout parameter is expressed in seconds.
         :return: Dict[str, Union[str, datetime]]
         """
+        lease_id = kwargs.get('lease_id', None)
+        lease_duration = kwargs.get('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         options = self._create_path_options(
             resource_type,
             content_settings=content_settings,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -278,15 +278,32 @@ class PathClient(StorageAccountHostsMixin):
         """
         lease_id = kwargs.get('lease_id', None)
         lease_duration = kwargs.get('lease_duration', None)
+        expires_on = kwargs.get('expires_on', None)
         if lease_id and not lease_duration:
             raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
+        if lease_duration and not lease_id:
             raise ValueError("Please specify a lease_id and a lease_duration.")
-        options = self._create_path_options(
-            resource_type,
-            content_settings=content_settings,
-            metadata=metadata,
-            **kwargs)
+        if expires_on:
+            if isinstance(expires_on, datetime):
+                options = self._create_path_options(
+                    resource_type,
+                    content_settings=content_settings,
+                    metadata=metadata,
+                    expiry_options='Absolute',
+                    **kwargs)
+            else:
+                options = self._create_path_options(
+                    resource_type,
+                    content_settings=content_settings,
+                    metadata=metadata,
+                    expiry_options='RelativeToNow',
+                    **kwargs)
+        else:
+            options = self._create_path_options(
+                resource_type,
+                content_settings=content_settings,
+                metadata=metadata,
+                **kwargs)
         try:
             return self._client.path.create(**options)
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
@@ -156,7 +156,13 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
                 :dedent: 8
                 :caption: Create directory.
         """
-        return await self._create('directory', metadata=metadata, **kwargs)
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        return await self._create('directory', lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
 
     async def exists(self, **kwargs):
         # type: (**Any) -> bool
@@ -422,8 +428,14 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
             The timeout parameter is expressed in seconds.
         :return: DataLakeDirectoryClient for the subdirectory.
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         subdir = self.get_sub_directory_client(sub_directory)
-        await subdir.create_directory(metadata=metadata, **kwargs)
+        await subdir.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
         return subdir
 
     async def delete_sub_directory(self, sub_directory,  # type: Union[DirectoryProperties, str]
@@ -549,8 +561,14 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
             The timeout parameter is expressed in seconds.
         :return: DataLakeFileClient
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        await file_client.create_file(**kwargs)
+        await file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
         return file_client
 
     def get_file_client(self, file  # type: Union[FileProperties, str]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
@@ -156,13 +156,7 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
                 :dedent: 8
                 :caption: Create directory.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        return await self._create('directory', lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
+        return await self._create('directory', metadata=metadata, **kwargs)
 
     async def exists(self, **kwargs):
         # type: (**Any) -> bool
@@ -428,14 +422,8 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
             The timeout parameter is expressed in seconds.
         :return: DataLakeDirectoryClient for the subdirectory.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         subdir = self.get_sub_directory_client(sub_directory)
-        await subdir.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
+        await subdir.create_directory(metadata=metadata, **kwargs)
         return subdir
 
     async def delete_sub_directory(self, sub_directory,  # type: Union[DirectoryProperties, str]
@@ -561,14 +549,8 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
             The timeout parameter is expressed in seconds.
         :return: DataLakeFileClient
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        await file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
+        await file_client.create_file(**kwargs)
         return file_client
 
     def get_file_client(self, file  # type: Union[FileProperties, str]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -167,7 +167,7 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
                 :dedent: 4
                 :caption: Create file.
         """
-        return await self._create('file', metadata=metadata, **kwargs)
+        return await self._create('file', content_settings=content_settings, metadata=metadata, **kwargs)
 
     async def exists(self, **kwargs):
         # type: (**Any) -> bool

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -167,13 +167,7 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
                 :dedent: 4
                 :caption: Create file.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        return await self._create('file', lease_id=lease_id, lease_duration=lease_duration, content_settings=content_settings, metadata=metadata, **kwargs)
+        return await self._create('file', metadata=metadata, **kwargs)
 
     async def exists(self, **kwargs):
         # type: (**Any) -> bool

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -167,7 +167,13 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
                 :dedent: 4
                 :caption: Create file.
         """
-        return await self._create('file', content_settings=content_settings, metadata=metadata, **kwargs)
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        return await self._create('file', lease_id=lease_id, lease_duration=lease_duration, content_settings=content_settings, metadata=metadata, **kwargs)
 
     async def exists(self, **kwargs):
         # type: (**Any) -> bool

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -569,14 +569,8 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
                 :dedent: 12
                 :caption: Create directory in the file system.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         directory_client = self.get_directory_client(directory)
-        await directory_client.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
+        await directory_client.create_directory(metadata=metadata, **kwargs)
         return directory_client
 
     @distributed_trace_async
@@ -719,14 +713,8 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
                 :dedent: 12
                 :caption: Create file in the file system.
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
-        if lease_id and not lease_duration:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
-            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        await file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
+        await file_client.create_file(**kwargs)
         return file_client
 
     @distributed_trace_async

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -780,7 +780,6 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
     async def delete_files(
         self,
         *files: str,
-        raise_on_any_failure=False,
         **kwargs) -> List[Optional[HttpResponseError]]:
         """Marks the specified files or empty directories for deletion.
 
@@ -808,7 +807,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
             Specify this header to perform the operation only if
             the resource has not been modified since the specified date/time.
         :keyword bool raise_on_any_failure:
-            This is a boolean param which defaults to False. When this is set, an exception
+            This is a boolean param which defaults to True. When this is set, an exception
             is raised even if there is a single operation failure.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -569,8 +569,14 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
                 :dedent: 12
                 :caption: Create directory in the file system.
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         directory_client = self.get_directory_client(directory)
-        await directory_client.create_directory(metadata=metadata, **kwargs)
+        await directory_client.create_directory(lease_id=lease_id, lease_duration=lease_duration, metadata=metadata, **kwargs)
         return directory_client
 
     @distributed_trace_async
@@ -713,8 +719,14 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
                 :dedent: 12
                 :caption: Create file in the file system.
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         file_client = self.get_file_client(file)
-        await file_client.create_file(**kwargs)
+        await file_client.create_file(lease_id=lease_id, lease_duration=lease_duration, **kwargs)
         return file_client
 
     @distributed_trace_async
@@ -768,6 +780,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
     async def delete_files(
         self,
         *files: str,
+        raise_on_any_failure=False,
         **kwargs) -> List[Optional[HttpResponseError]]:
         """Marks the specified files or empty directories for deletion.
 
@@ -795,7 +808,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
             Specify this header to perform the operation only if
             the resource has not been modified since the specified date/time.
         :keyword bool raise_on_any_failure:
-            This is a boolean param which defaults to True. When this is set, an exception
+            This is a boolean param which defaults to False. When this is set, an exception
             is raised even if there is a single operation failure.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -794,9 +794,6 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
             If a date is passed in without timezone info, it is assumed to be UTC.
             Specify this header to perform the operation only if
             the resource has not been modified since the specified date/time.
-        :keyword bool raise_on_any_failure:
-            This is a boolean param which defaults to True. When this is set, an exception
-            is raised even if there is a single operation failure.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :return: A list containing None for successful operations and
@@ -812,6 +809,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
                 :dedent: 4
                 :caption: Deleting multiple files or empty directories.
         """
+        kwargs['raise_on_any_failure'] = False
         response = await self._container_client.delete_blobs(*files, **kwargs)
 
         errors = []

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -809,8 +809,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
                 :dedent: 4
                 :caption: Deleting multiple files or empty directories.
         """
-        kwargs['raise_on_any_failure'] = False
-        response = await self._container_client.delete_blobs(*files, **kwargs)
+        response = await self._container_client.delete_blobs(raise_on_any_failure=False, *files, **kwargs)
 
         errors = []
         async for result in response:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
@@ -144,14 +144,13 @@ class PathClient(AsyncStorageAccountHostsMixin, PathClientBase):
             (-1) for a lease that never expires. A non-infinite lease can be
             between 15 and 60 seconds. A lease duration cannot be changed
             using renew or change.
-        :keyword expiry_options:
-            Indicates mode of the expiry time.
-            Possible values include: 'NeverExpire', 'RelativeToNow', 'Absolute'"
-        :paramtype expiry_options: Literal["NeverExpire", "RelativeToNow", "Absolute"]
         :keyword expires_on:
             The time to set the file to expiry.
-            When expiry_options is RelativeTo*, expires_on should be an int in milliseconds.
-            If the type of expires_on is datetime, it should be in UTC time.
+            If the type of expires_on is an int, expiration time will be set
+            as the number of milliseconds elapsed from creation time.
+            If the type of expires_on is datetime, expiration time will be set
+            absolute to the time provided. If no time zone info is provided, this
+            will be interpreted as UTC.
         :paramtype expires_on: datetime or int
         :keyword permissions:
             Optional and only valid if Hierarchical Namespace
@@ -192,27 +191,11 @@ class PathClient(AsyncStorageAccountHostsMixin, PathClientBase):
             raise ValueError("Please specify a lease_id and a lease_duration.")
         if lease_duration and not lease_id:
             raise ValueError("Please specify a lease_id and a lease_duration.")
-        if expires_on:
-            if isinstance(expires_on, datetime):
-                options = self._create_path_options(
-                    resource_type,
-                    content_settings=content_settings,
-                    metadata=metadata,
-                    expiry_options='Absolute',
-                    **kwargs)
-            else:
-                options = self._create_path_options(
-                    resource_type,
-                    content_settings=content_settings,
-                    metadata=metadata,
-                    expiry_options='RelativeToNow',
-                    **kwargs)
-        else:
-            options = self._create_path_options(
-                resource_type,
-                content_settings=content_settings,
-                metadata=metadata,
-                **kwargs)
+        options = self._create_path_options(
+            resource_type,
+            content_settings=content_settings,
+            metadata=metadata,
+            **kwargs)
         try:
             return await self._client.path.create(**options)
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
@@ -185,16 +185,14 @@ class PathClient(AsyncStorageAccountHostsMixin, PathClientBase):
             The timeout parameter is expressed in seconds.
         :return: Dict[str, Union[str, datetime]]
         """
-        lease_id = kwargs.pop('lease_id', None)
-        lease_duration = kwargs.pop('lease_duration', None)
+        lease_id = kwargs.get('lease_id', None)
+        lease_duration = kwargs.get('lease_duration', None)
         if lease_id and not lease_duration:
             raise ValueError("Please specify a lease_id and a lease_duration.")
         elif lease_duration and not lease_id:
             raise ValueError("Please specify a lease_id and a lease_duration.")
         options = self._create_path_options(
             resource_type,
-            lease_id=lease_id,
-            lease_duration=lease_duration,
             content_settings=content_settings,
             metadata=metadata,
             **kwargs)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
@@ -187,15 +187,32 @@ class PathClient(AsyncStorageAccountHostsMixin, PathClientBase):
         """
         lease_id = kwargs.get('lease_id', None)
         lease_duration = kwargs.get('lease_duration', None)
+        expires_on = kwargs.get('expires_on', None)
         if lease_id and not lease_duration:
             raise ValueError("Please specify a lease_id and a lease_duration.")
-        elif lease_duration and not lease_id:
+        if lease_duration and not lease_id:
             raise ValueError("Please specify a lease_id and a lease_duration.")
-        options = self._create_path_options(
-            resource_type,
-            content_settings=content_settings,
-            metadata=metadata,
-            **kwargs)
+        if expires_on:
+            if isinstance(expires_on, datetime):
+                options = self._create_path_options(
+                    resource_type,
+                    content_settings=content_settings,
+                    metadata=metadata,
+                    expiry_options='Absolute',
+                    **kwargs)
+            else:
+                options = self._create_path_options(
+                    resource_type,
+                    content_settings=content_settings,
+                    metadata=metadata,
+                    expiry_options='RelativeToNow',
+                    **kwargs)
+        else:
+            options = self._create_path_options(
+                resource_type,
+                content_settings=content_settings,
+                metadata=metadata,
+                **kwargs)
         try:
             return await self._client.path.create(**options)
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
@@ -185,8 +185,16 @@ class PathClient(AsyncStorageAccountHostsMixin, PathClientBase):
             The timeout parameter is expressed in seconds.
         :return: Dict[str, Union[str, datetime]]
         """
+        lease_id = kwargs.pop('lease_id', None)
+        lease_duration = kwargs.pop('lease_duration', None)
+        if lease_id and not lease_duration:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
+        elif lease_duration and not lease_id:
+            raise ValueError("Please specify a lease_id and a lease_duration.")
         options = self._create_path_options(
             resource_type,
+            lease_id=lease_id,
+            lease_duration=lease_duration,
             content_settings=content_settings,
             metadata=metadata,
             **kwargs)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
@@ -186,7 +186,6 @@ class PathClient(AsyncStorageAccountHostsMixin, PathClientBase):
         """
         lease_id = kwargs.get('lease_id', None)
         lease_duration = kwargs.get('lease_duration', None)
-        expires_on = kwargs.get('expires_on', None)
         if lease_id and not lease_duration:
             raise ValueError("Please specify a lease_id and a lease_duration.")
         if lease_duration and not lease_id:

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system.py
@@ -243,7 +243,6 @@ class FileSystemSamples(object):
             'file3',
             'dir1', # dir1 is not empty
             'dir8', # dir8 doesn't exist
-            raise_on_any_failure=False
         )
         print("Total number of sub-responses: " + len(response) + "\n")
         print("First failure error code: " + response[3].error_code + "\n")

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system_async.py
@@ -252,7 +252,6 @@ class FileSystemSamplesAsync(object):
             'file3',
             'dir1', # dir1 is not empty
             'dir8', # dir8 doesn't exist
-            raise_on_any_failure=False
         )
         print("Total number of sub-responses: " + len(response) + "\n")
         print("First failure error code: " + response[3].error_code + "\n")

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file_absolute_expiry.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file_absolute_expiry.yaml
@@ -13,9 +13,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/filesystem6e95113e?restype=container&timeout=5
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 06 May 2022 21:01:26 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       etag:
-      - '"0x8DA2FA395EC3B2F"'
+      - '"0x8DA44288AC24FF8"'
       last-modified:
-      - Fri, 06 May 2022 21:01:26 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -51,9 +51,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem6e95113e/directory6e95113e?resource=directory
   response:
@@ -63,17 +63,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 06 May 2022 21:01:26 GMT
+      - Wed, 01 Jun 2022 23:43:33 GMT
       etag:
-      - '"0x8DA2FA396462837"'
+      - '"0x8DA44288B0EDF92"'
       last-modified:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -91,13 +91,13 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:01:28 GMT
+      - Wed, 01 Jun 2022 23:43:35 GMT
       x-ms-expiry-option:
       - Absolute
       x-ms-expiry-time:
       - Thu, 04 Apr 2075 00:00:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem6e95113e/directory6e95113e%2Ffilename?resource=file
   response:
@@ -107,17 +107,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 06 May 2022 21:01:26 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       etag:
-      - '"0x8DA2FA3965737FB"'
+      - '"0x8DA44288B202DD9"'
       last-modified:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -133,9 +133,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:01:28 GMT
+      - Wed, 01 Jun 2022 23:43:35 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystem6e95113e/directory6e95113e/filename
   response:
@@ -149,11 +149,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       etag:
-      - '"0x8DA2FA3965737FB"'
+      - '"0x8DA44288B202DD9"'
       last-modified:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
@@ -163,7 +163,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:34 GMT
       x-ms-expiry-time:
       - Thu, 04 Apr 2075 00:00:00 GMT
       x-ms-group:
@@ -181,7 +181,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -199,9 +199,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:01:28 GMT
+      - Wed, 01 Jun 2022 23:43:35 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/filesystem6e95113e?restype=container
   response:
@@ -211,11 +211,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 06 May 2022 21:01:27 GMT
+      - Wed, 01 Jun 2022 23:43:35 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file_relative_expiry.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_create_file_relative_expiry.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:11:36 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/filesystem6ead113b?restype=container&timeout=5
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 04 May 2022 23:11:36 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       etag:
-      - '"0x8DA2E2370557AFC"'
+      - '"0x8DA44288427ACD7"'
       last-modified:
-      - Wed, 04 May 2022 23:11:36 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:11:36 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem6ead113b/directory6ead113b?resource=directory
   response:
@@ -63,17 +63,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       etag:
-      - '"0x8DA2E2370A86755"'
+      - '"0x8DA4428845D302E"'
       last-modified:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -89,15 +89,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       x-ms-expiry-option:
       - RelativeToNow
       x-ms-expiry-time:
       - '86400000'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem6ead113b/directory6ead113b%2Ffilename?resource=file
   response:
@@ -107,17 +107,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       etag:
-      - '"0x8DA2E2370C04A23"'
+      - '"0x8DA4428846F140A"'
       last-modified:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -131,11 +131,11 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystem6ead113b/directory6ead113b/filename
   response:
@@ -149,11 +149,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 04 May 2022 23:11:36 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       etag:
-      - '"0x8DA2E2370C04A23"'
+      - '"0x8DA4428846F140A"'
       last-modified:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
@@ -163,9 +163,9 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       x-ms-expiry-time:
-      - Thu, 05 May 2022 23:11:37 GMT
+      - Thu, 02 Jun 2022 23:43:23 GMT
       x-ms-group:
       - $superuser
       x-ms-lease-state:
@@ -181,7 +181,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -197,11 +197,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/filesystem6ead113b?restype=container
   response:
@@ -211,11 +211,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 04 May 2022 23:11:37 GMT
+      - Wed, 01 Jun 2022 23:43:23 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_absolute_expiry_async.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_absolute_expiry_async.yaml
@@ -7,9 +7,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:03:55 GMT
+      - Wed, 01 Jun 2022 23:45:52 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/filesystem5ecd1638?restype=container&timeout=5
   response:
@@ -17,15 +17,15 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 06 May 2022 21:03:54 GMT
-      etag: '"0x8DA2FA3EE640BB7"'
-      last-modified: Fri, 06 May 2022 21:03:55 GMT
+      date: Wed, 01 Jun 2022 23:45:51 GMT
+      etag: '"0x8DA4428DCD84CFE"'
+      last-modified: Wed, 01 Jun 2022 23:45:52 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem5ecd1638?restype=container&timeout=5
+    url: https://vincenttranhns.blob.core.windows.net/filesystem5ecd1638?restype=container&timeout=5
 - request:
     body: null
     headers:
@@ -34,9 +34,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:03:56 GMT
+      - Wed, 01 Jun 2022 23:45:52 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem5ecd1638/directory5ecd1638?resource=directory
   response:
@@ -44,16 +44,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 06 May 2022 21:03:54 GMT
-      etag: '"0x8DA2FA3EEAAA193"'
-      last-modified: Fri, 06 May 2022 21:03:55 GMT
+      date: Wed, 01 Jun 2022 23:45:51 GMT
+      etag: '"0x8DA4428DD048871"'
+      last-modified: Wed, 01 Jun 2022 23:45:52 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/filesystem5ecd1638/directory5ecd1638?resource=directory
+    url: https://vincenttranhns.dfs.core.windows.net/filesystem5ecd1638/directory5ecd1638?resource=directory
 - request:
     body: null
     headers:
@@ -62,13 +62,13 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:03:56 GMT
+      - Wed, 01 Jun 2022 23:45:52 GMT
       x-ms-expiry-option:
       - Absolute
       x-ms-expiry-time:
       - Thu, 04 Apr 2075 00:00:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem5ecd1638/directory5ecd1638%2Ffilename?resource=file
   response:
@@ -76,16 +76,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 06 May 2022 21:03:55 GMT
-      etag: '"0x8DA2FA3EEBC12A6"'
-      last-modified: Fri, 06 May 2022 21:03:55 GMT
+      date: Wed, 01 Jun 2022 23:45:52 GMT
+      etag: '"0x8DA4428DD11F840"'
+      last-modified: Wed, 01 Jun 2022 23:45:52 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/filesystem5ecd1638/directory5ecd1638%2Ffilename?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/filesystem5ecd1638/directory5ecd1638%2Ffilename?resource=file
 - request:
     body: null
     headers:
@@ -94,9 +94,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:03:56 GMT
+      - Wed, 01 Jun 2022 23:45:52 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystem5ecd1638/directory5ecd1638/filename
   response:
@@ -106,14 +106,14 @@ interactions:
       accept-ranges: bytes
       content-length: '0'
       content-type: application/octet-stream
-      date: Fri, 06 May 2022 21:03:55 GMT
-      etag: '"0x8DA2FA3EEBC12A6"'
-      last-modified: Fri, 06 May 2022 21:03:55 GMT
+      date: Wed, 01 Jun 2022 23:45:51 GMT
+      etag: '"0x8DA4428DD11F840"'
+      last-modified: Wed, 01 Jun 2022 23:45:52 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Fri, 06 May 2022 21:03:55 GMT
+      x-ms-creation-time: Wed, 01 Jun 2022 23:45:52 GMT
       x-ms-expiry-time: Thu, 04 Apr 2075 00:00:00 GMT
       x-ms-group: $superuser
       x-ms-lease-state: available
@@ -122,11 +122,11 @@ interactions:
       x-ms-permissions: rw-r-----
       x-ms-resource-type: file
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem5ecd1638/directory5ecd1638/filename
+    url: https://vincenttranhns.blob.core.windows.net/filesystem5ecd1638/directory5ecd1638/filename
 - request:
     body: null
     headers:
@@ -135,9 +135,9 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 06 May 2022 21:03:56 GMT
+      - Wed, 01 Jun 2022 23:45:52 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/filesystem5ecd1638?restype=container
   response:
@@ -145,11 +145,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 06 May 2022 21:03:55 GMT
+      date: Wed, 01 Jun 2022 23:45:51 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem5ecd1638?restype=container
+    url: https://vincenttranhns.blob.core.windows.net/filesystem5ecd1638?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_relative_expiry_async.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_create_file_relative_expiry_async.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:36:07 GMT
+      - Wed, 01 Jun 2022 23:45:40 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/filesystem5ed31635?restype=container&timeout=5
   response:
@@ -17,26 +17,26 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 04 May 2022 23:36:07 GMT
-      etag: '"0x8DA2E26DD1DA579"'
-      last-modified: Wed, 04 May 2022 23:36:07 GMT
+      date: Wed, 01 Jun 2022 23:45:40 GMT
+      etag: '"0x8DA4428D5E2DBD3"'
+      last-modified: Wed, 01 Jun 2022 23:45:40 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem5ed31635?restype=container&timeout=5
+    url: https://vincenttranhns.blob.core.windows.net/filesystem5ed31635?restype=container&timeout=5
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:36:07 GMT
+      - Wed, 01 Jun 2022 23:45:40 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem5ed31635/directory5ed31635?resource=directory
   response:
@@ -44,31 +44,31 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 04 May 2022 23:36:07 GMT
-      etag: '"0x8DA2E26DD5554B8"'
-      last-modified: Wed, 04 May 2022 23:36:08 GMT
+      date: Wed, 01 Jun 2022 23:45:40 GMT
+      etag: '"0x8DA4428D61781F4"'
+      last-modified: Wed, 01 Jun 2022 23:45:40 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/filesystem5ed31635/directory5ed31635?resource=directory
+    url: https://vincenttranhns.dfs.core.windows.net/filesystem5ed31635/directory5ed31635?resource=directory
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:36:08 GMT
+      - Wed, 01 Jun 2022 23:45:41 GMT
       x-ms-expiry-option:
       - RelativeToNow
       x-ms-expiry-time:
       - '86400000'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/filesystem5ed31635/directory5ed31635%2Ffilename?resource=file
   response:
@@ -76,27 +76,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 04 May 2022 23:36:07 GMT
-      etag: '"0x8DA2E26DD6C9022"'
-      last-modified: Wed, 04 May 2022 23:36:08 GMT
+      date: Wed, 01 Jun 2022 23:45:40 GMT
+      etag: '"0x8DA4428D624E786"'
+      last-modified: Wed, 01 Jun 2022 23:45:40 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/filesystem5ed31635/directory5ed31635%2Ffilename?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/filesystem5ed31635/directory5ed31635%2Ffilename?resource=file
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:36:08 GMT
+      - Wed, 01 Jun 2022 23:45:41 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/filesystem5ed31635/directory5ed31635/filename
   response:
@@ -106,15 +106,15 @@ interactions:
       accept-ranges: bytes
       content-length: '0'
       content-type: application/octet-stream
-      date: Wed, 04 May 2022 23:36:08 GMT
-      etag: '"0x8DA2E26DD6C9022"'
-      last-modified: Wed, 04 May 2022 23:36:08 GMT
+      date: Wed, 01 Jun 2022 23:45:40 GMT
+      etag: '"0x8DA4428D624E786"'
+      last-modified: Wed, 01 Jun 2022 23:45:40 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 04 May 2022 23:36:08 GMT
-      x-ms-expiry-time: Thu, 05 May 2022 23:36:08 GMT
+      x-ms-creation-time: Wed, 01 Jun 2022 23:45:40 GMT
+      x-ms-expiry-time: Thu, 02 Jun 2022 23:45:40 GMT
       x-ms-group: $superuser
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
@@ -122,22 +122,22 @@ interactions:
       x-ms-permissions: rw-r-----
       x-ms-resource-type: file
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem5ed31635/directory5ed31635/filename
+    url: https://vincenttranhns.blob.core.windows.net/filesystem5ed31635/directory5ed31635/filename
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Wed, 04 May 2022 23:36:08 GMT
+      - Wed, 01 Jun 2022 23:45:41 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/filesystem5ed31635?restype=container
   response:
@@ -145,11 +145,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 04 May 2022 23:36:08 GMT
+      date: Wed, 01 Jun 2022 23:45:40 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/filesystem5ed31635?restype=container
+    url: https://vincenttranhns.blob.core.windows.net/filesystem5ed31635?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_simple_no_raise.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_simple_no_raise.yaml
@@ -480,24 +480,19 @@ interactions:
 - request:
     body: "--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       0\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/file1? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 7939cb0d-e2c6-11ec-adc2-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:qPQlEdY0dIaLv1Dwk8hFmaOyuvwW0XNcxUYrYxeSLxM=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 7939cb0d-e2c6-11ec-adc2-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       1\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/file2? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 7939f076-e2c6-11ec-a360-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:zKgRWF2w6JCwcAtYUFb8DqIRVZ/eWJ4YaTTewiC3DqA=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 7939f076-e2c6-11ec-a360-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       2\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/file3? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180d-e2c6-11ec-841a-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:aaVGnedtPP9tx/EYrDVQgdhjvef+HhVmImX9S+ucdwY=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180d-e2c6-11ec-841a-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       3\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/dir1? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180e-e2c6-11ec-9fca-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:gTFcuNdHkXJ9Yw/4LG0aWCOHAsDDOQhqwX5zyyiRkO8=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180e-e2c6-11ec-9fca-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       4\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/dir2? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180f-e2c6-11ec-95cf-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:sUeWl+uxnJ5n+NGLH1Eib58vu0nNzuDtteUKNBrxUwQ=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180f-e2c6-11ec-95cf-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0--\r\n"
     headers:
       Accept:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_simple_no_raise.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_simple_no_raise.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:23 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/fs1d66148e?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:23 GMT
+      - Thu, 02 Jun 2022 22:50:58 GMT
       etag:
-      - '"0x8DA2A308D0BF7DC"'
+      - '"0x8DA44EA5C3CB3DC"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:23 GMT
+      - Thu, 02 Jun 2022 22:50:58 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file1?resource=file
   response:
@@ -63,17 +63,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:23 GMT
+      - Thu, 02 Jun 2022 22:50:58 GMT
       etag:
-      - '"0x8DA2A308D7188EE"'
+      - '"0x8DA44EA5C700833"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -91,11 +91,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file1?action=append&position=0
   response:
@@ -105,13 +105,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:58 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -127,13 +127,13 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - '"0x8DA2A308D7188EE"'
+      - '"0x8DA44EA5C700833"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file1?action=flush&position=11&close=true
   response:
@@ -143,17 +143,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:58 GMT
       etag:
-      - '"0x8DA2A308D962C00"'
+      - '"0x8DA44EA5C88BDEC"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -169,11 +169,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file2?resource=file
   response:
@@ -183,17 +183,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       etag:
-      - '"0x8DA2A308DA83ED5"'
+      - '"0x8DA44EA5C953D76"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -211,11 +211,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file2?action=append&position=0
   response:
@@ -225,13 +225,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -247,13 +247,13 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - '"0x8DA2A308DA83ED5"'
+      - '"0x8DA44EA5C953D76"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file2?action=flush&position=11&close=true
   response:
@@ -263,17 +263,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       etag:
-      - '"0x8DA2A308DCB08CA"'
+      - '"0x8DA44EA5CAD2F12"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -289,11 +289,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file3?resource=file
   response:
@@ -303,17 +303,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       etag:
-      - '"0x8DA2A308DDC195E"'
+      - '"0x8DA44EA5CBA58F1"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -331,11 +331,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file3?action=append&position=0
   response:
@@ -345,13 +345,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -367,13 +367,13 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - '"0x8DA2A308DDC195E"'
+      - '"0x8DA44EA5CBA58F1"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/file3?action=flush&position=11&close=true
   response:
@@ -383,17 +383,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:24 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       etag:
-      - '"0x8DA2A308DFF8708"'
+      - '"0x8DA44EA5CD421A4"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -409,11 +409,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/dir1?resource=directory
   response:
@@ -423,17 +423,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       etag:
-      - '"0x8DA2A308E103719"'
+      - '"0x8DA44EA5CDFE9E8"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -449,11 +449,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs1d66148e/dir2?resource=directory
   response:
@@ -463,37 +463,42 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       etag:
-      - '"0x8DA2A308E212E76"'
+      - '"0x8DA44EA5CEBE139"'
       last-modified:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
 - request:
-    body: "--batch_a9ea145f-c80c-11ec-8646-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+    body: "--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       0\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/file1? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 22:35:25 GMT\r\nx-ms-client-request-id: a9ea875c-c80c-11ec-9ed1-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_a9ea145f-c80c-11ec-8646-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 7939cb0d-e2c6-11ec-adc2-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:qPQlEdY0dIaLv1Dwk8hFmaOyuvwW0XNcxUYrYxeSLxM=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       1\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/file2? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 22:35:25 GMT\r\nx-ms-client-request-id: a9ea875d-c80c-11ec-9a45-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_a9ea145f-c80c-11ec-8646-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 7939f076-e2c6-11ec-a360-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:zKgRWF2w6JCwcAtYUFb8DqIRVZ/eWJ4YaTTewiC3DqA=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       2\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/file3? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 22:35:25 GMT\r\nx-ms-client-request-id: a9ea875e-c80c-11ec-be13-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_a9ea145f-c80c-11ec-8646-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180d-e2c6-11ec-841a-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:aaVGnedtPP9tx/EYrDVQgdhjvef+HhVmImX9S+ucdwY=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       3\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/dir1? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 22:35:25 GMT\r\nx-ms-client-request-id: a9eaaff1-c80c-11ec-b972-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_a9ea145f-c80c-11ec-8646-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180e-e2c6-11ec-9fca-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:gTFcuNdHkXJ9Yw/4LG0aWCOHAsDDOQhqwX5zyyiRkO8=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       4\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs1d66148e/dir2? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 22:35:25 GMT\r\nx-ms-client-request-id: a9eaaff2-c80c-11ec-8019-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_a9ea145f-c80c-11ec-8646-4851c58829e0--\r\n"
+      Thu, 02 Jun 2022 22:51:00 GMT\r\nx-ms-client-request-id: 793a180f-e2c6-11ec-95cf-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:sUeWl+uxnJ5n+NGLH1Eib58vu0nNzuDtteUKNBrxUwQ=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_79395630-e2c6-11ec-8c1f-4851c58829e0--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -502,51 +507,51 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1956'
+      - '1941'
       Content-Type:
-      - multipart/mixed; boundary=batch_a9ea145f-c80c-11ec-8646-4851c58829e0
+      - multipart/mixed; boundary=batch_79395630-e2c6-11ec-8c1f-4851c58829e0
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:25 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: POST
     uri: https://storagename.blob.core.windows.net/fs1d66148e?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_ba9f8e54-15a7-4b17-a7c9-ec22696fb0df\r\nContent-Type:
+      string: "--batchresponse_43c8c3ec-c6dd-4df4-82d2-660996cc714a\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 2cb7ed92-e01e-0071-0619-5c3ce91e34b6\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a9ea875c-c80c-11ec-9ed1-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ba9f8e54-15a7-4b17-a7c9-ec22696fb0df\r\nContent-Type:
+        true\r\nx-ms-request-id: de1371b8-a01e-0078-52d3-7639791ea0dc\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 7939cb0d-e2c6-11ec-adc2-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_43c8c3ec-c6dd-4df4-82d2-660996cc714a\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 2cb7ed92-e01e-0071-0619-5c3ce91e34ba\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a9ea875d-c80c-11ec-9a45-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ba9f8e54-15a7-4b17-a7c9-ec22696fb0df\r\nContent-Type:
+        true\r\nx-ms-request-id: de1371b8-a01e-0078-52d3-7639791ea0de\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 7939f076-e2c6-11ec-a360-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_43c8c3ec-c6dd-4df4-82d2-660996cc714a\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 2cb7ed92-e01e-0071-0619-5c3ce91e34bb\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a9ea875e-c80c-11ec-be13-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ba9f8e54-15a7-4b17-a7c9-ec22696fb0df\r\nContent-Type:
+        true\r\nx-ms-request-id: de1371b8-a01e-0078-52d3-7639791ea0df\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 793a180d-e2c6-11ec-841a-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_43c8c3ec-c6dd-4df4-82d2-660996cc714a\r\nContent-Type:
         application/http\r\nContent-ID: 3\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 2cb7ed92-e01e-0071-0619-5c3ce91e34bc\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a9eaaff1-c80c-11ec-b972-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ba9f8e54-15a7-4b17-a7c9-ec22696fb0df\r\nContent-Type:
+        true\r\nx-ms-request-id: de1371b8-a01e-0078-52d3-7639791ea0e0\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 793a180e-e2c6-11ec-9fca-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_43c8c3ec-c6dd-4df4-82d2-660996cc714a\r\nContent-Type:
         application/http\r\nContent-ID: 4\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 2cb7ed92-e01e-0071-0619-5c3ce91e34bd\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a9eaaff2-c80c-11ec-8019-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ba9f8e54-15a7-4b17-a7c9-ec22696fb0df--"
+        true\r\nx-ms-request-id: de1371b8-a01e-0078-52d3-7639791ea0e1\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 793a180f-e2c6-11ec-95cf-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_43c8c3ec-c6dd-4df4-82d2-660996cc714a--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_ba9f8e54-15a7-4b17-a7c9-ec22696fb0df
+      - multipart/mixed; boundary=batchresponse_43c8c3ec-c6dd-4df4-82d2-660996cc714a
       date:
-      - Fri, 29 Apr 2022 22:35:28 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -562,11 +567,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 22:35:28 GMT
+      - Thu, 02 Jun 2022 22:51:00 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/fs1d66148e?restype=container
   response:
@@ -576,11 +581,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 22:35:28 GMT
+      - Thu, 02 Jun 2022 22:50:59 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_with_failed_subrequest.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_with_failed_subrequest.yaml
@@ -440,24 +440,19 @@ interactions:
 - request:
     body: "--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       0\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/file1? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f114-e2c6-11ec-980f-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:4RB3cs+kkQDmrfGDHWxj6SVsapBW0gKTob9zUEEWXXM=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f114-e2c6-11ec-980f-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       1\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/file2? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f115-e2c6-11ec-b3eb-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:NmuVV5uaqWyrTgadxgb6HgdCKzTueNVn9n67neHu5A8=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f115-e2c6-11ec-b3eb-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       2\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/file3? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f116-e2c6-11ec-852c-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:OMPB0R1YzfH2lf2GQW8bBMIOs4TsDSlQSY82v2Jc/yI=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f116-e2c6-11ec-852c-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       3\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/dir1? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f117-e2c6-11ec-b4e1-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:U7J0O5/HvC2qifYBFnHg1g1pI6XBLzIBPy0ktBRDwbg=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f117-e2c6-11ec-b4e1-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       4\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/dir8? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 70691b56-e2c6-11ec-8fab-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:X046UmioS5zqf9wkx3aVVTQbRXvETl+IsAEvVhpo+us=\r\nContent-Length:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 70691b56-e2c6-11ec-8fab-4851c58829e0\r\r\nContent-Length:
       0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0--\r\n"
     headers:
       Accept:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_with_failed_subrequest.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_delete_files_with_failed_subrequest.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:25 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/fs2a8621787?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:43 GMT
       etag:
-      - '"0x8DA2A3624DCF7E3"'
+      - '"0x8DA44EA535EB30C"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:43 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file1?resource=file
   response:
@@ -63,17 +63,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       etag:
-      - '"0x8DA2A36253BBA22"'
+      - '"0x8DA44EA53A89162"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -91,11 +91,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file1?action=append&position=0
   response:
@@ -105,13 +105,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -127,13 +127,13 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - '"0x8DA2A36253BBA22"'
+      - '"0x8DA44EA53A89162"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file1?action=flush&position=11&close=true
   response:
@@ -143,17 +143,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       etag:
-      - '"0x8DA2A36255AD18E"'
+      - '"0x8DA44EA53C15F48"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -169,11 +169,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file2?resource=file
   response:
@@ -183,17 +183,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       etag:
-      - '"0x8DA2A3625696885"'
+      - '"0x8DA44EA53CE02F5"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -211,11 +211,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file2?action=append&position=0
   response:
@@ -225,13 +225,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -247,13 +247,13 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - '"0x8DA2A3625696885"'
+      - '"0x8DA44EA53CE02F5"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file2?action=flush&position=11&close=true
   response:
@@ -263,17 +263,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       etag:
-      - '"0x8DA2A36258795C0"'
+      - '"0x8DA44EA53E5D3AE"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -289,11 +289,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file3?resource=file
   response:
@@ -303,17 +303,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       etag:
-      - '"0x8DA2A3625957FE0"'
+      - '"0x8DA44EA53F201AB"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -331,11 +331,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file3?action=append&position=0
   response:
@@ -345,13 +345,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -367,13 +367,13 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - '"0x8DA2A3625957FE0"'
+      - '"0x8DA44EA53F201AB"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/file3?action=flush&position=11&close=true
   response:
@@ -383,17 +383,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:26 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       etag:
-      - '"0x8DA2A3625B2DB32"'
+      - '"0x8DA44EA540B6288"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -409,11 +409,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2a8621787/dir1%2Ffile4?resource=file
   response:
@@ -423,37 +423,42 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       etag:
-      - '"0x8DA2A3625C56F9F"'
+      - '"0x8DA44EA541B16EA"'
       last-modified:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       server:
       - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
 - request:
-    body: "--batch_4189a7ce-c812-11ec-a629-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+    body: "--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       0\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/file1? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 23:15:27 GMT\r\nx-ms-client-request-id: 418a1d14-c812-11ec-bfb8-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_4189a7ce-c812-11ec-a629-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f114-e2c6-11ec-980f-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:4RB3cs+kkQDmrfGDHWxj6SVsapBW0gKTob9zUEEWXXM=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       1\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/file2? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 23:15:27 GMT\r\nx-ms-client-request-id: 418a448a-c812-11ec-8b10-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_4189a7ce-c812-11ec-a629-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f115-e2c6-11ec-b3eb-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:NmuVV5uaqWyrTgadxgb6HgdCKzTueNVn9n67neHu5A8=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       2\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/file3? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 23:15:27 GMT\r\nx-ms-client-request-id: 418a6d44-c812-11ec-92a9-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_4189a7ce-c812-11ec-a629-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f116-e2c6-11ec-852c-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:OMPB0R1YzfH2lf2GQW8bBMIOs4TsDSlQSY82v2Jc/yI=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       3\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/dir1? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 23:15:27 GMT\r\nx-ms-client-request-id: 418a6d45-c812-11ec-b617-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_4189a7ce-c812-11ec-a629-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 7068f117-e2c6-11ec-b4e1-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:U7J0O5/HvC2qifYBFnHg1g1pI6XBLzIBPy0ktBRDwbg=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0\r\nContent-Type: application/http\r\nContent-ID:
       4\r\nContent-Transfer-Encoding: binary\r\n\r\nDELETE /fs2a8621787/dir8? HTTP/1.1\r\nx-ms-date:
-      Fri, 29 Apr 2022 23:15:27 GMT\r\nx-ms-client-request-id: 418a9421-c812-11ec-a874-4851c58829e0\r\nContent-Length:
-      0\r\n\r\n\r\n--batch_4189a7ce-c812-11ec-a629-4851c58829e0--\r\n"
+      Thu, 02 Jun 2022 22:50:45 GMT\r\nx-ms-client-request-id: 70691b56-e2c6-11ec-8fab-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:X046UmioS5zqf9wkx3aVVTQbRXvETl+IsAEvVhpo+us=\r\nContent-Length:
+      0\r\n\r\n\r\n--batch_7068a476-e2c6-11ec-986b-4851c58829e0--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -462,56 +467,56 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1961'
+      - '1946'
       Content-Type:
-      - multipart/mixed; boundary=batch_4189a7ce-c812-11ec-a629-4851c58829e0
+      - multipart/mixed; boundary=batch_7068a476-e2c6-11ec-986b-4851c58829e0
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: POST
     uri: https://storagename.blob.core.windows.net/fs2a8621787?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_8c8a1494-ab24-45e6-9002-72fefb959551\r\nContent-Type:
+      string: "--batchresponse_17796a07-cb06-4d65-9d79-aa0f8c6b6a8f\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 7644e28f-001e-009d-3b1f-5c28781e453b\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: 418a1d14-c812-11ec-bfb8-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8c8a1494-ab24-45e6-9002-72fefb959551\r\nContent-Type:
+        true\r\nx-ms-request-id: 446a0760-701e-00c2-0dd3-76dc071ea5a1\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 7068f114-e2c6-11ec-980f-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_17796a07-cb06-4d65-9d79-aa0f8c6b6a8f\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 7644e28f-001e-009d-3b1f-5c28781e453d\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: 418a448a-c812-11ec-8b10-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8c8a1494-ab24-45e6-9002-72fefb959551\r\nContent-Type:
+        true\r\nx-ms-request-id: 446a0760-701e-00c2-0dd3-76dc071ea5a3\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 7068f115-e2c6-11ec-b3eb-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_17796a07-cb06-4d65-9d79-aa0f8c6b6a8f\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 7644e28f-001e-009d-3b1f-5c28781e453e\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: 418a6d44-c812-11ec-92a9-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8c8a1494-ab24-45e6-9002-72fefb959551\r\nContent-Type:
+        true\r\nx-ms-request-id: 446a0760-701e-00c2-0dd3-76dc071ea5a4\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 7068f116-e2c6-11ec-852c-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_17796a07-cb06-4d65-9d79-aa0f8c6b6a8f\r\nContent-Type:
         application/http\r\nContent-ID: 3\r\n\r\nHTTP/1.1 409 The directory involved
         in this operation is not empty\r\nx-ms-error-code: DirectoryNotEmpty\r\nx-ms-request-id:
-        7644e28f-001e-009d-3b1f-5c28781e4540\r\nx-ms-version: 2021-06-08\r\nx-ms-client-request-id:
-        418a6d45-c812-11ec-b617-4851c58829e0\r\nContent-Length: 240\r\nContent-Type:
+        446a0760-701e-00c2-0dd3-76dc071ea5a5\r\nx-ms-version: 2021-08-06\r\nx-ms-client-request-id:
+        7068f117-e2c6-11ec-b4e1-4851c58829e0\r\nContent-Length: 240\r\nContent-Type:
         application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
         encoding=\"utf-8\"?>\n<Error><Code>DirectoryNotEmpty</Code><Message>The directory
-        involved in this operation is not empty\nRequestId:7644e28f-001e-009d-3b1f-5c28781e4540\nTime:2022-04-29T23:15:28.0807231Z</Message></Error>\r\n--batchresponse_8c8a1494-ab24-45e6-9002-72fefb959551\r\nContent-Type:
+        involved in this operation is not empty\nRequestId:446a0760-701e-00c2-0dd3-76dc071ea5a5\nTime:2022-06-02T22:50:45.1359939Z</Message></Error>\r\n--batchresponse_17796a07-cb06-4d65-9d79-aa0f8c6b6a8f\r\nContent-Type:
         application/http\r\nContent-ID: 4\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 7644e28f-001e-009d-3b1f-5c28781e4541\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: 418a9421-c812-11ec-a874-4851c58829e0\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 446a0760-701e-00c2-0dd3-76dc071ea5a6\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 70691b56-e2c6-11ec-8fab-4851c58829e0\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:7644e28f-001e-009d-3b1f-5c28781e4541\nTime:2022-04-29T23:15:28.0697292Z</Message></Error>\r\n--batchresponse_8c8a1494-ab24-45e6-9002-72fefb959551--"
+        specified blob does not exist.\nRequestId:446a0760-701e-00c2-0dd3-76dc071ea5a6\nTime:2022-06-02T22:50:45.1439887Z</Message></Error>\r\n--batchresponse_17796a07-cb06-4d65-9d79-aa0f8c6b6a8f--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_8c8a1494-ab24-45e6-9002-72fefb959551
+      - multipart/mixed; boundary=batchresponse_17796a07-cb06-4d65-9d79-aa0f8c6b6a8f
       date:
-      - Fri, 29 Apr 2022 23:15:27 GMT
+      - Thu, 02 Jun 2022 22:50:44 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted
@@ -527,11 +532,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 23:15:28 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/fs2a8621787?restype=container
   response:
@@ -541,11 +546,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 29 Apr 2022 23:15:28 GMT
+      - Thu, 02 Jun 2022 22:50:45 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_simple_no_raise.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_simple_no_raise.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:04 GMT
+      - Thu, 02 Jun 2022 22:51:32 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/fs2932d170b?restype=container
   response:
@@ -17,26 +17,26 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:04 GMT
-      etag: '"0x8DA2A42871313E8"'
-      last-modified: Sat, 30 Apr 2022 00:44:04 GMT
+      date: Thu, 02 Jun 2022 22:51:31 GMT
+      etag: '"0x8DA44EA700F0B50"'
+      last-modified: Thu, 02 Jun 2022 22:51:31 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.blob.core.windows.net/fs2932d170b?restype=container
+    url: https://vincenttranhns.blob.core.windows.net/fs2932d170b?restype=container
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:04 GMT
+      - Thu, 02 Jun 2022 22:51:32 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file1?resource=file
   response:
@@ -44,16 +44,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:04 GMT
-      etag: '"0x8DA2A428776CDF2"'
-      last-modified: Sat, 30 Apr 2022 00:44:05 GMT
+      date: Thu, 02 Jun 2022 22:51:31 GMT
+      etag: '"0x8DA44EA7041A0B2"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file1?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file1?resource=file
 - request:
     body: hello world
     headers:
@@ -64,11 +64,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:05 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file1?action=append&position=0
   response:
@@ -76,27 +76,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:04 GMT
+      date: Thu, 02 Jun 2022 22:51:31 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file1?action=append&position=0
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file1?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA2A428776CDF2"'
+      - '"0x8DA44EA7041A0B2"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:05 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file1?action=flush&position=11&close=true
   response:
@@ -104,27 +104,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:04 GMT
-      etag: '"0x8DA2A428793423C"'
-      last-modified: Sat, 30 Apr 2022 00:44:05 GMT
+      date: Thu, 02 Jun 2022 22:51:31 GMT
+      etag: '"0x8DA44EA705857F2"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file1?action=flush&position=11&close=true
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file1?action=flush&position=11&close=true
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:05 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file2?resource=file
   response:
@@ -132,16 +132,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:04 GMT
-      etag: '"0x8DA2A4287A01595"'
-      last-modified: Sat, 30 Apr 2022 00:44:05 GMT
+      date: Thu, 02 Jun 2022 22:51:31 GMT
+      etag: '"0x8DA44EA70628B21"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file2?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file2?resource=file
 - request:
     body: hello world
     headers:
@@ -152,11 +152,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:05 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file2?action=append&position=0
   response:
@@ -164,27 +164,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:05 GMT
+      date: Thu, 02 Jun 2022 22:51:31 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file2?action=append&position=0
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file2?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA2A4287A01595"'
+      - '"0x8DA44EA70628B21"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:05 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file2?action=flush&position=11&close=true
   response:
@@ -192,27 +192,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:05 GMT
-      etag: '"0x8DA2A4287BAB088"'
-      last-modified: Sat, 30 Apr 2022 00:44:05 GMT
+      date: Thu, 02 Jun 2022 22:51:32 GMT
+      etag: '"0x8DA44EA70778166"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file2?action=flush&position=11&close=true
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file2?action=flush&position=11&close=true
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:05 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file3?resource=file
   response:
@@ -220,16 +220,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:05 GMT
-      etag: '"0x8DA2A4287C81BDA"'
-      last-modified: Sat, 30 Apr 2022 00:44:06 GMT
+      date: Thu, 02 Jun 2022 22:51:32 GMT
+      etag: '"0x8DA44EA70820FA1"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file3?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file3?resource=file
 - request:
     body: hello world
     headers:
@@ -240,11 +240,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:05 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file3?action=append&position=0
   response:
@@ -252,27 +252,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:05 GMT
+      date: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file3?action=append&position=0
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file3?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA2A4287C81BDA"'
+      - '"0x8DA44EA70820FA1"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:06 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/file3?action=flush&position=11&close=true
   response:
@@ -280,27 +280,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:05 GMT
-      etag: '"0x8DA2A4287E62DB3"'
-      last-modified: Sat, 30 Apr 2022 00:44:06 GMT
+      date: Thu, 02 Jun 2022 22:51:32 GMT
+      etag: '"0x8DA44EA7098A865"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/file3?action=flush&position=11&close=true
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/file3?action=flush&position=11&close=true
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:06 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/dir1?resource=directory
   response:
@@ -308,27 +308,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:05 GMT
-      etag: '"0x8DA2A4287F3D5CA"'
-      last-modified: Sat, 30 Apr 2022 00:44:06 GMT
+      date: Thu, 02 Jun 2022 22:51:32 GMT
+      etag: '"0x8DA44EA70A71A01"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/dir1?resource=directory
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/dir1?resource=directory
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:06 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs2932d170b/dir2?resource=directory
   response:
@@ -336,89 +336,90 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:05 GMT
-      etag: '"0x8DA2A4288020604"'
-      last-modified: Sat, 30 Apr 2022 00:44:06 GMT
+      date: Thu, 02 Jun 2022 22:51:32 GMT
+      etag: '"0x8DA44EA70B07EFD"'
+      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs2932d170b/dir2?resource=directory
+    url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/dir2?resource=directory
 - request:
-    body: "--===============3037934373549405382==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0440666501650017511==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /fs2932d170b/file1? HTTP/1.1\r\nx-ms-date:
-      Sat, 30 Apr 2022 00:44:06 GMT\r\nx-ms-client-request-id: a3c17acd-c81e-11ec-bc93-4851c58829e0\r\n\r\n\r\n--===============3037934373549405382==\r\nContent-Type:
+      Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id: 8cfdea98-e2c6-11ec-8fe5-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:V/VZeiMNOHdCrVeWw9KnXpnG+4UzwGYPcXqzLhqcALw=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /fs2932d170b/file2? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:06 GMT\r\nx-ms-client-request-id:
-      a3c17ace-c81e-11ec-9d31-4851c58829e0\r\n\r\n\r\n--===============3037934373549405382==\r\nContent-Type:
+      /fs2932d170b/file2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
+      8cfdea99-e2c6-11ec-9da2-4851c58829e0\r\nAuthorization: SharedKey storagename:Pe9zlNMjy74rTw1khuHICSYRqKM5Qm39322qEaKkIOI=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /fs2932d170b/file3? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:06 GMT\r\nx-ms-client-request-id:
-      a3c17acf-c81e-11ec-9b71-4851c58829e0\r\n\r\n\r\n--===============3037934373549405382==\r\nContent-Type:
+      /fs2932d170b/file3? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
+      8cfdea9a-e2c6-11ec-9442-4851c58829e0\r\nAuthorization: SharedKey storagename:71nqqGnFHeMO9MGhoV9HtRFCNkQROjUAMT00iuo32uQ=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nDELETE
-      /fs2932d170b/dir1? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:06 GMT\r\nx-ms-client-request-id:
-      a3c17ad0-c81e-11ec-891f-4851c58829e0\r\n\r\n\r\n--===============3037934373549405382==\r\nContent-Type:
+      /fs2932d170b/dir1? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
+      8cfdea9b-e2c6-11ec-a1e6-4851c58829e0\r\nAuthorization: SharedKey storagename:Ls1kwHi3TmILg6crnjcilnULKnSvqMx2OOyi2gvrh40=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 4\r\n\r\nDELETE
-      /fs2932d170b/dir2? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:06 GMT\r\nx-ms-client-request-id:
-      a3c17ad1-c81e-11ec-9eab-4851c58829e0\r\n\r\n\r\n--===============3037934373549405382==--\r\n"
+      /fs2932d170b/dir2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
+      8cfdea9c-e2c6-11ec-b94e-4851c58829e0\r\nAuthorization: SharedKey storagename:VknYvUvuj3T8q+MITuy9xIkKaM7mZXzAtMVBy9IpB7g=\r\n\r\n\r\n--===============0440666501650017511==--\r\n"
     headers:
       Content-Length:
-      - '1830'
+      - '1815'
       Content-Type:
-      - multipart/mixed; boundary================3037934373549405382==
+      - multipart/mixed; boundary================0440666501650017511==
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:06 GMT
+      - Thu, 02 Jun 2022 22:51:33 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: POST
     uri: https://storagename.blob.core.windows.net/fs2932d170b?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_63b1b985-a34b-4277-a897-7691544429eb\r\nContent-Type:
+      string: "--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 142b6a6d-e01e-002c-5d2b-5c366d1e22ea\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a3c17acd-c81e-11ec-bc93-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_63b1b985-a34b-4277-a897-7691544429eb\r\nContent-Type:
+        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326a\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 8cfdea98-e2c6-11ec-8fe5-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 142b6a6d-e01e-002c-5d2b-5c366d1e22ec\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a3c17ace-c81e-11ec-9d31-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_63b1b985-a34b-4277-a897-7691544429eb\r\nContent-Type:
+        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326c\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 8cfdea99-e2c6-11ec-9da2-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 142b6a6d-e01e-002c-5d2b-5c366d1e22ed\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a3c17acf-c81e-11ec-9b71-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_63b1b985-a34b-4277-a897-7691544429eb\r\nContent-Type:
+        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326d\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 8cfdea9a-e2c6-11ec-9442-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
         application/http\r\nContent-ID: 3\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 142b6a6d-e01e-002c-5d2b-5c366d1e22ee\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a3c17ad0-c81e-11ec-891f-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_63b1b985-a34b-4277-a897-7691544429eb\r\nContent-Type:
+        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326e\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 8cfdea9b-e2c6-11ec-a1e6-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
         application/http\r\nContent-ID: 4\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 142b6a6d-e01e-002c-5d2b-5c366d1e22ef\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: a3c17ad1-c81e-11ec-9eab-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_63b1b985-a34b-4277-a897-7691544429eb--"
+        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326f\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 8cfdea9c-e2c6-11ec-b94e-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_63b1b985-a34b-4277-a897-7691544429eb
-      date: Sat, 30 Apr 2022 00:44:06 GMT
+      content-type: multipart/mixed; boundary=batchresponse_931748a2-0972-475a-a013-2c8d35c168c1
+      date: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/fs2932d170b?restype=container&comp=batch
+    url: https://vincenttranhns.blob.core.windows.net/fs2932d170b?restype=container&comp=batch
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:06 GMT
+      - Thu, 02 Jun 2022 22:51:34 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/fs2932d170b?restype=container
   response:
@@ -426,11 +427,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:06 GMT
+      date: Thu, 02 Jun 2022 22:51:32 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/fs2932d170b?restype=container
+    url: https://vincenttranhns.blob.core.windows.net/fs2932d170b?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_simple_no_raise.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_simple_no_raise.yaml
@@ -349,20 +349,19 @@ interactions:
 - request:
     body: "--===============0440666501650017511==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /fs2932d170b/file1? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id: 8cfdea98-e2c6-11ec-8fe5-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:V/VZeiMNOHdCrVeWw9KnXpnG+4UzwGYPcXqzLhqcALw=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id: 8cfdea98-e2c6-11ec-8fe5-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /fs2932d170b/file2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea99-e2c6-11ec-9da2-4851c58829e0\r\nAuthorization: SharedKey storagename:Pe9zlNMjy74rTw1khuHICSYRqKM5Qm39322qEaKkIOI=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      8cfdea99-e2c6-11ec-9da2-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /fs2932d170b/file3? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea9a-e2c6-11ec-9442-4851c58829e0\r\nAuthorization: SharedKey storagename:71nqqGnFHeMO9MGhoV9HtRFCNkQROjUAMT00iuo32uQ=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      8cfdea9a-e2c6-11ec-9442-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nDELETE
       /fs2932d170b/dir1? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea9b-e2c6-11ec-a1e6-4851c58829e0\r\nAuthorization: SharedKey storagename:Ls1kwHi3TmILg6crnjcilnULKnSvqMx2OOyi2gvrh40=\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      8cfdea9b-e2c6-11ec-a1e6-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 4\r\n\r\nDELETE
       /fs2932d170b/dir2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea9c-e2c6-11ec-b94e-4851c58829e0\r\nAuthorization: SharedKey storagename:VknYvUvuj3T8q+MITuy9xIkKaM7mZXzAtMVBy9IpB7g=\r\n\r\n\r\n--===============0440666501650017511==--\r\n"
+      8cfdea9c-e2c6-11ec-b94e-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==--\r\n"
     headers:
       Content-Length:
       - '1815'

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_simple_no_raise.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_simple_no_raise.yaml
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:32 GMT
+      - Thu, 02 Jun 2022 23:38:55 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -17,9 +17,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:31 GMT
-      etag: '"0x8DA44EA700F0B50"'
-      last-modified: Thu, 02 Jun 2022 22:51:31 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
+      etag: '"0x8DA44F10EA01B3C"'
+      last-modified: Thu, 02 Jun 2022 23:38:54 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-08-06'
     status:
@@ -34,7 +34,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:32 GMT
+      - Thu, 02 Jun 2022 23:38:55 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -44,9 +44,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:31 GMT
-      etag: '"0x8DA44EA7041A0B2"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
+      etag: '"0x8DA44F10EEA201F"'
+      last-modified: Thu, 02 Jun 2022 23:38:55 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -76,7 +76,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:31 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -90,11 +90,11 @@ interactions:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA44EA7041A0B2"'
+      - '"0x8DA44F10EEA201F"'
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -104,9 +104,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:31 GMT
-      etag: '"0x8DA44EA705857F2"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
+      etag: '"0x8DA44F10F0240E2"'
+      last-modified: Thu, 02 Jun 2022 23:38:55 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
       x-ms-version: '2021-08-06'
@@ -122,7 +122,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -132,9 +132,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:31 GMT
-      etag: '"0x8DA44EA70628B21"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
+      etag: '"0x8DA44F10F0D4613"'
+      last-modified: Thu, 02 Jun 2022 23:38:55 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -154,7 +154,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -164,7 +164,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:31 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -178,11 +178,11 @@ interactions:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA44EA70628B21"'
+      - '"0x8DA44F10F0D4613"'
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -192,9 +192,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:32 GMT
-      etag: '"0x8DA44EA70778166"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
+      etag: '"0x8DA44F10F2232FF"'
+      last-modified: Thu, 02 Jun 2022 23:38:55 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
       x-ms-version: '2021-08-06'
@@ -210,7 +210,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -220,9 +220,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:32 GMT
-      etag: '"0x8DA44EA70820FA1"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
+      etag: '"0x8DA44F10F2BB435"'
+      last-modified: Thu, 02 Jun 2022 23:38:55 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -252,7 +252,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:54 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -266,11 +266,11 @@ interactions:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA44EA70820FA1"'
+      - '"0x8DA44F10F2BB435"'
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -280,9 +280,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:32 GMT
-      etag: '"0x8DA44EA7098A865"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:55 GMT
+      etag: '"0x8DA44F10F415124"'
+      last-modified: Thu, 02 Jun 2022 23:38:56 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
       x-ms-version: '2021-08-06'
@@ -298,7 +298,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -308,9 +308,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:32 GMT
-      etag: '"0x8DA44EA70A71A01"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:55 GMT
+      etag: '"0x8DA44F10F4A55EA"'
+      last-modified: Thu, 02 Jun 2022 23:38:56 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -326,7 +326,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:56 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -336,9 +336,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:32 GMT
-      etag: '"0x8DA44EA70B07EFD"'
-      last-modified: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:55 GMT
+      etag: '"0x8DA44F10F533476"'
+      last-modified: Thu, 02 Jun 2022 23:38:56 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -347,60 +347,60 @@ interactions:
       message: Created
     url: https://vincenttranhns.dfs.core.windows.net/fs2932d170b/dir2?resource=directory
 - request:
-    body: "--===============0440666501650017511==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============1178193531367231645==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /fs2932d170b/file1? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id: 8cfdea98-e2c6-11ec-8fe5-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      Thu, 02 Jun 2022 23:38:56 GMT\r\nx-ms-client-request-id: 2b9cc30f-e2cd-11ec-8037-4851c58829e0\r\r\n\r\n\r\n--===============1178193531367231645==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /fs2932d170b/file2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea99-e2c6-11ec-9da2-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      /fs2932d170b/file2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:38:56 GMT\r\nx-ms-client-request-id:
+      2b9cc310-e2cd-11ec-bd17-4851c58829e0\r\r\n\r\n\r\n--===============1178193531367231645==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /fs2932d170b/file3? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea9a-e2c6-11ec-9442-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      /fs2932d170b/file3? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:38:56 GMT\r\nx-ms-client-request-id:
+      2b9ce90c-e2cd-11ec-a8ba-4851c58829e0\r\r\n\r\n\r\n--===============1178193531367231645==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nDELETE
-      /fs2932d170b/dir1? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea9b-e2c6-11ec-a1e6-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==\r\nContent-Type:
+      /fs2932d170b/dir1? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:38:56 GMT\r\nx-ms-client-request-id:
+      2b9ce90d-e2cd-11ec-997c-4851c58829e0\r\r\n\r\n\r\n--===============1178193531367231645==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 4\r\n\r\nDELETE
-      /fs2932d170b/dir2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:51:33 GMT\r\nx-ms-client-request-id:
-      8cfdea9c-e2c6-11ec-b94e-4851c58829e0\r\r\n\r\n\r\n--===============0440666501650017511==--\r\n"
+      /fs2932d170b/dir2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:38:56 GMT\r\nx-ms-client-request-id:
+      2b9ce90e-e2cd-11ec-9809-4851c58829e0\r\r\n\r\n\r\n--===============1178193531367231645==--\r\n"
     headers:
       Content-Length:
       - '1815'
       Content-Type:
-      - multipart/mixed; boundary================0440666501650017511==
+      - multipart/mixed; boundary================1178193531367231645==
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:33 GMT
+      - Thu, 02 Jun 2022 23:38:57 GMT
       x-ms-version:
       - '2021-08-06'
     method: POST
     uri: https://storagename.blob.core.windows.net/fs2932d170b?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
+      string: "--batchresponse_cb90658f-da0e-4c9f-b2c6-60ac5f5004e5\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326a\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: 8cfdea98-e2c6-11ec-8fe5-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
+        true\r\nx-ms-request-id: 40ce4e7b-401e-010d-23d9-76ac581eb91d\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 2b9cc30f-e2cd-11ec-8037-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cb90658f-da0e-4c9f-b2c6-60ac5f5004e5\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326c\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: 8cfdea99-e2c6-11ec-9da2-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
+        true\r\nx-ms-request-id: 40ce4e7b-401e-010d-23d9-76ac581eb91f\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 2b9cc310-e2cd-11ec-bd17-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cb90658f-da0e-4c9f-b2c6-60ac5f5004e5\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326d\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: 8cfdea9a-e2c6-11ec-9442-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
+        true\r\nx-ms-request-id: 40ce4e7b-401e-010d-23d9-76ac581eb920\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 2b9ce90c-e2cd-11ec-a8ba-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cb90658f-da0e-4c9f-b2c6-60ac5f5004e5\r\nContent-Type:
         application/http\r\nContent-ID: 3\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326e\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: 8cfdea9b-e2c6-11ec-a1e6-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1\r\nContent-Type:
+        true\r\nx-ms-request-id: 40ce4e7b-401e-010d-23d9-76ac581eb921\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 2b9ce90d-e2cd-11ec-997c-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cb90658f-da0e-4c9f-b2c6-60ac5f5004e5\r\nContent-Type:
         application/http\r\nContent-ID: 4\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 8a39814f-901e-010e-50d3-764d3c1e326f\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: 8cfdea9c-e2c6-11ec-b94e-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_931748a2-0972-475a-a013-2c8d35c168c1--"
+        true\r\nx-ms-request-id: 40ce4e7b-401e-010d-23d9-76ac581eb922\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 2b9ce90e-e2cd-11ec-9809-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cb90658f-da0e-4c9f-b2c6-60ac5f5004e5--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_931748a2-0972-475a-a013-2c8d35c168c1
-      date: Thu, 02 Jun 2022 22:51:32 GMT
+      content-type: multipart/mixed; boundary=batchresponse_cb90658f-da0e-4c9f-b2c6-60ac5f5004e5
+      date: Thu, 02 Jun 2022 23:38:55 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2021-08-06'
@@ -416,7 +416,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:51:34 GMT
+      - Thu, 02 Jun 2022 23:38:57 GMT
       x-ms-version:
       - '2021-08-06'
     method: DELETE
@@ -426,7 +426,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:51:32 GMT
+      date: Thu, 02 Jun 2022 23:38:55 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-08-06'
     status:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_with_failed_subrequest.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_with_failed_subrequest.yaml
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:23 GMT
+      - Thu, 02 Jun 2022 23:39:12 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -17,9 +17,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:22 GMT
-      etag: '"0x8DA44EA8EA02268"'
-      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:11 GMT
+      etag: '"0x8DA44F11882CBFA"'
+      last-modified: Thu, 02 Jun 2022 23:39:11 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-08-06'
     status:
@@ -34,7 +34,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:12 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -44,9 +44,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
-      etag: '"0x8DA44EA8EEDA39F"'
-      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:11 GMT
+      etag: '"0x8DA44F118B6F12F"'
+      last-modified: Thu, 02 Jun 2022 23:39:11 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:12 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -76,7 +76,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:11 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -90,11 +90,11 @@ interactions:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA44EA8EEDA39F"'
+      - '"0x8DA44F118B6F12F"'
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:12 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -104,9 +104,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
-      etag: '"0x8DA44EA8F0323D5"'
-      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:11 GMT
+      etag: '"0x8DA44F118CDBCF9"'
+      last-modified: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
       x-ms-version: '2021-08-06'
@@ -122,7 +122,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:12 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -132,9 +132,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
-      etag: '"0x8DA44EA8F0D85D8"'
-      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:11 GMT
+      etag: '"0x8DA44F118D8339C"'
+      last-modified: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -154,7 +154,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:12 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -164,7 +164,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:11 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -178,11 +178,11 @@ interactions:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA44EA8F0D85D8"'
+      - '"0x8DA44F118D8339C"'
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:12 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -192,9 +192,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
-      etag: '"0x8DA44EA8F23715C"'
-      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
+      date: Thu, 02 Jun 2022 23:39:11 GMT
+      etag: '"0x8DA44F118EE59BF"'
+      last-modified: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
       x-ms-version: '2021-08-06'
@@ -210,7 +210,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:13 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -220,9 +220,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
-      etag: '"0x8DA44EA8F2D2327"'
-      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
+      date: Thu, 02 Jun 2022 23:39:12 GMT
+      etag: '"0x8DA44F118F93EBC"'
+      last-modified: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:24 GMT
+      - Thu, 02 Jun 2022 23:39:13 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -252,7 +252,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -266,11 +266,11 @@ interactions:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA44EA8F2D2327"'
+      - '"0x8DA44F118F93EBC"'
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:25 GMT
+      - Thu, 02 Jun 2022 23:39:13 GMT
       x-ms-version:
       - '2021-08-06'
     method: PATCH
@@ -280,9 +280,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:24 GMT
-      etag: '"0x8DA44EA8F40AE47"'
-      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
+      date: Thu, 02 Jun 2022 23:39:12 GMT
+      etag: '"0x8DA44F1190E8474"'
+      last-modified: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
       x-ms-version: '2021-08-06'
@@ -298,7 +298,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:25 GMT
+      - Thu, 02 Jun 2022 23:39:13 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -308,9 +308,9 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:24 GMT
-      etag: '"0x8DA44EA8F527445"'
-      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
+      date: Thu, 02 Jun 2022 23:39:12 GMT
+      etag: '"0x8DA44F1191E30DA"'
+      last-modified: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
       x-ms-version: '2021-08-06'
@@ -319,66 +319,65 @@ interactions:
       message: Created
     url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/dir1%2Ffile4?resource=file
 - request:
-    body: "--===============0828434275818804426==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0773684347739619427==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /fs13fa31a04/file1? HTTP/1.1\r\nx-ms-date:
-      Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id: aba27e4f-e2c6-11ec-a4b0-4851c58829e0\r\nAuthorization:
-      SharedKey storagename:WjMXwVG/AI2fKgMHwrOT6g/sg0cR/xYpMw9vzBXGrUQ=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
+      Thu, 02 Jun 2022 23:39:13 GMT\r\nx-ms-client-request-id: 3568ae85-e2cd-11ec-8f4e-4851c58829e0\r\r\n\r\n\r\n--===============0773684347739619427==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /fs13fa31a04/file2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
-      aba293b0-e2c6-11ec-8f68-4851c58829e0\r\nAuthorization: SharedKey storagename:ySbhvQTXfVY8xnb6abZPP49fpLu/oLnqMfQMPEEPXIM=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
+      /fs13fa31a04/file2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:39:13 GMT\r\nx-ms-client-request-id:
+      3568d54d-e2cd-11ec-810c-4851c58829e0\r\r\n\r\n\r\n--===============0773684347739619427==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /fs13fa31a04/file3? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
-      aba293b1-e2c6-11ec-a07b-4851c58829e0\r\nAuthorization: SharedKey storagename:ITj9EFFMruDA3dGgxK+nLxF9Dlh4DuctiJCvW9xUinc=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
+      /fs13fa31a04/file3? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:39:13 GMT\r\nx-ms-client-request-id:
+      3568d54e-e2cd-11ec-9ae6-4851c58829e0\r\r\n\r\n\r\n--===============0773684347739619427==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nDELETE
-      /fs13fa31a04/dir1? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
-      aba293b2-e2c6-11ec-b335-4851c58829e0\r\nAuthorization: SharedKey storagename:vUAF+1OMif4JUc6o7HUmoFdBQwcIjP32lboJCf9X6Xg=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
+      /fs13fa31a04/dir1? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:39:13 GMT\r\nx-ms-client-request-id:
+      3568d54f-e2cd-11ec-9eb2-4851c58829e0\r\r\n\r\n\r\n--===============0773684347739619427==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 4\r\n\r\nDELETE
-      /fs13fa31a04/dir8? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
-      aba293b3-e2c6-11ec-b778-4851c58829e0\r\nAuthorization: SharedKey storagename:muOkyLTHUiR23TEVODqICjha2i1L2P2AVdgUverKMjM=\r\n\r\n\r\n--===============0828434275818804426==--\r\n"
+      /fs13fa31a04/dir8? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 23:39:13 GMT\r\nx-ms-client-request-id:
+      3568d550-e2cd-11ec-9150-4851c58829e0\r\r\n\r\n\r\n--===============0773684347739619427==--\r\n"
     headers:
       Content-Length:
       - '1815'
       Content-Type:
-      - multipart/mixed; boundary================0828434275818804426==
+      - multipart/mixed; boundary================0773684347739619427==
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:25 GMT
+      - Thu, 02 Jun 2022 23:39:13 GMT
       x-ms-version:
       - '2021-08-06'
     method: POST
     uri: https://storagename.blob.core.windows.net/fs13fa31a04?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
+      string: "--batchresponse_14968008-83d1-40ed-8b80-f33a1f9b35b9\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a1\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: aba27e4f-e2c6-11ec-a4b0-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
+        true\r\nx-ms-request-id: fafae2bf-e01e-008d-7fd9-76ad531ec8eb\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 3568ae85-e2cd-11ec-8f4e-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_14968008-83d1-40ed-8b80-f33a1f9b35b9\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a3\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: aba293b0-e2c6-11ec-8f68-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
+        true\r\nx-ms-request-id: fafae2bf-e01e-008d-7fd9-76ad531ec8ed\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 3568d54d-e2cd-11ec-810c-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_14968008-83d1-40ed-8b80-f33a1f9b35b9\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a4\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: aba293b1-e2c6-11ec-a07b-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
+        true\r\nx-ms-request-id: fafae2bf-e01e-008d-7fd9-76ad531ec8ee\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 3568d54e-e2cd-11ec-9ae6-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_14968008-83d1-40ed-8b80-f33a1f9b35b9\r\nContent-Type:
         application/http\r\nContent-ID: 3\r\n\r\nHTTP/1.1 409 The directory involved
         in this operation is not empty\r\nx-ms-error-code: DirectoryNotEmpty\r\nx-ms-request-id:
-        73eb6ca9-d01e-00a9-11d3-765bf31e98a5\r\nx-ms-version: 2021-08-06\r\nx-ms-client-request-id:
-        aba293b2-e2c6-11ec-b335-4851c58829e0\r\nContent-Length: 240\r\nContent-Type:
+        fafae2bf-e01e-008d-7fd9-76ad531ec8ef\r\nx-ms-version: 2021-08-06\r\nx-ms-client-request-id:
+        3568d54f-e2cd-11ec-9eb2-4851c58829e0\r\nContent-Length: 240\r\nContent-Type:
         application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
         encoding=\"utf-8\"?>\n<Error><Code>DirectoryNotEmpty</Code><Message>The directory
-        involved in this operation is not empty\nRequestId:73eb6ca9-d01e-00a9-11d3-765bf31e98a5\nTime:2022-06-02T22:52:24.5384068Z</Message></Error>\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
+        involved in this operation is not empty\nRequestId:fafae2bf-e01e-008d-7fd9-76ad531ec8ef\nTime:2022-06-02T23:39:12.7081861Z</Message></Error>\r\n--batchresponse_14968008-83d1-40ed-8b80-f33a1f9b35b9\r\nContent-Type:
         application/http\r\nContent-ID: 4\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a6\r\nx-ms-version:
-        2021-08-06\r\nx-ms-client-request-id: aba293b3-e2c6-11ec-b778-4851c58829e0\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: fafae2bf-e01e-008d-7fd9-76ad531ec8f0\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: 3568d550-e2cd-11ec-9150-4851c58829e0\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:73eb6ca9-d01e-00a9-11d3-765bf31e98a6\nTime:2022-06-02T22:52:24.5424046Z</Message></Error>\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925--"
+        specified blob does not exist.\nRequestId:fafae2bf-e01e-008d-7fd9-76ad531ec8f0\nTime:2022-06-02T23:39:12.6901965Z</Message></Error>\r\n--batchresponse_14968008-83d1-40ed-8b80-f33a1f9b35b9--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_2c894915-c686-49bc-ab13-c186e3297925
-      date: Thu, 02 Jun 2022 22:52:23 GMT
+      content-type: multipart/mixed; boundary=batchresponse_14968008-83d1-40ed-8b80-f33a1f9b35b9
+      date: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2021-08-06'
@@ -394,7 +393,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Thu, 02 Jun 2022 22:52:25 GMT
+      - Thu, 02 Jun 2022 23:39:13 GMT
       x-ms-version:
       - '2021-08-06'
     method: DELETE
@@ -404,7 +403,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 02 Jun 2022 22:52:23 GMT
+      date: Thu, 02 Jun 2022 23:39:12 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2021-08-06'
     status:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_with_failed_subrequest.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_delete_files_with_failed_subrequest.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:22 GMT
+      - Thu, 02 Jun 2022 22:52:23 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.blob.core.windows.net/fs13fa31a04?restype=container
   response:
@@ -17,26 +17,26 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:23 GMT
-      etag: '"0x8DA2A4291EF0F25"'
-      last-modified: Sat, 30 Apr 2022 00:44:23 GMT
+      date: Thu, 02 Jun 2022 22:52:22 GMT
+      etag: '"0x8DA44EA8EA02268"'
+      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.blob.core.windows.net/fs13fa31a04?restype=container
+    url: https://vincenttranhns.blob.core.windows.net/fs13fa31a04?restype=container
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file1?resource=file
   response:
@@ -44,16 +44,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:22 GMT
-      etag: '"0x8DA2A429224559B"'
-      last-modified: Sat, 30 Apr 2022 00:44:23 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
+      etag: '"0x8DA44EA8EEDA39F"'
+      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file1?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file1?resource=file
 - request:
     body: hello world
     headers:
@@ -64,11 +64,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file1?action=append&position=0
   response:
@@ -76,27 +76,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:22 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file1?action=append&position=0
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file1?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA2A429224559B"'
+      - '"0x8DA44EA8EEDA39F"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file1?action=flush&position=11&close=true
   response:
@@ -104,27 +104,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:22 GMT
-      etag: '"0x8DA2A42923FE663"'
-      last-modified: Sat, 30 Apr 2022 00:44:23 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
+      etag: '"0x8DA44EA8F0323D5"'
+      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file1?action=flush&position=11&close=true
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file1?action=flush&position=11&close=true
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file2?resource=file
   response:
@@ -132,16 +132,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:22 GMT
-      etag: '"0x8DA2A42924D7B62"'
-      last-modified: Sat, 30 Apr 2022 00:44:23 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
+      etag: '"0x8DA44EA8F0D85D8"'
+      last-modified: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file2?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file2?resource=file
 - request:
     body: hello world
     headers:
@@ -152,11 +152,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file2?action=append&position=0
   response:
@@ -164,27 +164,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:22 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file2?action=append&position=0
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file2?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA2A42924D7B62"'
+      - '"0x8DA44EA8F0D85D8"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file2?action=flush&position=11&close=true
   response:
@@ -192,27 +192,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:22 GMT
-      etag: '"0x8DA2A4292666BE8"'
-      last-modified: Sat, 30 Apr 2022 00:44:23 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
+      etag: '"0x8DA44EA8F23715C"'
+      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file2?action=flush&position=11&close=true
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file2?action=flush&position=11&close=true
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file3?resource=file
   response:
@@ -220,16 +220,16 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:23 GMT
-      etag: '"0x8DA2A429272CA9A"'
-      last-modified: Sat, 30 Apr 2022 00:44:23 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
+      etag: '"0x8DA44EA8F2D2327"'
+      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file3?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file3?resource=file
 - request:
     body: hello world
     headers:
@@ -240,11 +240,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:24 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file3?action=append&position=0
   response:
@@ -252,27 +252,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:23 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file3?action=append&position=0
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file3?action=append&position=0
 - request:
     body: null
     headers:
       Accept:
       - application/json
       If-Match:
-      - '"0x8DA2A429272CA9A"'
+      - '"0x8DA44EA8F2D2327"'
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:23 GMT
+      - Thu, 02 Jun 2022 22:52:25 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PATCH
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/file3?action=flush&position=11&close=true
   response:
@@ -280,27 +280,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:23 GMT
-      etag: '"0x8DA2A42928BA2BC"'
-      last-modified: Sat, 30 Apr 2022 00:44:24 GMT
+      date: Thu, 02 Jun 2022 22:52:24 GMT
+      etag: '"0x8DA44EA8F40AE47"'
+      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/file3?action=flush&position=11&close=true
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/file3?action=flush&position=11&close=true
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:24 GMT
+      - Thu, 02 Jun 2022 22:52:25 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: PUT
     uri: https://storagename.dfs.core.windows.net/fs13fa31a04/dir1%2Ffile4?resource=file
   response:
@@ -308,94 +308,95 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:23 GMT
-      etag: '"0x8DA2A4292BE0BD4"'
-      last-modified: Sat, 30 Apr 2022 00:44:24 GMT
+      date: Thu, 02 Jun 2022 22:52:24 GMT
+      etag: '"0x8DA44EA8F527445"'
+      last-modified: Thu, 02 Jun 2022 22:52:24 GMT
       server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: https://vincenttrancanary.dfs.core.windows.net/fs13fa31a04/dir1%2Ffile4?resource=file
+    url: https://vincenttranhns.dfs.core.windows.net/fs13fa31a04/dir1%2Ffile4?resource=file
 - request:
-    body: "--===============0750080793628137266==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0828434275818804426==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /fs13fa31a04/file1? HTTP/1.1\r\nx-ms-date:
-      Sat, 30 Apr 2022 00:44:24 GMT\r\nx-ms-client-request-id: ae7b2e57-c81e-11ec-bc36-4851c58829e0\r\n\r\n\r\n--===============0750080793628137266==\r\nContent-Type:
+      Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id: aba27e4f-e2c6-11ec-a4b0-4851c58829e0\r\nAuthorization:
+      SharedKey storagename:WjMXwVG/AI2fKgMHwrOT6g/sg0cR/xYpMw9vzBXGrUQ=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /fs13fa31a04/file2? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:24 GMT\r\nx-ms-client-request-id:
-      ae7b2e58-c81e-11ec-a7ca-4851c58829e0\r\n\r\n\r\n--===============0750080793628137266==\r\nContent-Type:
+      /fs13fa31a04/file2? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
+      aba293b0-e2c6-11ec-8f68-4851c58829e0\r\nAuthorization: SharedKey storagename:ySbhvQTXfVY8xnb6abZPP49fpLu/oLnqMfQMPEEPXIM=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /fs13fa31a04/file3? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:24 GMT\r\nx-ms-client-request-id:
-      ae7b2e59-c81e-11ec-8bfd-4851c58829e0\r\n\r\n\r\n--===============0750080793628137266==\r\nContent-Type:
+      /fs13fa31a04/file3? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
+      aba293b1-e2c6-11ec-a07b-4851c58829e0\r\nAuthorization: SharedKey storagename:ITj9EFFMruDA3dGgxK+nLxF9Dlh4DuctiJCvW9xUinc=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nDELETE
-      /fs13fa31a04/dir1? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:24 GMT\r\nx-ms-client-request-id:
-      ae7b2e5a-c81e-11ec-872f-4851c58829e0\r\n\r\n\r\n--===============0750080793628137266==\r\nContent-Type:
+      /fs13fa31a04/dir1? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
+      aba293b2-e2c6-11ec-b335-4851c58829e0\r\nAuthorization: SharedKey storagename:vUAF+1OMif4JUc6o7HUmoFdBQwcIjP32lboJCf9X6Xg=\r\n\r\n\r\n--===============0828434275818804426==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 4\r\n\r\nDELETE
-      /fs13fa31a04/dir8? HTTP/1.1\r\nx-ms-date: Sat, 30 Apr 2022 00:44:24 GMT\r\nx-ms-client-request-id:
-      ae7b2e5b-c81e-11ec-8fae-4851c58829e0\r\n\r\n\r\n--===============0750080793628137266==--\r\n"
+      /fs13fa31a04/dir8? HTTP/1.1\r\nx-ms-date: Thu, 02 Jun 2022 22:52:25 GMT\r\nx-ms-client-request-id:
+      aba293b3-e2c6-11ec-b778-4851c58829e0\r\nAuthorization: SharedKey storagename:muOkyLTHUiR23TEVODqICjha2i1L2P2AVdgUverKMjM=\r\n\r\n\r\n--===============0828434275818804426==--\r\n"
     headers:
       Content-Length:
-      - '1830'
+      - '1815'
       Content-Type:
-      - multipart/mixed; boundary================0750080793628137266==
+      - multipart/mixed; boundary================0828434275818804426==
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:24 GMT
+      - Thu, 02 Jun 2022 22:52:25 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: POST
     uri: https://storagename.blob.core.windows.net/fs13fa31a04?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_a8e8fe71-0859-4cab-b61f-d4d47640298b\r\nContent-Type:
+      string: "--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 85748917-b01e-001e-232b-5c361a1e6a14\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: ae7b2e57-c81e-11ec-bc36-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a8e8fe71-0859-4cab-b61f-d4d47640298b\r\nContent-Type:
+        true\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a1\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: aba27e4f-e2c6-11ec-a4b0-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 85748917-b01e-001e-232b-5c361a1e6a17\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: ae7b2e58-c81e-11ec-a7ca-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a8e8fe71-0859-4cab-b61f-d4d47640298b\r\nContent-Type:
+        true\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a3\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: aba293b0-e2c6-11ec-8f68-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 85748917-b01e-001e-232b-5c361a1e6a18\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: ae7b2e59-c81e-11ec-8bfd-4851c58829e0\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a8e8fe71-0859-4cab-b61f-d4d47640298b\r\nContent-Type:
+        true\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a4\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: aba293b1-e2c6-11ec-a07b-4851c58829e0\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
         application/http\r\nContent-ID: 3\r\n\r\nHTTP/1.1 409 The directory involved
         in this operation is not empty\r\nx-ms-error-code: DirectoryNotEmpty\r\nx-ms-request-id:
-        85748917-b01e-001e-232b-5c361a1e6a19\r\nx-ms-version: 2021-06-08\r\nx-ms-client-request-id:
-        ae7b2e5a-c81e-11ec-872f-4851c58829e0\r\nContent-Length: 240\r\nContent-Type:
+        73eb6ca9-d01e-00a9-11d3-765bf31e98a5\r\nx-ms-version: 2021-08-06\r\nx-ms-client-request-id:
+        aba293b2-e2c6-11ec-b335-4851c58829e0\r\nContent-Length: 240\r\nContent-Type:
         application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
         encoding=\"utf-8\"?>\n<Error><Code>DirectoryNotEmpty</Code><Message>The directory
-        involved in this operation is not empty\nRequestId:85748917-b01e-001e-232b-5c361a1e6a19\nTime:2022-04-30T00:44:24.5929162Z</Message></Error>\r\n--batchresponse_a8e8fe71-0859-4cab-b61f-d4d47640298b\r\nContent-Type:
+        involved in this operation is not empty\nRequestId:73eb6ca9-d01e-00a9-11d3-765bf31e98a5\nTime:2022-06-02T22:52:24.5384068Z</Message></Error>\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925\r\nContent-Type:
         application/http\r\nContent-ID: 4\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 85748917-b01e-001e-232b-5c361a1e6a1a\r\nx-ms-version:
-        2021-06-08\r\nx-ms-client-request-id: ae7b2e5b-c81e-11ec-8fae-4851c58829e0\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 73eb6ca9-d01e-00a9-11d3-765bf31e98a6\r\nx-ms-version:
+        2021-08-06\r\nx-ms-client-request-id: aba293b3-e2c6-11ec-b778-4851c58829e0\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:85748917-b01e-001e-232b-5c361a1e6a1a\nTime:2022-04-30T00:44:24.5819230Z</Message></Error>\r\n--batchresponse_a8e8fe71-0859-4cab-b61f-d4d47640298b--"
+        specified blob does not exist.\nRequestId:73eb6ca9-d01e-00a9-11d3-765bf31e98a6\nTime:2022-06-02T22:52:24.5424046Z</Message></Error>\r\n--batchresponse_2c894915-c686-49bc-ab13-c186e3297925--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_a8e8fe71-0859-4cab-b61f-d4d47640298b
-      date: Sat, 30 Apr 2022 00:44:24 GMT
+      content-type: multipart/mixed; boundary=batchresponse_2c894915-c686-49bc-ab13-c186e3297925
+      date: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/fs13fa31a04?restype=container&comp=batch
+    url: https://vincenttranhns.blob.core.windows.net/fs13fa31a04?restype=container&comp=batch
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-dfs/12.7.0 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-dfs/12.8.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Sat, 30 Apr 2022 00:44:24 GMT
+      - Thu, 02 Jun 2022 22:52:25 GMT
       x-ms-version:
-      - '2021-06-08'
+      - '2021-08-06'
     method: DELETE
     uri: https://storagename.blob.core.windows.net/fs13fa31a04?restype=container
   response:
@@ -403,11 +404,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Sat, 30 Apr 2022 00:44:24 GMT
+      date: Thu, 02 Jun 2022 22:52:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2021-06-08'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: https://vincenttrancanary.blob.core.windows.net/fs13fa31a04?restype=container
+    url: https://vincenttranhns.blob.core.windows.net/fs13fa31a04?restype=container
 version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -154,7 +154,7 @@ class FileTest(StorageTestCase):
         directory_client.create_directory()
 
         file_client = directory_client.get_file_client('filename')
-        file_client.create_file(expiry_options="RelativeToNow", expires_on=test_expiry_time)
+        file_client.create_file(expires_on=test_expiry_time)
 
         # Assert
         file_properties = file_client.get_file_properties()
@@ -177,7 +177,7 @@ class FileTest(StorageTestCase):
         directory_client.create_directory()
 
         file_client = directory_client.get_file_client('filename')
-        file_client.create_file(expiry_options="Absolute", expires_on=test_expiry_time)
+        file_client.create_file(expires_on=test_expiry_time)
 
         # Assert
         file_properties = file_client.get_file_properties()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
@@ -161,7 +161,7 @@ class FileTest(StorageTestCase):
         await directory_client.create_directory()
 
         file_client = directory_client.get_file_client('filename')
-        await file_client.create_file(expiry_options="RelativeToNow", expires_on=test_expiry_time)
+        await file_client.create_file(expires_on=test_expiry_time)
 
         # Assert
         file_properties = await file_client.get_file_properties()
@@ -184,7 +184,7 @@ class FileTest(StorageTestCase):
         await directory_client.create_directory()
 
         file_client = directory_client.get_file_client('filename')
-        await file_client.create_file(expiry_options="Absolute", expires_on=test_expiry_time)
+        await file_client.create_file(expires_on=test_expiry_time)
 
         # Assert
         file_properties = await file_client.get_file_properties()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -733,7 +733,6 @@ class FileSystemTest(StorageTestCase):
             files[2],
             files[3],
             files[4],
-            raise_on_any_failure=False
         )
 
         # Assert
@@ -777,7 +776,6 @@ class FileSystemTest(StorageTestCase):
             files[2],
             files[3],  # dir1 is not empty
             files[4],  # dir8 doesn't exist
-            raise_on_any_failure=False
         )
 
         # Assert

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
@@ -890,7 +890,6 @@ class FileSystemTest(StorageTestCase):
             files[2],
             files[3],
             files[4],
-            raise_on_any_failure=False
         )
 
         # Assert
@@ -934,7 +933,6 @@ class FileSystemTest(StorageTestCase):
             files[2],
             files[3],  # dir1 is not empty
             files[4],  # dir8 doesn't exist
-            raise_on_any_failure=False
         )
 
         # Assert

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -293,12 +293,13 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         :keyword str file_permission_key:
             Key of the permission to be set for the directory/file.
             Note: Only one of the file-permission or file-permission-key should be specified.
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the directory. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword dict(str,str) metadata:
             Name-value pairs associated with the directory as metadata.
         :keyword int timeout:
@@ -409,12 +410,13 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         :keyword file_last_write_time:
             Last write time for the file.
         :paramtype file_last_write_time:~datetime.datetime or str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the directory. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword Dict[str,str] metadata:
             A name-value pair to associate with a file storage object.
         :keyword destination_lease:
@@ -725,12 +727,13 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the directory. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :returns: File-updated property dict (Etag and last modified).

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -350,12 +350,13 @@ class ShareFileClient(StorageAccountHostsMixin):
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword ~azure.storage.fileshare.ContentSettings content_settings:
             ContentSettings object used to set file properties. Used to set content type, encoding,
             language, disposition, md5, and cache control.
@@ -463,12 +464,13 @@ class ShareFileClient(StorageAccountHostsMixin):
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time
+       :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword dict(str,str) metadata:
             Name-value pairs associated with the file as metadata.
         :keyword ~azure.storage.fileshare.ContentSettings content_settings:
@@ -608,12 +610,13 @@ class ShareFileClient(StorageAccountHostsMixin):
                 This parameter was introduced in API version '2019-07-07'.
 
         :paramtype file_last_write_time: str or ~datetime.datetime
-        :keyword ~datetime.datetime file_change_time:
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.9.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword bool ignore_read_only:
             Specifies the option to overwrite the target file if it already exists and has read-only attribute set.
 
@@ -854,12 +857,13 @@ class ShareFileClient(StorageAccountHostsMixin):
         :keyword file_last_write_time:
             Last write time for the file.
         :paramtype file_last_write_time:~datetime.datetime or str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword str content_type:
             The Content Type of the new file.
 
@@ -1003,12 +1007,13 @@ class ShareFileClient(StorageAccountHostsMixin):
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword lease:
             Required if the file has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=no-self-use
-from typing import Any, Dict, Optional, TypeVar, TYPE_CHECKING
+from typing import Any, Dict, TypeVar, TYPE_CHECKING
 
 from azure.core import MatchConditions
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
@@ -173,12 +173,13 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
         :keyword str file_permission_key:
             Key of the permission to be set for the directory/file.
             Note: Only one of the file-permission or file-permission-key should be specified.
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the directory. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword dict(str,str) metadata:
             Name-value pairs associated with the directory as metadata.
         :keyword int timeout:
@@ -598,12 +599,13 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the directory. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :returns: File-updated property dict (Etag and last modified).

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -218,12 +218,13 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time:
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword ~azure.storage.fileshare.ContentSettings content_settings:
             ContentSettings object used to set file properties. Used to set content type, encoding,
             language, disposition, md5, and cache control.
@@ -332,12 +333,13 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword dict(str,str) metadata:
             Name-value pairs associated with the file as metadata.
         :keyword ~azure.storage.fileshare.ContentSettings content_settings:
@@ -478,12 +480,13 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
                 This parameter was introduced in API version '2019-07-07'.
 
         :paramtype file_last_write_time: str or ~datetime.datetime
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.9.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword bool ignore_read_only:
             Specifies the option to overwrite the target file if it already exists and has read-only attribute set.
 
@@ -730,12 +733,13 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         :keyword file_last_write_time:
             Last write time for the file.
         :paramtype file_last_write_time:~datetime.datetime or str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword str content_type:
             The Content Type of the new file.
 
@@ -880,12 +884,13 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
             directory/file. Note: Only one of the x-ms-file-permission or
             x-ms-file-permission-key should be specified.
         :type permission_key: str
-        :keyword ~datetime.datetime file_change_time
+        :keyword file_change_time:
             Change time for the file. If not specified, change time will be set to the current date/time.
 
             .. versionadded:: 12.8.0
                 This parameter was introduced in API version '2021-06-08'.
 
+        :paramtype file_change_time: str or ~datetime.datetime
         :keyword lease:
             Required if the file has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.


### PR DESCRIPTION
This PR addresses some of the feedback given in the arch-board review meeting for STG83. The following tasks still need to be completed:

- [x] Refactor `expires_on` and `expiry_options` to better guide the customer experience
- [x] Gain context on how `delete_files()` came to be for Python SDK, and why we need `raise_on_any_failure`
- [x] Allow `file_change_time` to accept `str` objects 
- [x] Remove `raise_on_any` from `delete_files()`, update docstring, and then pass in
- [x] Update samples for `delete_files()`