### PR TITLE
Fix Pagination on Usage Details List Operation

### DIFF
--- a/sdk/consumption/azure-mgmt-consumption/azure/mgmt/consumption/operations/_usage_details_operations.py
+++ b/sdk/consumption/azure-mgmt-consumption/azure/mgmt/consumption/operations/_usage_details_operations.py
@@ -103,6 +103,7 @@ class UsageDetailsOperations(object):
         skiptoken: Optional[str] = None,
         top: Optional[int] = None,
         metric: Optional[Union[str, "_models.Metrictype"]] = None,
+        params: Optional[dict] = None,
         **kwargs: Any
     ) -> Iterable["_models.UsageDetailsListResult"]:
         """Lists the usage details for the defined scope. Usage details are available via this API only
@@ -169,6 +170,7 @@ class UsageDetailsOperations(object):
                     skiptoken=skiptoken,
                     top=top,
                     metric=metric,
+                    params=params,
                     template_url=self.list.metadata['url'],
                 )
                 request = _convert_request(request)
@@ -183,6 +185,7 @@ class UsageDetailsOperations(object):
                     skiptoken=skiptoken,
                     top=top,
                     metric=metric,
+                    params=params,
                     template_url=next_link,
                 )
                 request = _convert_request(request)


### PR DESCRIPTION
Passing params variable to the underlying request function so they don't get dropped.  Allows pagination to work as expected since it isn't being dropped during the first API request.  Fixes #24663 


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
