### PR TITLE
Add Build Definition For `Azure-CLI` tests

### DIFF
--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -75,3 +75,7 @@ jobs:
       - template: /eng/pipelines/templates/steps/use-python-version.yml
         parameters:
           versionSpec: '${{ parameters.PythonVersion }}'
+
+      - template: .azure-pipelines/templates/azdev_setup.yml@AzureCLI
+        parameters:
+          CLIRepoPath: $(Build.SourcesDirectory)/cli

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -95,5 +95,5 @@ jobs:
           source env/bin/activate
 
           serial_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
-          python scripts/ci/automation_full_test.py "1" "1" "latest" "$serial_modules"
+          python $(Agent.BuildDirectory)/cli/scripts/ci/automation_full_test.py "1" "1" "latest" "$serial_modules"
         displayName: Run CLI Tests

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -1,7 +1,7 @@
 resources:
   repositories:
-    - repository: azurecli
-      type: git
+    - repository: AzureCLI
+      type: github
       name: azure/azure-cli
       ref: refs/heads/dev
 
@@ -45,7 +45,7 @@ jobs:
       name: '$(poolName)'
 
     steps:
-      - checkout: azurecli
+      - checkout: AzureCLI
         fetchDepth: 1
         path: 'cli'
 

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -33,9 +33,9 @@ jobs:
         linux:
           imageName: 'ubuntu-20.04'
           poolName: 'azsdk-pool-mms-ubuntu-2004-general'
-        windows:
-          imageName: 'windows-2019'
-          poolName: 'azsdk-pool-mms-win-2019-general'
+        # windows:
+        #   imageName: 'windows-2019'
+        #   poolName: 'azsdk-pool-mms-win-2019-general'
         mac:
           imageName: 'macOS-10.15'
           poolName: 'Azure Pipelines'
@@ -60,8 +60,6 @@ jobs:
         parameters:
           CLIRepoPath: $(Agent.BuildDirectory)/cli
 
-      # walk injected packages, install them
-      # walk file paths, install those  
       - ${{ each artifact in parameters.TargetRepoPackages }}:
         - bash: |
             set -ev
@@ -69,7 +67,13 @@ jobs:
             pip install -e $(Build.SourcesDirectory)/${{ artifact }}
           displayName: Install ${{ artifact }} 
 
-      # run tests
+      - ${{ each package_spec in parameters.InjectedPackages }}:
+        - bash: |
+            set -ev
+            source env/bin/activate
+            pip install -e ${{ package_spec }}
+          displayName: Install ${{ package_spec }} 
+
       - bash: |
           set -ev
           source env/bin/activate

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -3,6 +3,7 @@ resources:
     - repository: AzureCLI
       type: github
       name: azure/azure-cli
+      endpoint: Azure
       ref: refs/heads/dev
 
 parameters:

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -21,7 +21,7 @@ parameters:
     default: "3.9"
 
 jobs:
- - job:
+  - job:
     displayName: 'Run AZDev Tests'
     timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
 
@@ -56,4 +56,3 @@ jobs:
       - pwsh: |
           Write-Host "Hello World"
         displayName: "Greetings"
-  

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -51,9 +51,22 @@ jobs:
         fetchDepth: 1
         path: 'cli'
 
-      - template: /eng/pipelines/templates/steps/use-python-version.yml
-        parameters:
-          versionSpec: '${{ parameters.PythonVersion }}'
+
+      - pwsh: |
+          Write-Host "Hello World"
+        displayName: "Greetings"
+
+      - pwsh: |
+          Get-ChildItem -Force -Path $(Build.BuildDirectory)
+        displayName: "Build Directory"
+
+      - pwsh: |
+          Get-ChildItem -Force -Path $(Build.SourcesDirectory)
+        displayName: "Examining Sources Directory"
+
+      # - template: /eng/pipelines/templates/steps/use-python-version.yml
+      #   parameters:
+      #     versionSpec: '${{ parameters.PythonVersion }}'
 
       - pwsh: |
           Write-Host "Hello World"

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -1,0 +1,59 @@
+resources:
+  repositories:
+    - repository: azure-cli
+      type: git
+      name: azure/azure-cli
+      ref: refs/heads/dev
+
+parameters:
+  - name: TargetRepoPackages
+    type: object
+    default: 
+      - 'sdk/core/azure-core'
+# a list of any resolvable pip install. EG:
+# - https://<path-to-blobstorage>/blah.whl
+# - <packagename>==<version>
+  - name: InjectedPackages
+    type: object
+    default: []
+  - name: PythonVersion
+    type: string
+    default: "3.9"
+
+jobs:
+ - job:
+    displayName: 'Run AZDev Tests'
+    timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+
+    variables:
+      - template: ../variables/globals.yml
+
+    strategy:
+      matrix:
+        linux:
+          imageName: 'ubuntu-20.04'
+          poolName: 'azsdk-pool-mms-ubuntu-2004-general'
+        mac:
+          imageName: 'windows-2019'
+          poolName: 'azsdk-pool-mms-win-2019-general'
+        windows:
+          imageName: 'macOS-10.15'
+          poolName: 'Azure Pipelines'
+
+    pool:
+      vmImage: $(imageName)
+      name: '$(poolName)'
+
+    steps:
+      - checkout: azure-cli
+        fetchDepth: 1
+        path: 'cli'
+
+      - template: /eng/pipelines/templates/steps/use-python-version.yml
+        parameters:
+          versionSpec: '${{ parameters.PythonVersion }}'
+
+      - pwsh: |
+          Write-Host "Hello World"
+        displayName: "Greetings"
+  

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -57,11 +57,11 @@ jobs:
         displayName: "Greetings"
 
       - pwsh: |
-          Get-ChildItem -Force -Path "$(Agent.BuildDirectory)"
+          Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)"
         displayName: "Examining Build Directory"
 
       - pwsh: |
-          Get-ChildItem -Force -Path "$(Build.SourcesDirectory)"
+          Get-ChildItem -Name -Force -Path "$(Build.SourcesDirectory)"
         displayName: "Examining Sources Directory"
 
       - pwsh: |
@@ -69,7 +69,7 @@ jobs:
         displayName: "Greetings"
 
       - pwsh: |
-          Get-ChildItem -Force -Path "$(Agent.BuildDirectory)/cli"
+          Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)/cli"
         displayName: "cli dump"
 
       - template: /eng/pipelines/templates/steps/use-python-version.yml

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -11,15 +11,18 @@ parameters:
     type: object
     default: 
       - 'sdk/core/azure-core'
-# a list of any resolvable pip install. EG:
-# - https://<path-to-blobstorage>/blah.whl
-# - <packagename>==<version>
+    # a list of any resolvable pip install. EG:
+    # - https://<path-to-blobstorage>/blah.whl
+    # - <packagename>==<version>
   - name: InjectedPackages
     type: object
     default: []
   - name: PythonVersion
     type: string
     default: "3.9"
+  - name: TargetModules
+    type: string
+    default: "appservice botservice cloud network azure-cli-core azure-cli-telemetry"
 
 jobs:
   - job:
@@ -80,6 +83,5 @@ jobs:
 
           python -m pip freeze
 
-          serial_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
-          python $(Agent.BuildDirectory)/cli/scripts/ci/automation_full_test.py "1" "1" "latest" "$serial_modules"
+          python $(Agent.BuildDirectory)/cli/scripts/ci/automation_full_test.py "1" "1" "latest" "${{ parameters.TargetModules }}"
         displayName: Run CLI Tests

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -78,4 +78,4 @@ jobs:
 
       - template: .azure-pipelines/templates/azdev_setup.yml@AzureCLI
         parameters:
-          CLIRepoPath: $(Build.SourcesDirectory)/cli
+          CLIRepoPath: $(Agent.BuildDirectory)/cli

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -57,16 +57,12 @@ jobs:
         displayName: "Greetings"
 
       - pwsh: |
-          Get-ChildItem -Force -Path $(Build.BuildDirectory)
-        displayName: "Build Directory"
+          Get-ChildItem -Force -Path $(Agent.BuildDirectory)
+        displayName: "Examining Build Directory"
 
       - pwsh: |
           Get-ChildItem -Force -Path $(Build.SourcesDirectory)
         displayName: "Examining Sources Directory"
-
-      - template: /eng/pipelines/templates/steps/use-python-version.yml
-        parameters:
-          versionSpec: '${{ parameters.PythonVersion }}'
 
       - pwsh: |
           Write-Host "Hello World"
@@ -74,4 +70,8 @@ jobs:
 
       - pwsh: |
           Get-ChildItem -R -Force -Path $(Build.BuildDirectory)/cli
-        displayName: "Greetings"
+        displayName: "cli dump"
+
+      - template: /eng/pipelines/templates/steps/use-python-version.yml
+        parameters:
+          versionSpec: '${{ parameters.PythonVersion }}'

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -1,6 +1,6 @@
 resources:
   repositories:
-    - repository: azure-cli
+    - repository: azurecli
       type: git
       name: azure/azure-cli
       ref: refs/heads/dev
@@ -45,7 +45,7 @@ jobs:
       name: '$(poolName)'
 
     steps:
-      - checkout: azure-cli
+      - checkout: azurecli
         fetchDepth: 1
         path: 'cli'
 

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -26,7 +26,7 @@ parameters:
 
 jobs:
   - job:
-    displayName: 'Run CLI Tests'
+    displayName: 'Run Azure CLI Tests'
 
     variables:
       - template: ../variables/globals.yml
@@ -51,13 +51,17 @@ jobs:
       - checkout: self
         path: 's'
 
+      - checkout: AzureCLI
+        fetchDepth: 1
+        path: 'cli'
+
       - template: /eng/pipelines/templates/steps/use-python-version.yml
         parameters:
           versionSpec: '${{ parameters.PythonVersion }}'
 
       - template: .azure-pipelines/templates/azdev_setup.yml@AzureCLI
         parameters:
-          CLIRepoPath: $(Build.SourcesDirectory)/azure-cli
+          CLIRepoPath: $(Agent.BuildDirectory)/cli
 
       - ${{ each artifact in parameters.TargetRepoPackages }}:
         - bash: |
@@ -79,5 +83,5 @@ jobs:
 
           python -m pip freeze
 
-          python $(Build.SourcesDirectory)/azure-cli/scripts/ci/automation_full_test.py "1" "1" "latest" "${{ parameters.TargetModules }}"
+          python $(Agent.BuildDirectory)/cli/scripts/ci/automation_full_test.py "1" "1" "latest" "${{ parameters.TargetModules }}"
         displayName: Run Tests

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -39,9 +39,9 @@ jobs:
         # windows:
         #   imageName: 'windows-2019'
         #   poolName: 'azsdk-pool-mms-win-2019-general'
-        mac:
-          imageName: 'macOS-10.15'
-          poolName: 'Azure Pipelines'
+        # mac:
+        #   imageName: 'macOS-10.15'
+        #   poolName: 'Azure Pipelines'
 
     pool:
       vmImage: $(imageName)

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -24,7 +24,6 @@ parameters:
 jobs:
   - job:
     displayName: 'Run AZDev Tests'
-    timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
 
     variables:
       - template: ../variables/globals.yml

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -46,11 +46,11 @@ jobs:
 
     steps:
       - checkout: self
+        path: 's'
 
       - checkout: AzureCLI
         fetchDepth: 1
         path: 'cli'
-
 
       - pwsh: |
           Write-Host "Hello World"
@@ -64,9 +64,9 @@ jobs:
           Get-ChildItem -Force -Path $(Build.SourcesDirectory)
         displayName: "Examining Sources Directory"
 
-      # - template: /eng/pipelines/templates/steps/use-python-version.yml
-      #   parameters:
-      #     versionSpec: '${{ parameters.PythonVersion }}'
+      - template: /eng/pipelines/templates/steps/use-python-version.yml
+        parameters:
+          versionSpec: '${{ parameters.PythonVersion }}'
 
       - pwsh: |
           Write-Host "Hello World"

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -33,10 +33,10 @@ jobs:
         linux:
           imageName: 'ubuntu-20.04'
           poolName: 'azsdk-pool-mms-ubuntu-2004-general'
-        mac:
+        windows:
           imageName: 'windows-2019'
           poolName: 'azsdk-pool-mms-win-2019-general'
-        windows:
+        mac:
           imageName: 'macOS-10.15'
           poolName: 'Azure Pipelines'
 
@@ -51,26 +51,6 @@ jobs:
       - checkout: AzureCLI
         fetchDepth: 1
         path: 'cli'
-
-      # - pwsh: |
-      #     Write-Host "Hello World"
-      #   displayName: "Greetings"
-
-      # - pwsh: |
-      #     Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)"
-      #   displayName: "Examining Build Directory"
-
-      # - pwsh: |
-      #     Get-ChildItem -Name -Force -Path "$(Build.SourcesDirectory)"
-      #   displayName: "Examining Sources Directory"
-
-      # - pwsh: |
-      #     Write-Host "Hello World"
-      #   displayName: "Greetings"
-
-      # - pwsh: |
-      #     Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)/cli"
-      #   displayName: "cli dump"
 
       - template: /eng/pipelines/templates/steps/use-python-version.yml
         parameters:
@@ -93,6 +73,8 @@ jobs:
       - bash: |
           set -ev
           source env/bin/activate
+
+          python -m pip freeze
 
           serial_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
           python $(Agent.BuildDirectory)/cli/scripts/ci/automation_full_test.py "1" "1" "latest" "$serial_modules"

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -26,7 +26,7 @@ parameters:
 
 jobs:
   - job:
-    displayName: 'Run AZDev Tests'
+    displayName: 'Run CLI Tests'
 
     variables:
       - template: ../variables/globals.yml
@@ -51,17 +51,13 @@ jobs:
       - checkout: self
         path: 's'
 
-      - checkout: AzureCLI
-        fetchDepth: 1
-        path: 'cli'
-
       - template: /eng/pipelines/templates/steps/use-python-version.yml
         parameters:
           versionSpec: '${{ parameters.PythonVersion }}'
 
       - template: .azure-pipelines/templates/azdev_setup.yml@AzureCLI
         parameters:
-          CLIRepoPath: $(Agent.BuildDirectory)/cli
+          CLIRepoPath: $(Build.SourcesDirectory)/azure-cli
 
       - ${{ each artifact in parameters.TargetRepoPackages }}:
         - bash: |
@@ -83,5 +79,5 @@ jobs:
 
           python -m pip freeze
 
-          python $(Agent.BuildDirectory)/cli/scripts/ci/automation_full_test.py "1" "1" "latest" "${{ parameters.TargetModules }}"
-        displayName: Run CLI Tests
+          python $(Build.SourcesDirectory)/azure-cli/scripts/ci/automation_full_test.py "1" "1" "latest" "${{ parameters.TargetModules }}"
+        displayName: Run Tests

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -52,25 +52,25 @@ jobs:
         fetchDepth: 1
         path: 'cli'
 
-      - pwsh: |
-          Write-Host "Hello World"
-        displayName: "Greetings"
+      # - pwsh: |
+      #     Write-Host "Hello World"
+      #   displayName: "Greetings"
 
-      - pwsh: |
-          Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)"
-        displayName: "Examining Build Directory"
+      # - pwsh: |
+      #     Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)"
+      #   displayName: "Examining Build Directory"
 
-      - pwsh: |
-          Get-ChildItem -Name -Force -Path "$(Build.SourcesDirectory)"
-        displayName: "Examining Sources Directory"
+      # - pwsh: |
+      #     Get-ChildItem -Name -Force -Path "$(Build.SourcesDirectory)"
+      #   displayName: "Examining Sources Directory"
 
-      - pwsh: |
-          Write-Host "Hello World"
-        displayName: "Greetings"
+      # - pwsh: |
+      #     Write-Host "Hello World"
+      #   displayName: "Greetings"
 
-      - pwsh: |
-          Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)/cli"
-        displayName: "cli dump"
+      # - pwsh: |
+      #     Get-ChildItem -Name -Force -Path "$(Agent.BuildDirectory)/cli"
+      #   displayName: "cli dump"
 
       - template: /eng/pipelines/templates/steps/use-python-version.yml
         parameters:
@@ -79,3 +79,20 @@ jobs:
       - template: .azure-pipelines/templates/azdev_setup.yml@AzureCLI
         parameters:
           CLIRepoPath: $(Agent.BuildDirectory)/cli
+
+      # walk injected packages, install them
+      # walk file paths, install those  
+      - ${{ each artifact in parameters.TargetRepoPackages }}:
+        - pwsh: |
+            pip install -e $(Build.SourcesDirectory)/${{ artifact }}
+          displayName: Install ${{ artifact }} 
+
+      # run tests
+      - bash: |
+          set -ev
+          source env/bin/activate
+
+          serial_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
+          python scripts/ci/automation_full_test.py "1" "1" "latest" "$serial_modules"
+        displayName: Run CLI Tests
+        workingDirectory: $(Agent.BuildDirectory)/cli

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -57,11 +57,11 @@ jobs:
         displayName: "Greetings"
 
       - pwsh: |
-          Get-ChildItem -Force -Path $(Agent.BuildDirectory)
+          Get-ChildItem -Force -Path "$(Agent.BuildDirectory)"
         displayName: "Examining Build Directory"
 
       - pwsh: |
-          Get-ChildItem -Force -Path $(Build.SourcesDirectory)
+          Get-ChildItem -Force -Path "$(Build.SourcesDirectory)"
         displayName: "Examining Sources Directory"
 
       - pwsh: |
@@ -69,7 +69,7 @@ jobs:
         displayName: "Greetings"
 
       - pwsh: |
-          Get-ChildItem -R -Force -Path $(Build.BuildDirectory)/cli
+          Get-ChildItem -Force -Path "$(Agent.BuildDirectory)/cli"
         displayName: "cli dump"
 
       - template: /eng/pipelines/templates/steps/use-python-version.yml

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -83,7 +83,9 @@ jobs:
       # walk injected packages, install them
       # walk file paths, install those  
       - ${{ each artifact in parameters.TargetRepoPackages }}:
-        - pwsh: |
+        - bash: |
+            set -ev
+            source env/bin/activate
             pip install -e $(Build.SourcesDirectory)/${{ artifact }}
           displayName: Install ${{ artifact }} 
 
@@ -95,4 +97,3 @@ jobs:
           serial_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
           python scripts/ci/automation_full_test.py "1" "1" "latest" "$serial_modules"
         displayName: Run CLI Tests
-        workingDirectory: $(Agent.BuildDirectory)/cli

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -45,6 +45,8 @@ jobs:
       name: '$(poolName)'
 
     steps:
+      - checkout: self
+
       - checkout: AzureCLI
         fetchDepth: 1
         path: 'cli'
@@ -55,4 +57,8 @@ jobs:
 
       - pwsh: |
           Write-Host "Hello World"
+        displayName: "Greetings"
+
+      - pwsh: |
+          Get-ChildItem -R -Force -Path $(Build.BuildDirectory)/cli
         displayName: "Greetings"


### PR DESCRIPTION
Running this build allows us to invoke the CLI tests against any package within our repo. Also parametrized are:

- `PythonVersion`: which python version is used
- `TargetModules`: which cli modules to invoke tests for
- `TargetRepoPackages`: list of repo paths that should be installed`
- `InjectedPackages`: list of pip installable requirements. These can be a VCS url, a raw URI to a blob stored wheel, a python version specifier, or any other pip installable component.

Mac/Windows both hit issues in the azdev_setup.yml. More work is necessary to enable those. Probably will need to roll our own setup code if we want crossplat.

Resolves #24722 24722