### PR TITLE
Exclude intentionally invalid files from Verify-Resource-Ref.ps1

### DIFF
--- a/eng/common/scripts/Verify-Resource-Ref.ps1
+++ b/eng/common/scripts/Verify-Resource-Ref.ps1
@@ -1,6 +1,6 @@
 . (Join-Path $PSScriptRoot common.ps1)
 Install-Module -Name powershell-yaml -RequiredVersion 0.4.1 -Force -Scope CurrentUser
-$ymlfiles = Get-ChildItem $RepoRoot -recurse | Where-Object {$_ -like '*.yml'}
+$ymlfiles = Get-ChildItem $RepoRoot -recurse | Where-Object {$_ -like '*.yml' -and $_ -notlike '*/invalid/*'}
 $affectedRepos = [System.Collections.ArrayList]::new()
 
 foreach ($file in $ymlfiles)
@@ -9,7 +9,7 @@ foreach ($file in $ymlfiles)
   $ymlContent = Get-Content $file.FullName -Raw
   $ymlObject = ConvertFrom-Yaml $ymlContent -Ordered
 
-  if ($null -ne $ymlObject -and $ymlObject.Contains("resources"))
+  if ($ymlObject.Contains("resources"))
   {
     if ($ymlObject["resources"]["repositories"])
     {

--- a/eng/common/scripts/Verify-Resource-Ref.ps1
+++ b/eng/common/scripts/Verify-Resource-Ref.ps1
@@ -9,7 +9,7 @@ foreach ($file in $ymlfiles)
   $ymlContent = Get-Content $file.FullName -Raw
   $ymlObject = ConvertFrom-Yaml $ymlContent -Ordered
 
-  if ($ymlObject.Contains("resources"))
+  if ($null -ne $ymlObject -and $ymlObject.Contains("resources"))
   {
     if ($ymlObject["resources"]["repositories"])
     {

--- a/eng/common/scripts/Verify-Resource-Ref.ps1
+++ b/eng/common/scripts/Verify-Resource-Ref.ps1
@@ -1,6 +1,6 @@
 . (Join-Path $PSScriptRoot common.ps1)
 Install-Module -Name powershell-yaml -RequiredVersion 0.4.1 -Force -Scope CurrentUser
-$ymlfiles = Get-ChildItem $RepoRoot -recurse | Where-Object {$_ -like '*.yml' -and $_ -notlike '*/invalid/*'}
+$ymlfiles = Get-ChildItem $RepoRoot -recurse | Where-Object {$_ -like '*.yml' -and $_ -notlike '*\invalid\*'}
 $affectedRepos = [System.Collections.ArrayList]::new()
 
 foreach ($file in $ymlfiles)


### PR DESCRIPTION
# Description

Context: recent errors have appeared in the `python - aggregate-reports` nightly pipeline ([example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1617863&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=b8bbf1e3-69f9-5ed2-638f-150827b62757&l=293)). This appears to be because we're calling a method on a null object -- in this case, the `ymlObject` variable is null because an [empty YAML file](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ml/azure-ai-ml/tests/test_configs/components/invalid/empty.yml) from `azure-ai-ml` is being evaluated. 

After adding a null check to fix this error, we ran into another error from a different file in the same `invalid` directory. These invalid YAML files are necessary for Azure ML tests, so this PR adds a condition to exclude files in any `invalid` directory from getting processed.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
