### PR TITLE
[Storage] Improve exception raised when uploading 'dict' Blob

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -376,7 +376,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             stream = BytesIO(data)
         elif hasattr(data, 'read'):
             stream = data
-        elif hasattr(data, '__iter__') and not isinstance(data, dict):
+        elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
             stream = IterStreamer(data, encoding=encoding)
         else:
             raise TypeError("Unsupported data type: {}".format(type(data)))

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -376,6 +376,8 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             stream = BytesIO(data)
         elif hasattr(data, 'read'):
             stream = data
+        elif isinstance(data, dict):
+            raise TypeError("Unsupported data type: dict")
         elif hasattr(data, '__iter__'):
             stream = IterStreamer(data, encoding=encoding)
         else:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -376,9 +376,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             stream = BytesIO(data)
         elif hasattr(data, 'read'):
             stream = data
-        elif isinstance(data, dict):
-            raise TypeError("Unsupported data type: dict")
-        elif hasattr(data, '__iter__'):
+        elif hasattr(data, '__iter__') and not isinstance(data, dict):
             stream = IterStreamer(data, encoding=encoding)
         else:
             raise TypeError("Unsupported data type: {}".format(type(data)))

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_upload_blob_with_dictionary.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_upload_blob_with_dictionary.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 07 Jun 2022 18:47:01 GMT
+      - Tue, 07 Jun 2022 19:20:35 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -21,14 +21,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:759e4bb7-a01e-000f-619e-7a804d000000\nTime:2022-06-07T18:47:01.2108048Z</Message></Error>"
+        specified container already exists.\nRequestId:e6910659-b01e-0003-5ca3-7a1745000000\nTime:2022-06-07T19:20:34.5823446Z</Message></Error>"
     headers:
       content-length:
       - '230'
       content-type:
       - application/xml
       date:
-      - Tue, 07 Jun 2022 18:47:00 GMT
+      - Tue, 07 Jun 2022 19:20:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 07 Jun 2022 18:47:02 GMT
+      - Tue, 07 Jun 2022 19:20:35 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -60,14 +60,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:759e4bc0-a01e-000f-679e-7a804d000000\nTime:2022-06-07T18:47:01.3077737Z</Message></Error>"
+        specified container already exists.\nRequestId:e6910683-b01e-0003-7fa3-7a1745000000\nTime:2022-06-07T19:20:34.6763141Z</Message></Error>"
     headers:
       content-length:
       - '230'
       content-type:
       - application/xml
       date:
-      - Tue, 07 Jun 2022 18:47:00 GMT
+      - Tue, 07 Jun 2022 19:20:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_upload_blob_with_dictionary.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_upload_blob_with_dictionary.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Mon, 06 Jun 2022 23:33:54 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainerf66d1427?restype=container&timeout=5
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:fb4b3eaa-701e-00c7-23fd-79627c000000\nTime:2022-06-06T23:33:55.0116684Z</Message></Error>"
+    headers:
+      content-length:
+      - '230'
+      content-type:
+      - application/xml
+      date:
+      - Mon, 06 Jun 2022 23:33:54 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-error-code:
+      - ContainerAlreadyExists
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 409
+      message: The specified container already exists.
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Mon, 06 Jun 2022 23:33:54 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainersourcef66d1427?restype=container&timeout=5
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:fb4b3eb6-701e-00c7-2dfd-79627c000000\nTime:2022-06-06T23:33:55.1156354Z</Message></Error>"
+    headers:
+      content-length:
+      - '230'
+      content-type:
+      - application/xml
+      date:
+      - Mon, 06 Jun 2022 23:33:54 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-error-code:
+      - ContainerAlreadyExists
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 409
+      message: The specified container already exists.
+version: 1

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_upload_blob_with_dictionary.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_upload_blob_with_dictionary.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 06 Jun 2022 23:33:54 GMT
+      - Tue, 07 Jun 2022 18:47:01 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -21,14 +21,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:fb4b3eaa-701e-00c7-23fd-79627c000000\nTime:2022-06-06T23:33:55.0116684Z</Message></Error>"
+        specified container already exists.\nRequestId:759e4bb7-a01e-000f-619e-7a804d000000\nTime:2022-06-07T18:47:01.2108048Z</Message></Error>"
     headers:
       content-length:
       - '230'
       content-type:
       - application/xml
       date:
-      - Mon, 06 Jun 2022 23:33:54 GMT
+      - Tue, 07 Jun 2022 18:47:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 06 Jun 2022 23:33:54 GMT
+      - Tue, 07 Jun 2022 18:47:02 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -60,14 +60,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:fb4b3eb6-701e-00c7-2dfd-79627c000000\nTime:2022-06-06T23:33:55.1156354Z</Message></Error>"
+        specified container already exists.\nRequestId:759e4bc0-a01e-000f-679e-7a804d000000\nTime:2022-06-07T18:47:01.3077737Z</Message></Error>"
     headers:
       content-length:
       - '230'
       content-type:
       - application/xml
       date:
-      - Mon, 06 Jun 2022 23:33:54 GMT
+      - Tue, 07 Jun 2022 18:47:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code:

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_upload_blob_with_dictionary_async.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_upload_blob_with_dictionary_async.yaml
@@ -7,24 +7,25 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 06 Jun 2022 23:29:23 GMT
+      - Tue, 07 Jun 2022 18:47:25 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/utcontainer9941921?restype=container
   response:
     body:
-      string: ''
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:dc31729a-a01e-00eb-399f-7a8ed3000000\nTime:2022-06-07T18:47:24.9874609Z</Message></Error>"
     headers:
-      content-length: '0'
-      date: Mon, 06 Jun 2022 23:29:23 GMT
-      etag: '"0x8DA48146428FF7E"'
-      last-modified: Mon, 06 Jun 2022 23:29:24 GMT
+      content-length: '230'
+      content-type: application/xml
+      date: Tue, 07 Jun 2022 18:47:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-error-code: ContainerAlreadyExists
       x-ms-version: '2021-06-08'
     status:
-      code: 201
-      message: Created
+      code: 409
+      message: The specified container already exists.
     url: https://vincenttranstock.blob.core.windows.net/utcontainer9941921?restype=container
 - request:
     body: null
@@ -34,23 +35,24 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Mon, 06 Jun 2022 23:29:24 GMT
+      - Tue, 07 Jun 2022 18:47:26 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
     uri: https://storagename.blob.core.windows.net/utcontainersource9941921?restype=container
   response:
     body:
-      string: ''
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:dc3172b0-a01e-00eb-489f-7a8ed3000000\nTime:2022-06-07T18:47:25.0884273Z</Message></Error>"
     headers:
-      content-length: '0'
-      date: Mon, 06 Jun 2022 23:29:23 GMT
-      etag: '"0x8DA4814643978E2"'
-      last-modified: Mon, 06 Jun 2022 23:29:24 GMT
+      content-length: '230'
+      content-type: application/xml
+      date: Tue, 07 Jun 2022 18:47:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-error-code: ContainerAlreadyExists
       x-ms-version: '2021-06-08'
     status:
-      code: 201
-      message: Created
+      code: 409
+      message: The specified container already exists.
     url: https://vincenttranstock.blob.core.windows.net/utcontainersource9941921?restype=container
 version: 1

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_upload_blob_with_dictionary_async.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_upload_blob_with_dictionary_async.yaml
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 07 Jun 2022 18:47:25 GMT
+      - Tue, 07 Jun 2022 19:20:45 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -15,11 +15,11 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:dc31729a-a01e-00eb-399f-7a8ed3000000\nTime:2022-06-07T18:47:24.9874609Z</Message></Error>"
+        specified container already exists.\nRequestId:3c4418c3-601e-003f-37a3-7a3e82000000\nTime:2022-06-07T19:20:44.6188664Z</Message></Error>"
     headers:
       content-length: '230'
       content-type: application/xml
-      date: Tue, 07 Jun 2022 18:47:24 GMT
+      date: Tue, 07 Jun 2022 19:20:44 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code: ContainerAlreadyExists
       x-ms-version: '2021-06-08'
@@ -35,7 +35,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Tue, 07 Jun 2022 18:47:26 GMT
+      - Tue, 07 Jun 2022 19:20:45 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -43,11 +43,11 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:dc3172b0-a01e-00eb-489f-7a8ed3000000\nTime:2022-06-07T18:47:25.0884273Z</Message></Error>"
+        specified container already exists.\nRequestId:3c4418db-601e-003f-4aa3-7a3e82000000\nTime:2022-06-07T19:20:44.7418262Z</Message></Error>"
     headers:
       content-length: '230'
       content-type: application/xml
-      date: Tue, 07 Jun 2022 18:47:24 GMT
+      date: Tue, 07 Jun 2022 19:20:44 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-error-code: ContainerAlreadyExists
       x-ms-version: '2021-06-08'

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_upload_blob_with_dictionary_async.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_upload_blob_with_dictionary_async.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Mon, 06 Jun 2022 23:29:23 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainer9941921?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Mon, 06 Jun 2022 23:29:23 GMT
+      etag: '"0x8DA48146428FF7E"'
+      last-modified: Mon, 06 Jun 2022 23:29:24 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-06-08'
+    status:
+      code: 201
+      message: Created
+    url: https://vincenttranstock.blob.core.windows.net/utcontainer9941921?restype=container
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.12.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Mon, 06 Jun 2022 23:29:24 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainersource9941921?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Mon, 06 Jun 2022 23:29:23 GMT
+      etag: '"0x8DA4814643978E2"'
+      last-modified: Mon, 06 Jun 2022 23:29:24 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-06-08'
+    status:
+      code: 201
+      message: Created
+    url: https://vincenttranstock.blob.core.windows.net/utcontainersource9941921?restype=container
+version: 1

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -365,6 +365,19 @@ class StorageCommonBlobTest(StorageTestCase):
         self.assertDictEqual(md, metadata)
 
     @BlobPreparer()
+    def test_upload_blob_with_dictionary(self, storage_account_name, storage_account_key):
+        self._setup(storage_account_name, storage_account_key)
+        blob_name = 'test_blob'
+        blob_data = {'hello': 'world'}
+
+        # Act
+        blob = self.bsc.get_blob_client(self.container_name, blob_name)
+
+        # Assert
+        with self.assertRaises(TypeError):
+            blob.upload_blob(blob_data)
+
+    @BlobPreparer()
     def test_upload_blob_from_generator(self, storage_account_name, storage_account_key):
         self._setup(storage_account_name, storage_account_key)
         blob_name = self._get_blob_reference()

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -452,6 +452,20 @@ class StorageCommonBlobAsyncTest(AsyncStorageTestCase):
 
     @BlobPreparer()
     @AsyncStorageTestCase.await_prepared_test
+    async def test_upload_blob_with_dictionary_async(self, storage_account_name, storage_account_key):
+        await self._setup(storage_account_name, storage_account_key)
+        blob_name = 'test_blob'
+        blob_data = {'hello': 'world'}
+
+        # Act
+        blob = self.bsc.get_blob_client(self.container_name, blob_name)
+
+        # Assert
+        with self.assertRaises(TypeError):
+            await blob.upload_blob(blob_data)
+
+    @BlobPreparer()
+    @AsyncStorageTestCase.await_prepared_test
     async def test_create_blob_with_generator_async(self, storage_account_name, storage_account_key):
         await self._setup(storage_account_name, storage_account_key)
 


### PR DESCRIPTION
As raised by a customer in #18122, current behavior does correctly reject `dict` objects from being uploaded, but returns a cryptic `HttpResponseError` rather than a helpful message regarding data type.

The reason for this is that `dict` types are being accepted in the `if-elif` chain for the condition: 
`elif hasattr(data, '__iter__'):`
while the expectation is that `dict` types should be caught in the final else and raise a `TypeError`

Open to suggestions on possible refactoring (or if there's a better place to handle this type-catching 😄)