### PR TITLE
[Key Vault] Add error logging for when downloading an HSM's security domain fails

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -267,6 +267,7 @@
     "rwdlacu",
     "scbedd",
     "sdist",
+    "sdpath",
     "secbak",
     "SECG",
     "SECP",

--- a/sdk/keyvault/test-resources-post.ps1
+++ b/sdk/keyvault/test-resources-post.ps1
@@ -95,7 +95,13 @@ if (Test-Path $sdpath) {
     Remove-Item $sdPath -Force
 }
 
-Export-AzKeyVaultSecurityDomain -Name $hsmName -Quorum 2 -Certificates $wrappingFiles -OutputPath $sdPath
+Export-AzKeyVaultSecurityDomain -Name $hsmName -Quorum 2 -Certificates $wrappingFiles -OutputPath $sdPath -ErrorAction SilentlyContinue -Verbose
+if ( !$? ) {
+    Write-Host $Error[0].Exception
+    Write-Error $Error[0]
+
+    exit
+}
 
 Log "Security domain downloaded to '$sdPath'; Managed HSM is now active at '$hsmUrl'"
 


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/24670.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
