### PR TITLE
[Servicebus] message settlement and pyamqp

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/_configuration.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/_configuration.py
@@ -5,8 +5,11 @@
 from typing import Optional, Dict, Any
 from urllib.parse import urlparse
 
-from uamqp.constants import TransportType, DEFAULT_AMQP_WSS_PORT, DEFAULT_AMQPS_PORT
+from .._pyamqp.constants import TransportType
 from azure.core.pipeline.policies import RetryMode
+
+DEFAULT_AMQPS_PORT = 1571
+DEFAULT_AMQP_WSS_PORT = 443
 
 
 class Configuration(object):  # pylint:disable=too-many-instance-attributes

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/constants.py
@@ -5,7 +5,10 @@
 # -------------------------------------------------------------------------
 from enum import Enum
 
-from uamqp import constants, types
+from .._pyamqp import (
+    types,
+    constants,
+)
 from azure.core import CaseInsensitiveEnumMeta
 
 VENDOR = b"com.microsoft"
@@ -179,8 +182,8 @@ class ServiceBusMessageState(int, Enum):
 
 # To enable extensible string enums for the public facing parameter, and translate to the "real" uamqp constants.
 ServiceBusToAMQPReceiveModeMap = {
-    ServiceBusReceiveMode.PEEK_LOCK: constants.ReceiverSettleMode.PeekLock,
-    ServiceBusReceiveMode.RECEIVE_AND_DELETE: constants.ReceiverSettleMode.ReceiveAndDelete,
+    ServiceBusReceiveMode.PEEK_LOCK: constants.ReceiverSettleMode.Second,
+    ServiceBusReceiveMode.RECEIVE_AND_DELETE: constants.ReceiverSettleMode.First,
 }
 
 
@@ -193,11 +196,9 @@ class ServiceBusSubQueue(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     TRANSFER_DEAD_LETTER = "transferdeadletter"
 
 
-ANNOTATION_SYMBOL_PARTITION_KEY = types.AMQPSymbol(_X_OPT_PARTITION_KEY)
-ANNOTATION_SYMBOL_VIA_PARTITION_KEY = types.AMQPSymbol(_X_OPT_VIA_PARTITION_KEY)
-ANNOTATION_SYMBOL_SCHEDULED_ENQUEUE_TIME = types.AMQPSymbol(
-    _X_OPT_SCHEDULED_ENQUEUE_TIME
-)
+ANNOTATION_SYMBOL_PARTITION_KEY = _X_OPT_PARTITION_KEY
+ANNOTATION_SYMBOL_VIA_PARTITION_KEY = _X_OPT_VIA_PARTITION_KEY
+ANNOTATION_SYMBOL_SCHEDULED_ENQUEUE_TIME = _X_OPT_SCHEDULED_ENQUEUE_TIME
 
 ANNOTATION_SYMBOL_KEY_MAP = {
     _X_OPT_PARTITION_KEY: ANNOTATION_SYMBOL_PARTITION_KEY,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -13,8 +13,8 @@ from typing import Optional, Dict, List, Union, Iterable, TYPE_CHECKING, Any, Ma
 
 import six
 
-import uamqp.errors
-import uamqp.message
+from .._pyamqp.constants import MAX_FRAME_SIZE_BYTES as MAX_MESSAGE_LENGTH_BYTES
+from .._pyamqp.message import Message, BatchMessage
 
 from .constants import (
     _BATCH_MESSAGE_OVERHEAD_COST,
@@ -670,11 +670,11 @@ class ServiceBusMessageBatch(object):
 
     def __init__(self, max_size_in_bytes=None):
         # type: (Optional[int]) -> None
-        self.message = uamqp.BatchMessage(
+        self.message = BatchMessage(
             data=[], multi_messages=False, properties=None
         )
         self._max_size_in_bytes = (
-            max_size_in_bytes or uamqp.constants.MAX_MESSAGE_LENGTH_BYTES
+            max_size_in_bytes or MAX_MESSAGE_LENGTH_BYTES
         )
         self._size = self.message.gather()[0].get_message_encoded_size()
         self._count = 0
@@ -782,7 +782,7 @@ class ServiceBusReceivedMessage(ServiceBusMessage):
     """
 
     def __init__(self, message, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, **kwargs):
-        # type: (uamqp.message.Message, Union[ServiceBusReceiveMode, str], Any) -> None
+        # type: (Message, Union[ServiceBusReceiveMode, str], Any) -> None
         super(ServiceBusReceivedMessage, self).__init__(None, message=message)  # type: ignore
         self._settled = receive_mode == ServiceBusReceiveMode.RECEIVE_AND_DELETE
         self._received_timestamp_utc = utc_now()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/mgmt_handlers.py
@@ -5,7 +5,7 @@
 # -------------------------------------------------------------------------
 
 import logging
-import uamqp
+from .._pyamqp.message import Message
 from .message import ServiceBusReceivedMessage
 from ..exceptions import _handle_amqp_mgmt_error
 from .constants import ServiceBusReceiveMode, MGMT_RESPONSE_MESSAGE_ERROR_CONDITION
@@ -64,7 +64,7 @@ def peek_op(  # pylint: disable=inconsistent-return-statements
     if status_code == 200:
         parsed = []
         for m in message.get_data()[b"messages"]:
-            wrapped = uamqp.Message.decode_from_bytes(bytearray(m[b"message"]))
+            wrapped = Message.decode_from_bytes(bytearray(m[b"message"]))
             parsed.append(
                 ServiceBusReceivedMessage(
                     wrapped, is_peeked_message=True, receiver=receiver
@@ -112,7 +112,7 @@ def deferred_message_op(  # pylint: disable=inconsistent-return-statements
     if status_code == 200:
         parsed = []
         for m in message.get_data()[b"messages"]:
-            wrapped = uamqp.Message.decode_from_bytes(bytearray(m[b"message"]))
+            wrapped = Message.decode_from_bytes(bytearray(m[b"message"]))
             parsed.append(
                 message_type(
                     wrapped, receive_mode, is_deferred_message=True, receiver=receiver

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/receiver_mixins.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/receiver_mixins.py
@@ -7,7 +7,7 @@ import uuid
 import functools
 from typing import Optional, Callable
 
-from uamqp import Source
+from .._pyamqp.endpoints import Source
 
 from .message import ServiceBusReceivedMessage
 from .constants import (

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
@@ -31,7 +31,8 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from uamqp import authentication, types
+from .._pyamqp.authentication import JWTTokenAuth
+from .._pyamqp import types
 
 from azure.core.settings import settings
 from azure.core.tracing import SpanKind, Link
@@ -110,14 +111,14 @@ def create_properties(user_agent=None):
     :rtype: dict
     """
     properties = {}
-    properties[types.AMQPSymbol("product")] = USER_AGENT_PREFIX
-    properties[types.AMQPSymbol("version")] = VERSION
+    properties["product"] = USER_AGENT_PREFIX
+    properties["version"] = VERSION
     framework = "Python/{}.{}.{}".format(
         sys.version_info[0], sys.version_info[1], sys.version_info[2]
     )
-    properties[types.AMQPSymbol("framework")] = framework
+    properties["framework"] = framework
     platform_str = platform.platform()
-    properties[types.AMQPSymbol("platform")] = platform_str
+    properties["platform"] = platform_str
 
     final_user_agent = "{}/{} {} ({})".format(
         USER_AGENT_PREFIX, VERSION, framework, platform_str
@@ -125,7 +126,7 @@ def create_properties(user_agent=None):
     if user_agent:
         final_user_agent = "{} {}".format(user_agent, final_user_agent)
 
-    properties[types.AMQPSymbol("user-agent")] = final_user_agent
+    properties["user-agent"] = final_user_agent
     return properties
 
 
@@ -165,7 +166,7 @@ def create_authentication(client):
     except AttributeError:
         token_type = TOKEN_TYPE_JWT
     if token_type == TOKEN_TYPE_SASTOKEN:
-        auth = authentication.JWTTokenAuth(
+        auth =JWTTokenAuth(
             client._auth_uri,
             client._auth_uri,
             functools.partial(client._credential.get_token, client._auth_uri),
@@ -179,7 +180,7 @@ def create_authentication(client):
         )
         auth.update_token()
         return auth
-    return authentication.JWTTokenAuth(
+    return JWTTokenAuth(
         client._auth_uri,
         client._auth_uri,
         functools.partial(client._credential.get_token, JWT_TOKEN_SCOPE),

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/__init__.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/__init__.py
@@ -1,0 +1,13 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#-------------------------------------------------------------------------
+
+__version__ = "2.0.0a1"
+
+
+from ._connection import Connection
+from ._transport import SSLTransport
+
+from .client import AMQPClient, ReceiveClient, SendClient

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -657,7 +657,9 @@ class Connection(object):
                 )
                 return
             for _ in range(batch):
+                # print(wait)
                 new_frame = self._read_frame(wait=wait, **kwargs)
+                # print(new_frame[1])
                 if self._process_incoming_frame(*new_frame):
                     break
         except (OSError, IOError, SSLError, socket.error) as exc:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -1,0 +1,760 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import uuid
+import logging
+import time
+from urllib.parse import urlparse
+import socket
+from ssl import SSLError
+
+from ._transport import Transport
+from .sasl import SASLTransport, SASLWithWebSocket
+from .session import Session
+from .performatives import OpenFrame, CloseFrame
+from .constants import (
+    PORT,
+    SECURE_PORT,
+    MAX_CHANNELS,
+    MAX_FRAME_SIZE_BYTES,
+    HEADER_FRAME,
+    ConnectionState,
+    EMPTY_FRAME,
+    TransportType
+)
+
+from .error import (
+    ErrorCondition,
+    AMQPConnectionError,
+    AMQPError
+)
+
+_LOGGER = logging.getLogger(__name__)
+_CLOSING_STATES = (
+    ConnectionState.OC_PIPE,
+    ConnectionState.CLOSE_PIPE,
+    ConnectionState.DISCARDING,
+    ConnectionState.CLOSE_SENT,
+    ConnectionState.END
+)
+
+
+def get_local_timeout(now, idle_timeout, last_frame_received_time):
+    # type: (float, float, float) -> bool
+    """Check whether the local timeout has been reached since a new incoming frame was received.
+
+    :param float now: The current time to check against.
+    :rtype: bool
+    :returns: Whether to shutdown the connection due to timeout.
+    """
+    if idle_timeout and last_frame_received_time:
+        time_since_last_received = now - last_frame_received_time
+        return time_since_last_received > idle_timeout
+    return False
+
+
+class Connection(object):
+    """An AMQP Connection.
+
+    :ivar str state: The connection state.
+    :param str endpoint: The endpoint to connect to. Must be fully qualified with scheme and port number.
+    :keyword str container_id: The ID of the source container. If not set a GUID will be generated.
+    :keyword int max_frame_size: Proposed maximum frame size in bytes. Default value is 64kb.
+    :keyword int channel_max: The maximum channel number that may be used on the Connection. Default value is 65535.
+    :keyword int idle_timeout: Connection idle time-out in seconds.
+    :keyword list(str) outgoing_locales: Locales available for outgoing text.
+    :keyword list(str) incoming_locales: Desired locales for incoming text in decreasing level of preference.
+    :keyword list(str) offered_capabilities: The extension capabilities the sender supports.
+    :keyword list(str) desired_capabilities: The extension capabilities the sender may use if the receiver supports
+    :keyword dict properties: Connection properties.
+    :keyword bool allow_pipelined_open: Allow frames to be sent on the connection before a response Open frame
+     has been received. Default value is `True`.
+    :keyword float idle_timeout_empty_frame_send_ratio: Portion of the idle timeout time to wait before sending an
+     empty frame. The default portion is 50% of the idle timeout value (i.e. `0.5`).
+    :keyword float idle_wait_time: The time in seconds to sleep while waiting for a response from the endpoint.
+     Default value is `0.1`.
+    :keyword bool network_trace: Whether to log the network traffic. Default value is `False`. If enabled, frames
+     will be logged at the logging.INFO level.
+    :keyword str transport_type: Determines if the transport type is Amqp or AmqpOverWebSocket. 
+     Defaults to TransportType.Amqp. It will be AmqpOverWebSocket if using http_proxy.
+    :keyword Dict http_proxy: HTTP proxy settings. This must be a dictionary with the following
+     keys: `'proxy_hostname'` (str value) and `'proxy_port'` (int value). When using these settings,
+     the transport_type would be AmqpOverWebSocket.
+     Additionally the following keys may also be present: `'username', 'password'`.
+    """
+
+    def __init__(self, endpoint, **kwargs):
+        # type(str, Any) -> None
+        parsed_url = urlparse(endpoint)
+        self._hostname = parsed_url.hostname
+        endpoint = self._hostname
+        if parsed_url.port:
+            self._port = parsed_url.port
+        elif parsed_url.scheme == 'amqps':
+            self._port = SECURE_PORT
+        else:
+            self._port = PORT
+        self.state = None  # type: Optional[ConnectionState]
+
+        transport = kwargs.get('transport')
+        self._transport_type = kwargs.pop('transport_type', TransportType.Amqp)
+        if transport:
+            self._transport = transport
+        elif 'sasl_credential' in kwargs:
+            sasl_transport = SASLTransport
+            if self._transport_type.name == 'AmqpOverWebsocket' or kwargs.get("http_proxy"):
+                sasl_transport = SASLWithWebSocket
+                endpoint = parsed_url.hostname + parsed_url.path
+            self._transport = sasl_transport(
+                host=endpoint,
+                credential=kwargs['sasl_credential'],
+                **kwargs
+            )
+        else:
+            self._transport = Transport(parsed_url.netloc, transport_type=self._transport_type, **kwargs)
+
+        self._container_id = kwargs.pop('container_id', None) or str(uuid.uuid4())  # type: str
+        self._max_frame_size = kwargs.pop('max_frame_size', MAX_FRAME_SIZE_BYTES)  # type: int
+        self._remote_max_frame_size = None  # type: Optional[int]
+        self._channel_max = kwargs.pop('channel_max', MAX_CHANNELS)  # type: int
+        self._idle_timeout = kwargs.pop('idle_timeout', None)  # type: Optional[int]
+        self._outgoing_locales = kwargs.pop('outgoing_locales', None)  # type: Optional[List[str]]
+        self._incoming_locales = kwargs.pop('incoming_locales', None)  # type: Optional[List[str]]
+        self._offered_capabilities = None  # type: Optional[str]
+        self._desired_capabilities = kwargs.pop('desired_capabilities', None)  # type: Optional[str]
+        self._properties = kwargs.pop('properties', None)  # type: Optional[Dict[str, str]]
+
+        self._allow_pipelined_open = kwargs.pop('allow_pipelined_open', True)  # type: bool
+        self._remote_idle_timeout = None  # type: Optional[int]
+        self._remote_idle_timeout_send_frame = None  # type: Optional[int]
+        self._idle_timeout_empty_frame_send_ratio = kwargs.get('idle_timeout_empty_frame_send_ratio', 0.5)  # type: float
+        self._last_frame_received_time = None  # type: Optional[float]
+        self._last_frame_sent_time = None  # type: Optional[float]
+        self._idle_wait_time = kwargs.get('idle_wait_time', 0.1)  # type: float
+        self._network_trace = kwargs.get('network_trace', False)
+        self._network_trace_params = {
+            'connection': self._container_id,
+            'session': None,
+            'link': None
+        }
+        self._error = None
+        self._outgoing_endpoints = {}  # type: Dict[int, Session]
+        self._incoming_endpoints = {}  # type: Dict[int, Session]
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def _set_state(self, new_state):
+        # type: (ConnectionState) -> None
+        """Update the connection state."""
+        if new_state is None:
+            return
+        previous_state = self.state
+        self.state = new_state
+        _LOGGER.info("Connection '%s' state changed: %r -> %r", self._container_id, previous_state, new_state)
+        for session in self._outgoing_endpoints.values():
+            session._on_connection_state_change()  # pylint:disable=protected-access
+
+    def _connect(self):
+        # type: () -> None
+        """Initiate the connection.
+
+        If `allow_pipelined_open` is enabled, the incoming response header will be processed immediately
+        and the state on exiting will be HDR_EXCH. Otherwise, the function will return before waiting for
+        the response header and the final state will be HDR_SENT.
+
+        :raises ValueError: If a reciprocating protocol header is not received during negotiation.
+        """
+        try:
+            if not self.state:
+                self._transport.connect()
+                self._set_state(ConnectionState.START)
+            self._transport.negotiate()
+            self._outgoing_header()
+            self._set_state(ConnectionState.HDR_SENT)
+            if not self._allow_pipelined_open:
+                self._process_incoming_frame(*self._read_frame(wait=True))
+                if self.state != ConnectionState.HDR_EXCH:
+                    self._disconnect()
+                    raise ValueError("Did not receive reciprocal protocol header. Disconnecting.")
+            else:
+                self._set_state(ConnectionState.HDR_SENT)
+        except (OSError, IOError, SSLError, socket.error) as exc:
+            raise AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Failed to initiate the connection due to exception: " + str(exc),
+                error=exc
+            )
+        except Exception:
+            raise
+
+    def _disconnect(self):
+        # type: () -> None
+        """Disconnect the transport and set state to END."""
+        if self.state == ConnectionState.END:
+            return
+        self._set_state(ConnectionState.END)
+        self._transport.close()
+
+    def _can_read(self):
+        # type: () -> bool
+        """Whether the connection is in a state where it is legal to read for incoming frames."""
+        return self.state not in (ConnectionState.CLOSE_RCVD, ConnectionState.END)
+
+    def _read_frame(self, wait=True, **kwargs):
+        # type: (bool, Any) -> Tuple[int, Optional[Tuple[int, NamedTuple]]]
+        """Read an incoming frame from the transport.
+
+        :param Union[bool, float] wait: Whether to block on the socket while waiting for an incoming frame.
+         The default value is `False`, where the frame will block for the configured timeout only (0.1 seconds).
+         If set to `True`, socket will block indefinitely. If set to a timeout value in seconds, the socket will
+         block for at most that value.
+        :rtype: Tuple[int, Optional[Tuple[int, NamedTuple]]]
+        :returns: A tuple with the incoming channel number, and the frame in the form or a tuple of performative
+         descriptor and field values.
+        """
+        if self._can_read():
+            if wait == False:
+                return self._transport.receive_frame(**kwargs)
+            elif wait == True:
+                with self._transport.block():
+                    return self._transport.receive_frame(**kwargs)
+            else:
+                with self._transport.block_with_timeout(timeout=wait):
+                    return self._transport.receive_frame(**kwargs)
+        _LOGGER.warning("Cannot read frame in current state: %r", self.state)
+
+    def _can_write(self):
+        # type: () -> bool
+        """Whether the connection is in a state where it is legal to write outgoing frames."""
+        return self.state not in _CLOSING_STATES
+
+    def _send_frame(self, channel, frame, timeout=None, **kwargs):
+        # type: (int, NamedTuple, Optional[int], Any) -> None
+        """Send a frame over the connection.
+
+        :param int channel: The outgoing channel number.
+        :param NamedTuple: The outgoing frame.
+        :param int timeout: An optional timeout value to wait until the socket is ready to send the frame.
+        :rtype: None
+        """
+        try:
+            raise self._error
+        except TypeError:
+            pass
+
+        if self._can_write():
+            try:
+                self._last_frame_sent_time = time.time()
+                if timeout:
+                    with self._transport.block_with_timeout(timeout):
+                        self._transport.send_frame(channel, frame, **kwargs)
+                else:
+                    self._transport.send_frame(channel, frame, **kwargs)
+            except (OSError, IOError, SSLError, socket.error) as exc:
+                self._error = AMQPConnectionError(
+                    ErrorCondition.SocketError,
+                    description="Can not send frame out due to exception: " + str(exc),
+                    error=exc
+                )
+            except Exception:
+                raise
+        else:
+            _LOGGER.warning("Cannot write frame in current state: %r", self.state)
+
+    def _get_next_outgoing_channel(self):
+        # type: () -> int
+        """Get the next available outgoing channel number within the max channel limit.
+
+        :raises ValueError: If maximum channels has been reached.
+        :returns: The next available outgoing channel number.
+        :rtype: int
+        """
+        if (len(self._incoming_endpoints) + len(self._outgoing_endpoints)) >= self._channel_max:
+            raise ValueError("Maximum number of channels ({}) has been reached.".format(self._channel_max))
+        next_channel = next(i for i in range(1, self._channel_max) if i not in self._outgoing_endpoints)
+        return next_channel
+
+    def _outgoing_empty(self):
+        # type: () -> None
+        """Send an empty frame to prevent the connection from reaching an idle timeout."""
+        if self._network_trace:
+            _LOGGER.info("-> empty()", extra=self._network_trace_params)
+        try:
+            raise self._error
+        except TypeError:
+            pass
+        try:
+            if self._can_write():
+                self._transport.write(EMPTY_FRAME)
+                self._last_frame_sent_time = time.time()
+        except (OSError, IOError, SSLError, socket.error) as exc:
+            self._error = AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Can not send empty frame due to exception: " + str(exc),
+                error=exc
+            )
+        except Exception:
+            raise
+
+    def _outgoing_header(self):
+        # type: () -> None
+        """Send the AMQP protocol header to initiate the connection."""
+        self._last_frame_sent_time = time.time()
+        if self._network_trace:
+            _LOGGER.info("-> header(%r)", HEADER_FRAME, extra=self._network_trace_params)
+        self._transport.write(HEADER_FRAME)
+
+    def _incoming_header(self, _, frame):
+        # type: (int, bytes) -> None
+        """Process an incoming AMQP protocol header and update the connection state."""
+        if self._network_trace:
+            _LOGGER.info("<- header(%r)", frame, extra=self._network_trace_params)
+        if self.state == ConnectionState.START:
+            self._set_state(ConnectionState.HDR_RCVD)
+        elif self.state == ConnectionState.HDR_SENT:
+            self._set_state(ConnectionState.HDR_EXCH)
+        elif self.state == ConnectionState.OPEN_PIPE:
+            self._set_state(ConnectionState.OPEN_SENT)
+
+    def _outgoing_open(self):
+        # type: () -> None
+        """Send an Open frame to negotiate the AMQP connection functionality."""
+        open_frame = OpenFrame(
+            container_id=self._container_id,
+            hostname=self._hostname,
+            max_frame_size=self._max_frame_size,
+            channel_max=self._channel_max,
+            idle_timeout=self._idle_timeout * 1000 if self._idle_timeout else None,  # Convert to milliseconds
+            outgoing_locales=self._outgoing_locales,
+            incoming_locales=self._incoming_locales,
+            offered_capabilities=self._offered_capabilities if self.state == ConnectionState.OPEN_RCVD else None,
+            desired_capabilities=self._desired_capabilities if self.state == ConnectionState.HDR_EXCH else None,
+            properties=self._properties,
+        )
+        if self._network_trace:
+            _LOGGER.info("-> %r", open_frame, extra=self._network_trace_params)
+        self._send_frame(0, open_frame)
+
+    def _incoming_open(self, channel, frame):
+        # type: (int, Tuple[Any, ...]) -> None
+        """Process incoming Open frame to finish the connection negotiation.
+
+        The incoming frame format is::
+
+            - frame[0]: container_id (str)
+            - frame[1]: hostname (str)
+            - frame[2]: max_frame_size (int)
+            - frame[3]: channel_max (int)
+            - frame[4]: idle_timeout (Optional[int])
+            - frame[5]: outgoing_locales (Optional[List[bytes]])
+            - frame[6]: incoming_locales (Optional[List[bytes]])
+            - frame[7]: offered_capabilities (Optional[List[bytes]])
+            - frame[8]: desired_capabilities (Optional[List[bytes]])
+            - frame[9]: properties (Optional[Dict[bytes, bytes]])
+
+        :param int channel: The incoming channel number.
+        :param frame: The incoming Open frame.
+        :type frame: Tuple[Any, ...]
+        :rtype: None
+        """
+        # TODO: Add type hints for full frame tuple contents.
+        if self._network_trace:
+            _LOGGER.info("<- %r", OpenFrame(*frame), extra=self._network_trace_params)
+        if channel != 0:
+            _LOGGER.error("OPEN frame received on a channel that is not 0.")
+            self.close(
+                error=AMQPError(
+                    condition=ErrorCondition.NotAllowed,
+                    description="OPEN frame received on a channel that is not 0."
+                )
+            )
+            self._set_state(ConnectionState.END)
+        if self.state == ConnectionState.OPENED:
+            _LOGGER.error("OPEN frame received in the OPENED state.")
+            self.close()
+        if frame[4]:
+            self._remote_idle_timeout = frame[4]/1000  # Convert to seconds
+            self._remote_idle_timeout_send_frame = self._idle_timeout_empty_frame_send_ratio * self._remote_idle_timeout
+
+        if frame[2] < 512:  # Ensure minimum max frame size.
+            pass  # TODO: error
+        self._remote_max_frame_size = frame[2]
+        if self.state == ConnectionState.OPEN_SENT:
+            self._set_state(ConnectionState.OPENED)
+        elif self.state == ConnectionState.HDR_EXCH:
+            self._set_state(ConnectionState.OPEN_RCVD)
+            self._outgoing_open()
+            self._set_state(ConnectionState.OPENED)
+        else:
+            pass # TODO what now...?
+
+    def _outgoing_close(self, error=None):
+        # type: (Optional[AMQPError]) -> None
+        """Send a Close frame to shutdown connection with optional error information."""
+        close_frame = CloseFrame(error=error)
+        if self._network_trace:
+            _LOGGER.info("-> %r", close_frame, extra=self._network_trace_params)
+        self._send_frame(0, close_frame)
+
+    def _incoming_close(self, channel, frame):
+        # type: (int, Tuple[Any, ...]) -> None
+        """Process incoming Open frame to finish the connection negotiation.
+
+        The incoming frame format is::
+
+            - frame[0]: error (Optional[AMQPError])
+
+        """
+        if self._network_trace:
+            _LOGGER.info("<- %r", CloseFrame(*frame), extra=self._network_trace_params)
+        disconnect_states = [
+            ConnectionState.HDR_RCVD,
+            ConnectionState.HDR_EXCH,
+            ConnectionState.OPEN_RCVD,
+            ConnectionState.CLOSE_SENT,
+            ConnectionState.DISCARDING
+        ]
+        if self.state in disconnect_states:
+            self._disconnect()
+            self._set_state(ConnectionState.END)
+            return
+
+        close_error = None
+        if channel > self._channel_max:
+            _LOGGER.error("Invalid channel")
+            close_error = AMQPError(condition=ErrorCondition.InvalidField, description="Invalid channel", info=None)
+
+        self._set_state(ConnectionState.CLOSE_RCVD)
+        self._outgoing_close(error=close_error)
+        self._disconnect()
+        self._set_state(ConnectionState.END)
+
+        if frame[0]:
+            self._error = AMQPConnectionError(
+                condition=frame[0][0],
+                description=frame[0][1],
+                info=frame[0][2]
+            )
+            _LOGGER.error("Connection error: {}".format(frame[0]))
+
+    def _incoming_begin(self, channel, frame):
+        # type: (int, Tuple[Any, ...]) -> None
+        """Process incoming Begin frame to finish negotiating a new session.
+
+        The incoming frame format is::
+
+            - frame[0]: remote_channel (int)
+            - frame[1]: next_outgoing_id (int)
+            - frame[2]: incoming_window (int)
+            - frame[3]: outgoing_window (int)
+            - frame[4]: handle_max (int)
+            - frame[5]: offered_capabilities (Optional[List[bytes]])
+            - frame[6]: desired_capabilities (Optional[List[bytes]])
+            - frame[7]: properties (Optional[Dict[bytes, bytes]])
+
+        :param int channel: The incoming channel number.
+        :param frame: The incoming Begin frame.
+        :type frame: Tuple[Any, ...]
+        :rtype: None
+        """
+        try:
+            existing_session = self._outgoing_endpoints[frame[0]]
+            self._incoming_endpoints[channel] = existing_session
+            self._incoming_endpoints[channel]._incoming_begin(frame)  # pylint:disable=protected-access
+        except KeyError:
+            new_session = Session.from_incoming_frame(self, channel, frame)
+            self._incoming_endpoints[channel] = new_session
+            new_session._incoming_begin(frame)  # pylint:disable=protected-access
+
+    def _incoming_end(self, channel, frame):
+        # type: (int, Tuple[Any, ...]) -> None
+        """Process incoming End frame to close a session.
+
+        The incoming frame format is::
+
+            - frame[0]: error (Optional[AMQPError])
+
+        :param int channel: The incoming channel number.
+        :param frame: The incoming End frame.
+        :type frame: Tuple[Any, ...]
+        :rtype: None
+        """
+        try:
+            self._incoming_endpoints[channel]._incoming_end(frame)  # pylint:disable=protected-access
+        except KeyError:
+            pass  # TODO: channel error
+        #self._incoming_endpoints.pop(channel)  # TODO
+        #self._outgoing_endpoints.pop(channel)  # TODO
+
+    def _process_incoming_frame(self, channel, frame):
+        # type: (int, Optional[Union[bytes, Tuple[int, Tuple[Any, ...]]]]) -> bool
+        """Process an incoming frame, either directly or by passing to the necessary Session.
+
+        :param int channel: The channel the frame arrived on.
+        :param frame: A tuple containing the performative descriptor and the field values of the frame.
+         This parameter can be None in the case of an empty frame or a socket timeout.
+        :type frame: Optional[Tuple[int, NamedTuple]]
+        :rtype: bool
+        :returns: A boolean to indicate whether more frames in a batch can be processed or whether the
+         incoming frame has altered the state. If `True` is returned, the state has changed and the batch
+         should be interrupted.
+        """
+        try:
+            performative, fields = frame  # type: int, Tuple[Any, ...]
+        except TypeError:
+            return True  # Empty Frame or socket timeout
+        try:
+            self._last_frame_received_time = time.time()
+            if performative == 20:
+                self._incoming_endpoints[channel]._incoming_transfer(fields)  # pylint:disable=protected-access
+                return False
+            if performative == 21:
+                self._incoming_endpoints[channel]._incoming_disposition(fields)  # pylint:disable=protected-access
+                return False
+            if performative == 19:
+                self._incoming_endpoints[channel]._incoming_flow(fields)  # pylint:disable=protected-access
+                return False
+            if performative == 18:
+                self._incoming_endpoints[channel]._incoming_attach(fields)  # pylint:disable=protected-access
+                return False
+            if performative == 22:
+                self._incoming_endpoints[channel]._incoming_detach(fields)  # pylint:disable=protected-access
+                return True
+            if performative == 17:
+                self._incoming_begin(channel, fields)
+                return True
+            if performative == 23:
+                self._incoming_end(channel, fields)
+                return True
+            if performative == 16:
+                self._incoming_open(channel, fields)
+                return True
+            if performative == 24:
+                self._incoming_close(channel, fields)
+                return True
+            if performative == 0:
+                self._incoming_header(channel, fields)
+                return True
+            if performative == 1:
+                return False  # TODO: incoming EMPTY
+            else:
+                _LOGGER.error("Unrecognized incoming frame: {}".format(frame))
+                return True
+        except KeyError:
+            return True  #TODO: channel error
+
+    def _process_outgoing_frame(self, channel, frame):
+        # type: (int, NamedTuple) -> None
+        """Send an outgoing frame if the connection is in a legal state.
+
+        :raises ValueError: If the connection is not open or not in a valid state.
+        """
+        if self._network_trace:
+            _LOGGER.info("-> %r", frame, extra=self._network_trace_params)
+        if not self._allow_pipelined_open and self.state in [ConnectionState.OPEN_PIPE, ConnectionState.OPEN_SENT]:
+            raise ValueError("Connection not configured to allow pipeline send.")
+        if self.state not in [ConnectionState.OPEN_PIPE, ConnectionState.OPEN_SENT, ConnectionState.OPENED]:
+            raise ValueError("Connection not open.")
+        now = time.time()
+        if get_local_timeout(now, self._idle_timeout, self._last_frame_received_time) or self._get_remote_timeout(now):
+            self.close(
+                # TODO: check error condition
+                error=AMQPError(
+                    condition=ErrorCondition.ConnectionCloseForced,
+                    description="No frame received for the idle timeout."
+                ),
+                wait=False
+            )
+            return
+        self._send_frame(channel, frame)
+
+    def _get_remote_timeout(self, now):
+        # type: (float) -> bool
+        """Check whether the local connection has reached the remote endpoints idle timeout since
+        the last outgoing frame was sent.
+
+        If the time since the last since frame is greater than the allowed idle interval, an Empty
+        frame will be sent to maintain the connection.
+
+        :param float now: The current time to check against.
+        :rtype: bool
+        :returns: Whether the local connection should be shutdown due to timeout.
+        """
+        if self._remote_idle_timeout and self._last_frame_sent_time:
+            time_since_last_sent = now - self._last_frame_sent_time
+            if time_since_last_sent > self._remote_idle_timeout_send_frame:
+                self._outgoing_empty()
+        return False
+
+    def _wait_for_response(self, wait, end_state):
+        # type: (Union[bool, float], ConnectionState) -> None
+        """Wait for an incoming frame to be processed that will result in a desired state change.
+
+        :param wait: Whether to wait for an incoming frame to be processed. Can be set to `True` to wait
+         indefinitely, or an int to wait for a specified amount of time (in seconds). To not wait, set to `False`.
+        :type wait: bool or float
+        :param ConnectionState end_state: The desired end state to wait until.
+        :rtype: None
+        """
+        if wait is True:
+            self.listen(wait=False)
+            while self.state != end_state:
+                time.sleep(self._idle_wait_time)
+                self.listen(wait=False)
+        elif wait:
+            self.listen(wait=False)
+            timeout = time.time() + wait
+            while self.state != end_state:
+                if time.time() >= timeout:
+                    break
+                time.sleep(self._idle_wait_time)
+                self.listen(wait=False)
+
+    def listen(self, wait=False, batch=1, **kwargs):
+        # type: (Union[float, int, bool], int, Any) -> None
+        """Listen on the socket for incoming frames and process them.
+
+        :param wait: Whether to block on the socket until a frame arrives. If set to `True`, socket will
+         block indefinitely. Alternatively, if set to a time in seconds, the socket will block for at most
+         the specified timeout. Default value is `False`, where the socket will block for its configured read
+         timeout (by default 0.1 seconds).
+        :type wait: int or float or bool
+        :param int batch: The number of frames to attempt to read and process before returning. The default value
+         is 1, i.e. process frames one-at-a-time. A higher value should only be used when a receiver is established
+         and is processing incoming Transfer frames.
+        :rtype: None
+        """
+        try:
+            raise self._error
+        except TypeError:
+            pass
+        try:
+            if self.state not in _CLOSING_STATES:
+                now = time.time()
+                if get_local_timeout(now, self._idle_timeout, self._last_frame_received_time) or self._get_remote_timeout(now):
+                    # TODO: check error condition
+                    self.close(
+                        error=AMQPError(
+                            condition=ErrorCondition.ConnectionCloseForced,
+                            description="No frame received for the idle timeout."
+                        ),
+                        wait=False
+                    )
+                    return
+            if self.state == ConnectionState.END:
+                # TODO: check error condition
+                self._error = AMQPConnectionError(
+                    condition=ErrorCondition.ConnectionCloseForced,
+                    description="Connection was already closed."
+                )
+                return
+            for _ in range(batch):
+                new_frame = self._read_frame(wait=wait, **kwargs)
+                if self._process_incoming_frame(*new_frame):
+                    break
+        except (OSError, IOError, SSLError, socket.error) as exc:
+            self._error = AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Can not send frame out due to exception: " + str(exc),
+                error=exc
+            )
+        except Exception:
+            raise
+
+    def create_session(self, **kwargs):
+        # type: (Any) -> Session
+        """Create a new session within this connection.
+
+        :keyword str name: The name of the connection. If not set a GUID will be generated.
+        :keyword int next_outgoing_id: The transfer-id of the first transfer id the sender will send.
+         Default value is 0.
+        :keyword int incoming_window: The initial incoming-window of the Session. Default value is 1.
+        :keyword int outgoing_window: The initial outgoing-window of the Session. Default value is 1.
+        :keyword int handle_max: The maximum handle value that may be used on the session. Default value is 4294967295.
+        :keyword list(str) offered_capabilities: The extension capabilities the session supports.
+        :keyword list(str) desired_capabilities: The extension capabilities the session may use if
+         the endpoint supports it.
+        :keyword dict properties: Session properties.
+        :keyword bool allow_pipelined_open: Allow frames to be sent on the connection before a response Open frame
+         has been received. Default value is that configured for the connection.
+        :keyword float idle_wait_time: The time in seconds to sleep while waiting for a response from the endpoint.
+         Default value is that configured for the connection.
+        :keyword bool network_trace: Whether to log the network traffic of this session. If enabled, frames
+         will be logged at the logging.INFO level. Default value is that configured for the connection.
+        """
+        assigned_channel = self._get_next_outgoing_channel()
+        kwargs['allow_pipelined_open'] = self._allow_pipelined_open
+        kwargs['idle_wait_time'] = self._idle_wait_time
+        session = Session(
+            self,
+            assigned_channel,
+            network_trace=kwargs.pop('network_trace', self._network_trace),
+            network_trace_params=dict(self._network_trace_params),
+            **kwargs)
+        self._outgoing_endpoints[assigned_channel] = session
+        return session
+
+    def open(self, wait=False):
+        # type: (bool) -> None
+        """Send an Open frame to start the connection.
+
+        Alternatively, this will be called on entering a Connection context manager.
+
+        :param bool wait: Whether to wait to receive an Open response from the endpoint. Default is `False`.
+        :raises ValueError: If `wait` is set to `False` and `allow_pipelined_open` is disabled.
+        :rtype: None
+        """
+        self._connect()
+        self._outgoing_open()
+        if self.state == ConnectionState.HDR_EXCH:
+            self._set_state(ConnectionState.OPEN_SENT)
+        elif self.state == ConnectionState.HDR_SENT:
+            self._set_state(ConnectionState.OPEN_PIPE)
+        if wait:
+            self._wait_for_response(wait, ConnectionState.OPENED)
+        elif not self._allow_pipelined_open:
+            raise ValueError("Connection has been configured to not allow piplined-open. Please set 'wait' parameter.")
+
+    def close(self, error=None, wait=False):
+        # type: (Optional[AMQPError], bool) -> None
+        """Close the connection and disconnect the transport.
+
+        Alternatively this method will be called on exiting a Connection context manager.
+
+        :param ~uamqp.AMQPError error: Optional error information to include in the close request.
+        :param bool wait: Whether to wait for a service Close response. Default is `False`.
+        :rtype: None
+        """
+        if self.state in [ConnectionState.END, ConnectionState.CLOSE_SENT, ConnectionState.DISCARDING]:
+            return
+        try:
+            self._outgoing_close(error=error)
+            if error:
+                self._error = AMQPConnectionError(
+                    condition=error.condition,
+                    description=error.descrption,
+                    info=error.info
+                )
+            if self.state == ConnectionState.OPEN_PIPE:
+                self._set_state(ConnectionState.OC_PIPE)
+            elif self.state == ConnectionState.OPEN_SENT:
+                self._set_state(ConnectionState.CLOSE_PIPE)
+            elif error:
+                self._set_state(ConnectionState.DISCARDING)
+            else:
+                self._set_state(ConnectionState.CLOSE_SENT)
+            self._wait_for_response(wait, ConnectionState.END)
+        except Exception as exc:
+            # If error happened during closing, ignore the error and set state to END
+            _LOGGER.info("An error occurred when closing the connection: %r", exc)
+            self._set_state(ConnectionState.END)
+        finally:
+            self._disconnect()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_counter.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_counter.py
@@ -1,0 +1,8 @@
+import time
+
+class TickCounter():
+    def __init__(self):
+        self._start_time = time.perf_counter()
+
+    def get_current_ms(self):
+        return time.perf_counter() * 500

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_decode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_decode.py
@@ -1,0 +1,349 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+# pylint: disable=redefined-builtin, import-error
+
+import struct
+import uuid
+import logging
+from typing import List, Union, Tuple, Dict, Callable  # pylint: disable=unused-import
+
+
+from .message import Message, Header, Properties
+
+_LOGGER = logging.getLogger(__name__)
+_HEADER_PREFIX = memoryview(b'AMQP')
+_COMPOSITES = {
+    35: 'received',
+    36: 'accepted',
+    37: 'rejected',
+    38: 'released',
+    39: 'modified',
+}
+
+c_unsigned_char = struct.Struct('>B')
+c_signed_char = struct.Struct('>b')
+c_unsigned_short = struct.Struct('>H')
+c_signed_short = struct.Struct('>h')
+c_unsigned_int = struct.Struct('>I')
+c_signed_int = struct.Struct('>i')
+c_unsigned_long = struct.Struct('>L')
+c_unsigned_long_long = struct.Struct('>Q')
+c_signed_long_long = struct.Struct('>q')
+c_float = struct.Struct('>f')
+c_double = struct.Struct('>d')
+
+
+def _decode_null(buffer):
+    # type: (memoryview) -> Tuple[memoryview, None]
+    return buffer, None
+
+
+def _decode_true(buffer):
+    # type: (memoryview) -> Tuple[memoryview, bool]
+    return buffer, True
+
+
+def _decode_false(buffer):
+    # type: (memoryview) -> Tuple[memoryview, bool]
+    return buffer, False
+
+
+def _decode_zero(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer, 0
+
+
+def _decode_empty(buffer):
+    # type: (memoryview) -> Tuple[memoryview, List[None]]
+    return buffer, []
+
+
+def _decode_boolean(buffer):
+    # type: (memoryview) -> Tuple[memoryview, bool]
+    return buffer[1:], buffer[:1] == b'\x01'
+
+
+def _decode_ubyte(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[1:], buffer[0]
+
+
+def _decode_ushort(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[2:], c_unsigned_short.unpack(buffer[:2])[0]
+
+
+def _decode_uint_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[1:], buffer[0]
+
+
+def _decode_uint_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[4:], c_unsigned_int.unpack(buffer[:4])[0]
+
+
+def _decode_ulong_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[1:], buffer[0]
+
+
+def _decode_ulong_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[8:], c_unsigned_long_long.unpack(buffer[:8])[0]
+
+
+def _decode_byte(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[1:], c_signed_char.unpack(buffer[:1])[0]
+
+
+def _decode_short(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[2:], c_signed_short.unpack(buffer[:2])[0]
+
+
+def _decode_int_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[1:], c_signed_char.unpack(buffer[:1])[0]
+
+
+def _decode_int_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[4:], c_signed_int.unpack(buffer[:4])[0]
+
+
+def _decode_long_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[1:], c_signed_char.unpack(buffer[:1])[0]
+
+
+def _decode_long_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[8:], c_signed_long_long.unpack(buffer[:8])[0]
+
+
+def _decode_float(buffer):
+    # type: (memoryview) -> Tuple[memoryview, float]
+    return buffer[4:], c_float.unpack(buffer[:4])[0]
+
+
+def _decode_double(buffer):
+    # type: (memoryview) -> Tuple[memoryview, float]
+    return buffer[8:], c_double.unpack(buffer[:8])[0]
+
+
+def _decode_timestamp(buffer):
+    # type: (memoryview) -> Tuple[memoryview, int]
+    return buffer[8:], c_signed_long_long.unpack(buffer[:8])[0]
+
+
+def _decode_uuid(buffer):
+    # type: (memoryview) -> Tuple[memoryview, uuid.UUID]
+    return buffer[16:], uuid.UUID(bytes=buffer[:16].tobytes())
+
+
+def _decode_binary_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, bytes]
+    length_index = buffer[0] + 1
+    return buffer[length_index:], buffer[1:length_index].tobytes()
+
+
+def _decode_binary_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, bytes]
+    length_index = c_unsigned_long.unpack(buffer[:4])[0] + 4
+    return buffer[length_index:], buffer[4:length_index].tobytes()
+
+
+def _decode_list_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, List[Any]]
+    count = buffer[1]
+    buffer = buffer[2:]
+    values = [None] * count
+    for i in range(count):
+        buffer, values[i] = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+    return buffer, values
+
+
+def _decode_list_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, List[Any]]
+    count = c_unsigned_long.unpack(buffer[4:8])[0]
+    buffer = buffer[8:]
+    values = [None] * count
+    for i in range(count):
+        buffer, values[i] = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+    return buffer, values
+
+
+def _decode_map_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, Dict[Any, Any]]
+    count = int(buffer[1]/2)
+    buffer = buffer[2:]
+    values = {}
+    for  _ in range(count):
+        buffer, key = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+        buffer, value = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+        values[key] = value
+    return buffer, values
+
+
+def _decode_map_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, Dict[Any, Any]]
+    count = int(c_unsigned_long.unpack(buffer[4:8])[0]/2)
+    buffer = buffer[8:]
+    values = {}
+    for  _ in range(count):
+        buffer, key = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+        buffer, value = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+        values[key] = value
+    return buffer, values
+
+
+def _decode_array_small(buffer):
+    # type: (memoryview) -> Tuple[memoryview, List[Any]]
+    count = buffer[1]  # Ignore first byte (size) and just rely on count
+    if count:
+        subconstructor = buffer[2]
+        buffer = buffer[3:]
+        values = [None] * count
+        for i in range(count):
+            buffer, values[i] = _DECODE_BY_CONSTRUCTOR[subconstructor](buffer)
+        return buffer, values
+    return buffer[2:], []
+
+
+def _decode_array_large(buffer):
+    # type: (memoryview) -> Tuple[memoryview, List[Any]]
+    count = c_unsigned_long.unpack(buffer[4:8])[0]
+    if count:
+        subconstructor = buffer[8]
+        buffer = buffer[9:]
+        values = [None] * count
+        for i in range(count):
+            buffer, values[i] = _DECODE_BY_CONSTRUCTOR[subconstructor](buffer)
+        return buffer, values
+    return buffer[8:], []
+
+
+def _decode_described(buffer):
+    # type: (memoryview) -> Tuple[memoryview, Any]
+    # TODO: to move the cursor of the buffer to the described value based on size of the
+    #  descriptor without decoding descriptor value
+    composite_type = buffer[0]
+    buffer, descriptor = _DECODE_BY_CONSTRUCTOR[composite_type](buffer[1:])
+    buffer, value = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+    try:
+        composite_type = _COMPOSITES[descriptor]
+        return buffer, {composite_type: value}
+    except KeyError:
+        return buffer, value
+
+
+def decode_payload(buffer):
+    # type: (memoryview) -> Message
+    message = {}
+    while buffer:
+        # Ignore the first two bytes, they will always be the constructors for
+        # described type then ulong.
+        descriptor = buffer[2]
+        buffer, value = _DECODE_BY_CONSTRUCTOR[buffer[3]](buffer[4:])
+        if descriptor == 112:
+            message["header"] = Header(*value)
+        elif descriptor == 113:
+            message["delivery_annotations"] = value
+        elif descriptor == 114:
+            message["message_annotations"] = value
+        elif descriptor == 115:
+            message["properties"] = Properties(*value)
+        elif descriptor == 116:
+            message["application_properties"] = value
+        elif descriptor == 117:
+            try:
+                message["data"].append(value)
+            except KeyError:
+                message["data"] = [value]
+        elif descriptor == 118:
+            try:
+                message["sequence"].append(value)
+            except KeyError:
+                message["sequence"] = [value]
+        elif descriptor == 119:
+            message["value"] = value
+        elif descriptor == 120:
+            message["footer"] = value
+    # TODO: we can possibly swap out the Message construct with a TypedDict
+    #  for both input and output so we get the best of both.
+    return Message(**message)
+
+
+def decode_frame(data):
+    # type: (memoryview) -> Tuple[int, List[Any]]
+    # Ignore the first two bytes, they will always be the constructors for
+    # described type then ulong.
+    frame_type = data[2]
+    compound_list_type = data[3]
+    if compound_list_type == 0xd0:
+        # list32 0xd0: data[4:8] is size, data[8:12] is count
+        count = c_signed_int.unpack(data[8:12])[0]
+        buffer = data[12:]
+    else:
+        # list8 0xc0: data[4] is size, data[5] is count
+        count = data[5]
+        buffer = data[6:]
+    fields = [None] * count
+    for i in range(count):
+        buffer, fields[i] = _DECODE_BY_CONSTRUCTOR[buffer[0]](buffer[1:])
+    if frame_type == 20:
+        fields.append(buffer)
+    return frame_type, fields
+
+
+def decode_empty_frame(header):
+    # type: (memory) -> bytes
+    if header[0:4] == _HEADER_PREFIX:
+        return 0, header.tobytes()
+    if header[5] == 0:
+        return 1, b"EMPTY"
+    raise ValueError("Received unrecognized empty frame")
+
+
+_DECODE_BY_CONSTRUCTOR = [None] * 256  # type: List[Callable[memoryview]]
+_DECODE_BY_CONSTRUCTOR[0] = _decode_described
+_DECODE_BY_CONSTRUCTOR[64] = _decode_null
+_DECODE_BY_CONSTRUCTOR[65] = _decode_true
+_DECODE_BY_CONSTRUCTOR[66] = _decode_false
+_DECODE_BY_CONSTRUCTOR[67] = _decode_zero
+_DECODE_BY_CONSTRUCTOR[68] = _decode_zero
+_DECODE_BY_CONSTRUCTOR[69] = _decode_empty
+_DECODE_BY_CONSTRUCTOR[80] = _decode_ubyte
+_DECODE_BY_CONSTRUCTOR[81] = _decode_byte
+_DECODE_BY_CONSTRUCTOR[82] = _decode_uint_small
+_DECODE_BY_CONSTRUCTOR[83] = _decode_ulong_small
+_DECODE_BY_CONSTRUCTOR[84] = _decode_int_small
+_DECODE_BY_CONSTRUCTOR[85] = _decode_long_small
+_DECODE_BY_CONSTRUCTOR[86] = _decode_boolean
+_DECODE_BY_CONSTRUCTOR[96] = _decode_ushort
+_DECODE_BY_CONSTRUCTOR[97] = _decode_short
+_DECODE_BY_CONSTRUCTOR[112] = _decode_uint_large
+_DECODE_BY_CONSTRUCTOR[113] = _decode_int_large
+_DECODE_BY_CONSTRUCTOR[114] = _decode_float
+_DECODE_BY_CONSTRUCTOR[128] = _decode_ulong_large
+_DECODE_BY_CONSTRUCTOR[129] = _decode_long_large
+_DECODE_BY_CONSTRUCTOR[130] = _decode_double
+_DECODE_BY_CONSTRUCTOR[131] = _decode_timestamp
+_DECODE_BY_CONSTRUCTOR[152] = _decode_uuid
+_DECODE_BY_CONSTRUCTOR[160] = _decode_binary_small
+_DECODE_BY_CONSTRUCTOR[161] = _decode_binary_small
+_DECODE_BY_CONSTRUCTOR[163] = _decode_binary_small
+_DECODE_BY_CONSTRUCTOR[176] = _decode_binary_large
+_DECODE_BY_CONSTRUCTOR[177] = _decode_binary_large
+_DECODE_BY_CONSTRUCTOR[179] = _decode_binary_large
+_DECODE_BY_CONSTRUCTOR[192] = _decode_list_small
+_DECODE_BY_CONSTRUCTOR[193] = _decode_map_small
+_DECODE_BY_CONSTRUCTOR[208] = _decode_list_large
+_DECODE_BY_CONSTRUCTOR[209] = _decode_map_large
+_DECODE_BY_CONSTRUCTOR[224] = _decode_array_small
+_DECODE_BY_CONSTRUCTOR[240] = _decode_array_large

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -1,0 +1,804 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import calendar
+import struct
+import uuid
+from datetime import datetime
+from typing import Iterable, Union, Tuple, Dict  # pylint: disable=unused-import
+
+import six
+
+from .types import TYPE, VALUE, AMQPTypes, FieldDefinition, ObjDefinition, ConstructorBytes
+from .message import Header, Properties, Message
+from . import performatives
+from . import outcomes
+from . import endpoints
+from . import error
+
+
+_FRAME_OFFSET = b"\x02"
+_FRAME_TYPE = b'\x00'
+
+
+def _construct(byte, construct):
+    # type: (bytes, bool) -> bytes
+    return byte if construct else b''
+
+
+def encode_null(output, *args, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, Any, Any) -> None
+    """
+    encoding code="0x40" category="fixed" width="0" label="the null value"
+    """
+    output.extend(ConstructorBytes.null)
+
+
+def encode_boolean(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, bool, bool, Any) -> None
+    """
+    <encoding name="true" code="0x41" category="fixed" width="0" label="the boolean value true"/>
+    <encoding name="false" code="0x42" category="fixed" width="0" label="the boolean value false"/>
+    <encoding code="0x56" category="fixed" width="1"
+        label="boolean with the octet 0x00 being false and octet 0x01 being true"/>
+    """
+    value = bool(value)
+    if with_constructor:
+        output.extend(_construct(ConstructorBytes.bool, with_constructor))
+        output.extend(b'\x01' if value else b'\x00')
+        return
+
+    output.extend(ConstructorBytes.bool_true if value else ConstructorBytes.bool_false)
+
+
+def encode_ubyte(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, Union[int, bytes], bool, Any) -> None
+    """
+    <encoding code="0x50" category="fixed" width="1" label="8-bit unsigned integer"/>
+    """
+    try:
+        value = int(value)
+    except ValueError:
+        value = ord(value)
+    try:
+        output.extend(_construct(ConstructorBytes.ubyte, with_constructor))
+        output.extend(struct.pack('>B', abs(value)))
+    except struct.error:
+        raise ValueError("Unsigned byte value must be 0-255")
+
+
+def encode_ushort(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, int, bool, Any) -> None
+    """
+    <encoding code="0x60" category="fixed" width="2" label="16-bit unsigned integer in network byte order"/>
+    """
+    value = int(value)
+    try:
+        output.extend(_construct(ConstructorBytes.ushort, with_constructor))
+        output.extend(struct.pack('>H', abs(value)))
+    except struct.error:
+        raise ValueError("Unsigned byte value must be 0-65535")
+
+
+def encode_uint(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, int, bool, bool) -> None
+    """
+    <encoding name="uint0" code="0x43" category="fixed" width="0" label="the uint value 0"/>
+    <encoding name="smalluint" code="0x52" category="fixed" width="1"
+        label="unsigned integer value in the range 0 to 255 inclusive"/>
+    <encoding code="0x70" category="fixed" width="4" label="32-bit unsigned integer in network byte order"/>
+    """
+    value = int(value)
+    if value == 0:
+        output.extend(ConstructorBytes.uint_0)
+        return
+    try:
+        if use_smallest and value <= 255:
+            output.extend(_construct(ConstructorBytes.uint_small, with_constructor))
+            output.extend(struct.pack('>B', abs(value)))
+            return
+        output.extend(_construct(ConstructorBytes.uint_large, with_constructor))
+        output.extend(struct.pack('>I', abs(value)))
+    except struct.error:
+        raise ValueError("Value supplied for unsigned int invalid: {}".format(value))
+
+
+def encode_ulong(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, int, bool, bool) -> None
+    """
+    <encoding name="ulong0" code="0x44" category="fixed" width="0" label="the ulong value 0"/>
+    <encoding name="smallulong" code="0x53" category="fixed" width="1"
+        label="unsigned long value in the range 0 to 255 inclusive"/>
+    <encoding code="0x80" category="fixed" width="8" label="64-bit unsigned integer in network byte order"/>
+    """
+    try:
+        value = long(value)
+    except NameError:
+        value = int(value)
+    if value == 0:
+        output.extend(ConstructorBytes.ulong_0)
+        return
+    try:
+        if use_smallest and value <= 255:
+            output.extend(_construct(ConstructorBytes.ulong_small, with_constructor))
+            output.extend(struct.pack('>B', abs(value)))
+            return
+        output.extend(_construct(ConstructorBytes.ulong_large, with_constructor))
+        output.extend(struct.pack('>Q', abs(value)))
+    except struct.error:
+        raise ValueError("Value supplied for unsigned long invalid: {}".format(value))
+
+
+def encode_byte(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, int, bool, Any) -> None
+    """
+    <encoding code="0x51" category="fixed" width="1" label="8-bit two's-complement integer"/>
+    """
+    value = int(value)
+    try:
+        output.extend(_construct(ConstructorBytes.byte, with_constructor))
+        output.extend(struct.pack('>b', value))
+    except struct.error:
+        raise ValueError("Byte value must be -128-127")
+
+
+def encode_short(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, int, bool, Any) -> None
+    """
+    <encoding code="0x61" category="fixed" width="2" label="16-bit two's-complement integer in network byte order"/>
+    """
+    value = int(value)
+    try:
+        output.extend(_construct(ConstructorBytes.short, with_constructor))
+        output.extend(struct.pack('>h', value))
+    except struct.error:
+        raise ValueError("Short value must be -32768-32767")
+
+
+def encode_int(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, int, bool, bool) -> None
+    """
+    <encoding name="smallint" code="0x54" category="fixed" width="1" label="8-bit two's-complement integer"/>
+    <encoding code="0x71" category="fixed" width="4" label="32-bit two's-complement integer in network byte order"/>
+    """
+    value = int(value)
+    try:
+        if use_smallest and (-128 <= value <= 127):
+            output.extend(_construct(ConstructorBytes.int_small, with_constructor))
+            output.extend(struct.pack('>b', value))
+            return
+        output.extend(_construct(ConstructorBytes.int_large, with_constructor))
+        output.extend(struct.pack('>i', value))
+    except struct.error:
+        raise ValueError("Value supplied for int invalid: {}".format(value))
+
+
+def encode_long(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, int, bool, bool) -> None
+    """
+    <encoding name="smalllong" code="0x55" category="fixed" width="1" label="8-bit two's-complement integer"/>
+    <encoding code="0x81" category="fixed" width="8" label="64-bit two's-complement integer in network byte order"/>
+    """
+    try:
+        value = long(value)
+    except NameError:
+        value = int(value)
+    try:
+        if use_smallest and (-128 <= value <= 127):
+            output.extend(_construct(ConstructorBytes.long_small, with_constructor))
+            output.extend(struct.pack('>b', value))
+            return
+        output.extend(_construct(ConstructorBytes.long_large, with_constructor))
+        output.extend(struct.pack('>q', value))
+    except struct.error:
+        raise ValueError("Value supplied for long invalid: {}".format(value))
+
+def encode_float(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, float, bool, Any) -> None
+    """
+    <encoding name="ieee-754" code="0x72" category="fixed" width="4" label="IEEE 754-2008 binary32"/>
+    """
+    value = float(value)
+    output.extend(_construct(ConstructorBytes.float, with_constructor))
+    output.extend(struct.pack('>f', value))
+
+
+def encode_double(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, float, bool, Any) -> None
+    """
+    <encoding name="ieee-754" code="0x82" category="fixed" width="8" label="IEEE 754-2008 binary64"/>
+    """
+    value = float(value)
+    output.extend(_construct(ConstructorBytes.double, with_constructor))
+    output.extend(struct.pack('>d', value))
+
+
+def encode_timestamp(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, Union[int, datetime], bool, Any) -> None
+    """
+    <encoding name="ms64" code="0x83" category="fixed" width="8"
+        label="64-bit two's-complement integer representing milliseconds since the unix epoch"/>
+    """
+    if isinstance(value, datetime):
+        value = (calendar.timegm(value.utctimetuple()) * 1000) + (value.microsecond/1000)
+    value = int(value)
+    output.extend(_construct(ConstructorBytes.timestamp, with_constructor))
+    output.extend(struct.pack('>q', value))
+
+
+def encode_uuid(output, value, with_constructor=True, **kwargs):  # pylint: disable=unused-argument
+    # type: (bytearray, Union[uuid.UUID, str, bytes], bool, Any) -> None
+    """
+    <encoding code="0x98" category="fixed" width="16" label="UUID as defined in section 4.1.2 of RFC-4122"/>
+    """
+    if isinstance(value, six.text_type):
+        value = uuid.UUID(value).bytes
+    elif isinstance(value, uuid.UUID):
+        value = value.bytes
+    elif isinstance(value, six.binary_type):
+        value = uuid.UUID(bytes=value).bytes
+    else:
+        raise TypeError("Invalid UUID type: {}".format(type(value)))
+    output.extend(_construct(ConstructorBytes.uuid, with_constructor))
+    output.extend(value)
+
+
+def encode_binary(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, Union[bytes, bytearray], bool, bool) -> None
+    """
+    <encoding name="vbin8" code="0xa0" category="variable" width="1" label="up to 2^8 - 1 octets of binary data"/>
+    <encoding name="vbin32" code="0xb0" category="variable" width="4" label="up to 2^32 - 1 octets of binary data"/>
+    """
+    length = len(value)
+    if use_smallest and length <= 255:
+        output.extend(_construct(ConstructorBytes.binary_small, with_constructor))
+        output.extend(struct.pack('>B', length))
+        output.extend(value)
+        return
+    try:
+        output.extend(_construct(ConstructorBytes.binary_large, with_constructor))
+        output.extend(struct.pack('>L', length))
+        output.extend(value)
+    except struct.error:
+        raise ValueError("Binary data to long to encode")
+
+
+def encode_string(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, Union[bytes, str], bool, bool) -> None
+    """
+    <encoding name="str8-utf8" code="0xa1" category="variable" width="1"
+        label="up to 2^8 - 1 octets worth of UTF-8 Unicode (with no byte order mark)"/>
+    <encoding name="str32-utf8" code="0xb1" category="variable" width="4"
+        label="up to 2^32 - 1 octets worth of UTF-8 Unicode (with no byte order mark)"/>
+    """
+    if isinstance(value, six.text_type):
+        value = value.encode('utf-8')
+    length = len(value)
+    if use_smallest and length <= 255:
+        output.extend(_construct(ConstructorBytes.string_small, with_constructor))
+        output.extend(struct.pack('>B', length))
+        output.extend(value)
+        return
+    try:
+        output.extend(_construct(ConstructorBytes.string_large, with_constructor))
+        output.extend(struct.pack('>L', length))
+        output.extend(value)
+    except struct.error:
+        raise ValueError("String value too long to encode.")
+
+
+def encode_symbol(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, Union[bytes, str], bool, bool) -> None
+    """
+    <encoding name="sym8" code="0xa3" category="variable" width="1"
+        label="up to 2^8 - 1 seven bit ASCII characters representing a symbolic value"/>
+    <encoding name="sym32" code="0xb3" category="variable" width="4"
+        label="up to 2^32 - 1 seven bit ASCII characters representing a symbolic value"/>
+    """
+    if isinstance(value, six.text_type):
+        value = value.encode('utf-8')
+    length = len(value)
+    if use_smallest and length <= 255:
+        output.extend(_construct(ConstructorBytes.symbol_small, with_constructor))
+        output.extend(struct.pack('>B', length))
+        output.extend(value)
+        return
+    try:
+        output.extend(_construct(ConstructorBytes.symbol_large, with_constructor))
+        output.extend(struct.pack('>L', length))
+        output.extend(value)
+    except struct.error:
+        raise ValueError("Symbol value too long to encode.")
+
+
+def encode_list(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, Iterable[Any], bool, bool) -> None
+    """
+    <encoding name="list0" code="0x45" category="fixed" width="0"
+        label="the empty list (i.e. the list with no elements)"/>
+    <encoding name="list8" code="0xc0" category="compound" width="1"
+        label="up to 2^8 - 1 list elements with total size less than 2^8 octets"/>
+    <encoding name="list32" code="0xd0" category="compound" width="4"
+        label="up to 2^32 - 1 list elements with total size less than 2^32 octets"/>
+    """
+    count = len(value)
+    if use_smallest and count == 0:
+        output.extend(ConstructorBytes.list_0)
+        return
+    encoded_size = 0
+    encoded_values = bytearray()
+    for item in value:
+        encode_value(encoded_values, item, with_constructor=True)
+    encoded_size += len(encoded_values)
+    if use_smallest and count <= 255 and encoded_size < 255:
+        output.extend(_construct(ConstructorBytes.list_small, with_constructor))
+        output.extend(struct.pack('>B', encoded_size + 1))
+        output.extend(struct.pack('>B', count))
+    else:
+        try:
+            output.extend(_construct(ConstructorBytes.list_large, with_constructor))
+            output.extend(struct.pack('>L', encoded_size + 4))
+            output.extend(struct.pack('>L', count))
+        except struct.error:
+            raise ValueError("List is too large or too long to be encoded.")
+    output.extend(encoded_values)
+
+
+def encode_map(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, Union[Dict[Any, Any], Iterable[Tuple[Any, Any]]], bool, bool) -> None
+    """
+    <encoding name="map8" code="0xc1" category="compound" width="1"
+        label="up to 2^8 - 1 octets of encoded map data"/>
+    <encoding name="map32" code="0xd1" category="compound" width="4"
+        label="up to 2^32 - 1 octets of encoded map data"/>
+    """
+    count = len(value) * 2
+    encoded_size = 0
+    encoded_values = bytearray()
+    try:
+        items = value.items()
+    except AttributeError:
+        items = value
+    for key, data in items:
+        encode_value(encoded_values, key, with_constructor=True)
+        encode_value(encoded_values, data, with_constructor=True)
+    encoded_size = len(encoded_values)
+    if use_smallest and count <= 255 and encoded_size < 255:
+        output.extend(_construct(ConstructorBytes.map_small, with_constructor))
+        output.extend(struct.pack('>B', encoded_size + 1))
+        output.extend(struct.pack('>B', count))
+    else:
+        try:
+            output.extend(_construct(ConstructorBytes.map_large, with_constructor))
+            output.extend(struct.pack('>L', encoded_size + 4))
+            output.extend(struct.pack('>L', count))
+        except struct.error:
+            raise ValueError("Map is too large or too long to be encoded.")
+    output.extend(encoded_values)
+    return
+
+
+def _check_element_type(item, element_type):
+    if not element_type:
+        try:
+            return item['TYPE']
+        except (KeyError, TypeError):
+            return type(item)
+    try:
+        if item['TYPE'] != element_type:
+            raise TypeError("All elements in an array must be the same type.")
+    except (KeyError, TypeError):
+        if not isinstance(item, element_type):
+            raise TypeError("All elements in an array must be the same type.")
+    return element_type
+
+
+def encode_array(output, value, with_constructor=True, use_smallest=True):
+    # type: (bytearray, Iterable[Any], bool, bool) -> None
+    """
+    <encoding name="map8" code="0xE0" category="compound" width="1"
+        label="up to 2^8 - 1 octets of encoded map data"/>
+    <encoding name="map32" code="0xF0" category="compound" width="4"
+        label="up to 2^32 - 1 octets of encoded map data"/>
+    """
+    count = len(value)
+    encoded_size = 0
+    encoded_values = bytearray()
+    first_item = True
+    element_type = None
+    for item in value:
+        element_type = _check_element_type(item, element_type)
+        encode_value(encoded_values, item, with_constructor=first_item, use_smallest=False)
+        first_item = False
+        if item is None:
+            encoded_size -= 1
+            break
+    encoded_size += len(encoded_values)
+    if use_smallest and count <= 255 and encoded_size < 255:
+        output.extend(_construct(ConstructorBytes.array_small, with_constructor))
+        output.extend(struct.pack('>B', encoded_size + 1))
+        output.extend(struct.pack('>B', count))
+    else:
+        try:
+            output.extend(_construct(ConstructorBytes.array_large, with_constructor))
+            output.extend(struct.pack('>L', encoded_size + 4))
+            output.extend(struct.pack('>L', count))
+        except struct.error:
+            raise ValueError("Array is too large or too long to be encoded.")
+    output.extend(encoded_values)
+
+
+def encode_described(output, value, _=None, **kwargs):
+    # type: (bytearray, Tuple(Any, Any), bool, Any) -> None
+    output.extend(ConstructorBytes.descriptor)
+    encode_value(output, value[0], **kwargs)
+    encode_value(output, value[1], **kwargs)
+
+
+def encode_fields(value):
+    # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
+    """A mapping from field name to value.
+
+    The fields type is a map where the keys are restricted to be of type symbol (this excludes the possibility
+    of a null key).  There is no further restriction implied by the fields type on the allowed values for the
+    entries or the set of allowed keys.
+
+    <type name="fields" class="restricted" source="map"/>
+    """
+    if not value:
+        return {TYPE: AMQPTypes.null, VALUE: None}
+    fields = {TYPE: AMQPTypes.map, VALUE:[]}
+    for key, data in value.items():
+        if isinstance(key, six.text_type):
+            key = key.encode('utf-8')
+        fields[VALUE].append(({TYPE: AMQPTypes.symbol, VALUE: key}, data))
+    return fields
+
+
+def encode_annotations(value):
+    # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
+    """The annotations type is a map where the keys are restricted to be of type symbol or of type ulong.
+
+    All ulong keys, and all symbolic keys except those beginning with "x-" are reserved.
+    On receiving an annotations map containing keys or values which it does not recognize, and for which the
+    key does not begin with the string 'x-opt-' an AMQP container MUST detach the link with the not-implemented
+    amqp-error.
+
+    <type name="annotations" class="restricted" source="map"/>
+    """
+    if not value:
+        return {TYPE: AMQPTypes.null, VALUE: None}
+    fields = {TYPE: AMQPTypes.map, VALUE:[]}
+    for key, data in value.items():
+        if isinstance(key, int):
+            fields[VALUE].append(({TYPE: AMQPTypes.ulong, VALUE: key}, {TYPE: None, VALUE: data}))
+        else:
+            if isinstance(key, six.text_type):
+                key = key.encode('utf-8')
+            fields[VALUE].append(({TYPE: AMQPTypes.symbol, VALUE: key}, {TYPE: None, VALUE: data}))
+    return fields
+
+
+def encode_application_properties(value):
+    # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
+    """The application-properties section is a part of the bare message used for structured application data.
+
+    <type name="application-properties" class="restricted" source="map" provides="section">
+        <descriptor name="amqp:application-properties:map" code="0x00000000:0x00000074"/>
+    </type>
+
+    Intermediaries may use the data within this structure for the purposes of filtering or routing.
+    The keys of this map are restricted to be of type string (which excludes the possibility of a null key)
+    and the values are restricted to be of simple types only, that is (excluding map, list, and array types).
+    """
+    if not value:
+        return {TYPE: AMQPTypes.null, VALUE: None}
+    fields = {TYPE: AMQPTypes.map, VALUE:[]}
+    for key, data in value.items():
+        fields[VALUE].append(({TYPE: AMQPTypes.string, VALUE: key}, data))
+    return fields
+
+
+def encode_message_id(value):
+    # type: (Any) -> Dict[str, Union[int, uuid.UUID, bytes, str]]
+    """
+    <type name="message-id-ulong" class="restricted" source="ulong" provides="message-id"/>
+    <type name="message-id-uuid" class="restricted" source="uuid" provides="message-id"/>
+    <type name="message-id-binary" class="restricted" source="binary" provides="message-id"/>
+    <type name="message-id-string" class="restricted" source="string" provides="message-id"/>
+    """
+    if isinstance(value, int):
+        return {TYPE: AMQPTypes.ulong, VALUE: value}
+    elif isinstance(value, uuid.UUID):
+        return {TYPE: AMQPTypes.uuid, VALUE: value}
+    elif isinstance(value, six.binary_type):
+        return {TYPE: AMQPTypes.binary, VALUE: value}
+    elif isinstance(value, six.text_type):
+        return {TYPE: AMQPTypes.string, VALUE: value}
+    raise TypeError("Unsupported Message ID type.")
+
+
+def encode_node_properties(value):
+    # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
+    """Properties of a node.
+
+    <type name="node-properties" class="restricted" source="fields"/>
+    
+    A symbol-keyed map containing properties of a node used when requesting creation or reporting
+    the creation of a dynamic node. The following common properties are defined::
+    
+        - `lifetime-policy`: The lifetime of a dynamically generated node. Definitionally, the lifetime will
+          never be less than the lifetime of the link which caused its creation, however it is possible to extend
+          the lifetime of dynamically created node using a lifetime policy. The value of this entry MUST be of a type
+          which provides the lifetime-policy archetype. The following standard lifetime-policies are defined below:
+          delete-on-close, delete-on-no-links, delete-on-no-messages or delete-on-no-links-or-messages.
+        
+        - `supported-dist-modes`: The distribution modes that the node supports. The value of this entry MUST be one or
+          more symbols which are valid distribution-modes. That is, the value MUST be of the same type as would be valid
+          in a field defined with the following attributes:
+          type="symbol" multiple="true" requires="distribution-mode"
+    """
+    if not value:
+        return {TYPE: AMQPTypes.null, VALUE: None}
+    # TODO
+    fields = {TYPE: AMQPTypes.map, VALUE:[]}
+    # fields[{TYPE: AMQPTypes.symbol, VALUE: b'lifetime-policy'}] = {
+    #     TYPE: AMQPTypes.described,
+    #     VALUE: (
+    #         {TYPE: AMQPTypes.ulong, VALUE: value['lifetime_policy']},
+    #         {TYPE: AMQPTypes.list, VALUE: []}
+    #     )
+    # }
+    # fields[{TYPE: AMQPTypes.symbol, VALUE: b'supported-dist-modes'}] = {}
+    return fields
+
+
+def encode_filter_set(value):
+    # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
+    """A set of predicates to filter the Messages admitted onto the Link.
+
+    <type name="filter-set" class="restricted" source="map"/>
+
+    A set of named filters. Every key in the map MUST be of type symbol, every value MUST be either null or of a
+    described type which provides the archetype filter. A filter acts as a function on a message which returns a
+    boolean result indicating whether the message can pass through that filter or not. A message will pass
+    through a filter-set if and only if it passes through each of the named filters. If the value for a given key is
+    null, this acts as if there were no such key present (i.e., all messages pass through the null filter).
+
+    Filter types are a defined extension point. The filter types that a given source supports will be indicated
+    by the capabilities of the source.
+    """
+    if not value:
+        return {TYPE: AMQPTypes.null, VALUE: None}
+    fields = {TYPE: AMQPTypes.map, VALUE:[]}
+    for name, data in value.items():
+        if data is None:
+            described_filter = {TYPE: AMQPTypes.null, VALUE: None}
+        else:
+            if isinstance(name, six.text_type):
+                name = name.encode('utf-8')
+            descriptor, filter_value = data
+            described_filter = {
+                TYPE: AMQPTypes.described,
+                VALUE: (
+                    {TYPE: AMQPTypes.symbol, VALUE: descriptor},
+                    filter_value
+                )
+            }
+        fields[VALUE].append(({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter))
+    return fields
+
+
+def encode_unknown(output, value, **kwargs):
+    # type: (bytearray, Optional[Any]) -> None
+    """
+    Dynamic encoding according to the type of `value`.
+    """
+    if value is None:
+        encode_null(output, **kwargs)
+    elif isinstance(value, bool):
+        encode_boolean(output, value, **kwargs)
+    elif isinstance(value, six.string_types):
+        encode_string(output, value, **kwargs)
+    elif isinstance(value, uuid.UUID):
+        encode_uuid(output, value, **kwargs)
+    elif isinstance(value, (bytearray, six.binary_type)):
+        encode_binary(output, value, **kwargs)
+    elif isinstance(value, float):
+        encode_double(output, value, **kwargs)
+    elif isinstance(value, six.integer_types):
+        encode_int(output, value, **kwargs)
+    elif isinstance(value, datetime):
+        encode_timestamp(output, value, **kwargs)
+    elif isinstance(value, list):
+        encode_list(output, value, **kwargs)
+    elif isinstance(value, tuple):
+        encode_described(output, value, **kwargs)
+    elif isinstance(value, dict):
+        encode_map(output, value, **kwargs)
+    else:
+        raise TypeError("Unable to encode unknown value: {}".format(value))
+
+
+_FIELD_DEFINITIONS = {
+    FieldDefinition.fields: encode_fields,
+    FieldDefinition.annotations: encode_annotations,
+    FieldDefinition.message_id: encode_message_id,
+    FieldDefinition.app_properties: encode_application_properties,
+    FieldDefinition.node_properties: encode_node_properties,
+    FieldDefinition.filter_set: encode_filter_set,
+}
+
+_ENCODE_MAP = {
+    None: encode_unknown,
+    AMQPTypes.null: encode_null,
+    AMQPTypes.boolean: encode_boolean,
+    AMQPTypes.ubyte: encode_ubyte,
+    AMQPTypes.byte: encode_byte,
+    AMQPTypes.ushort: encode_ushort,
+    AMQPTypes.short: encode_short,
+    AMQPTypes.uint: encode_uint,
+    AMQPTypes.int: encode_int,
+    AMQPTypes.ulong: encode_ulong,
+    AMQPTypes.long: encode_long,
+    AMQPTypes.float: encode_float,
+    AMQPTypes.double: encode_double,
+    AMQPTypes.timestamp: encode_timestamp,
+    AMQPTypes.uuid: encode_uuid,
+    AMQPTypes.binary: encode_binary,
+    AMQPTypes.string: encode_string,
+    AMQPTypes.symbol: encode_symbol,
+    AMQPTypes.list: encode_list,
+    AMQPTypes.map: encode_map,
+    AMQPTypes.array: encode_array,
+    AMQPTypes.described: encode_described,
+}
+
+
+def encode_value(output, value, **kwargs):
+    # type: (bytearray, Any, Any) -> None
+    try:
+        _ENCODE_MAP[value[TYPE]](output, value[VALUE], **kwargs)
+    except (KeyError, TypeError):
+        encode_unknown(output, value, **kwargs)
+
+
+def describe_performative(performative):
+    # type: (Performative) -> Tuple(bytes, bytes)
+    body = []
+    for index, value in enumerate(performative):
+        field = performative._definition[index]
+        if value is None:
+            body.append({TYPE: AMQPTypes.null, VALUE: None})
+        elif field is None:
+            continue
+        elif isinstance(field.type, FieldDefinition):
+            if field.multiple:
+                body.append({TYPE: AMQPTypes.array, VALUE: [_FIELD_DEFINITIONS[field.type](v) for v in value]})
+            else:
+                body.append(_FIELD_DEFINITIONS[field.type](value))
+        elif isinstance(field.type, ObjDefinition):
+            body.append(describe_performative(value))
+        else:
+            if field.multiple:
+                body.append({TYPE: AMQPTypes.array, VALUE: [{TYPE: field.type, VALUE: v} for v in value]})
+            else:
+                body.append({TYPE: field.type, VALUE: value})
+
+    return {
+        TYPE: AMQPTypes.described,
+        VALUE: (
+            {TYPE: AMQPTypes.ulong, VALUE: performative._code},
+            {TYPE: AMQPTypes.list, VALUE: body}
+        )
+    }
+
+
+def encode_payload(output, payload):
+    # type: (bytearray, Message) -> bytes
+
+    if payload[0]:  # header
+        # TODO: Header and Properties encoding can be optimized to
+        #  1. not encoding trailing None fields
+        #  2. encoding bool without constructor
+        encode_value(output, describe_performative(payload[0]))
+
+    if payload[2]:  # message annotations
+        encode_value(output, {
+            TYPE: AMQPTypes.described,
+            VALUE: (
+                {TYPE: AMQPTypes.ulong, VALUE: 0x00000072},
+                encode_annotations(payload[2]),
+            )
+        })
+
+    if payload[3]:  # properties
+        # TODO: Header and Properties encoding can be optimized to
+        #  1. not encoding trailing None fields
+        #  2. encoding bool without constructor
+        encode_value(output, describe_performative(payload[3]))
+
+    if payload[4]:  # application properties
+        encode_value(output, {
+            TYPE: AMQPTypes.described,
+            VALUE: (
+                {TYPE: AMQPTypes.ulong, VALUE: 0x00000074},
+                {TYPE: AMQPTypes.map, VALUE: payload[4]}
+            )
+        })
+
+    if payload[5]:  # data
+        for item_value in payload[5]:
+            encode_value(output, {
+                TYPE: AMQPTypes.described,
+                VALUE: (
+                    {TYPE: AMQPTypes.ulong, VALUE: 0x00000075},
+                    {TYPE: AMQPTypes.binary, VALUE: item_value}
+                )
+            })
+
+    if payload[6]:  # sequence
+        for item_value in payload[6]:
+            encode_value(output, {
+                TYPE: AMQPTypes.described,
+                VALUE: (
+                    {TYPE: AMQPTypes.ulong, VALUE: 0x00000076},
+                    {TYPE: None, VALUE: item_value}
+                )
+            })
+
+    if payload[7]:  # value
+        encode_value(output, {
+            TYPE: AMQPTypes.described,
+            VALUE: (
+                {TYPE: AMQPTypes.ulong, VALUE: 0x00000077},
+                {TYPE: None, VALUE: payload[7]}
+            )
+        })
+
+    if payload[8]:  # footer
+        encode_value(output, {
+            TYPE: AMQPTypes.described,
+            VALUE: (
+                {TYPE: AMQPTypes.ulong, VALUE: 0x00000078},
+                encode_annotations(payload[8]),
+            )
+        })
+
+    # TODO:
+    #  currently the delivery annotations must be finally encoded instead of being encoded at the 2nd position
+    #  otherwise the event hubs service would ignore the delivery annotations
+    #  -- received message doesn't have it populated
+    #  check with service team?
+    if payload[1]:  # delivery annotations
+        encode_value(output, {
+            TYPE: AMQPTypes.described,
+            VALUE: (
+                {TYPE: AMQPTypes.ulong, VALUE: 0x00000071},
+                encode_annotations(payload[1]),
+            )
+        })
+
+    return output
+
+
+def encode_frame(frame, frame_type=_FRAME_TYPE):
+    # type: (Performative) -> Tuple(bytes, bytes)
+    # TODO: allow passing type specific bytes manually, e.g. Empty Frame needs padding
+    if frame is None:
+        size = 8
+        header = size.to_bytes(4, 'big') + _FRAME_OFFSET + frame_type
+        return header, None
+
+    frame_description = describe_performative(frame)
+    frame_data = bytearray()
+    encode_value(frame_data, frame_description)
+    if isinstance(frame, performatives.TransferFrame):
+        frame_data += frame.payload
+
+    size = len(frame_data) + 8
+    header = size.to_bytes(4, 'big') + _FRAME_OFFSET + frame_type
+    return header, frame_data

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_platform.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_platform.py
@@ -1,0 +1,106 @@
+"""Platform compatibility."""
+# pylint: skip-file
+
+from __future__ import absolute_import, unicode_literals
+
+import platform
+import re
+import struct
+import sys
+
+# Jython does not have this attribute
+try:
+    from socket import SOL_TCP
+except ImportError:  # pragma: no cover
+    from socket import IPPROTO_TCP as SOL_TCP  # noqa
+
+
+RE_NUM = re.compile(r'(\d+).+')
+
+
+def _linux_version_to_tuple(s):
+    # type: (str) -> Tuple[int, int, int]
+    return tuple(map(_versionatom, s.split('.')[:3]))
+
+
+def _versionatom(s):
+    # type: (str) -> int
+    if s.isdigit():
+        return int(s)
+    match = RE_NUM.match(s)
+    return int(match.groups()[0]) if match else 0
+
+
+# available socket options for TCP level
+KNOWN_TCP_OPTS = {
+    'TCP_CORK', 'TCP_DEFER_ACCEPT', 'TCP_KEEPCNT',
+    'TCP_KEEPIDLE', 'TCP_KEEPINTVL', 'TCP_LINGER2',
+    'TCP_MAXSEG', 'TCP_NODELAY', 'TCP_QUICKACK',
+    'TCP_SYNCNT', 'TCP_USER_TIMEOUT', 'TCP_WINDOW_CLAMP',
+}
+
+LINUX_VERSION = None
+if sys.platform.startswith('linux'):
+    LINUX_VERSION = _linux_version_to_tuple(platform.release())
+    if LINUX_VERSION < (2, 6, 37):
+        KNOWN_TCP_OPTS.remove('TCP_USER_TIMEOUT')
+
+    # Windows Subsystem for Linux is an edge-case: the Python socket library
+    # returns most TCP_* enums, but they aren't actually supported
+    if platform.release().endswith("Microsoft"):
+        KNOWN_TCP_OPTS = {'TCP_NODELAY', 'TCP_KEEPIDLE', 'TCP_KEEPINTVL',
+                          'TCP_KEEPCNT'}
+
+elif sys.platform.startswith('darwin'):
+    KNOWN_TCP_OPTS.remove('TCP_USER_TIMEOUT')
+
+elif 'bsd' in sys.platform:
+    KNOWN_TCP_OPTS.remove('TCP_USER_TIMEOUT')
+
+# According to MSDN Windows platforms support getsockopt(TCP_MAXSSEG) but not
+# setsockopt(TCP_MAXSEG) on IPPROTO_TCP sockets.
+elif sys.platform.startswith('win'):
+    KNOWN_TCP_OPTS = {'TCP_NODELAY'}
+
+elif sys.platform.startswith('cygwin'):
+    KNOWN_TCP_OPTS = {'TCP_NODELAY'}
+
+# illumos does not allow to set the TCP_MAXSEG socket option,
+# even if the Oracle documentation says otherwise.
+elif sys.platform.startswith('sunos'):
+    KNOWN_TCP_OPTS.remove('TCP_MAXSEG')
+
+# aix does not allow to set the TCP_MAXSEG
+# or the TCP_USER_TIMEOUT socket options.
+elif sys.platform.startswith('aix'):
+    KNOWN_TCP_OPTS.remove('TCP_MAXSEG')
+    KNOWN_TCP_OPTS.remove('TCP_USER_TIMEOUT')
+
+if sys.version_info < (2, 7, 7):  # pragma: no cover
+    import functools
+
+    def _to_bytes_arg(fun):
+        @functools.wraps(fun)
+        def _inner(s, *args, **kwargs):
+            return fun(s.encode(), *args, **kwargs)
+        return _inner
+
+    pack = _to_bytes_arg(struct.pack)
+    pack_into = _to_bytes_arg(struct.pack_into)
+    unpack = _to_bytes_arg(struct.unpack)
+    unpack_from = _to_bytes_arg(struct.unpack_from)
+else:
+    pack = struct.pack
+    pack_into = struct.pack_into
+    unpack = struct.unpack
+    unpack_from = struct.unpack_from
+
+__all__ = [
+    'LINUX_VERSION',
+    'SOL_TCP',
+    'KNOWN_TCP_OPTS',
+    'pack',
+    'pack_into',
+    'unpack',
+    'unpack_from',
+]

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -1,0 +1,729 @@
+#-------------------------------------------------------------------------
+# This is a fork of the transport.py which was originally written by Barry Pederson and
+# maintained by the Celery project: https://github.com/celery/py-amqp.
+#
+# Copyright (C) 2009 Barry Pederson <bp@barryp.org>
+#
+# The license text can also be found here:
+# http://www.opensource.org/licenses/BSD-3-Clause
+#
+# License
+# =======
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#-------------------------------------------------------------------------
+
+
+from __future__ import absolute_import, unicode_literals
+
+import errno
+import re
+import socket
+import ssl
+import struct
+from ssl import SSLError
+from contextlib import contextmanager
+from io import BytesIO
+import logging
+from threading import Lock
+
+import certifi
+
+from ._platform import KNOWN_TCP_OPTS, SOL_TCP, pack, unpack
+from ._encode import encode_frame
+from ._decode import decode_frame, decode_empty_frame
+from .constants import TLS_HEADER_FRAME, WEBSOCKET_PORT, TransportType, AMQP_WS_SUBPROTOCOL
+
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None   # noqa
+try:
+    from os import set_cloexec  # Python 3.4?
+except ImportError:  # pragma: no cover
+    # TODO: Drop this once we drop Python 2.7 support
+    def set_cloexec(fd, cloexec):  # noqa
+        """Set flag to close fd after exec."""
+        if fcntl is None:
+            return
+        try:
+            FD_CLOEXEC = fcntl.FD_CLOEXEC
+        except AttributeError:
+            raise NotImplementedError(
+                'close-on-exec flag not supported on this platform',
+            )
+        flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+        if cloexec:
+            flags |= FD_CLOEXEC
+        else:
+            flags &= ~FD_CLOEXEC
+        return fcntl.fcntl(fd, fcntl.F_SETFD, flags)
+
+_LOGGER = logging.getLogger(__name__)
+_UNAVAIL = {errno.EAGAIN, errno.EINTR, errno.ENOENT, errno.EWOULDBLOCK}
+
+AMQP_PORT = 5672
+AMQPS_PORT = 5671
+AMQP_FRAME = memoryview(b'AMQP')
+EMPTY_BUFFER = bytes()
+SIGNED_INT_MAX = 0x7FFFFFFF
+
+# Match things like: [fe80::1]:5432, from RFC 2732
+IPV6_LITERAL = re.compile(r'\[([\.0-9a-f:]+)\](?::(\d+))?')
+
+DEFAULT_SOCKET_SETTINGS = {
+    'TCP_NODELAY': 1,
+    'TCP_USER_TIMEOUT': 1000,
+    'TCP_KEEPIDLE': 60,
+    'TCP_KEEPINTVL': 10,
+    'TCP_KEEPCNT': 9,
+}
+
+
+def get_errno(exc):
+    """Get exception errno (if set).
+
+    Notes:
+        :exc:`socket.error` and :exc:`IOError` first got
+        the ``.errno`` attribute in Py2.7.
+    """
+    try:
+        return exc.errno
+    except AttributeError:
+        try:
+            # e.args = (errno, reason)
+            if isinstance(exc.args, tuple) and len(exc.args) == 2:
+                return exc.args[0]
+        except AttributeError:
+            pass
+    return 0
+
+
+def to_host_port(host, port=AMQP_PORT):
+    """Convert hostname:port string to host, port tuple."""
+    m = IPV6_LITERAL.match(host)
+    if m:
+        host = m.group(1)
+        if m.group(2):
+            port = int(m.group(2))
+    else:
+        if ':' in host:
+            host, port = host.rsplit(':', 1)
+            port = int(port)
+    return host, port
+
+
+class UnexpectedFrame(Exception):
+    pass
+
+
+class _AbstractTransport(object):
+    """Common superclass for TCP and SSL transports."""
+
+    def __init__(self, host, port=AMQP_PORT, connect_timeout=None,
+                 read_timeout=None, write_timeout=None,
+                 socket_settings=None, raise_on_initial_eintr=True, **kwargs):
+        self.connected = False
+        self.sock = None
+        self.raise_on_initial_eintr = raise_on_initial_eintr
+        self._read_buffer = BytesIO()
+        self.host, self.port = to_host_port(host, port)
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self.write_timeout = write_timeout
+        self.socket_settings = socket_settings
+        self.socket_lock = Lock()
+
+    def connect(self):
+        try:
+            # are we already connected?
+            if self.connected:
+                return
+            self._connect(self.host, self.port, self.connect_timeout)
+            self._init_socket(
+                self.socket_settings, self.read_timeout, self.write_timeout,
+            )
+            # we've sent the banner; signal connect
+            # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
+            # has _not_ been sent
+            self.connected = True
+        except (OSError, IOError, SSLError):
+            # if not fully connected, close socket, and reraise error
+            if self.sock and not self.connected:
+                self.sock.close()
+                self.sock = None
+            raise
+
+    @contextmanager
+    def block_with_timeout(self, timeout):
+        if timeout is None:
+            yield self.sock
+        else:
+            sock = self.sock
+            prev = sock.gettimeout()
+            if prev != timeout:
+                sock.settimeout(timeout)
+            try:
+                yield self.sock
+            except SSLError as exc:
+                if 'timed out' in str(exc):
+                    # http://bugs.python.org/issue10272
+                    raise socket.timeout()
+                elif 'The operation did not complete' in str(exc):
+                    # Non-blocking SSL sockets can throw SSLError
+                    raise socket.timeout()
+                raise
+            except socket.error as exc:
+                if get_errno(exc) == errno.EWOULDBLOCK:
+                    raise socket.timeout()
+                raise
+            finally:
+                if timeout != prev:
+                    sock.settimeout(prev)
+
+    @contextmanager
+    def block(self):
+        bocking_timeout = None
+        sock = self.sock
+        prev = sock.gettimeout()
+        if prev != bocking_timeout:
+            sock.settimeout(bocking_timeout)
+        try:
+            yield self.sock
+        except SSLError as exc:
+            if 'timed out' in str(exc):
+                # http://bugs.python.org/issue10272
+                raise socket.timeout()
+            elif 'The operation did not complete' in str(exc):
+                # Non-blocking SSL sockets can throw SSLError
+                raise socket.timeout()
+            raise
+        except socket.error as exc:
+            if get_errno(exc) == errno.EWOULDBLOCK:
+                raise socket.timeout()
+            raise
+        finally:
+            if bocking_timeout != prev:
+                sock.settimeout(prev)
+
+    @contextmanager
+    def non_blocking(self):
+        non_bocking_timeout = 0.0
+        sock = self.sock
+        prev = sock.gettimeout()
+        if prev != non_bocking_timeout:
+            sock.settimeout(non_bocking_timeout)
+        try:
+            yield self.sock
+        except SSLError as exc:
+            if 'timed out' in str(exc):
+                # http://bugs.python.org/issue10272
+                raise socket.timeout()
+            elif 'The operation did not complete' in str(exc):
+                # Non-blocking SSL sockets can throw SSLError
+                raise socket.timeout()
+            raise
+        except socket.error as exc:
+            if get_errno(exc) == errno.EWOULDBLOCK:
+                raise socket.timeout()
+            raise
+        finally:
+            if non_bocking_timeout != prev:
+                sock.settimeout(prev)
+
+    def _connect(self, host, port, timeout):
+        e = None
+
+        # Below we are trying to avoid additional DNS requests for AAAA if A
+        # succeeds. This helps a lot in case when a hostname has an IPv4 entry
+        # in /etc/hosts but not IPv6. Without the (arguably somewhat twisted)
+        # logic below, getaddrinfo would attempt to resolve the hostname for
+        # both IP versions, which would make the resolver talk to configured
+        # DNS servers. If those servers are for some reason not available
+        # during resolution attempt (either because of system misconfiguration,
+        # or network connectivity problem), resolution process locks the
+        # _connect call for extended time.
+        addr_types = (socket.AF_INET, socket.AF_INET6)
+        addr_types_num = len(addr_types)
+        for n, family in enumerate(addr_types):
+            # first, resolve the address for a single address family
+            try:
+                entries = socket.getaddrinfo(
+                    host, port, family, socket.SOCK_STREAM, SOL_TCP)
+                entries_num = len(entries)
+            except socket.gaierror:
+                # we may have depleted all our options
+                if n + 1 >= addr_types_num:
+                    # if getaddrinfo succeeded before for another address
+                    # family, reraise the previous socket.error since it's more
+                    # relevant to users
+                    raise (e
+                           if e is not None
+                           else socket.error(
+                               "failed to resolve broker hostname"))
+                continue  # pragma: no cover
+
+            # now that we have address(es) for the hostname, connect to broker
+            for i, res in enumerate(entries):
+                af, socktype, proto, _, sa = res
+                try:
+                    self.sock = socket.socket(af, socktype, proto)
+                    try:
+                        set_cloexec(self.sock, True)
+                    except NotImplementedError:
+                        pass
+                    self.sock.settimeout(timeout)
+                    self.sock.connect(sa)
+                except socket.error as ex:
+                    e = ex
+                    if self.sock is not None:
+                        self.sock.close()
+                        self.sock = None
+                    # we may have depleted all our options
+                    if i + 1 >= entries_num and n + 1 >= addr_types_num:
+                        raise
+                else:
+                    # hurray, we established connection
+                    return
+
+    def _init_socket(self, socket_settings, read_timeout, write_timeout):
+        self.sock.settimeout(None)  # set socket back to blocking mode
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        self._set_socket_options(socket_settings)
+
+        # set socket timeouts
+        # for timeout, interval in ((socket.SO_SNDTIMEO, write_timeout),
+        #                           (socket.SO_RCVTIMEO, read_timeout)):
+        #     if interval is not None:
+        #         sec = int(interval)
+        #         usec = int((interval - sec) * 1000000)
+        #         self.sock.setsockopt(
+        #             socket.SOL_SOCKET, timeout,
+        #             pack('ll', sec, usec),
+        #         )
+        self._setup_transport()
+        # TODO: a greater timeout value is needed in long distance communication
+        #  we should either figure out a reasonable value error/dynamically adjust the timeout
+        #  1 second is enough for perf analysis
+        self.sock.settimeout(1)  # set socket back to non-blocking mode
+
+    def _get_tcp_socket_defaults(self, sock):
+        tcp_opts = {}
+        for opt in KNOWN_TCP_OPTS:
+            enum = None
+            if opt == 'TCP_USER_TIMEOUT':
+                try:
+                    from socket import TCP_USER_TIMEOUT as enum
+                except ImportError:
+                    # should be in Python 3.6+ on Linux.
+                    enum = 18
+            elif hasattr(socket, opt):
+                enum = getattr(socket, opt)
+
+            if enum:
+                if opt in DEFAULT_SOCKET_SETTINGS:
+                    tcp_opts[enum] = DEFAULT_SOCKET_SETTINGS[opt]
+                elif hasattr(socket, opt):
+                    tcp_opts[enum] = sock.getsockopt(
+                        SOL_TCP, getattr(socket, opt))
+        return tcp_opts
+
+    def _set_socket_options(self, socket_settings):
+        tcp_opts = self._get_tcp_socket_defaults(self.sock)
+        if socket_settings:
+            tcp_opts.update(socket_settings)
+        for opt, val in tcp_opts.items():
+            self.sock.setsockopt(SOL_TCP, opt, val)
+
+    def _read(self, n, initial=False):
+        """Read exactly n bytes from the peer."""
+        raise NotImplementedError('Must be overriden in subclass')
+
+    def _setup_transport(self):
+        """Do any additional initialization of the class."""
+        pass
+
+    def _shutdown_transport(self):
+        """Do any preliminary work in shutting down the connection."""
+        pass
+
+    def _write(self, s):
+        """Completely write a string to the peer."""
+        raise NotImplementedError('Must be overriden in subclass')
+
+    def close(self):
+        if self.sock is not None:
+            self._shutdown_transport()
+            # Call shutdown first to make sure that pending messages
+            # reach the AMQP broker if the program exits after
+            # calling this method.
+            try:
+                self.sock.shutdown(socket.SHUT_RDWR)
+            except Exception as exc:
+                # TODO: shutdown could raise OSError, Transport endpoint is not connected if the endpoint is already
+                #  disconnected. can we safely ignore the errors since the close operation is initiated by us.
+                _LOGGER.info("An error occurred when shutting down the socket: %r", exc)
+            self.sock.close()
+            self.sock = None
+        self.connected = False
+
+    def read(self, verify_frame_type=0, **kwargs):  # TODO: verify frame type?
+        read = self._read
+        read_frame_buffer = BytesIO()
+        try:
+            frame_header = memoryview(bytearray(8))
+            read_frame_buffer.write(read(8, buffer=frame_header, initial=True))
+
+            channel = struct.unpack('>H', frame_header[6:])[0]
+            size = frame_header[0:4]
+            if size == AMQP_FRAME:  # Empty frame or AMQP header negotiation TODO
+                return frame_header, channel, None
+            size = struct.unpack('>I', size)[0]
+            offset = frame_header[4]
+            frame_type = frame_header[5]
+
+            # >I is an unsigned int, but the argument to sock.recv is signed,
+            # so we know the size can be at most 2 * SIGNED_INT_MAX
+            payload_size = size - len(frame_header)
+            payload = memoryview(bytearray(payload_size))
+            if size > SIGNED_INT_MAX:
+                read_frame_buffer.write(read(SIGNED_INT_MAX, buffer=payload))
+                read_frame_buffer.write(read(size - SIGNED_INT_MAX, buffer=payload[SIGNED_INT_MAX:]))
+            else:
+                read_frame_buffer.write(read(payload_size, buffer=payload))
+        except (socket.timeout, TimeoutError):
+            read_frame_buffer.write(self._read_buffer.getvalue())
+            self._read_buffer = read_frame_buffer
+            self._read_buffer.seek(0)
+            raise
+        except (OSError, IOError, SSLError, socket.error) as exc:
+            # Don't disconnect for ssl read time outs
+            # http://bugs.python.org/issue10272
+            if isinstance(exc, SSLError) and 'timed out' in str(exc):
+                raise socket.timeout()
+            if get_errno(exc) not in _UNAVAIL:
+                self.connected = False
+            raise
+        offset -= 2
+        return frame_header, channel, payload[offset:]
+
+    def write(self, s):
+        try:
+            self._write(s)
+        except socket.timeout:
+            raise
+        except (OSError, IOError, socket.error) as exc:
+            if get_errno(exc) not in _UNAVAIL:
+                self.connected = False
+            raise
+
+    def receive_frame(self, *args, **kwargs):
+        try:
+            header, channel, payload = self.read(**kwargs)
+            if not payload:
+                decoded = decode_empty_frame(header)
+            else:
+                decoded = decode_frame(payload)
+            # TODO: Catch decode error and return amqp:decode-error
+            return channel, decoded
+        except (socket.timeout, TimeoutError):
+            return None, None
+
+    def send_frame(self, channel, frame, **kwargs):
+        header, performative = encode_frame(frame, **kwargs)
+        if performative is None:
+            data = header
+        else:
+            encoded_channel = struct.pack('>H', channel)
+            data = header + encoded_channel + performative
+        self.write(data)
+
+    def negotiate(self, encode, decode):
+        pass
+
+
+class SSLTransport(_AbstractTransport):
+    """Transport that works over SSL."""
+
+    def __init__(self, host, port=AMQPS_PORT, connect_timeout=None, ssl=None, **kwargs):
+        self.sslopts = ssl if isinstance(ssl, dict) else {}
+        self._read_buffer = BytesIO()
+        super(SSLTransport, self).__init__(
+            host,
+            port=port,
+            connect_timeout=connect_timeout,
+            **kwargs
+        )
+
+    def _setup_transport(self):
+        """Wrap the socket in an SSL object."""
+        self.sock = self._wrap_socket(self.sock, **self.sslopts)
+        a = self.sock.do_handshake()
+        self._quick_recv = self.sock.recv
+
+    def _wrap_socket(self, sock, context=None, **sslopts):
+        if context:
+            return self._wrap_context(sock, sslopts, **context)
+        return self._wrap_socket_sni(sock, **sslopts)
+
+    def _wrap_context(self, sock, sslopts, check_hostname=None, **ctx_options):
+        ctx = ssl.create_default_context(**ctx_options)
+        ctx.verify_mode = ssl.CERT_REQUIRED
+        ctx.load_verify_locations(cafile=certifi.where())
+        ctx.check_hostname = check_hostname
+        return ctx.wrap_socket(sock, **sslopts)
+
+    def _wrap_socket_sni(self, sock, keyfile=None, certfile=None,
+                         server_side=False, cert_reqs=ssl.CERT_REQUIRED,
+                         ca_certs=None, do_handshake_on_connect=False,
+                         suppress_ragged_eofs=True, server_hostname=None,
+                         ciphers=None, ssl_version=None):
+        """Socket wrap with SNI headers.
+
+        Default `ssl.wrap_socket` method augmented with support for
+        setting the server_hostname field required for SNI hostname header
+        """
+        # Setup the right SSL version; default to optimal versions across
+        # ssl implementations
+        if ssl_version is None:
+            # older versions of python 2.7 and python 2.6 do not have the
+            # ssl.PROTOCOL_TLS defined the equivalent is ssl.PROTOCOL_SSLv23
+            # we default to PROTOCOL_TLS and fallback to PROTOCOL_SSLv23
+            # TODO: Drop this once we drop Python 2.7 support
+            if hasattr(ssl, 'PROTOCOL_TLS'):
+                ssl_version = ssl.PROTOCOL_TLS
+            else:
+                ssl_version = ssl.PROTOCOL_SSLv23
+
+        opts = {
+            'sock': sock,
+            'keyfile': keyfile,
+            'certfile': certfile,
+            'server_side': server_side,
+            'cert_reqs': cert_reqs,
+            'ca_certs': ca_certs,
+            'do_handshake_on_connect': do_handshake_on_connect,
+            'suppress_ragged_eofs': suppress_ragged_eofs,
+            'ciphers': ciphers,
+            #'ssl_version': ssl_version
+        }
+
+        sock = ssl.wrap_socket(**opts)
+        # Set SNI headers if supported
+        if (server_hostname is not None) and (
+                hasattr(ssl, 'HAS_SNI') and ssl.HAS_SNI) and (
+                hasattr(ssl, 'SSLContext')):
+            context = ssl.SSLContext(opts['ssl_version'])
+            context.verify_mode = cert_reqs
+            if cert_reqs != ssl.CERT_NONE:
+                context.check_hostname = True
+            if (certfile is not None) and (keyfile is not None):
+                context.load_cert_chain(certfile, keyfile)
+            sock = context.wrap_socket(sock, server_hostname=server_hostname)
+        return sock
+
+    def _shutdown_transport(self):
+        """Unwrap a SSL socket, so we can call shutdown()."""
+        if self.sock is not None:
+            try:
+                self.sock = self.sock.unwrap()
+            except OSError:
+                pass
+
+    def _read(self, toread, initial=False, buffer=None,
+              _errnos=(errno.ENOENT, errno.EAGAIN, errno.EINTR)):
+        # According to SSL_read(3), it can at most return 16kb of data.
+        # Thus, we use an internal read buffer like TCPTransport._read
+        # to get the exact number of bytes wanted.
+        length = 0
+        view = buffer or memoryview(bytearray(toread))
+        nbytes = self._read_buffer.readinto(view)
+        toread -= nbytes
+        length += nbytes
+        try:
+            while toread:
+                try:
+                    nbytes = self.sock.recv_into(view[length:])
+                except socket.error as exc:
+                    # ssl.sock.read may cause a SSLerror without errno
+                    # http://bugs.python.org/issue10272
+                    if isinstance(exc, SSLError) and 'timed out' in str(exc):
+                        raise socket.timeout()
+                    # ssl.sock.read may cause ENOENT if the
+                    # operation couldn't be performed (Issue celery#1414).
+                    if exc.errno in _errnos:
+                        if initial and self.raise_on_initial_eintr:
+                            raise socket.timeout()
+                        continue
+                    raise
+                if not nbytes:
+                    raise IOError('Server unexpectedly closed connection')
+
+                length += nbytes
+                toread -= nbytes
+        except:  # noqa
+            self._read_buffer = BytesIO(view[:length])
+            raise
+        return view
+
+    def _write(self, s):
+        """Write a string out to the SSL socket fully."""
+        write = self.sock.send
+        while s:
+            try:
+                n = write(s)
+            except ValueError:
+                # AG: sock._sslobj might become null in the meantime if the
+                # remote connection has hung up.
+                # In python 3.4, a ValueError is raised is self._sslobj is
+                # None.
+                n = 0
+            if not n:
+                raise IOError('Socket closed')
+            s = s[n:]
+
+    def negotiate(self):
+        with self.block():
+            self.write(TLS_HEADER_FRAME)
+            channel, returned_header = self.receive_frame(verify_frame_type=None)
+            if returned_header[1] == TLS_HEADER_FRAME:
+                raise ValueError("Mismatching TLS header protocol. Excpected: {}, received: {}".format(
+                    TLS_HEADER_FRAME, returned_header[1]))
+
+
+class TCPTransport(_AbstractTransport):
+    """Transport that deals directly with TCP socket."""
+
+    def _setup_transport(self):
+        # Setup to _write() directly to the socket, and
+        # do our own buffered reads.
+        self._write = self.sock.sendall
+        self._read_buffer = EMPTY_BUFFER
+        self._quick_recv = self.sock.recv
+
+    def _read(self, n, initial=False, _errnos=(errno.EAGAIN, errno.EINTR)):
+        """Read exactly n bytes from the socket."""
+        recv = self._quick_recv
+        rbuf = self._read_buffer
+        try:
+            while len(rbuf) < n:
+                try:
+                    s = self.sock.read(n - len(rbuf))
+                except socket.error as exc:
+                    if exc.errno in _errnos:
+                        if initial and self.raise_on_initial_eintr:
+                            raise socket.timeout()
+                        continue
+                    raise
+                if not s:
+                    raise IOError('Server unexpectedly closed connection')
+                rbuf += s
+        except:  # noqa
+            self._read_buffer = rbuf
+            raise
+
+        result, self._read_buffer = rbuf[:n], rbuf[n:]
+        return result
+
+def Transport(host, transport_type, connect_timeout=None, ssl=False, **kwargs):
+    """Create transport.
+
+    Given a few parameters from the Connection constructor,
+    select and create a subclass of _AbstractTransport.
+    """
+    if transport_type == TransportType.AmqpOverWebsocket:
+        transport = WebSocketTransport
+    else:
+        transport = SSLTransport if ssl else TCPTransport
+    return transport(host, connect_timeout=connect_timeout, ssl=ssl, **kwargs)
+
+class WebSocketTransport(_AbstractTransport):
+    def __init__(self, host, port=WEBSOCKET_PORT, connect_timeout=1, ssl=None, **kwargs):
+        self.sslopts = ssl if isinstance(ssl, dict) else {}
+        self._connect_timeout = connect_timeout
+        self._host = host
+        super().__init__(
+            host, port, connect_timeout, **kwargs
+            )
+        self.ws = None
+        self._http_proxy = kwargs.get('http_proxy', None)
+
+    def connect(self):
+        http_proxy_host, http_proxy_port, http_proxy_auth = None, None, None
+        if self._http_proxy:
+            http_proxy_host = self._http_proxy['proxy_hostname']
+            http_proxy_port = self._http_proxy['proxy_port']
+            username = self._http_proxy.get('username', None)
+            password = self._http_proxy.get('password', None)
+            if username or password:
+                http_proxy_auth = (username, password)
+        try:
+            from websocket import create_connection
+            self.ws = create_connection(
+                url="wss://{}".format(self._host),
+                subprotocols=[AMQP_WS_SUBPROTOCOL],
+                timeout=self._connect_timeout,
+                skip_utf8_validation=True,
+                sslopt=self.sslopts,
+                http_proxy_host=http_proxy_host,
+                http_proxy_port=http_proxy_port,
+                http_proxy_auth=http_proxy_auth
+            )
+        except ImportError:
+            raise ValueError("Please install websocket-client library to use websocket transport.")
+
+    def _read(self, n, initial=False, buffer=None, **kwargs):  # pylint: disable=unused-arguments
+        """Read exactly n bytes from the peer."""
+        from websocket import WebSocketTimeoutException
+
+        length = 0
+        view = buffer or memoryview(bytearray(n))
+        nbytes = self._read_buffer.readinto(view)
+        length += nbytes
+        n -= nbytes
+        try:
+            while n:
+                data = self.ws.recv()
+
+                if len(data) <= n:
+                    view[length: length + len(data)] = data
+                    n -= len(data)
+                else:
+                    view[length: length + n] = data[0:n]
+                    self._read_buffer = BytesIO(data[n:])
+                    n = 0
+            return view
+        except WebSocketTimeoutException:
+            raise TimeoutError()
+
+    def _shutdown_transport(self):
+        """Do any preliminary work in shutting down the connection."""
+        self.ws.close()
+
+    def _write(self, s):
+        """Completely write a string to the peer.
+        ABNF, OPCODE_BINARY = 0x2
+        See http://tools.ietf.org/html/rfc5234
+        http://tools.ietf.org/html/rfc6455#section-5.2
+        """
+        self.ws.send_binary(s)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/__init__.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/__init__.py
@@ -1,0 +1,15 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+from ._connection_async import Connection, ConnectionState
+from ._link_async import Link, LinkDeliverySettleReason, LinkState
+from ._receiver_async import ReceiverLink
+from ._sasl_async import SASLPlainCredential, SASLTransport
+from ._sender_async import SenderLink
+from ._session_async import Session, SessionState
+from ._transport_async import AsyncTransport
+from ._client_async import AMQPClientAsync, ReceiveClientAsync, SendClientAsync
+from ._authentication_async import SASTokenAuthAsync

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_authentication_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_authentication_async.py
@@ -1,0 +1,76 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#-------------------------------------------------------------------------
+from functools import partial
+
+from ..authentication import (
+    _generate_sas_access_token,
+    SASTokenAuth,
+    JWTTokenAuth
+)
+from ..constants import AUTH_DEFAULT_EXPIRATION_SECONDS
+
+try:
+    from urlparse import urlparse
+    from urllib import quote_plus  # type: ignore
+except ImportError:
+    from urllib.parse import urlparse, quote_plus
+
+
+async def _generate_sas_token_async(auth_uri, sas_name, sas_key, expiry_in=AUTH_DEFAULT_EXPIRATION_SECONDS):
+    return _generate_sas_access_token(auth_uri, sas_name, sas_key, expiry_in=expiry_in)
+
+
+class JWTTokenAuthAsync(JWTTokenAuth):
+    """"""
+    # TODO:
+    #  1. naming decision, suffix with Auth vs Credential
+
+
+class SASTokenAuthAsync(SASTokenAuth):
+    # TODO:
+    #  1. naming decision, suffix with Auth vs Credential
+    def __init__(
+        self,
+        uri,
+        audience,
+        username,
+        password,
+        **kwargs
+    ):
+        """
+        CBS authentication using SAS tokens.
+
+        :param uri: The AMQP endpoint URI. This must be provided as
+         a decoded string.
+        :type uri: str
+        :param audience: The token audience field. For SAS tokens
+         this is usually the URI.
+        :type audience: str
+        :param username: The SAS token username, also referred to as the key
+         name or policy name. This can optionally be encoded into the URI.
+        :type username: str
+        :param password: The SAS token password, also referred to as the key.
+         This can optionally be encoded into the URI.
+        :type password: str
+        :param expires_in: The total remaining seconds until the token
+         expires.
+        :type expires_in: int
+        :param expires_on: The timestamp at which the SAS token will expire
+         formatted as seconds since epoch.
+        :type expires_on: float
+        :param token_type: The type field of the token request.
+         Default value is `"servicebus.windows.net:sastoken"`.
+        :type token_type: str
+
+        """
+        super(SASTokenAuthAsync, self).__init__(
+            uri,
+            audience,
+            username,
+            password,
+            **kwargs
+        )
+        self.get_token = partial(_generate_sas_token_async, uri, username, password, self.expires_in)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_cbs_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_cbs_async.py
@@ -1,0 +1,221 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#-------------------------------------------------------------------------
+
+import logging
+import asyncio
+from datetime import datetime
+
+from ._management_link_async import ManagementLink
+from ..utils import utc_now, utc_from_timestamp
+from ..message import Message, Properties
+from ..error import (
+    AuthenticationException,
+    TokenAuthFailure,
+    TokenExpired,
+    ErrorCondition
+)
+from ..constants import (
+    CbsState,
+    CbsAuthState,
+    CBS_PUT_TOKEN,
+    CBS_EXPIRATION,
+    CBS_NAME,
+    CBS_TYPE,
+    CBS_OPERATION,
+    ManagementExecuteOperationResult,
+    ManagementOpenResult,
+    DEFAULT_AUTH_TIMEOUT
+)
+from ..cbs import (
+    check_put_timeout_status,
+    check_expiration_and_refresh_status
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CBSAuthenticator(object):
+    def __init__(
+        self,
+        session,
+        auth,
+        **kwargs
+    ):
+        self._session = session
+        self._connection = self._session._connection
+        self._mgmt_link = self._session.create_request_response_link_pair(
+            endpoint='$cbs',
+            on_amqp_management_open_complete=self._on_amqp_management_open_complete,
+            on_amqp_management_error=self._on_amqp_management_error,
+            status_code_field=b'status-code',
+            status_description_field=b'status-description'
+        )  # type: ManagementLink
+        self._auth = auth
+        self._encoding = 'UTF-8'
+        self._auth_timeout = kwargs.pop('auth_timeout', DEFAULT_AUTH_TIMEOUT)
+        self._token_put_time = None
+        self._expires_on = None
+        self._token = None
+        self._refresh_window = None
+
+        self._token_status_code = None
+        self._token_status_description = None
+
+        self.state = CbsState.CLOSED
+        self.auth_state = CbsAuthState.IDLE
+
+    async def _put_token(self, token, token_type, audience, expires_on=None):
+        # type: (str, str, str, datetime) -> None
+        message = Message(
+            value=token,
+            properties=Properties(message_id=self._mgmt_link.next_message_id),
+            application_properties={
+                CBS_NAME: audience,
+                CBS_OPERATION: CBS_PUT_TOKEN,
+                CBS_TYPE: token_type,
+                CBS_EXPIRATION: expires_on
+            }
+        )
+        await self._mgmt_link.execute_operation(
+            message,
+            self._on_execute_operation_complete,
+            timeout=self._auth_timeout,
+            operation=CBS_PUT_TOKEN,
+            type=token_type
+        )
+        self._mgmt_link.next_message_id += 1
+
+    async def _on_amqp_management_open_complete(self, management_open_result):
+        if self.state in (CbsState.CLOSED, CbsState.ERROR):
+            _LOGGER.debug("Unexpected AMQP management open complete.")
+        elif self.state == CbsState.OPEN:
+            self.state = CbsState.ERROR
+            _LOGGER.info(
+                "Unexpected AMQP management open complete in OPEN, CBS error occurred on connection %r.",
+                self._connection._container_id
+            )
+        elif self.state == CbsState.OPENING:
+            self.state = CbsState.OPEN if management_open_result == ManagementOpenResult.OK else CbsState.CLOSED
+            _LOGGER.info("CBS for connection %r completed opening with status: %r",
+                         self._connection._container_id, management_open_result)
+
+    async def _on_amqp_management_error(self):
+        # TODO: review the logging information, adjust level/information
+        #  this should be applied to overall logging
+        if self.state == CbsState.CLOSED:
+            _LOGGER.debug("Unexpected AMQP error in CLOSED state.")
+        elif self.state == CbsState.OPENING:
+            self.state = CbsState.ERROR
+            await self._mgmt_link.close()
+            _LOGGER.info("CBS for connection %r failed to open with status: %r",
+                         self._connection._container_id, ManagementOpenResult.ERROR)
+        elif self.state == CbsState.OPEN:
+            self.state = CbsState.ERROR
+            _LOGGER.info("CBS error occurred on connection %r.", self._connection._container_id)
+
+    async def _on_execute_operation_complete(
+            self,
+            execute_operation_result,
+            status_code,
+            status_description,
+            message,
+            error_condition=None
+    ):
+        _LOGGER.info("CBS Put token result (%r), status code: %s, status_description: %s.",
+                     execute_operation_result, status_code, status_description)
+        self._token_status_code = status_code
+        self._token_status_description = status_description
+
+        if execute_operation_result == ManagementExecuteOperationResult.OK:
+            self.auth_state = CbsAuthState.OK
+        elif execute_operation_result == ManagementExecuteOperationResult.ERROR:
+            self.auth_state = CbsAuthState.ERROR
+            # put-token-message sending failure, rejected
+            self._token_status_code = 0
+            self._token_status_description = "Auth message has been rejected."
+        elif execute_operation_result == ManagementExecuteOperationResult.FAILED_BAD_STATUS:
+            self.auth_state = CbsAuthState.ERROR
+
+    async def _update_status(self):
+        if self.state == CbsAuthState.OK or self.state == CbsAuthState.REFRESH_REQUIRED:
+            is_expired, is_refresh_required = check_expiration_and_refresh_status(self._expires_on, self._refresh_window)
+            if is_expired:
+                self.state = CbsAuthState.EXPIRED
+            elif is_refresh_required:
+                self.state = CbsAuthState.REFRESH_REQUIRED
+        elif self.state == CbsAuthState.IN_PROGRESS:
+            put_timeout = check_put_timeout_status(self._auth_timeout, self._token_put_time)
+            if put_timeout:
+                self.state = CbsAuthState.TIMEOUT
+
+    async def _cbs_link_ready(self):
+        if self.state == CbsState.OPEN:
+            return True
+        if self.state != CbsState.OPEN:
+            return False
+        if self.state in (CbsState.CLOSED, CbsState.ERROR):
+            # TODO: raise proper error type also should this be a ClientError?
+            #  Think how upper layer handle this exception + condition code
+            raise AuthenticationException(
+                condition=ErrorCondition.ClientError,
+                description="CBS authentication link is in broken status, please recreate the cbs link."
+            )
+
+    async def open(self):
+        self.state = CbsState.OPENING
+        await self._mgmt_link.open()
+
+    async def close(self):
+        await self._mgmt_link.close()
+        self.state = CbsState.CLOSED
+
+    async def update_token(self):
+        self.auth_state = CbsAuthState.IN_PROGRESS
+        access_token = await self._auth.get_token()
+        self._expires_on = access_token.expires_on
+        expires_in = self._expires_on - int(utc_now().timestamp())
+        self._refresh_window = int(float(expires_in) * 0.1)
+        try:
+            self._token = access_token.token.decode()
+        except AttributeError:
+            self._token = access_token.token
+        self._token_put_time = int(utc_now().timestamp())
+        await self._put_token(self._token, self._auth.token_type, self._auth.audience, utc_from_timestamp(self._expires_on))
+
+    async def handle_token(self):
+        if not (await self._cbs_link_ready()):
+            return False
+        await self._update_status()
+        if self.auth_state == CbsAuthState.IDLE:
+            await self.update_token()
+            return False
+        elif self.auth_state == CbsAuthState.IN_PROGRESS:
+            return False
+        elif self.auth_state == CbsAuthState.OK:
+            return True
+        elif self.auth_state == CbsAuthState.REFRESH_REQUIRED:
+            _LOGGER.info("Token on connection %r will expire soon - attempting to refresh.",
+                         self._connection._container_id)
+            await self.update_token()
+            return False
+        elif self.auth_state == CbsAuthState.FAILURE:
+            raise AuthenticationException(
+                condition=ErrorCondition.InternalError,
+                description="Failed to open CBS authentication link."
+            )
+        elif self.auth_state == CbsAuthState.ERROR:
+            raise TokenAuthFailure(
+                self._token_status_code,
+                self._token_status_description,
+                encoding=self._encoding  # TODO: drop off all the encodings
+            )
+        elif self.auth_state == CbsAuthState.TIMEOUT:
+            raise TimeoutError("Authentication attempt timed-out.")
+        elif self.auth_state == CbsAuthState.EXPIRED:
+            raise TokenExpired(
+                condition=ErrorCondition.InternalError,
+                description="CBS Authentication Expired."
+            )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -1,0 +1,692 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+# TODO: check this
+# pylint: disable=super-init-not-called,too-many-lines
+
+import asyncio
+import collections.abc
+import logging
+import uuid
+import time
+import queue
+import certifi
+from functools import partial
+
+from ._connection_async import Connection
+from ._management_operation_async import ManagementOperation
+from ._receiver_async import ReceiverLink
+from ._sender_async import SenderLink
+from ._session_async import Session
+from ._cbs_async import CBSAuthenticator
+from ..client import AMQPClient as AMQPClientSync
+from ..client import ReceiveClient as ReceiveClientSync
+from ..client import SendClient as SendClientSync
+from ..message import _MessageDelivery
+from ..endpoints import Source, Target
+from ..constants import (
+    SenderSettleMode,
+    ReceiverSettleMode,
+    MessageDeliveryState,
+    SEND_DISPOSITION_ACCEPT,
+    SEND_DISPOSITION_REJECT,
+    LinkDeliverySettleReason,
+    MESSAGE_DELIVERY_DONE_STATES,
+    AUTH_TYPE_CBS,
+)
+from ..error import (
+    ErrorResponse,
+    ErrorCondition,
+    AMQPException,
+    MessageException
+)
+from ..constants import LinkState
+
+_logger = logging.getLogger(__name__)
+
+
+class AMQPClientAsync(AMQPClientSync):
+    """An asynchronous AMQP client.
+
+    :param remote_address: The AMQP endpoint to connect to. This could be a send target
+     or a receive source.
+    :type remote_address: str, bytes or ~uamqp.address.Address
+    :param auth: Authentication for the connection. This should be one of the subclasses of
+     uamqp.authentication.AMQPAuth. Currently this includes:
+        - uamqp.authentication.SASLAnonymous
+        - uamqp.authentication.SASLPlain
+        - uamqp.authentication.SASTokenAsync
+     If no authentication is supplied, SASLAnnoymous will be used by default.
+    :type auth: ~uamqp.authentication.common.AMQPAuth
+    :param client_name: The name for the client, also known as the Container ID.
+     If no name is provided, a random GUID will be used.
+    :type client_name: str or bytes
+    :param loop: A user specified event loop.
+    :type loop: ~asycnio.AbstractEventLoop
+    :param debug: Whether to turn on network trace logs. If `True`, trace logs
+     will be logged at INFO level. Default is `False`.
+    :type debug: bool
+    :param error_policy: A policy for parsing errors on link, connection and message
+     disposition to determine whether the error should be retryable.
+    :type error_policy: ~uamqp.errors.ErrorPolicy
+    :param keep_alive_interval: If set, a thread will be started to keep the connection
+     alive during periods of user inactivity. The value will determine how long the
+     thread will sleep (in seconds) between pinging the connection. If 0 or None, no
+     thread will be started.
+    :type keep_alive_interval: int
+    :param max_frame_size: Maximum AMQP frame size. Default is 63488 bytes.
+    :type max_frame_size: int
+    :param channel_max: Maximum number of Session channels in the Connection.
+    :type channel_max: int
+    :param idle_timeout: Timeout in seconds after which the Connection will close
+     if there is no further activity.
+    :type idle_timeout: int
+    :param properties: Connection properties.
+    :type properties: dict
+    :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
+     idle time for Connections with no activity. Value must be between
+     0.0 and 1.0 inclusive. Default is 0.5.
+    :type remote_idle_timeout_empty_frame_send_ratio: float
+    :param incoming_window: The size of the allowed window for incoming messages.
+    :type incoming_window: int
+    :param outgoing_window: The size of the allowed window for outgoing messages.
+    :type outgoing_window: int
+    :param handle_max: The maximum number of concurrent link handles.
+    :type handle_max: int
+    :param on_attach: A callback function to be run on receipt of an ATTACH frame.
+     The function must take 4 arguments: source, target, properties and error.
+    :type on_attach: func[~uamqp.address.Source, ~uamqp.address.Target, dict, ~uamqp.errors.AMQPConnectionError]
+    :param send_settle_mode: The mode by which to settle message send
+     operations. If set to `Unsettled`, the client will wait for a confirmation
+     from the service that the message was successfully sent. If set to 'Settled',
+     the client will not wait for confirmation and assume success.
+    :type send_settle_mode: ~uamqp.constants.SenderSettleMode
+    :param receive_settle_mode: The mode by which to settle message receive
+     operations. If set to `PeekLock`, the receiver will lock a message once received until
+     the client accepts or rejects the message. If set to `ReceiveAndDelete`, the service
+     will assume successful receipt of the message and clear it from the queue. The
+     default is `PeekLock`.
+    :type receive_settle_mode: ~uamqp.constants.ReceiverSettleMode
+    :param encoding: The encoding to use for parameters supplied as strings.
+     Default is 'UTF-8'
+    :type encoding: str
+    """
+
+    async def __aenter__(self):
+        """Run Client in an async context manager."""
+        await self.open_async()
+        return self
+
+    async def __aexit__(self, *args):
+        """Close and destroy Client on exiting an async context manager."""
+        await self.close_async()
+
+    async def _client_ready_async(self):  # pylint: disable=no-self-use
+        """Determine whether the client is ready to start sending and/or
+        receiving messages. To be ready, the connection must be open and
+        authentication complete.
+
+        :rtype: bool
+        """
+        return True
+
+    async def _client_run_async(self, **kwargs):
+        """Perform a single Connection iteration."""
+        await self._connection.listen(wait=self._socket_timeout)
+
+    async def _close_link_async(self, **kwargs):
+        if self._link and not self._link._is_closed:
+            await self._link.detach(close=True)
+            self._link = None
+
+    async def _do_retryable_operation_async(self, operation, *args, **kwargs):
+        retry_settings = self._retry_policy.configure_retries()
+        retry_active = True
+        absolute_timeout = kwargs.pop("timeout", 0) or 0
+        start_time = time.time()
+        while retry_active:
+            try:
+                if absolute_timeout < 0:
+                    raise TimeoutError("Operation timed out.")
+                return await operation(*args, timeout=absolute_timeout, **kwargs)
+            except AMQPException as exc:
+                if not self._retry_policy.is_retryable(exc):
+                    raise
+                if absolute_timeout >= 0:
+                    retry_active = self._retry_policy.increment(retry_settings, exc)
+                    if not retry_active:
+                        break
+                    await asyncio.sleep(self._retry_policy.get_backoff_time(retry_settings, exc))
+                    if exc.condition == ErrorCondition.LinkDetachForced:
+                        await self._close_link_async()  # if link level error, close and open a new link
+                        # TODO: check if there's any other code that we want to close link?
+                    if exc.condition in (ErrorCondition.ConnectionCloseForced, ErrorCondition.SocketError):
+                        # if connection detach or socket error, close and open a new connection
+                        await self.close_async()
+                        # TODO: check if there's any other code we want to close connection
+            except Exception:
+                raise
+            finally:
+                end_time = time.time()
+                if absolute_timeout > 0:
+                    absolute_timeout -= (end_time - start_time)
+        raise retry_settings['history'][-1]
+
+    async def open_async(self):
+        """Asynchronously open the client. The client can create a new Connection
+        or an existing Connection can be passed in. This existing Connection
+        may have an existing CBS authentication Session, which will be
+        used for this client as well. Otherwise a new Session will be
+        created.
+
+        :param connection: An existing Connection that may be shared between
+         multiple clients.
+        :type connetion: ~uamqp.async_ops.connection_async.ConnectionAsync
+        """
+        # pylint: disable=protected-access
+        if self._session:
+            return  # already open.
+        _logger.debug("Opening client connection.")
+        if not self._connection:
+            self._connection = Connection(
+                "amqps://" + self._hostname,
+                sasl_credential=self._auth.sasl,
+                ssl={'ca_certs': certifi.where()},
+                container_id=self._name,
+                max_frame_size=self._max_frame_size,
+                channel_max=self._channel_max,
+                idle_timeout=self._idle_timeout,
+                properties=self._properties,
+                network_trace=self._network_trace,
+                transport_type=self._transport_type,
+                http_proxy=self._http_proxy
+            )
+            await self._connection.open()
+        if not self._session:
+            self._session = self._connection.create_session(
+                incoming_window=self._incoming_window,
+                outgoing_window=self._outgoing_window
+            )
+            await self._session.begin()
+        if self._auth.auth_type == AUTH_TYPE_CBS:
+            self._cbs_authenticator = CBSAuthenticator(
+                session=self._session,
+                auth=self._auth,
+                auth_timeout=self._auth_timeout
+            )
+            await self._cbs_authenticator.open()
+        self._shutdown = False
+
+    async def close_async(self):
+        """Close the client asynchronously. This includes closing the Session
+        and CBS authentication layer as well as the Connection.
+        If the client was opened using an external Connection,
+        this will be left intact.
+        """
+        self._shutdown = True
+        if not self._session:
+            return  # already closed.
+        await self._close_link_async(close=True)
+        if self._cbs_authenticator:
+            await self._cbs_authenticator.close()
+            self._cbs_authenticator = None
+        await self._session.end()
+        self._session = None
+        if not self._external_connection:
+            await self._connection.close()
+            self._connection = None
+
+    async def auth_complete_async(self):
+        """Whether the authentication handshake is complete during
+        connection initialization.
+
+        :rtype: bool
+        """
+        if self._cbs_authenticator and not (await self._cbs_authenticator.handle_token()):
+            await self._connection.listen(wait=self._socket_timeout)
+            return False
+        return True
+
+    async def client_ready_async(self):
+        """
+        Whether the handler has completed all start up processes such as
+        establishing the connection, session, link and authentication, and
+        is not ready to process messages.
+
+        :rtype: bool
+        """
+        if not await self.auth_complete_async():
+            return False
+        if not await self._client_ready_async():
+            try:
+                await self._connection.listen(wait=self._socket_timeout)
+            except ValueError:
+                return True
+            return False
+        return True
+
+    async def do_work_async(self, **kwargs):
+        """Run a single connection iteration asynchronously.
+        This will return `True` if the connection is still open
+        and ready to be used for further work, or `False` if it needs
+        to be shut down.
+
+        :rtype: bool
+        :raises: TimeoutError or ~uamqp.errors.ClientTimeout if CBS authentication timeout reached.
+        """
+        if self._shutdown:
+            return False
+        if not await self.client_ready_async():
+            return True
+        return await self._client_run_async(**kwargs)
+
+    async def mgmt_request_async(self, message, **kwargs):
+        """
+        :param message: The message to send in the management request.
+        :type message: ~uamqp.message.Message
+        :keyword str operation: The type of operation to be performed. This value will
+         be service-specific, but common values include READ, CREATE and UPDATE.
+         This value will be added as an application property on the message.
+        :keyword str operation_type: The type on which to carry out the operation. This will
+         be specific to the entities of the service. This value will be added as
+         an application property on the message.
+        :keyword str node: The target node. Default node is `$management`.
+        :keyword float timeout: Provide an optional timeout in seconds within which a response
+         to the management request must be received.
+        :rtype: ~uamqp.message.Message
+        """
+
+        # The method also takes "status_code_field" and "status_description_field"
+        # keyword arguments as alternate names for the status code and description
+        # in the response body. Those two keyword arguments are used in Azure services only.
+        operation = kwargs.pop("operation", None)
+        operation_type = kwargs.pop("operation_type", None)
+        node = kwargs.pop("node", "$management")
+        timeout = kwargs.pop('timeout', 0)
+        try:
+            mgmt_link = self._mgmt_links[node]
+        except KeyError:
+
+            mgmt_link = ManagementOperation(self._session, endpoint=node, **kwargs)
+            self._mgmt_links[node] = mgmt_link
+            await mgmt_link.open()
+
+            while not await mgmt_link.ready():
+                await self._connection.listen(wait=False)
+
+        operation_type = operation_type or b'empty'
+        status, description, response = await mgmt_link.execute(
+            message,
+            operation=operation,
+            operation_type=operation_type,
+            timeout=timeout
+        )
+        return response
+
+
+class SendClientAsync(SendClientSync, AMQPClientAsync):
+
+    async def _client_ready_async(self):
+        """Determine whether the client is ready to start receiving messages.
+        To be ready, the connection must be open and authentication complete,
+        The Session, Link and MessageReceiver must be open and in non-errored
+        states.
+
+        :rtype: bool
+        :raises: ~uamqp.errors.MessageHandlerError if the MessageReceiver
+         goes into an error state.
+        """
+        # pylint: disable=protected-access
+        if not self._link:
+            self._link = self._session.create_sender_link(
+                target_address=self.target,
+                link_credit=self._link_credit,
+                send_settle_mode=self._send_settle_mode,
+                rcv_settle_mode=self._receive_settle_mode,
+                max_message_size=self._max_message_size,
+                properties=self._link_properties)
+            await self._link.attach()
+            return False
+        if (await self._link.get_state()) != LinkState.ATTACHED:  # ATTACHED
+            return False
+        return True
+
+    async def _client_run_async(self, **kwargs):
+        """MessageSender Link is now open - perform message send
+        on all pending messages.
+        Will return True if operation successful and client can remain open for
+        further work.
+
+        :rtype: bool
+        """
+        try:
+            await self._connection.listen(**kwargs)
+        except ValueError:
+            _logger.info("Timeout reached, closing sender.")
+            self._shutdown = True
+            return False
+        return True
+
+    async def _transfer_message_async(self, message_delivery, timeout=0):
+        message_delivery.state = MessageDeliveryState.WaitingForSendAck
+        on_send_complete = partial(self._on_send_complete_async, message_delivery)
+        delivery = await self._link.send_transfer(
+            message_delivery.message,
+            on_send_complete=on_send_complete,
+            timeout=timeout
+        )
+        if not delivery.sent:
+            raise RuntimeError("Message is not sent.")
+
+    async def _on_send_complete_async(self, message_delivery, reason, state):
+        # TODO: check whether the callback would be called in case of message expiry or link going down
+        #  and if so handle the state in the callback
+        message_delivery.reason = reason
+        if reason == LinkDeliverySettleReason.DISPOSITION_RECEIVED:
+            if state and SEND_DISPOSITION_ACCEPT in state:
+                message_delivery.state = MessageDeliveryState.Ok
+            else:
+                try:
+                    error_info = state[SEND_DISPOSITION_REJECT]
+                    self._process_send_error(
+                        message_delivery,
+                        condition=error_info[0][0],
+                        description=error_info[0][1],
+                        info=error_info[0][2]
+                    )
+                except TypeError:
+                    self._process_send_error(
+                        message_delivery,
+                        condition=ErrorCondition.UnknownError
+                    )
+        elif reason == LinkDeliverySettleReason.SETTLED:
+            message_delivery.state = MessageDeliveryState.Ok
+        elif reason == LinkDeliverySettleReason.TIMEOUT:
+            message_delivery.state = MessageDeliveryState.Timeout
+            message_delivery.error = TimeoutError("Sending message timed out.")
+        else:
+            # NotDelivered and other unknown errors
+            self._process_send_error(
+                message_delivery,
+                condition=ErrorCondition.UnknownError
+            )
+
+    async def _send_message_impl_async(self, message, **kwargs):
+        timeout = kwargs.pop("timeout", 0)
+        expire_time = (time.time() + timeout) if timeout else None
+        await self.open_async()
+        message_delivery = _MessageDelivery(
+            message,
+            MessageDeliveryState.WaitingToBeSent,
+            expire_time
+        )
+
+        while not await self.client_ready_async():
+            await asyncio.sleep(0.05)
+
+        await self._transfer_message_async(message_delivery, timeout)
+
+        running = True
+        while running and message_delivery.state not in MESSAGE_DELIVERY_DONE_STATES:
+            await self.do_work_async()
+            if message_delivery.expiry and time.time() > message_delivery.expiry:
+                await self._on_send_complete_async(message_delivery, LinkDeliverySettleReason.TIMEOUT, None)
+
+        if message_delivery.state in (
+            MessageDeliveryState.Error,
+            MessageDeliveryState.Cancelled,
+            MessageDeliveryState.Timeout
+        ):
+            try:
+                raise message_delivery.error
+            except TypeError:
+                # This is a default handler
+                raise MessageException(condition=ErrorCondition.UnknownError, description="Send failed.")
+
+    async def send_message_async(self, message, **kwargs):
+        """
+        :param ~uamqp.message.Message message:
+        :param int timeout: timeout in seconds
+        """
+        await self._do_retryable_operation_async(self._send_message_impl_async, message=message, **kwargs)
+
+
+class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
+    """An AMQP client for receiving messages asynchronously.
+
+    :param target: The source AMQP service endpoint. This can either be the URI as
+     a string or a ~uamqp.address.Source object.
+    :type target: str, bytes or ~uamqp.address.Source
+    :param auth: Authentication for the connection. This should be one of the subclasses of
+     uamqp.authentication.AMQPAuth. Currently this includes:
+        - uamqp.authentication.SASLAnonymous
+        - uamqp.authentication.SASLPlain
+        - uamqp.authentication.SASTokenAsync
+     If no authentication is supplied, SASLAnnoymous will be used by default.
+    :type auth: ~uamqp.authentication.common.AMQPAuth
+    :param client_name: The name for the client, also known as the Container ID.
+     If no name is provided, a random GUID will be used.
+    :type client_name: str or bytes
+    :param loop: A user specified event loop.
+    :type loop: ~asycnio.AbstractEventLoop
+    :param debug: Whether to turn on network trace logs. If `True`, trace logs
+     will be logged at INFO level. Default is `False`.
+    :type debug: bool
+    :param timeout: A timeout in seconds. The receiver will shut down if no
+     new messages are received after the specified timeout. If set to 0, the receiver
+     will never timeout and will continue to listen. The default is 0.
+    :type timeout: float
+    :param auto_complete: Whether to automatically settle message received via callback
+     or via iterator. If the message has not been explicitly settled after processing
+     the message will be accepted. Alternatively, when used with batch receive, this setting
+     will determine whether the messages are pre-emptively settled during batching, or otherwise
+     let to the user to be explicitly settled.
+    :type auto_complete: bool
+    :param error_policy: A policy for parsing errors on link, connection and message
+     disposition to determine whether the error should be retryable.
+    :type error_policy: ~uamqp.errors.ErrorPolicy
+    :param keep_alive_interval: If set, a thread will be started to keep the connection
+     alive during periods of user inactivity. The value will determine how long the
+     thread will sleep (in seconds) between pinging the connection. If 0 or None, no
+     thread will be started.
+    :type keep_alive_interval: int
+    :param send_settle_mode: The mode by which to settle message send
+     operations. If set to `Unsettled`, the client will wait for a confirmation
+     from the service that the message was successfully sent. If set to 'Settled',
+     the client will not wait for confirmation and assume success.
+    :type send_settle_mode: ~uamqp.constants.SenderSettleMode
+    :param receive_settle_mode: The mode by which to settle message receive
+     operations. If set to `PeekLock`, the receiver will lock a message once received until
+     the client accepts or rejects the message. If set to `ReceiveAndDelete`, the service
+     will assume successful receipt of the message and clear it from the queue. The
+     default is `PeekLock`.
+    :type receive_settle_mode: ~uamqp.constants.ReceiverSettleMode
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint.
+     To create an desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
+    :param max_message_size: The maximum allowed message size negotiated for the Link.
+    :type max_message_size: int
+    :param link_properties: Metadata to be sent in the Link ATTACH frame.
+    :type link_properties: dict
+    :param prefetch: The receiver Link credit that determines how many
+     messages the Link will attempt to handle per connection iteration.
+     The default is 300.
+    :type prefetch: int
+    :param max_frame_size: Maximum AMQP frame size. Default is 63488 bytes.
+    :type max_frame_size: int
+    :param channel_max: Maximum number of Session channels in the Connection.
+    :type channel_max: int
+    :param idle_timeout: Timeout in seconds after which the Connection will close
+     if there is no further activity.
+    :type idle_timeout: int
+    :param properties: Connection properties.
+    :type properties: dict
+    :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
+     idle time for Connections with no activity. Value must be between
+     0.0 and 1.0 inclusive. Default is 0.5.
+    :type remote_idle_timeout_empty_frame_send_ratio: float
+    :param incoming_window: The size of the allowed window for incoming messages.
+    :type incoming_window: int
+    :param outgoing_window: The size of the allowed window for outgoing messages.
+    :type outgoing_window: int
+    :param handle_max: The maximum number of concurrent link handles.
+    :type handle_max: int
+    :param on_attach: A callback function to be run on receipt of an ATTACH frame.
+     The function must take 4 arguments: source, target, properties and error.
+    :type on_attach: func[~uamqp.address.Source, ~uamqp.address.Target, dict, ~uamqp.errors.AMQPConnectionError]
+    :param encoding: The encoding to use for parameters supplied as strings.
+     Default is 'UTF-8'
+    :type encoding: str
+    """
+
+    async def _client_ready_async(self):
+        """Determine whether the client is ready to start receiving messages.
+        To be ready, the connection must be open and authentication complete,
+        The Session, Link and MessageReceiver must be open and in non-errored
+        states.
+
+        :rtype: bool
+        :raises: ~uamqp.errors.MessageHandlerError if the MessageReceiver
+         goes into an error state.
+        """
+        # pylint: disable=protected-access
+        if not self._link:
+            self._link = self._session.create_receiver_link(
+                source_address=self.source,
+                link_credit=self._link_credit,
+                send_settle_mode=self._send_settle_mode,
+                rcv_settle_mode=self._receive_settle_mode,
+                max_message_size=self._max_message_size,
+                on_message_received=self._message_received,
+                properties=self._link_properties,
+                desired_capabilities=self._desired_capabilities
+            )
+            await self._link.attach()
+            return False
+        if (await self._link.get_state()) != LinkState.ATTACHED:  # ATTACHED
+            return False
+        return True
+
+    async def _client_run_async(self, **kwargs):
+        """MessageReceiver Link is now open - start receiving messages.
+        Will return True if operation successful and client can remain open for
+        further work.
+
+        :rtype: bool
+        """
+        try:
+            await self._connection.listen(wait=self._socket_timeout, **kwargs)
+        except ValueError:
+            _logger.info("Timeout reached, closing receiver.")
+            self._shutdown = True
+            return False
+        return True
+
+    async def _message_received(self, message):
+        """Callback run on receipt of every message. If there is
+        a user-defined callback, this will be called.
+        Additionally if the client is retrieving messages for a batch
+        or iterator, the message will be added to an internal queue.
+
+        :param message: Received message.
+        :type message: ~uamqp.message.Message
+        """
+        if self._message_received_callback:
+            await self._message_received_callback(message)
+        if not self._streaming_receive:
+            self._received_messages.put(message)
+        # TODO: do we need settled property for a message?
+        # elif not message.settled:
+        #    # Message was received with callback processing and wasn't settled.
+        #    _logger.info("Message was not settled.")
+
+    async def _receive_message_batch_impl_async(self, max_batch_size=None, on_message_received=None, timeout=0):
+        self._message_received_callback = on_message_received
+        max_batch_size = max_batch_size or self._link_credit
+        timeout_time = time.time() + timeout if timeout else 0
+        receiving = True
+        batch = []
+        await self.open_async()
+        while len(batch) < max_batch_size:
+            try:
+                batch.append(self._received_messages.get_nowait())
+                self._received_messages.task_done()
+            except queue.Empty:
+                break
+        else:
+            return batch
+
+        to_receive_size = max_batch_size - len(batch)
+        before_queue_size = self._received_messages.qsize()
+
+        while receiving and to_receive_size > 0:
+            now_time = time.time()
+            if timeout_time and now_time > timeout_time:
+                break
+
+            try:
+                await asyncio.wait_for(
+                    self.do_work_async(batch=to_receive_size),
+                    timeout=timeout_time - now_time if timeout else None
+                )
+            except asyncio.TimeoutError:
+                pass
+
+            receiving = await self.do_work_async(batch=to_receive_size)
+            cur_queue_size = self._received_messages.qsize()
+            # after do_work, check how many new messages have been received since previous iteration
+            received = cur_queue_size - before_queue_size
+            if to_receive_size < max_batch_size and received == 0:
+                # there are already messages in the batch, and no message is received in the current cycle
+                # return what we have
+                break
+
+            to_receive_size -= received
+            before_queue_size = cur_queue_size
+
+        while len(batch) < max_batch_size:
+            try:
+                batch.append(self._received_messages.get_nowait())
+                self._received_messages.task_done()
+            except queue.Empty:
+                break
+        return batch
+
+    async def close_async(self):
+        self._received_messages = queue.Queue()
+        await super(ReceiveClientAsync, self).close_async()
+
+    async def receive_message_batch_async(self, **kwargs):
+        """Receive a batch of messages. Messages returned in the batch have already been
+        accepted - if you wish to add logic to accept or reject messages based on custom
+        criteria, pass in a callback. This method will return as soon as some messages are
+        available rather than waiting to achieve a specific batch size, and therefore the
+        number of messages returned per call will vary up to the maximum allowed.
+
+        If the receive client is configured with `auto_complete=True` then the messages received
+        in the batch returned by this function will already be settled. Alternatively, if
+        `auto_complete=False`, then each message will need to be explicitly settled before
+        it expires and is released.
+
+        :param max_batch_size: The maximum number of messages that can be returned in
+         one call. This value cannot be larger than the prefetch value, and if not specified,
+         the prefetch value will be used.
+        :type max_batch_size: int
+        :param on_message_received: A callback to process messages as they arrive from the
+         service. It takes a single argument, a ~uamqp.message.Message object.
+        :type on_message_received: callable[~uamqp.message.Message]
+        :param timeout: Timeout in seconds for which to wait to receive any messages.
+         If no messages are received in this time, an empty list will be returned. If set to
+         0, the client will continue to wait until at least one message is received. The
+         default is 0.
+        :type timeout: float
+        """
+        return await self._do_retryable_operation(
+            self._receive_message_batch_impl_async,
+            **kwargs
+        )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -1,0 +1,527 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import threading
+import struct
+import uuid
+import logging
+import time
+from urllib.parse import urlparse
+import socket
+from ssl import SSLError
+from enum import Enum
+import asyncio
+
+from ._transport_async import AsyncTransport
+from ._sasl_async import SASLTransport, SASLWithWebSocket
+from ._session_async import Session
+from ..performatives import OpenFrame, CloseFrame
+from .._connection import get_local_timeout
+from ..constants import (
+    PORT,
+    SECURE_PORT,
+    MAX_FRAME_SIZE_BYTES,
+    MAX_CHANNELS,
+    HEADER_FRAME,
+    ConnectionState,
+    EMPTY_FRAME,
+    TransportType
+)
+
+from ..error import (
+    ErrorCondition,
+    AMQPConnectionError,
+    AMQPError
+)
+
+_LOGGER = logging.getLogger(__name__)
+_CLOSING_STATES = (
+    ConnectionState.OC_PIPE,
+    ConnectionState.CLOSE_PIPE,
+    ConnectionState.DISCARDING,
+    ConnectionState.CLOSE_SENT,
+    ConnectionState.END
+)
+
+
+class Connection(object):
+    """
+    :param str container_id: The ID of the source container.
+    :param str hostname: The name of the target host.
+    :param int max_frame_size: Proposed maximum frame size in bytes.
+    :param int channel_max: The maximum channel number that may be used on the Connection.
+    :param timedelta idle_timeout: Idle time-out in milliseconds.
+    :param list(str) outgoing_locales: Locales available for outgoing text.
+    :param list(str) incoming_locales: Desired locales for incoming text in decreasing level of preference.
+    :param list(str) offered_capabilities: The extension capabilities the sender supports.
+    :param list(str) desired_capabilities: The extension capabilities the sender may use if the receiver supports
+    :param dict properties: Connection properties.
+    :keyword str transport_type: Determines if the transport type is Amqp or AmqpOverWebSocket.
+     Defaults to TransportType.Amqp. It will be AmqpOverWebSocket if using http_proxy.
+    :keyword Dict http_proxy: HTTP proxy settings. This must be a dictionary with the following
+     keys: `'proxy_hostname'` (str value) and `'proxy_port'` (int value). When using these settings,
+     the transport_type would be AmqpOverWebSocket.
+     Additionally the following keys may also be present: `'username', 'password'`.
+    """
+
+    def __init__(self, endpoint, **kwargs):
+        parsed_url = urlparse(endpoint)
+        self.hostname = parsed_url.hostname
+        endpoint = self.hostname
+        self._transport_type = kwargs.pop('transport_type', TransportType.Amqp)
+        if parsed_url.port:
+            self.port = parsed_url.port
+        elif parsed_url.scheme == 'amqps':
+            self.port = SECURE_PORT
+        else:
+            self.port = PORT
+        self.state = None
+
+        transport = kwargs.get('transport')
+        if transport:
+            self.transport = transport
+        elif 'sasl_credential' in kwargs:
+            sasl_transport = SASLTransport
+            if self._transport_type.name == "AmqpOverWebsocket" or kwargs.get("http_proxy"):
+                sasl_transport = SASLWithWebSocket
+                endpoint = parsed_url.hostname + parsed_url.path
+            self.transport = sasl_transport(
+                host=endpoint,
+                credential=kwargs['sasl_credential'],
+                **kwargs
+            )
+        else:
+            self.transport = AsyncTransport(parsed_url.netloc, **kwargs)
+        self._container_id = kwargs.get('container_id') or str(uuid.uuid4())
+        self.max_frame_size = kwargs.get('max_frame_size', MAX_FRAME_SIZE_BYTES)
+        self._remote_max_frame_size = None
+        self.channel_max = kwargs.get('channel_max', MAX_CHANNELS)
+        self.idle_timeout = kwargs.get('idle_timeout')
+        self.outgoing_locales = kwargs.get('outgoing_locales')
+        self.incoming_locales = kwargs.get('incoming_locales')
+        self.offered_capabilities = None
+        self.desired_capabilities = kwargs.get('desired_capabilities')
+        self.properties = kwargs.pop('properties', None)
+
+        self.allow_pipelined_open = kwargs.get('allow_pipelined_open', True)
+        self.remote_idle_timeout = None
+        self.remote_idle_timeout_send_frame = None
+        self.idle_timeout_empty_frame_send_ratio = kwargs.get('idle_timeout_empty_frame_send_ratio', 0.5)
+        self.last_frame_received_time = None
+        self.last_frame_sent_time = None
+        self.idle_wait_time = kwargs.get('idle_wait_time', 0.1)
+        self.network_trace = kwargs.get('network_trace', False)
+        self.network_trace_params = {
+            'connection': self._container_id,
+            'session': None,
+            'link': None
+        }
+        self._error = None
+        self.outgoing_endpoints = {}
+        self.incoming_endpoints = {}
+
+    async def __aenter__(self):
+        await self.open()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()
+
+    async def _set_state(self, new_state):
+        # type: (ConnectionState) -> None
+        """Update the connection state."""
+        if new_state is None:
+            return
+        previous_state = self.state
+        self.state = new_state
+        _LOGGER.info("Connection '%s' state changed: %r -> %r", self._container_id, previous_state, new_state)
+
+        for session in self.outgoing_endpoints.values():
+            await session._on_connection_state_change()
+
+    async def _connect(self):
+        try:
+            if not self.state:
+                await self.transport.connect()
+                await self._set_state(ConnectionState.START)
+            await self.transport.negotiate()
+            await self._outgoing_header()
+            await self._set_state(ConnectionState.HDR_SENT)
+            if not self.allow_pipelined_open:
+                await self._process_incoming_frame(*(await self._read_frame(wait=True)))
+                if self.state != ConnectionState.HDR_EXCH:
+                    await self._disconnect()
+                    raise ValueError("Did not receive reciprocal protocol header. Disconnecting.")
+            else:
+                await self._set_state(ConnectionState.HDR_SENT)
+        except (OSError, IOError, SSLError, socket.error) as exc:
+            raise AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Failed to initiate the connection due to exception: " + str(exc),
+                error=exc
+            )
+
+    async def _disconnect(self, *args):
+        if self.state == ConnectionState.END:
+            return
+        await self._set_state(ConnectionState.END)
+        self.transport.close()
+
+    def _can_read(self):
+        # type: () -> bool
+        """Whether the connection is in a state where it is legal to read for incoming frames."""
+        return self.state not in (ConnectionState.CLOSE_RCVD, ConnectionState.END)
+
+    async def _read_frame(self, **kwargs):
+        if self._can_read():
+            return await self.transport.receive_frame(**kwargs)
+        _LOGGER.warning("Cannot read frame in current state: %r", self.state)
+
+    def _can_write(self):
+        # type: () -> bool
+        """Whether the connection is in a state where it is legal to write outgoing frames."""
+        return self.state not in _CLOSING_STATES
+
+    async def _send_frame(self, channel, frame, timeout=None, **kwargs):
+        try:
+            raise self._error
+        except TypeError:
+            pass
+
+        if self._can_write():
+            try:
+                self.last_frame_sent_time = time.time()
+                await self.transport.send_frame(channel, frame, **kwargs)
+            except (OSError, IOError, SSLError, socket.error) as exc:
+                self._error = AMQPConnectionError(
+                    ErrorCondition.SocketError,
+                    description="Can not send frame out due to exception: " + str(exc),
+                    error=exc
+                )
+        else:
+            _LOGGER.warning("Cannot write frame in current state: %r", self.state)
+
+    def _get_next_outgoing_channel(self):
+        # type: () -> int
+        """Get the next available outgoing channel number within the max channel limit.
+
+        :raises ValueError: If maximum channels has been reached.
+        :returns: The next available outgoing channel number.
+        :rtype: int
+        """
+        if (len(self.incoming_endpoints) + len(self.outgoing_endpoints)) >= self.channel_max:
+            raise ValueError("Maximum number of channels ({}) has been reached.".format(self.channel_max))
+        next_channel = next(i for i in range(1, self.channel_max) if i not in self.outgoing_endpoints)
+        return next_channel
+
+    async def _outgoing_empty(self):
+        if self.network_trace:
+            _LOGGER.info("-> empty()", extra=self.network_trace_params)
+        try:
+            if self._can_write():
+                await self.transport.write(EMPTY_FRAME)
+                self.last_frame_sent_time = time.time()
+        except (OSError, IOError, SSLError, socket.error) as exc:
+            self._error = AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Can not send empty frame due to exception: " + str(exc),
+                error=exc
+            )
+
+    async def _outgoing_header(self):
+        self.last_frame_sent_time = time.time()
+        if self.network_trace:
+            _LOGGER.info("-> header(%r)", HEADER_FRAME, extra=self.network_trace_params)
+        await self.transport.write(HEADER_FRAME)
+
+    async def _incoming_header(self, channel, frame):
+        if self.network_trace:
+            _LOGGER.info("<- header(%r)", frame, extra=self.network_trace_params)
+        if self.state == ConnectionState.START:
+            await self._set_state(ConnectionState.HDR_RCVD)
+        elif self.state == ConnectionState.HDR_SENT:
+            await self._set_state(ConnectionState.HDR_EXCH)
+        elif self.state == ConnectionState.OPEN_PIPE:
+            await self._set_state(ConnectionState.OPEN_SENT)
+
+    async def _outgoing_open(self):
+        open_frame = OpenFrame(
+            container_id=self._container_id,
+            hostname=self.hostname,
+            max_frame_size=self.max_frame_size,
+            channel_max=self.channel_max,
+            idle_timeout=self.idle_timeout * 1000 if self.idle_timeout else None,  # Convert to milliseconds
+            outgoing_locales=self.outgoing_locales,
+            incoming_locales=self.incoming_locales,
+            offered_capabilities=self.offered_capabilities if self.state == ConnectionState.OPEN_RCVD else None,
+            desired_capabilities=self.desired_capabilities if self.state == ConnectionState.HDR_EXCH else None,
+            properties=self.properties,
+        )
+        if self.network_trace:
+            _LOGGER.info("-> %r", open_frame, extra=self.network_trace_params)
+        await self._send_frame(0, open_frame)
+
+    async def _incoming_open(self, channel, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", OpenFrame(*frame), extra=self.network_trace_params)
+        if channel != 0:
+            _LOGGER.error("OPEN frame received on a channel that is not 0.")
+            await self.close(error=None)  # TODO: not allowed
+            await self._set_state(ConnectionState.END)
+        if self.state == ConnectionState.OPENED:
+            _LOGGER.error("OPEN frame received in the OPENED state.")
+            await self.close()
+        if frame[4]:
+            self.remote_idle_timeout = frame[4] / 1000  # Convert to seconds
+            self.remote_idle_timeout_send_frame = self.idle_timeout_empty_frame_send_ratio * self.remote_idle_timeout
+
+        if frame[2] < 512:
+            pass  # TODO: error
+        self._remote_max_frame_size = frame[2]
+        if self.state == ConnectionState.OPEN_SENT:
+            await self._set_state(ConnectionState.OPENED)
+        elif self.state == ConnectionState.HDR_EXCH:
+            await self._set_state(ConnectionState.OPEN_RCVD)
+            await self._outgoing_open()
+            await self._set_state(ConnectionState.OPENED)
+        else:
+            pass  # TODO what now...?
+
+    async def _outgoing_close(self, error=None):
+        close_frame = CloseFrame(error=error)
+        if self.network_trace:
+            _LOGGER.info("-> %r", close_frame, extra=self.network_trace_params)
+        await self._send_frame(0, close_frame)
+
+    async def _incoming_close(self, channel, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", CloseFrame(*frame), extra=self.network_trace_params)
+        disconnect_states = [
+            ConnectionState.HDR_RCVD,
+            ConnectionState.HDR_EXCH,
+            ConnectionState.OPEN_RCVD,
+            ConnectionState.CLOSE_SENT,
+            ConnectionState.DISCARDING
+        ]
+        if self.state in disconnect_states:
+            await self._disconnect()
+            await self._set_state(ConnectionState.END)
+            return
+        if channel > self.channel_max:
+            _LOGGER.error("Invalid channel")
+
+        await self._set_state(ConnectionState.CLOSE_RCVD)
+        await self._outgoing_close()
+        await self._disconnect()
+        await self._set_state(ConnectionState.END)
+
+        if frame[0]:
+            self._error = AMQPConnectionError(
+                condition=frame[0][0],
+                description=frame[0][1],
+                info=frame[0][2]
+            )
+            _LOGGER.error("Connection error: {}".format(frame[0]))
+
+    async def _incoming_begin(self, channel, frame):
+        try:
+            existing_session = self.outgoing_endpoints[frame[0]]
+            self.incoming_endpoints[channel] = existing_session
+            await self.incoming_endpoints[channel]._incoming_begin(frame)
+        except KeyError:
+            new_session = Session.from_incoming_frame(self, channel, frame)
+            self.incoming_endpoints[channel] = new_session
+            await new_session._incoming_begin(frame)
+
+    async def _incoming_end(self, channel, frame):
+        try:
+            await self.incoming_endpoints[channel]._incoming_end(frame)
+        except KeyError:
+            pass  # TODO: channel error
+        # self.incoming_endpoints.pop(channel)  # TODO
+        # self.outgoing_endpoints.pop(channel)  # TODO
+
+    async def _process_incoming_frame(self, channel, frame):
+        try:
+            performative, fields = frame
+        except TypeError:
+            return True  # Empty Frame or socket timeout
+        try:
+            self.last_frame_received_time = time.time()
+            if performative == 20:
+                await self.incoming_endpoints[channel]._incoming_transfer(fields)
+                return False
+            if performative == 21:
+                await self.incoming_endpoints[channel]._incoming_disposition(fields)
+                return False
+            if performative == 19:
+                await self.incoming_endpoints[channel]._incoming_flow(fields)
+                return False
+            if performative == 18:
+                await self.incoming_endpoints[channel]._incoming_attach(fields)
+                return False
+            if performative == 22:
+                await self.incoming_endpoints[channel]._incoming_detach(fields)
+                return True
+            if performative == 17:
+                await self._incoming_begin(channel, fields)
+                return True
+            if performative == 23:
+                await self._incoming_end(channel, fields)
+                return True
+            if performative == 16:
+                await self._incoming_open(channel, fields)
+                return True
+            if performative == 24:
+                await self._incoming_close(channel, fields)
+                return True
+            if performative == 0:
+                await self._incoming_header(channel, fields)
+                return True
+            if performative == 1:
+                return False  # TODO: incoming EMPTY
+            else:
+                _LOGGER.error("Unrecognized incoming frame: {}".format(frame))
+                return True
+        except KeyError:
+            return True  # TODO: channel error
+
+    async def _process_outgoing_frame(self, channel, frame):
+        if self.network_trace:
+            _LOGGER.info("-> %r", frame, extra=self.network_trace_params)
+        if not self.allow_pipelined_open and self.state in [ConnectionState.OPEN_PIPE, ConnectionState.OPEN_SENT]:
+            raise ValueError("Connection not configured to allow pipeline send.")
+        if self.state not in [ConnectionState.OPEN_PIPE, ConnectionState.OPEN_SENT, ConnectionState.OPENED]:
+            raise ValueError("Connection not open.")
+        now = time.time()
+        if get_local_timeout(now, self.idle_timeout, self.last_frame_received_time) or (
+        await self._get_remote_timeout(now)):
+            await self.close(
+                # TODO: check error condition
+                error=AMQPError(
+                    condition=ErrorCondition.ConnectionCloseForced,
+                    description="No frame received for the idle timeout."
+                ),
+                wait=False
+            )
+            return
+        await self._send_frame(channel, frame)
+
+    async def _get_remote_timeout(self, now):
+        if self.remote_idle_timeout and self.last_frame_sent_time:
+            time_since_last_sent = now - self.last_frame_sent_time
+            if time_since_last_sent > self.remote_idle_timeout_send_frame:
+                await self._outgoing_empty()
+        return False
+
+    async def _wait_for_response(self, wait, end_state):
+        # type: (Union[bool, float], ConnectionState) -> None
+        if wait == True:
+            await self.listen(wait=False)
+            while self.state != end_state:
+                await asyncio.sleep(self.idle_wait_time)
+                await self.listen(wait=False)
+        elif wait:
+            await self.listen(wait=False)
+            timeout = time.time() + wait
+            while self.state != end_state:
+                if time.time() >= timeout:
+                    break
+                await asyncio.sleep(self.idle_wait_time)
+                await self.listen(wait=False)
+
+    async def _listen_one_frame(self, **kwargs):
+        new_frame = await self._read_frame(**kwargs)
+        return await self._process_incoming_frame(*new_frame)
+
+    async def listen(self, wait=False, batch=1, **kwargs):
+        try:
+            raise self._error
+        except TypeError:
+            pass
+        try:
+            if self.state not in _CLOSING_STATES:
+                now = time.time()
+                if get_local_timeout(now, self.idle_timeout, self.last_frame_received_time) or (
+                await self._get_remote_timeout(now)):
+                    # TODO: check error condition
+                    await self.close(
+                        error=AMQPError(
+                            condition=ErrorCondition.ConnectionCloseForced,
+                            description="No frame received for the idle timeout."
+                        ),
+                        wait=False
+                    )
+                    return
+            if self.state == ConnectionState.END:
+                # TODO: check error condition
+                self._error = AMQPConnectionError(
+                    condition=ErrorCondition.ConnectionCloseForced,
+                    description="Connection was already closed."
+                )
+                return
+            for _ in range(batch):
+                if await asyncio.ensure_future(self._listen_one_frame(**kwargs)):
+                    # TODO: compare the perf difference between ensure_future and direct await
+                    break
+        except (OSError, IOError, SSLError, socket.error) as exc:
+            self._error = AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Can not send frame out due to exception: " + str(exc),
+                error=exc
+            )
+
+    def create_session(self, **kwargs):
+        assigned_channel = self._get_next_outgoing_channel()
+        kwargs['allow_pipelined_open'] = self.allow_pipelined_open
+        kwargs['idle_wait_time'] = self.idle_wait_time
+        session = Session(
+            self,
+            assigned_channel,
+            network_trace=kwargs.pop('network_trace', self.network_trace),
+            network_trace_params=dict(self.network_trace_params),
+            **kwargs)
+        self.outgoing_endpoints[assigned_channel] = session
+        return session
+
+    async def open(self, wait=False):
+        await self._connect()
+        await self._outgoing_open()
+        if self.state == ConnectionState.HDR_EXCH:
+            await self._set_state(ConnectionState.OPEN_SENT)
+        elif self.state == ConnectionState.HDR_SENT:
+            await self._set_state(ConnectionState.OPEN_PIPE)
+        if wait:
+            await self._wait_for_response(wait, ConnectionState.OPENED)
+        elif not self.allow_pipelined_open:
+            raise ValueError("Connection has been configured to not allow piplined-open. Please set 'wait' parameter.")
+
+    async def close(self, error=None, wait=False):
+        if self.state in [ConnectionState.END, ConnectionState.CLOSE_SENT]:
+            return
+        try:
+            await self._outgoing_close(error=error)
+            if error:
+                self._error = AMQPConnectionError(
+                    condition=error.condition,
+                    description=error.description,
+                    info=error.info
+                )
+            if self.state == ConnectionState.OPEN_PIPE:
+                await self._set_state(ConnectionState.OC_PIPE)
+            elif self.state == ConnectionState.OPEN_SENT:
+                await self._set_state(ConnectionState.CLOSE_PIPE)
+            elif error:
+                await self._set_state(ConnectionState.DISCARDING)
+            else:
+                await self._set_state(ConnectionState.CLOSE_SENT)
+            await self._wait_for_response(wait, ConnectionState.END)
+        except Exception as exc:
+            # If error happened during closing, ignore the error and set state to END
+            _LOGGER.info("An error occurred when closing the connection: %r", exc)
+            await self._set_state(ConnectionState.END)
+        finally:
+            await self._disconnect()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
@@ -1,0 +1,276 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+import asyncio
+import threading
+import struct
+import uuid
+import logging
+import time
+from urllib.parse import urlparse
+from enum import Enum
+from io import BytesIO
+
+from ..endpoints import Source, Target
+from ..constants import (
+    DEFAULT_LINK_CREDIT,
+    SessionState,
+    SessionTransferState,
+    LinkDeliverySettleReason,
+    LinkState,
+    Role,
+    SenderSettleMode,
+    ReceiverSettleMode
+)
+from ..performatives import (
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame,
+    FlowFrame,
+)
+from ..error import (
+    AMQPConnectionError,
+    AMQPLinkRedirect,
+    AMQPLinkError,
+    ErrorCondition
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Link(object):
+    """
+
+    """
+
+    def __init__(self, session, handle, name, role, **kwargs):
+        self.state = LinkState.DETACHED
+        self.name = name or str(uuid.uuid4())
+        self.handle = handle
+        self.remote_handle = None
+        self.role = role
+        source_address = kwargs['source_address']
+        target_address = kwargs["target_address"]
+        self.source = source_address if isinstance(source_address, Source) else Source(
+            address=kwargs['source_address'],
+            durable=kwargs.get('source_durable'),
+            expiry_policy=kwargs.get('source_expiry_policy'),
+            timeout=kwargs.get('source_timeout'),
+            dynamic=kwargs.get('source_dynamic'),
+            dynamic_node_properties=kwargs.get('source_dynamic_node_properties'),
+            distribution_mode=kwargs.get('source_distribution_mode'),
+            filters=kwargs.get('source_filters'),
+            default_outcome=kwargs.get('source_default_outcome'),
+            outcomes=kwargs.get('source_outcomes'),
+            capabilities=kwargs.get('source_capabilities'))
+        self.target = target_address if isinstance(target_address,Target) else Target(
+            address=kwargs['target_address'],
+            durable=kwargs.get('target_durable'),
+            expiry_policy=kwargs.get('target_expiry_policy'),
+            timeout=kwargs.get('target_timeout'),
+            dynamic=kwargs.get('target_dynamic'),
+            dynamic_node_properties=kwargs.get('target_dynamic_node_properties'),
+            capabilities=kwargs.get('target_capabilities'))
+        self.link_credit = kwargs.pop('link_credit', None) or DEFAULT_LINK_CREDIT
+        self.current_link_credit = self.link_credit
+        self.send_settle_mode = kwargs.pop('send_settle_mode', SenderSettleMode.Mixed)
+        self.rcv_settle_mode = kwargs.pop('rcv_settle_mode', ReceiverSettleMode.First)
+        self.unsettled = kwargs.pop('unsettled', None)
+        self.incomplete_unsettled = kwargs.pop('incomplete_unsettled', None)
+        self.initial_delivery_count = kwargs.pop('initial_delivery_count', 0)
+        self.delivery_count = self.initial_delivery_count
+        self.received_delivery_id = None
+        self.max_message_size = kwargs.pop('max_message_size', None)
+        self.remote_max_message_size = None
+        self.available = kwargs.pop('available', None)
+        self.properties = kwargs.pop('properties', None)
+        self.offered_capabilities = None
+        self.desired_capabilities = kwargs.pop('desired_capabilities', None)
+
+        self.network_trace = kwargs['network_trace']
+        self.network_trace_params = kwargs['network_trace_params']
+        self.network_trace_params['link'] = self.name
+        self._session = session
+        self._is_closed = False
+        self._send_links = {}
+        self._receive_links = {}
+        self._pending_deliveries = {}
+        self._received_payload = bytearray()
+        self._on_link_state_change = kwargs.get('on_link_state_change')
+        self._error = None
+
+    async def __aenter__(self):
+        await self.attach()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.detach(close=True)
+
+    @classmethod
+    def from_incoming_frame(cls, session, handle, frame):
+        # check link_create_from_endpoint in C lib
+        raise NotImplementedError('Pending')  # TODO: Assuming we establish all links for now...
+
+    async def get_state(self):
+        try:
+            raise self._error
+        except TypeError:
+            pass
+        return self.state
+
+    async def _check_if_closed(self):
+        if self._is_closed:
+            try:
+                raise self._error
+            except TypeError:
+                raise AMQPConnectionError(
+                    condition=ErrorCondition.InternalError,
+                    description="Link already closed."
+                )
+
+    async def _set_state(self, new_state):
+        # type: (LinkState) -> None
+        """Update the session state."""
+        if new_state is None:
+            return
+        previous_state = self.state
+        self.state = new_state
+        _LOGGER.info("Link state changed: %r -> %r", previous_state, new_state, extra=self.network_trace_params)
+        try:
+            await self._on_link_state_change(previous_state, new_state)
+        except TypeError:
+            pass
+        except Exception as e:  # pylint: disable=broad-except
+            _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
+
+    async def _remove_pending_deliveries(self):  # TODO: move to sender
+        futures = []
+        for delivery in self._pending_deliveries.values():
+            futures.append(asyncio.ensure_future(delivery.on_settled(LinkDeliverySettleReason.NOT_DELIVERED, None)))
+        await asyncio.gather(*futures)
+        self._pending_deliveries = {}
+    
+    async def _on_session_state_change(self):
+        if self._session.state == SessionState.MAPPED:
+            if not self._is_closed and self.state == LinkState.DETACHED:
+                await self._outgoing_attach()
+                await self._set_state(LinkState.ATTACH_SENT)
+        elif self._session.state == SessionState.DISCARDING:
+            await self._remove_pending_deliveries()
+            await self._set_state(LinkState.DETACHED)
+
+    async def _outgoing_attach(self):
+        self.delivery_count = self.initial_delivery_count
+        attach_frame = AttachFrame(
+            name=self.name,
+            handle=self.handle,
+            role=self.role,
+            send_settle_mode=self.send_settle_mode,
+            rcv_settle_mode=self.rcv_settle_mode,
+            source=self.source,
+            target=self.target,
+            unsettled=self.unsettled,
+            incomplete_unsettled=self.incomplete_unsettled,
+            initial_delivery_count=self.initial_delivery_count if self.role == Role.Sender else None,
+            max_message_size=self.max_message_size,
+            offered_capabilities=self.offered_capabilities if self.state == LinkState.ATTACH_RCVD else None,
+            desired_capabilities=self.desired_capabilities if self.state == LinkState.DETACHED else None,
+            properties=self.properties
+        )
+        if self.network_trace:
+            _LOGGER.info("-> %r", attach_frame, extra=self.network_trace_params)
+        await self._session._outgoing_attach(attach_frame)
+
+    async def _incoming_attach(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", AttachFrame(*frame), extra=self.network_trace_params)
+        if self._is_closed:
+            raise ValueError("Invalid link")
+        elif not frame[5] or not frame[6]:  # TODO: not sure if we should check here
+            _LOGGER.info("Cannot get source or target. Detaching link")
+            await self._remove_pending_deliveries()
+            await self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+            raise ValueError("Invalid link")
+        self.remote_handle = frame[1]
+        self.remote_max_message_size = frame[10]
+        self.offered_capabilities = frame[11]
+        if self.properties:
+            self.properties.update(frame[13])
+        else:
+            self.properties = frame[13]
+        if self.state == LinkState.DETACHED:
+            await self._set_state(LinkState.ATTACH_RCVD)
+        elif self.state == LinkState.ATTACH_SENT:
+            await self._set_state(LinkState.ATTACHED)
+    
+    async def _outgoing_flow(self):
+        flow_frame = {
+            'handle': self.handle,
+            'delivery_count': self.delivery_count,
+            'link_credit': self.current_link_credit,
+            'available': None,
+            'drain': None,
+            'echo': None,
+            'properties': None
+        }
+        await self._session._outgoing_flow(flow_frame)
+
+    async def _incoming_flow(self, frame):
+        pass
+
+    async def _incoming_disposition(self, frame):
+        pass
+
+    async def _outgoing_detach(self, close=False, error=None):
+        detach_frame = DetachFrame(handle=self.handle, closed=close, error=error)
+        if self.network_trace:
+            _LOGGER.info("-> %r", detach_frame, extra=self.network_trace_params)
+        await self._session._outgoing_detach(detach_frame)
+        if close:
+            self._is_closed = True
+
+    async def _incoming_detach(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", DetachFrame(*frame), extra=self.network_trace_params)
+        if self.state == LinkState.ATTACHED:
+            await self._outgoing_detach(close=frame[1])
+        elif frame[1] and not self._is_closed and self.state in [LinkState.ATTACH_SENT, LinkState.ATTACH_RCVD]:
+            # Received a closing detach after we sent a non-closing detach.
+            # In this case, we MUST signal that we closed by reattaching and then sending a closing detach.
+            await self._outgoing_attach()
+            await self._outgoing_detach(close=True)
+        await self._remove_pending_deliveries()
+        # TODO: on_detach_hook
+        if frame[2]:  # error
+            # frame[2][0] is condition, frame[2][1] is description, frame[2][2] is info
+            error_cls = AMQPLinkRedirect if frame[2][0] == ErrorCondition.LinkRedirect else AMQPLinkError
+            self._error = error_cls(condition=frame[2][0], description=frame[2][1], info=frame[2][2])
+            await self._set_state(LinkState.ERROR)
+        else:
+            await self._set_state(LinkState.DETACHED)
+
+    async def attach(self):
+        if self._is_closed:
+            raise ValueError("Link already closed.")
+        await self._outgoing_attach()
+        await self._set_state(LinkState.ATTACH_SENT)
+        self._received_payload = bytearray()
+
+    async def detach(self, close=False, error=None):
+        if self.state in (LinkState.DETACHED, LinkState.ERROR):
+            return
+        try:
+            await self._check_if_closed()
+            await self._remove_pending_deliveries()  # TODO: Keep?
+            if self.state in [LinkState.ATTACH_SENT, LinkState.ATTACH_RCVD]:
+                await self._outgoing_detach(close=close, error=error)
+                await self._set_state(LinkState.DETACHED)
+            elif self.state == LinkState.ATTACHED:
+                await self._outgoing_detach(close=close, error=error)
+                await self._set_state(LinkState.DETACH_SENT)
+        except Exception as exc:
+            _LOGGER.info("An error occurred when detaching the link: %r", exc)
+            await self._set_state(LinkState.DETACHED)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_management_link_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_management_link_async.py
@@ -1,0 +1,224 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import logging
+import time
+from functools import partial
+
+from ._sender_async import SenderLink
+from ._receiver_async import ReceiverLink
+from ..constants import (
+    ManagementLinkState,
+    LinkState,
+    SenderSettleMode,
+    ReceiverSettleMode,
+    ManagementExecuteOperationResult,
+    ManagementOpenResult,
+    MessageDeliveryState,
+    SEND_DISPOSITION_REJECT
+)
+from ..message import Properties, _MessageDelivery
+from ..management_link import PendingManagementOperation
+from ..error import AMQPException, ErrorCondition
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ManagementLink(object):
+    """
+    # TODO: this is more of a general design question
+    #  should the async ManagementLink/Link/Session/Connection inherit from
+    #  class in the sync module
+    """
+
+    def __init__(self, session, endpoint, **kwargs):
+        self.next_message_id = 0
+        self.state = ManagementLinkState.IDLE
+        self._pending_operations = []
+        self._session = session
+        self._request_link: SenderLink = session.create_sender_link(
+            endpoint,
+            on_link_state_change=self._on_sender_state_change,
+            send_settle_mode=SenderSettleMode.Unsettled,
+            rcv_settle_mode=ReceiverSettleMode.First
+        )
+        self._response_link: ReceiverLink = session.create_receiver_link(
+            endpoint,
+            on_link_state_change=self._on_receiver_state_change,
+            on_message_received=self._on_message_received,
+            send_settle_mode=SenderSettleMode.Unsettled,
+            rcv_settle_mode=ReceiverSettleMode.First
+        )
+        self._on_amqp_management_error = kwargs.get('on_amqp_management_error')
+        self._on_amqp_management_open_complete = kwargs.get('on_amqp_management_open_complete')
+
+        self._status_code_field = kwargs.pop('status_code_field', b'statusCode')
+        self._status_description_field = kwargs.pop('status_description_field', b'statusDescription')
+
+        self._sender_connected = False
+        self._receiver_connected = False
+
+    async def __aenter__(self):
+        await self.open()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()
+
+    async def _on_sender_state_change(self, previous_state, new_state):
+        _LOGGER.info("Management link sender state changed: %r -> %r", previous_state, new_state)
+        if new_state == previous_state:
+            return
+        if self.state == ManagementLinkState.OPENING:
+            if new_state == LinkState.ATTACHED:
+                self._sender_connected = True
+                if self._receiver_connected:
+                    self.state = ManagementLinkState.OPEN
+                    await self._on_amqp_management_open_complete(ManagementOpenResult.OK)
+            elif new_state in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD, LinkState.ERROR]:
+                self.state = ManagementLinkState.IDLE
+                await self._on_amqp_management_open_complete(ManagementOpenResult.ERROR)
+        elif self.state == ManagementLinkState.OPEN:
+            if new_state is not LinkState.ATTACHED:
+                self.state = ManagementLinkState.ERROR
+                await self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.CLOSING:
+            if new_state not in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD]:
+                self.state = ManagementLinkState.ERROR
+                await self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.ERROR:
+            # All state transitions shall be ignored.
+            return
+
+    async def _on_receiver_state_change(self, previous_state, new_state):
+        _LOGGER.info("Management link receiver state changed: %r -> %r", previous_state, new_state)
+        if new_state == previous_state:
+            return
+        if self.state == ManagementLinkState.OPENING:
+            if new_state == LinkState.ATTACHED:
+                self._receiver_connected = True
+                if self._sender_connected:
+                    self.state = ManagementLinkState.OPEN
+                    await self._on_amqp_management_open_complete(ManagementOpenResult.OK)
+            elif new_state in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD, LinkState.ERROR]:
+                self.state = ManagementLinkState.IDLE
+                await self._on_amqp_management_open_complete(ManagementOpenResult.ERROR)
+        elif self.state == ManagementLinkState.OPEN:
+            if new_state is not LinkState.ATTACHED:
+                self.state = ManagementLinkState.ERROR
+                await self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.CLOSING:
+            if new_state not in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD]:
+                self.state = ManagementLinkState.ERROR
+                await self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.ERROR:
+            # All state transitions shall be ignored.
+            return
+
+    async def _on_message_received(self, message):
+        message_properties = message.properties
+        correlation_id = message_properties[5]
+        response_detail = message.application_properties
+
+        status_code = response_detail.get(self._status_code_field)
+        status_description = response_detail.get(self._status_description_field)
+
+        to_remove_operation = None
+        for operation in self._pending_operations:
+            if operation.message.properties.message_id == correlation_id:
+                to_remove_operation = operation
+                break
+        if to_remove_operation:
+            mgmt_result = ManagementExecuteOperationResult.OK \
+                if 200 <= status_code <= 299 else ManagementExecuteOperationResult.FAILED_BAD_STATUS
+            await to_remove_operation.on_execute_operation_complete(
+                mgmt_result,
+                status_code,
+                status_description,
+                message,
+                response_detail.get(b'error-condition')
+            )
+            self._pending_operations.remove(to_remove_operation)
+
+    async def _on_send_complete(self, message_delivery, reason, state):  # todo: reason is never used, should check spec
+        if SEND_DISPOSITION_REJECT in state:
+            # sample reject state: {'rejected': [[b'amqp:not-allowed', b"Invalid command 'RE1AD'.", None]]}
+            to_remove_operation = None
+            for operation in self._pending_operations:
+                if message_delivery.message == operation.message:
+                    to_remove_operation = operation
+                    break
+            self._pending_operations.remove(to_remove_operation)
+            # TODO: better error handling
+            #  AMQPException is too general? to be more specific: MessageReject(Error) or AMQPManagementError?
+            #  or should there an error mapping which maps the condition to the error type
+            await to_remove_operation.on_execute_operation_complete(  # The callback is defined in management_operation.py
+                ManagementExecuteOperationResult.ERROR,
+                None,
+                None,
+                message_delivery.message,
+                error=AMQPException(
+                    condition=state[SEND_DISPOSITION_REJECT][0][0],  # 0 is error condition
+                    description=state[SEND_DISPOSITION_REJECT][0][1],  # 1 is error description
+                    info=state[SEND_DISPOSITION_REJECT][0][2],  # 2 is error info
+                )
+            )
+
+    async def open(self):
+        if self.state != ManagementLinkState.IDLE:
+            raise ValueError("Management links are already open or opening.")
+        self.state = ManagementLinkState.OPENING
+        await self._response_link.attach()
+        await self._request_link.attach()
+
+    async def execute_operation(
+        self,
+        message,
+        on_execute_operation_complete,
+        **kwargs
+    ):
+        timeout = kwargs.get("timeout")
+        message.application_properties["operation"] = kwargs.get("operation")
+        message.application_properties["type"] = kwargs.get("type")
+        message.application_properties["locales"] = kwargs.get("locales")
+        try:
+            # TODO: namedtuple is immutable, which may push us to re-think about the namedtuple approach for Message
+            new_properties = message.properties._replace(message_id=self.next_message_id)
+        except AttributeError:
+            new_properties = Properties(message_id=self.next_message_id)
+        message = message._replace(properties=new_properties)
+        expire_time = (time.time() + timeout) if timeout else None
+        message_delivery = _MessageDelivery(
+            message,
+            MessageDeliveryState.WaitingToBeSent,
+            expire_time
+        )
+
+        on_send_complete = partial(self._on_send_complete, message_delivery)
+
+        await self._request_link.send_transfer(
+            message,
+            on_send_complete=on_send_complete,
+            timeout=timeout
+        )
+        self.next_message_id += 1
+        self._pending_operations.append(PendingManagementOperation(message, on_execute_operation_complete))
+
+    async def close(self):
+        if self.state != ManagementLinkState.IDLE:
+            self.state = ManagementLinkState.CLOSING
+            await self._response_link.detach(close=True)
+            await self._request_link.detach(close=True)
+            for pending_operation in self._pending_operations:
+                await pending_operation.on_execute_operation_complete(
+                    ManagementExecuteOperationResult.LINK_CLOSED,
+                    None,
+                    None,
+                    pending_operation.message,
+                    AMQPException(condition=ErrorCondition.ClientError, description="Management link already closed.")
+                )
+            self._pending_operations = []
+        self.state = ManagementLinkState.IDLE

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_management_operation_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_management_operation_async.py
@@ -1,0 +1,138 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+import logging
+import uuid
+import time
+from functools import partial
+
+from ._management_link_async import ManagementLink
+from ..message import Message
+from ..error import (
+    AMQPException,
+    AMQPConnectionError,
+    AMQPLinkError,
+    ErrorCondition
+)
+
+from ..constants import (
+    ManagementOpenResult,
+    ManagementExecuteOperationResult
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ManagementOperation(object):
+    def __init__(self, session, endpoint='$management', **kwargs):
+        self._mgmt_link_open_status = None
+
+        self._session = session
+        self._connection = self._session._connection
+        self._mgmt_link = self._session.create_request_response_link_pair(
+            endpoint=endpoint,
+            on_amqp_management_open_complete=self._on_amqp_management_open_complete,
+            on_amqp_management_error=self._on_amqp_management_error,
+            **kwargs
+        )  # type: ManagementLink
+        self._responses = {}
+        self._mgmt_error = None
+
+    async def _on_amqp_management_open_complete(self, result):
+        """Callback run when the send/receive links are open and ready
+        to process messages.
+
+        :param result: Whether the link opening was successful.
+        :type result: int
+        """
+        self._mgmt_link_open_status = result
+
+    async def _on_amqp_management_error(self):
+        """Callback run if an error occurs in the send/receive links."""
+        # TODO: This probably shouldn't be ValueError
+        self._mgmt_error = ValueError("Management Operation error occurred.")
+
+    async def _on_execute_operation_complete(
+        self,
+        operation_id,
+        operation_result,
+        status_code,
+        status_description,
+        raw_message,
+        error=None
+    ):
+        _LOGGER.debug(
+            "mgmt operation completed, operation id: %r; operation_result: %r; status_code: %r; "
+            "status_description: %r, raw_message: %r, error: %r",
+            operation_id,
+            operation_result,
+            status_code,
+            status_description,
+            raw_message,
+            error
+        )
+
+        if operation_result in\
+                (ManagementExecuteOperationResult.ERROR, ManagementExecuteOperationResult.LINK_CLOSED):
+            self._mgmt_error = error
+            _LOGGER.error(
+                "Failed to complete mgmt operation due to error: %r. The management request message is: %r",
+                error, raw_message
+            )
+        else:
+            self._responses[operation_id] = (status_code, status_description, raw_message)
+
+    async def execute(self, message, operation=None, operation_type=None, timeout=0):
+        start_time = time.time()
+        operation_id = str(uuid.uuid4())
+        self._responses[operation_id] = None
+        self._mgmt_error = None
+
+        await self._mgmt_link.execute_operation(
+            message,
+            partial(self._on_execute_operation_complete, operation_id),
+            timeout=timeout,
+            operation=operation,
+            type=operation_type
+        )
+
+        while not self._responses[operation_id] and not self._mgmt_error:
+            if timeout > 0:
+                now = time.time()
+                if (now - start_time) >= timeout:
+                    raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
+            await self._connection.listen()
+
+        if self._mgmt_error:
+            self._responses.pop(operation_id)
+            raise self._mgmt_error
+
+        response = self._responses.pop(operation_id)
+        return response
+
+    async def open(self):
+        self._mgmt_link_open_status = ManagementOpenResult.OPENING
+        await self._mgmt_link.open()
+
+    async def ready(self):
+        try:
+            raise self._mgmt_error
+        except TypeError:
+            pass
+
+        if self._mgmt_link_open_status == ManagementOpenResult.OPENING:
+            return False
+        if self._mgmt_link_open_status == ManagementOpenResult.OK:
+            return True
+        # ManagementOpenResult.ERROR or CANCELLED
+        # TODO: update below with correct status code + info
+        raise AMQPLinkError(
+            condition=ErrorCondition.ClientError,
+            description="Failed to open mgmt link, management link status: {}".format(self._mgmt_link_open_status),
+            info=None
+        )
+
+    async def close(self):
+        await self._mgmt_link.close()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -1,0 +1,106 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import uuid
+import logging
+from io import BytesIO
+
+from .._decode import decode_payload
+from ._link_async import Link
+from ..constants import DEFAULT_LINK_CREDIT, Role
+from ..endpoints import Target
+from ..constants import (
+    DEFAULT_LINK_CREDIT,
+    SessionState,
+    SessionTransferState,
+    LinkDeliverySettleReason,
+    LinkState
+)
+from ..performatives import (
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame,
+    FlowFrame,
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ReceiverLink(Link):
+
+    def __init__(self, session, handle, source_address, **kwargs):
+        name = kwargs.pop('name', None) or str(uuid.uuid4())
+        role = Role.Receiver
+        if 'target_address' not in kwargs:
+            kwargs['target_address'] = "receiver-link-{}".format(name)
+        super(ReceiverLink, self).__init__(session, handle, name, role, source_address=source_address, **kwargs)
+        self.on_message_received = kwargs.get('on_message_received')
+        self.on_transfer_received = kwargs.get('on_transfer_received')
+        if not self.on_message_received and not self.on_transfer_received:
+            raise ValueError("Must specify either a message or transfer handler.")
+
+    async def _process_incoming_message(self, frame, message):
+        try:
+            if self.on_message_received:
+                return await self.on_message_received(message)
+            elif self.on_transfer_received:
+                return await self.on_transfer_received(frame, message)
+        except Exception as e:
+            _LOGGER.error("Handler function failed with error: %r", e)
+        return None
+
+    async def _incoming_attach(self, frame):
+        await super(ReceiverLink, self)._incoming_attach(frame)
+        if frame[9] is None:
+            _LOGGER.info("Cannot get initial-delivery-count. Detaching link")
+            await self._remove_pending_deliveries()
+            await self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+        self.delivery_count = frame[9]
+        self.current_link_credit = self.link_credit
+        await self._outgoing_flow()
+
+    async def _incoming_transfer(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", TransferFrame(*frame), extra=self.network_trace_params)
+        self.current_link_credit -= 1
+        self.delivery_count += 1
+        self.received_delivery_id = frame[1]
+        if not self.received_delivery_id and not self._received_payload:
+            pass  # TODO: delivery error
+        if self._received_payload or frame[5]:
+            self._received_payload.extend(frame[11])
+        if not frame[5]:
+            if self._received_payload:
+                message = decode_payload(memoryview(self._received_payload))
+                self._received_payload = bytearray()
+            else:
+                message = decode_payload(frame[11])
+            delivery_state = await self._process_incoming_message(frame, message)
+            if not frame[4] and delivery_state:  # settled
+                await self._outgoing_disposition(frame[1], delivery_state)
+        if self.current_link_credit <= 0:
+            self.current_link_credit = self.link_credit
+            await self._outgoing_flow()
+
+    async def _outgoing_disposition(self, delivery_id, delivery_state):
+        disposition_frame = DispositionFrame(
+            role=self.role,
+            first=delivery_id,
+            last=delivery_id,
+            settled=True,
+            state=delivery_state,
+            batchable=None
+        )
+        if self.network_trace:
+            _LOGGER.info("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
+        await self._session._outgoing_disposition(disposition_frame)
+
+    async def send_disposition(self, delivery_id, delivery_state=None):
+        if self._is_closed:
+            raise ValueError("Link already closed.")
+        await self._outgoing_disposition(delivery_id, delivery_state)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_sasl_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_sasl_async.py
@@ -1,0 +1,132 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import struct
+from enum import Enum
+
+from ._transport_async import AsyncTransport, WebSocketTransportAsync
+from ..types import AMQPTypes, TYPE, VALUE
+from ..constants import FIELD, SASLCode, SASL_HEADER_FRAME, WEBSOCKET_PORT, TransportType
+from .._transport import AMQPS_PORT
+from ..performatives import (
+    SASLOutcome,
+    SASLResponse,
+    SASLChallenge,
+    SASLInit
+)
+
+
+_SASL_FRAME_TYPE = b'\x01'
+
+
+# TODO: do we need it here? it's a duplicate of the sync version
+class SASLPlainCredential(object):
+    """PLAIN SASL authentication mechanism.
+    See https://tools.ietf.org/html/rfc4616 for details
+    """
+
+    mechanism = b'PLAIN'
+
+    def __init__(self, authcid, passwd, authzid=None):
+        self.authcid = authcid
+        self.passwd = passwd
+        self.authzid = authzid
+
+    def start(self):
+        if self.authzid:
+            login_response = self.authzid.encode('utf-8')
+        else:
+            login_response = b''
+        login_response += b'\0'
+        login_response += self.authcid.encode('utf-8')
+        login_response += b'\0'
+        login_response += self.passwd.encode('utf-8')
+        return login_response
+
+
+# TODO: do we need it here? it's a duplicate of the sync version
+class SASLAnonymousCredential(object):
+    """ANONYMOUS SASL authentication mechanism.
+    See https://tools.ietf.org/html/rfc4505 for details
+    """
+
+    mechanism = b'ANONYMOUS'
+
+    def start(self):
+        return b''
+
+
+# TODO: do we need it here? it's a duplicate of the sync version
+class SASLExternalCredential(object):
+    """EXTERNAL SASL mechanism.
+    Enables external authentication, i.e. not handled through this protocol.
+    Only passes 'EXTERNAL' as authentication mechanism, but no further
+    authentication data.
+    """
+
+    mechanism = b'EXTERNAL'
+
+    def start(self):
+        return b''
+
+
+class SASLTransportMixinAsync():
+    async def _negotiate(self):
+        await self.write(SASL_HEADER_FRAME)
+        _, returned_header = await self.receive_frame()
+        if returned_header[1] != SASL_HEADER_FRAME:
+            raise ValueError("Mismatching AMQP header protocol. Excpected: {}, received: {}".format(
+                SASL_HEADER_FRAME, returned_header[1]))
+
+        _, supported_mechanisms = await self.receive_frame(verify_frame_type=1)
+        if self.credential.mechanism not in supported_mechanisms[1][0]:  # sasl_server_mechanisms
+            raise ValueError("Unsupported SASL credential type: {}".format(self.credential.mechanism))
+        sasl_init = SASLInit(
+            mechanism=self.credential.mechanism,
+            initial_response=self.credential.start(),
+            hostname=self.host)
+        await self.send_frame(0, sasl_init, frame_type=_SASL_FRAME_TYPE)
+
+        _, next_frame = await self.receive_frame(verify_frame_type=1)
+        frame_type, fields = next_frame
+        if frame_type != 0x00000044:  # SASLOutcome
+            raise NotImplementedError("Unsupported SASL challenge")
+        if fields[0] == SASLCode.Ok:
+            return
+        else:
+            raise ValueError("SASL negotiation failed.\nOutcome: {}\nDetails: {}".format(*fields))
+
+
+class SASLTransport(AsyncTransport, SASLTransportMixinAsync):
+
+    def __init__(self, host, credential, port=AMQPS_PORT, connect_timeout=None, ssl=None, **kwargs):
+        self.credential = credential
+        ssl = ssl or True
+        super(SASLTransport, self).__init__(host, port=port, connect_timeout=connect_timeout, ssl=ssl, **kwargs)
+
+    async def negotiate(self):
+        await self._negotiate()
+
+
+class SASLWithWebSocket(WebSocketTransportAsync, SASLTransportMixinAsync):
+    def __init__(
+        self, host, credential, port=WEBSOCKET_PORT, connect_timeout=None, ssl=None, **kwargs
+    ):
+        self.credential = credential
+        ssl = ssl or True
+        http_proxy = kwargs.pop('http_proxy', None)
+        self._transport = WebSocketTransportAsync(
+            host,
+            port=port,
+            connect_timeout=connect_timeout,
+            ssl=ssl,
+            http_proxy=http_proxy,
+            **kwargs
+        )
+        super().__init__(host, port, connect_timeout, ssl, **kwargs)
+
+    async def negotiate(self):
+        await self._negotiate()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_sender_async.py
@@ -1,0 +1,178 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import uuid
+import logging
+import time
+
+from ._link_async import Link
+from .._encode import encode_payload
+from ..endpoints import Source
+from ..constants import (
+    SessionState,
+    SessionTransferState,
+    LinkDeliverySettleReason,
+    LinkState,
+    Role,
+    SenderSettleMode
+)
+from ..performatives import (
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame,
+    FlowFrame,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PendingDelivery(object):
+
+    def __init__(self, **kwargs):
+        self.message = kwargs.get('message')
+        self.sent = False
+        self.frame = None
+        self.on_delivery_settled = kwargs.get('on_delivery_settled')
+        self.link = kwargs.get('link')
+        self.start = time.time()
+        self.transfer_state = None
+        self.timeout = kwargs.get('timeout')
+        self.settled = kwargs.get('settled', False)
+    
+    async def on_settled(self, reason, state):
+        if self.on_delivery_settled and not self.settled:
+            try:
+                await self.on_delivery_settled(reason, state)
+            except Exception as e:
+                _LOGGER.warning("Message 'on_send_complete' callback failed: %r", e)
+
+
+class SenderLink(Link):
+
+    def __init__(self, session, handle, target_address, **kwargs):
+        name = kwargs.pop('name', None) or str(uuid.uuid4())
+        role = Role.Sender
+        if 'source_address' not in kwargs:
+            kwargs['source_address'] = "sender-link-{}".format(name)
+        super(SenderLink, self).__init__(session, handle, name, role, target_address=target_address, **kwargs)
+        self._unsent_messages = []
+
+    async def _incoming_attach(self, frame):
+        await super(SenderLink, self)._incoming_attach(frame)
+        self.current_link_credit = self.link_credit
+        await self._outgoing_flow()
+        await self._update_pending_delivery_status()
+
+    async def _incoming_flow(self, frame):
+        rcv_link_credit = frame[6]
+        rcv_delivery_count = frame[5]
+        if frame[4] is not None:
+            if rcv_link_credit is None or rcv_delivery_count is None:
+                _LOGGER.info("Unable to get link-credit or delivery-count from incoming ATTACH. Detaching link.")
+                await self._remove_pending_deliveries()
+                await self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+            else:
+                self.current_link_credit = rcv_delivery_count + rcv_link_credit - self.delivery_count
+        if self.current_link_credit > 0:
+            await self._send_unsent_messages()
+
+    async def _outgoing_transfer(self, delivery):
+        output = bytearray()
+        encode_payload(output, delivery.message)
+        delivery_count = self.delivery_count + 1
+        delivery.frame = {
+            'handle': self.handle,
+            'delivery_tag': bytes(delivery_count),
+            'message_format': delivery.message._code,
+            'settled': delivery.settled,
+            'more': False,
+            'rcv_settle_mode': None,
+            'state': None,
+            'resume': None,
+            'aborted': None,
+            'batchable': None,
+            'payload': output
+        }
+        if self.network_trace:
+            _LOGGER.info("-> %r", TransferFrame(delivery_id='<pending>', **delivery.frame), extra=self.network_trace_params)
+        await self._session._outgoing_transfer(delivery)
+        if delivery.transfer_state == SessionTransferState.OKAY:
+            self.delivery_count = delivery_count
+            self.current_link_credit -= 1
+            delivery.sent = True
+            if delivery.settled:
+                await delivery.on_settled(LinkDeliverySettleReason.SETTLED, None)
+            else:
+                self._pending_deliveries[delivery.frame['delivery_id']] = delivery
+        elif delivery.transfer_state == SessionTransferState.ERROR:
+            raise ValueError("Message failed to send")
+        if self.current_link_credit <= 0:
+            self.current_link_credit = self.link_credit
+            await self._outgoing_flow()
+
+    async def _incoming_disposition(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", DispositionFrame(*frame), extra=self.network_trace_params)
+        if not frame[3]:
+            return
+        range_end = (frame[2] or frame[1]) + 1
+        settled_ids = [i for i in range(frame[1], range_end)]
+        for settled_id in settled_ids:
+            delivery = self._pending_deliveries.pop(settled_id, None)
+            if delivery:
+                await delivery.on_settled(LinkDeliverySettleReason.DISPOSITION_RECEIVED, frame[4])
+
+    async def _update_pending_delivery_status(self):
+        now = time.time()
+        expired = []
+        for delivery in self._pending_deliveries.values():
+            if delivery.timeout and (now - delivery.start) >= delivery.timeout:
+                expired.append(delivery.frame['delivery_id'])
+                await delivery.on_settled(LinkDeliverySettleReason.TIMEOUT, None)
+        self._pending_deliveries = {i: d for i, d in self._pending_deliveries.items() if i not in expired}
+
+    async def _send_unsent_messages(self):
+        unsent = []
+        for delivery in self._unsent_messages:
+            if not delivery.sent:
+                await self._outgoing_transfer(delivery)
+                if not delivery.sent:
+                    unsent.append(delivery)
+        self._unsent_messages = unsent
+
+    async def send_transfer(self, message, **kwargs):
+        if self._is_closed:
+            raise ValueError("Link already closed.")
+        if self.state != LinkState.ATTACHED:
+            raise ValueError("Link is not attached.")
+        settled = self.send_settle_mode == SenderSettleMode.Settled
+        if self.send_settle_mode == SenderSettleMode.Mixed:
+            settled = kwargs.pop('settled', True)
+        delivery = PendingDelivery(
+            on_delivery_settled=kwargs.get('on_send_complete'),
+            timeout=kwargs.get('timeout'),
+            link=self,
+            message=message,
+            settled=settled,
+        )
+        if self.current_link_credit == 0:
+            self._unsent_messages.append(delivery)
+        else:
+            await self._outgoing_transfer(delivery)
+            if not delivery.sent:
+                self._unsent_messages.append(delivery)
+        return delivery
+
+    async def cancel_transfer(self, delivery):
+        try:
+            delivery = self._pending_deliveries.pop(delivery.frame['delivery_id'])
+            await delivery.on_settled(LinkDeliverySettleReason.CANCELLED, None)
+            return
+        except KeyError:
+            pass
+        # todo remove from unset messages
+        raise ValueError("No pending delivery with ID '{}' found.".format(delivery.frame['delivery_id']))

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
@@ -1,0 +1,385 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import uuid
+import logging
+import time
+import asyncio
+from typing import Optional, Union
+
+from ..constants import (
+    INCOMING_WINDOW,
+    OUTGOING_WIDNOW,
+    ConnectionState,
+    SessionState,
+    SessionTransferState,
+    Role
+)
+from ..endpoints import Source, Target
+from ._management_link_async import ManagementLink
+from ._sender_async import SenderLink
+from ._receiver_async import ReceiverLink
+from ..performatives import (
+    BeginFrame,
+    EndFrame,
+    FlowFrame,
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame
+)
+from .._encode import encode_frame
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Session(object):
+    """
+    :param int remote_channel: The remote channel for this Session.
+    :param int next_outgoing_id: The transfer-id of the first transfer id the sender will send.
+    :param int incoming_window: The initial incoming-window of the sender.
+    :param int outgoing_window: The initial outgoing-window of the sender.
+    :param int handle_max: The maximum handle value that may be used on the Session.
+    :param list(str) offered_capabilities: The extension capabilities the sender supports.
+    :param list(str) desired_capabilities: The extension capabilities the sender may use if the receiver supports
+    :param dict properties: Session properties.
+    """
+
+    def __init__(self, connection, channel, **kwargs):
+        self.name = kwargs.pop('name', None) or str(uuid.uuid4())
+        self.state = SessionState.UNMAPPED
+        self.handle_max = kwargs.get('handle_max', 4294967295)
+        self.properties = kwargs.pop('properties', None)
+        self.channel = channel
+        self.remote_channel = None
+        self.next_outgoing_id = kwargs.pop('next_outgoing_id', 0)
+        self.next_incoming_id = None
+        self.incoming_window = kwargs.pop('incoming_window', 1)
+        self.outgoing_window = kwargs.pop('outgoing_window', 1)
+        self.target_incoming_window = self.incoming_window
+        self.remote_incoming_window = 0
+        self.remote_outgoing_window = 0
+        self.offered_capabilities = None
+        self.desired_capabilities = kwargs.pop('desired_capabilities', None)
+
+        self.allow_pipelined_open = kwargs.pop('allow_pipelined_open', True)
+        self.idle_wait_time = kwargs.get('idle_wait_time', 0.1)
+        self.network_trace = kwargs['network_trace']
+        self.network_trace_params = kwargs['network_trace_params']
+        self.network_trace_params['session'] = self.name
+
+        self.links = {}
+        self._connection = connection
+        self._output_handles = {}
+        self._input_handles = {}
+
+    async def __aenter__(self):
+        await self.begin()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.end()
+
+    @classmethod
+    def from_incoming_frame(cls, connection, channel, frame):
+        # check session_create_from_endpoint in C lib
+        new_session = cls(connection, channel)
+        return new_session
+
+    async def _set_state(self, new_state):
+        # type: (SessionState) -> None
+        """Update the session state."""
+        if new_state is None:
+            return
+        previous_state = self.state
+        self.state = new_state
+        _LOGGER.info("Session state changed: %r -> %r", previous_state, new_state, extra=self.network_trace_params)
+
+        futures = []
+        for link in self.links.values():
+            futures.append(asyncio.ensure_future(link._on_session_state_change()))
+        await asyncio.gather(*futures)
+
+    async def _on_connection_state_change(self):
+        if self._connection.state in [ConnectionState.CLOSE_RCVD, ConnectionState.END]:
+            if self.state not in [SessionState.DISCARDING, SessionState.UNMAPPED]:
+                await self._set_state(SessionState.DISCARDING)
+
+    def _get_next_output_handle(self):
+        # type: () -> int
+        """Get the next available outgoing handle number within the max handle limit.
+
+        :raises ValueError: If maximum handle has been reached.
+        :returns: The next available outgoing handle number.
+        :rtype: int
+        """
+        if len(self._output_handles) >= self.handle_max:
+            raise ValueError("Maximum number of handles ({}) has been reached.".format(self.handle_max))
+        next_handle = next(i for i in range(1, self.handle_max) if i not in self._output_handles)
+        return next_handle
+    
+    async def _outgoing_begin(self):
+        begin_frame = BeginFrame(
+            remote_channel=self.remote_channel if self.state == SessionState.BEGIN_RCVD else None,
+            next_outgoing_id=self.next_outgoing_id,
+            outgoing_window=self.outgoing_window,
+            incoming_window=self.incoming_window,
+            handle_max=self.handle_max,
+            offered_capabilities=self.offered_capabilities if self.state == SessionState.BEGIN_RCVD else None,
+            desired_capabilities=self.desired_capabilities if self.state == SessionState.UNMAPPED else None,
+            properties=self.properties,
+        )
+        if self.network_trace:
+            _LOGGER.info("-> %r", begin_frame, extra=self.network_trace_params)
+        await self._connection._process_outgoing_frame(self.channel, begin_frame)
+
+    async def _incoming_begin(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", BeginFrame(*frame), extra=self.network_trace_params)
+        self.handle_max = frame[4]
+        self.next_incoming_id = frame[1]
+        self.remote_incoming_window = frame[2]
+        self.remote_outgoing_window = frame[3]
+        if self.state == SessionState.BEGIN_SENT:
+            self.remote_channel = frame[0]
+            await self._set_state(SessionState.MAPPED)
+        elif self.state == SessionState.UNMAPPED:
+            await self._set_state(SessionState.BEGIN_RCVD)
+            await self._outgoing_begin()
+            await self._set_state(SessionState.MAPPED)
+
+    async def _outgoing_end(self, error=None):
+        end_frame = EndFrame(error=error)
+        if self.network_trace:
+            _LOGGER.info("-> %r", end_frame, extra=self.network_trace_params)
+        await self._connection._process_outgoing_frame(self.channel, end_frame)
+
+    async def _incoming_end(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", EndFrame(*frame), extra=self.network_trace_params)
+        if self.state not in [SessionState.END_RCVD, SessionState.END_SENT, SessionState.DISCARDING]:
+            await self._set_state(SessionState.END_RCVD)
+            # TODO: Clean up all links
+            await self._outgoing_end()
+        await self._set_state(SessionState.UNMAPPED)
+
+    async def _outgoing_attach(self, frame):
+        await self._connection._process_outgoing_frame(self.channel, frame)
+
+    async def _incoming_attach(self, frame):
+        try:
+            self._input_handles[frame[1]] = self.links[frame[0].decode('utf-8')]
+            await self._input_handles[frame[1]]._incoming_attach(frame)
+        except KeyError:
+            outgoing_handle = self._get_next_output_handle()  # TODO: catch max-handles error
+            if frame[2] == Role.Sender:
+                new_link = ReceiverLink.from_incoming_frame(self, outgoing_handle, frame)
+            else:
+                new_link = SenderLink.from_incoming_frame(self, outgoing_handle, frame)
+            await new_link._incoming_attach(frame)
+            self.links[frame[0]] = new_link
+            self._output_handles[outgoing_handle] = new_link
+            self._input_handles[frame[1]] = new_link
+        except ValueError:
+            pass  # TODO: Reject link
+    
+    async def _outgoing_flow(self, frame=None):
+        link_flow = frame or {}
+        link_flow.update({
+            'next_incoming_id': self.next_incoming_id,
+            'incoming_window': self.incoming_window,
+            'next_outgoing_id': self.next_outgoing_id,
+            'outgoing_window': self.outgoing_window
+        })
+        flow_frame = FlowFrame(**link_flow)
+        if self.network_trace:
+            _LOGGER.info("-> %r", flow_frame, extra=self.network_trace_params)
+        await self._connection._process_outgoing_frame(self.channel, flow_frame)
+
+    async def _incoming_flow(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", FlowFrame(*frame), extra=self.network_trace_params)
+        self.next_incoming_id = frame[2]
+        remote_incoming_id = frame[0] or self.next_outgoing_id  # TODO "initial-outgoing-id"
+        self.remote_incoming_window = remote_incoming_id + frame[1] - self.next_outgoing_id
+        self.remote_outgoing_window = frame[3]
+        if frame[4] is not None:
+            await self._input_handles[frame[4]]._incoming_flow(frame)
+        else:
+            futures = []
+            for link in self._output_handles.values():
+                if self.remote_incoming_window > 0 and not link._is_closed:
+                    futures.append(link._incoming_flow(frame))
+            await asyncio.gather(*futures)
+
+    async def _outgoing_transfer(self, delivery):
+        if self.state != SessionState.MAPPED:
+            delivery.transfer_state = SessionTransferState.ERROR
+        if self.remote_incoming_window <= 0:
+            delivery.transfer_state = SessionTransferState.BUSY
+        else:
+
+            payload = delivery.frame['payload']
+            payload_size = len(payload)
+
+            delivery.frame['delivery_id'] = self.next_outgoing_id
+            # calculate the transfer frame encoding size excluding the payload
+            delivery.frame['payload'] = b""
+            # TODO: encoding a frame would be expensive, we might want to improve depending on the perf test results
+            encoded_frame = encode_frame(TransferFrame(**delivery.frame))[1]
+            transfer_overhead_size = len(encoded_frame)
+
+            # available size for payload per frame is calculated as following:
+            # remote max frame size - transfer overhead (calculated) - header (8 bytes)
+            available_frame_size = self._connection._remote_max_frame_size - transfer_overhead_size - 8
+
+            start_idx = 0
+            remaining_payload_cnt = payload_size
+            # encode n-1 frames if payload_size > available_frame_size
+            while remaining_payload_cnt > available_frame_size:
+                tmp_delivery_frame = {
+                    'handle': delivery.frame['handle'],
+                    'delivery_tag': delivery.frame['delivery_tag'],
+                    'message_format': delivery.frame['message_format'],
+                    'settled': delivery.frame['settled'],
+                    'more': True,
+                    'rcv_settle_mode': delivery.frame['rcv_settle_mode'],
+                    'state': delivery.frame['state'],
+                    'resume': delivery.frame['resume'],
+                    'aborted': delivery.frame['aborted'],
+                    'batchable': delivery.frame['batchable'],
+                    'payload': payload[start_idx:start_idx+available_frame_size],
+                    'delivery_id': self.next_outgoing_id
+                }
+                await self._connection._process_outgoing_frame(self.channel, TransferFrame(**tmp_delivery_frame))
+                start_idx += available_frame_size
+                remaining_payload_cnt -= available_frame_size
+
+            # encode the last frame
+            tmp_delivery_frame = {
+                'handle': delivery.frame['handle'],
+                'delivery_tag': delivery.frame['delivery_tag'],
+                'message_format': delivery.frame['message_format'],
+                'settled': delivery.frame['settled'],
+                'more': False,
+                'rcv_settle_mode': delivery.frame['rcv_settle_mode'],
+                'state': delivery.frame['state'],
+                'resume': delivery.frame['resume'],
+                'aborted': delivery.frame['aborted'],
+                'batchable': delivery.frame['batchable'],
+                'payload': payload[start_idx:],
+                'delivery_id': self.next_outgoing_id
+            }
+            await self._connection._process_outgoing_frame(self.channel, TransferFrame(**tmp_delivery_frame))
+            self.next_outgoing_id += 1
+            self.remote_incoming_window -= 1
+            self.outgoing_window -= 1
+            delivery.transfer_state = SessionTransferState.OKAY
+
+    async def _incoming_transfer(self, frame):
+        self.next_incoming_id += 1
+        self.remote_outgoing_window -= 1
+        self.incoming_window -= 1
+        try:
+            await self._input_handles[frame[0]]._incoming_transfer(frame)
+        except KeyError:
+            pass  #TODO: "unattached handle"
+        if self.incoming_window == 0:
+            self.incoming_window = self.target_incoming_window
+            await self._outgoing_flow()
+
+    async def _outgoing_disposition(self, frame):
+        await self._connection._process_outgoing_frame(self.channel, frame)
+
+    async def _incoming_disposition(self, frame):
+        futures = []
+        for link in self._input_handles.values():
+            asyncio.ensure_future(link._incoming_disposition(frame))
+        await asyncio.gather(*futures)
+
+    async def _outgoing_detach(self, frame):
+        await self._connection._process_outgoing_frame(self.channel, frame)
+
+    async def _incoming_detach(self, frame):
+        try:
+            link = self._input_handles[frame[0]]
+            await link._incoming_detach(frame)
+            # if link._is_closed:  TODO
+            #     self.links.pop(link.name, None)
+            #     self._input_handles.pop(link.remote_handle, None)
+            #     self._output_handles.pop(link.handle, None)
+        except KeyError:
+            pass  # TODO: close session with unattached-handle
+
+    async def _wait_for_response(self, wait, end_state):
+        # type: (Union[bool, float], SessionState) -> None
+        if wait == True:
+            await self._connection.listen(wait=False)
+            while self.state != end_state:
+                await asyncio.sleep(self.idle_wait_time)
+                await self._connection.listen(wait=False)
+        elif wait:
+            await self._connection.listen(wait=False)
+            timeout = time.time() + wait
+            while self.state != end_state:
+                if time.time() >= timeout:
+                    break
+                await asyncio.sleep(self.idle_wait_time)
+                await self._connection.listen(wait=False)
+
+    async def begin(self, wait=False):
+        await self._outgoing_begin()
+        await self._set_state(SessionState.BEGIN_SENT)
+        if wait:
+            await self._wait_for_response(wait, SessionState.BEGIN_SENT)
+        elif not self.allow_pipelined_open:
+            raise ValueError("Connection has been configured to not allow piplined-open. Please set 'wait' parameter.")
+
+    async def end(self, error=None, wait=False):
+        # type: (Optional[AMQPError]) -> None
+        try:
+            if self.state not in [SessionState.UNMAPPED, SessionState.DISCARDING]:
+                await self._outgoing_end(error=error)
+            # TODO: destroy all links
+            new_state = SessionState.DISCARDING if error else SessionState.END_SENT
+            await self._set_state(new_state)
+            await self._wait_for_response(wait, SessionState.UNMAPPED)
+        except Exception as exc:
+            _LOGGER.info("An error occurred when ending the session: %r", exc)
+            await self._set_state(SessionState.UNMAPPED)
+
+    def create_receiver_link(self, source_address, **kwargs):
+        assigned_handle = self._get_next_output_handle()
+        link = ReceiverLink(
+            self,
+            handle=assigned_handle,
+            source_address=source_address,
+            network_trace=kwargs.pop('network_trace', self.network_trace),
+            network_trace_params=dict(self.network_trace_params),
+            **kwargs)
+        self.links[link.name] = link
+        self._output_handles[assigned_handle] = link
+        return link
+
+    def create_sender_link(self, target_address, **kwargs):
+        assigned_handle = self._get_next_output_handle()
+        link = SenderLink(
+            self,
+            handle=assigned_handle,
+            target_address=target_address,
+            network_trace=kwargs.pop('network_trace', self.network_trace),
+            network_trace_params=dict(self.network_trace_params),
+            **kwargs)
+        self._output_handles[assigned_handle] = link
+        self.links[link.name] = link
+        return link
+
+    def create_request_response_link_pair(self, endpoint, **kwargs):
+        return ManagementLink(
+            self,
+            endpoint,
+            network_trace=kwargs.pop('network_trace', self.network_trace),
+            **kwargs)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -1,0 +1,499 @@
+#-------------------------------------------------------------------------
+# This is a fork of the transport.py which was originally written by Barry Pederson and
+# maintained by the Celery project: https://github.com/celery/py-amqp.
+#
+# Copyright (C) 2009 Barry Pederson <bp@barryp.org>
+#
+# The license text can also be found here:
+# http://www.opensource.org/licenses/BSD-3-Clause
+#
+# License
+# =======
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#-------------------------------------------------------------------------
+
+import asyncio
+import errno
+import re
+import socket
+import ssl
+import struct
+from ssl import SSLError
+from contextlib import contextmanager
+from io import BytesIO
+import logging
+from threading import Lock
+
+import certifi
+
+from .._platform import KNOWN_TCP_OPTS, SOL_TCP, pack, unpack
+from .._encode import encode_frame
+from .._decode import decode_frame, decode_empty_frame
+from ..constants import TLS_HEADER_FRAME, WEBSOCKET_PORT, AMQP_WS_SUBPROTOCOL
+from .._transport import (
+    AMQP_FRAME,
+    get_errno,
+    to_host_port,
+    DEFAULT_SOCKET_SETTINGS,
+    IPV6_LITERAL,
+    SIGNED_INT_MAX,
+    _UNAVAIL,
+    set_cloexec,
+    AMQP_PORT,
+    WebSocketTransport
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_running_loop():
+    try:
+        import asyncio  # pylint: disable=import-error
+        return asyncio.get_running_loop()
+    except AttributeError:  # 3.6
+        loop = None
+        try:
+            loop = asyncio._get_running_loop()  # pylint: disable=protected-access
+        except AttributeError:
+            _LOGGER.warning('This version of Python is deprecated, please upgrade to >= v3.6')
+        if loop is None:
+            _LOGGER.warning('No running event loop')
+            loop = asyncio.get_event_loop()
+        return loop
+
+
+class AsyncTransportMixin():
+    async def receive_frame(self, *args, **kwargs):
+        try:
+            header, channel, payload = await self.read(**kwargs)
+            if not payload:
+                decoded = decode_empty_frame(header)
+            else:
+                decoded = decode_frame(payload)
+            # TODO: Catch decode error and return amqp:decode-error
+            #_LOGGER.info("ICH%d <- %r", channel, decoded)
+            return channel, decoded
+        except (TimeoutError, socket.timeout, asyncio.IncompleteReadError, asyncio.TimeoutError):
+            return None, None
+
+    async def read(self, verify_frame_type=0, **kwargs):  # TODO: verify frame type?
+        async with self.socket_lock:
+            read_frame_buffer = BytesIO()
+            try:
+                frame_header = memoryview(bytearray(8))
+                read_frame_buffer.write(await self._read(8, buffer=frame_header, initial=True))
+
+                channel = struct.unpack('>H', frame_header[6:])[0]
+                size = frame_header[0:4]
+                if size == AMQP_FRAME:  # Empty frame or AMQP header negotiation
+                    return frame_header, channel, None
+                size = struct.unpack('>I', size)[0]
+                offset = frame_header[4]
+                frame_type = frame_header[5]
+
+                # >I is an unsigned int, but the argument to sock.recv is signed,
+                # so we know the size can be at most 2 * SIGNED_INT_MAX
+                payload_size = size - len(frame_header)
+                payload = memoryview(bytearray(payload_size))
+                if size > SIGNED_INT_MAX:
+                    read_frame_buffer.write(await self._read(SIGNED_INT_MAX, buffer=payload))
+                    read_frame_buffer.write(await self._read(size - SIGNED_INT_MAX, buffer=payload[SIGNED_INT_MAX:]))
+                else:
+                    read_frame_buffer.write(await self._read(payload_size, buffer=payload))
+            except (TimeoutError, socket.timeout,  asyncio.IncompleteReadError):
+                read_frame_buffer.write(self._read_buffer.getvalue())
+                self._read_buffer = read_frame_buffer
+                self._read_buffer.seek(0)
+                raise
+            except (OSError, IOError, SSLError, socket.error) as exc:
+                # Don't disconnect for ssl read time outs
+                # http://bugs.python.org/issue10272
+                if isinstance(exc, SSLError) and 'timed out' in str(exc):
+                    raise socket.timeout()
+                if get_errno(exc) not in _UNAVAIL:
+                    self.connected = False
+                raise
+            offset -= 2
+        return frame_header, channel, payload[offset:]
+
+    async def send_frame(self, channel, frame, **kwargs):
+        header, performative = encode_frame(frame, **kwargs)
+        if performative is None:
+            data = header
+        else:
+            encoded_channel = struct.pack('>H', channel)
+            data = header + encoded_channel + performative
+
+        await self.write(data)
+        #_LOGGER.info("OCH%d -> %r", channel, frame)
+
+
+class AsyncTransport(AsyncTransportMixin):
+    """Common superclass for TCP and SSL transports."""
+
+    def __init__(self, host, port=AMQP_PORT, connect_timeout=None,
+                 read_timeout=None, write_timeout=None, ssl=False,
+                 socket_settings=None, raise_on_initial_eintr=True, **kwargs):
+        self.connected = False
+        self.sock = None
+        self.reader = None
+        self.writer = None
+        self.raise_on_initial_eintr = raise_on_initial_eintr
+        self._read_buffer = BytesIO()
+        self.host, self.port = to_host_port(host, port)
+
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self.write_timeout = write_timeout
+        self.socket_settings = socket_settings
+        self.loop = get_running_loop()
+        self.socket_lock = asyncio.Lock()
+        self.sslopts = self._build_ssl_opts(ssl)
+
+    def _build_ssl_opts(self, sslopts):
+        if sslopts in [True, False, None, {}]:
+            return sslopts
+        try:
+            if 'context' in sslopts:
+                return self._build_ssl_context(sslopts, **sslopts.pop('context'))
+            ssl_version = sslopts.get('ssl_version')
+            if ssl_version is None:
+                ssl_version = ssl.PROTOCOL_TLS
+
+            # Set SNI headers if supported
+            server_hostname = sslopts.get('server_hostname')
+            if (server_hostname is not None) and (hasattr(ssl, 'HAS_SNI') and ssl.HAS_SNI) and (hasattr(ssl, 'SSLContext')):
+                context = ssl.SSLContext(ssl_version)
+                cert_reqs = sslopts.get('cert_reqs', ssl.CERT_REQUIRED)
+                certfile = sslopts.get('certfile')
+                keyfile = sslopts.get('keyfile')
+                context.verify_mode = cert_reqs
+                if cert_reqs != ssl.CERT_NONE:
+                    context.check_hostname = True
+                if (certfile is not None) and (keyfile is not None):
+                    context.load_cert_chain(certfile, keyfile)
+                return context
+            return True
+        except TypeError:
+            raise TypeError('SSL configuration must be a dictionary, or the value True.')
+
+    def _build_ssl_context(self, sslopts, check_hostname=None, **ctx_options):
+        ctx = ssl.create_default_context(**ctx_options)
+        ctx.verify_mode = ssl.CERT_REQUIRED
+        ctx.load_verify_locations(cafile=certifi.where())
+        ctx.check_hostname = check_hostname
+        return ctx
+
+    async def connect(self):
+        try:
+            # are we already connected?
+            if self.connected:
+                return
+            await self._connect(self.host, self.port, self.connect_timeout)
+            self._init_socket(
+                self.socket_settings, self.read_timeout, self.write_timeout,
+            )
+            self.reader, self.writer = await asyncio.open_connection(
+                sock=self.sock,
+                ssl=self.sslopts,
+                server_hostname=self.host if self.sslopts else None
+            )
+            # we've sent the banner; signal connect
+            # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
+            # has _not_ been sent
+            self.connected = True
+        except (OSError, IOError, SSLError):
+            # if not fully connected, close socket, and reraise error
+            if self.sock and not self.connected:
+                self.sock.close()
+                self.sock = None
+            raise
+
+    async def _connect(self, host, port, timeout):
+        # Below we are trying to avoid additional DNS requests for AAAA if A
+        # succeeds. This helps a lot in case when a hostname has an IPv4 entry
+        # in /etc/hosts but not IPv6. Without the (arguably somewhat twisted)
+        # logic below, getaddrinfo would attempt to resolve the hostname for
+        # both IP versions, which would make the resolver talk to configured
+        # DNS servers. If those servers are for some reason not available
+        # during resolution attempt (either because of system misconfiguration,
+        # or network connectivity problem), resolution process locks the
+        # _connect call for extended time.
+        e = None
+        addr_types = (socket.AF_INET, socket.AF_INET6)
+        addr_types_num = len(addr_types)
+        for n, family in enumerate(addr_types):
+            # first, resolve the address for a single address family
+            try:
+                entries = await self.loop.getaddrinfo(
+                    host, port, family=family, type=socket.SOCK_STREAM, proto=SOL_TCP)
+                entries_num = len(entries)
+            except socket.gaierror:
+                # we may have depleted all our options
+                if n + 1 >= addr_types_num:
+                    # if getaddrinfo succeeded before for another address
+                    # family, reraise the previous socket.error since it's more
+                    # relevant to users
+                    raise (e
+                           if e is not None
+                           else socket.error(
+                               "failed to resolve broker hostname"))
+                continue  # pragma: no cover
+
+            # now that we have address(es) for the hostname, connect to broker
+            for i, res in enumerate(entries):
+                af, socktype, proto, _, sa = res
+                try:
+                    self.sock = socket.socket(af, socktype, proto)
+                    try:
+                        set_cloexec(self.sock, True)
+                    except NotImplementedError:
+                        pass
+                    self.sock.settimeout(timeout)
+                    await self.loop.sock_connect(self.sock, sa)
+                except socket.error as ex:
+                    e = ex
+                    if self.sock is not None:
+                        self.sock.close()
+                        self.sock = None
+                    # we may have depleted all our options
+                    if i + 1 >= entries_num and n + 1 >= addr_types_num:
+                        raise
+                else:
+                    # hurray, we established connection
+                    return
+
+    def _init_socket(self, socket_settings, read_timeout, write_timeout):
+        self.sock.settimeout(None)  # set socket back to blocking mode
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        self._set_socket_options(socket_settings)
+
+        # set socket timeouts
+        # for timeout, interval in ((socket.SO_SNDTIMEO, write_timeout),
+        #                           (socket.SO_RCVTIMEO, read_timeout)):
+        #     if interval is not None:
+        #         sec = int(interval)
+        #         usec = int((interval - sec) * 1000000)
+        #         self.sock.setsockopt(
+        #             socket.SOL_SOCKET, timeout,
+        #             pack('ll', sec, usec),
+        #         )
+
+        self.sock.settimeout(1)  # set socket back to non-blocking mode
+
+    def _get_tcp_socket_defaults(self, sock):
+        tcp_opts = {}
+        for opt in KNOWN_TCP_OPTS:
+            enum = None
+            if opt == 'TCP_USER_TIMEOUT':
+                try:
+                    from socket import TCP_USER_TIMEOUT as enum
+                except ImportError:
+                    # should be in Python 3.6+ on Linux.
+                    enum = 18
+            elif hasattr(socket, opt):
+                enum = getattr(socket, opt)
+
+            if enum:
+                if opt in DEFAULT_SOCKET_SETTINGS:
+                    tcp_opts[enum] = DEFAULT_SOCKET_SETTINGS[opt]
+                elif hasattr(socket, opt):
+                    tcp_opts[enum] = sock.getsockopt(
+                        SOL_TCP, getattr(socket, opt))
+        return tcp_opts
+
+    def _set_socket_options(self, socket_settings):
+        tcp_opts = self._get_tcp_socket_defaults(self.sock)
+        if socket_settings:
+            tcp_opts.update(socket_settings)
+        for opt, val in tcp_opts.items():
+            self.sock.setsockopt(SOL_TCP, opt, val)
+
+    async def _read(self, toread, initial=False, buffer=None,
+              _errnos=(errno.ENOENT, errno.EAGAIN, errno.EINTR)):
+        # According to SSL_read(3), it can at most return 16kb of data.
+        # Thus, we use an internal read buffer like TCPTransport._read
+        # to get the exact number of bytes wanted.
+        length = 0
+        view = buffer or memoryview(bytearray(toread))
+        nbytes = self._read_buffer.readinto(view)
+        toread -= nbytes
+        length += nbytes
+        try:
+            while toread:
+                try:
+                    view[nbytes:nbytes + toread] = await self.reader.readexactly(toread)
+                    nbytes = toread
+                except asyncio.IncompleteReadError as exc:
+                    pbytes = len(exc.partial)
+                    view[nbytes:nbytes + pbytes] = exc.partial
+                    nbytes = pbytes
+                except socket.error as exc:
+                    # ssl.sock.read may cause a SSLerror without errno
+                    # http://bugs.python.org/issue10272
+                    if isinstance(exc, SSLError) and 'timed out' in str(exc):
+                        raise socket.timeout()
+                    # ssl.sock.read may cause ENOENT if the
+                    # operation couldn't be performed (Issue celery#1414).
+                    if exc.errno in _errnos:
+                        if initial and self.raise_on_initial_eintr:
+                            raise socket.timeout()
+                        continue
+                    raise
+                if not nbytes:
+                    raise IOError('Server unexpectedly closed connection')
+
+                length += nbytes
+                toread -= nbytes
+        except:  # noqa
+            self._read_buffer = BytesIO(view[:length])
+            raise
+        return view
+
+    async def _write(self, s):
+        """Write a string out to the SSL socket fully."""
+        self.writer.write(s)
+
+    def close(self):
+        if self.writer is not None:
+            if self.sslopts:
+                # see issue: https://github.com/encode/httpx/issues/914
+                self.writer.transport.abort()
+            self.writer.close()
+            self.writer, self.reader = None, None
+        self.sock = None
+        self.connected = False
+
+    async def write(self, s):
+        try:
+            await self._write(s)
+        except socket.timeout:
+            raise
+        except (OSError, IOError, socket.error) as exc:
+            if get_errno(exc) not in _UNAVAIL:
+                self.connected = False
+            raise
+
+    async def receive_frame_with_lock(self, *args, **kwargs):
+        try:
+            async with self.socket_lock:
+                header, channel, payload = await self.read(**kwargs)
+            if not payload:
+                decoded = decode_empty_frame(header)
+            else:
+                decoded = decode_frame(payload)
+            return channel, decoded
+        except (socket.timeout, TimeoutError):
+            return None, None
+
+    async def negotiate(self):
+        if not self.sslopts:
+            return
+        await self.write(TLS_HEADER_FRAME)
+        channel, returned_header = await self.receive_frame(verify_frame_type=None)
+        if returned_header[1] == TLS_HEADER_FRAME:
+            raise ValueError("Mismatching TLS header protocol. Excpected: {}, received: {}".format(
+                TLS_HEADER_FRAME, returned_header[1]))
+
+
+class WebSocketTransportAsync(AsyncTransportMixin):
+    def __init__(self, host, port=WEBSOCKET_PORT, connect_timeout=1, ssl=None, **kwargs
+        ):
+        self._read_buffer = BytesIO()
+        self.loop = get_running_loop()
+        self.socket_lock = asyncio.Lock()
+        self.sslopts = ssl if isinstance(ssl, dict) else {}
+        self._connect_timeout = connect_timeout
+        self.host = host
+        self.ws = None
+        self._http_proxy = kwargs.get('http_proxy', None)
+
+    async def connect(self):
+        http_proxy_host, http_proxy_port, http_proxy_auth = None, None, None
+        if self._http_proxy:
+            http_proxy_host = self._http_proxy['proxy_hostname']
+            http_proxy_port = self._http_proxy['proxy_port']
+            username = self._http_proxy.get('username', None)
+            password = self._http_proxy.get('password', None)
+            if username or password:
+                http_proxy_auth = (username, password)
+        try:
+            from websocket import create_connection
+            self.ws = create_connection(
+                url="wss://{}".format(self.host),
+                subprotocols=[AMQP_WS_SUBPROTOCOL],
+                timeout=self._connect_timeout,
+                skip_utf8_validation=True,
+                sslopt=self.sslopts,
+                http_proxy_host=http_proxy_host,
+                http_proxy_port=http_proxy_port,
+                http_proxy_auth=http_proxy_auth
+            )
+        except ImportError:
+            raise ValueError("Please install websocket-client library to use websocket transport.")
+
+    async def _read(self, n, buffer=None, **kwargs): # pylint: disable=unused-arguments
+        """Read exactly n bytes from the peer."""
+        from websocket import WebSocketTimeoutException
+
+        length = 0
+        view = buffer or memoryview(bytearray(n))
+        nbytes = self._read_buffer.readinto(view)
+        length += nbytes
+        n -= nbytes
+        try:
+            while n:
+                data = await self.loop.run_in_executor(
+                    None, self.ws.recv
+                )
+
+                if len(data) <= n:
+                    view[length: length + len(data)] = data
+                    n -= len(data)
+                else:
+                    view[length: length + n] = data[0:n]
+                    self._read_buffer = BytesIO(data[n:])
+                    n = 0
+
+            return view 
+        except WebSocketTimeoutException as wex:
+            raise TimeoutError()
+
+    def close(self):
+        """Do any preliminary work in shutting down the connection."""
+        # TODO: async close doesn't:
+        # 1) shutdown socket and close. --> self.sock.shutdown(socket.SHUT_RDWR) and self.sock.close()
+        # 2) set self.connected = False
+        # I think we need to do this, like in sync
+        self.ws.close()
+
+    async def write(self, s):
+        """Completely write a string to the peer.
+        ABNF, OPCODE_BINARY = 0x2
+        See http://tools.ietf.org/html/rfc5234
+        http://tools.ietf.org/html/rfc6455#section-5.2
+        """
+        await self.loop.run_in_executor(
+                None, self.ws.send_binary, s
+                )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/authentication.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/authentication.py
@@ -1,0 +1,182 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#-------------------------------------------------------------------------
+
+import time
+import urllib
+from collections import namedtuple
+from functools import partial
+
+from .sasl import SASLAnonymousCredential, SASLPlainCredential
+from .utils import generate_sas_token
+
+from .constants import (
+    AUTH_DEFAULT_EXPIRATION_SECONDS,
+    TOKEN_TYPE_JWT,
+    TOKEN_TYPE_SASTOKEN,
+    AUTH_TYPE_CBS,
+    AUTH_TYPE_SASL_PLAIN
+)
+
+try:
+    from urlparse import urlparse
+    from urllib import quote_plus  # type: ignore
+except ImportError:
+    from urllib.parse import urlparse, quote_plus
+
+AccessToken = namedtuple("AccessToken", ["token", "expires_on"])
+
+
+def _generate_sas_access_token(auth_uri, sas_name, sas_key, expiry_in=AUTH_DEFAULT_EXPIRATION_SECONDS):
+    expires_on = int(time.time() + expiry_in)
+    token = generate_sas_token(auth_uri, sas_name, sas_key, expires_on)
+    return AccessToken(
+        token,
+        expires_on
+    )
+
+
+class SASLPlainAuth(object):
+    # TODO:
+    #  1. naming decision, suffix with Auth vs Credential
+    auth_type = AUTH_TYPE_SASL_PLAIN
+
+    def __init__(self, authcid, passwd, authzid=None):
+        self.sasl = SASLPlainCredential(authcid, passwd, authzid)
+
+
+class _CBSAuth(object):
+    # TODO:
+    #  1. naming decision, suffix with Auth vs Credential
+    auth_type = AUTH_TYPE_CBS
+
+    def __init__(
+        self,
+        uri,
+        audience,
+        token_type,
+        get_token,
+        **kwargs
+    ):
+        """
+        CBS authentication using JWT tokens.
+
+        :param uri: The AMQP endpoint URI. This must be provided as
+         a decoded string.
+        :type uri: str
+        :param audience: The token audience field. For SAS tokens
+         this is usually the URI.
+        :type audience: str
+        :param get_token: The callback function used for getting and refreshing
+         tokens. It should return a valid jwt token each time it is called.
+        :type get_token: callable object
+        :param token_type: The type field of the token request.
+         Default value is `"jwt"`.
+        :type token_type: str
+
+        """
+        self.sasl = SASLAnonymousCredential()
+        self.uri = uri
+        self.audience = audience
+        self.token_type = token_type
+        self.get_token = get_token
+        self.expires_in = kwargs.pop("expires_in", AUTH_DEFAULT_EXPIRATION_SECONDS)
+        self.expires_on = kwargs.pop("expires_on", None)
+
+    @staticmethod
+    def _set_expiry(expires_in, expires_on):
+        if not expires_on and not expires_in:
+            raise ValueError("Must specify either 'expires_on' or 'expires_in'.")
+        if not expires_on:
+            expires_on = time.time() + expires_in
+        else:
+            expires_in = expires_on - time.time()
+            if expires_in < 1:
+                raise ValueError("Token has already expired.")
+        return expires_in, expires_on
+
+
+class JWTTokenAuth(_CBSAuth):
+    # TODO:
+    #  1. naming decision, suffix with Auth vs Credential
+    def __init__(
+        self,
+        uri,
+        audience,
+        get_token,
+        **kwargs
+    ):
+        """
+        CBS authentication using JWT tokens.
+
+        :param uri: The AMQP endpoint URI. This must be provided as
+         a decoded string.
+        :type uri: str
+        :param audience: The token audience field. For SAS tokens
+         this is usually the URI.
+        :type audience: str
+        :param get_token: The callback function used for getting and refreshing
+         tokens. It should return a valid jwt token each time it is called.
+        :type get_token: callable object
+        :param token_type: The type field of the token request.
+         Default value is `"jwt"`.
+        :type token_type: str
+
+        """
+        super(JWTTokenAuth, self).__init__(uri, audience, kwargs.pop("kwargs", TOKEN_TYPE_JWT), get_token)
+        self.get_token = get_token
+
+
+class SASTokenAuth(_CBSAuth):
+    # TODO:
+    #  1. naming decision, suffix with Auth vs Credential
+    def __init__(
+        self,
+        uri,
+        audience,
+        username,
+        password,
+        **kwargs
+    ):
+        """
+        CBS authentication using SAS tokens.
+
+        :param uri: The AMQP endpoint URI. This must be provided as
+         a decoded string.
+        :type uri: str
+        :param audience: The token audience field. For SAS tokens
+         this is usually the URI.
+        :type audience: str
+        :param username: The SAS token username, also referred to as the key
+         name or policy name. This can optionally be encoded into the URI.
+        :type username: str
+        :param password: The SAS token password, also referred to as the key.
+         This can optionally be encoded into the URI.
+        :type password: str
+        :param expires_in: The total remaining seconds until the token
+         expires.
+        :type expires_in: int
+        :param expires_on: The timestamp at which the SAS token will expire
+         formatted as seconds since epoch.
+        :type expires_on: float
+        :param token_type: The type field of the token request.
+         Default value is `"servicebus.windows.net:sastoken"`.
+        :type token_type: str
+
+        """
+        self.username = username
+        self.password = password
+        expires_in = kwargs.pop("expires_in", AUTH_DEFAULT_EXPIRATION_SECONDS)
+        expires_on = kwargs.pop("expires_on", None)
+        expires_in, expires_on = self._set_expiry(expires_in, expires_on)
+        self.get_token = partial(_generate_sas_access_token, uri, username, password, expires_in)
+        super(SASTokenAuth, self).__init__(
+            uri,
+            audience,
+            kwargs.pop("token_type", TOKEN_TYPE_SASTOKEN),
+            self.get_token,
+            expires_in=expires_in,
+            expires_on=expires_on
+        )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/cbs.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/cbs.py
@@ -1,0 +1,232 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#-------------------------------------------------------------------------
+
+import logging
+from datetime import datetime
+
+from .utils import utc_now, utc_from_timestamp
+from .management_link import ManagementLink
+from .message import Message, Properties
+from .error import (
+    AuthenticationException,
+    ErrorCondition,
+    TokenAuthFailure,
+    TokenExpired
+)
+from .constants import (
+    CbsState,
+    CbsAuthState,
+    CBS_PUT_TOKEN,
+    CBS_EXPIRATION,
+    CBS_NAME,
+    CBS_TYPE,
+    CBS_OPERATION,
+    ManagementExecuteOperationResult,
+    ManagementOpenResult,
+    DEFAULT_AUTH_TIMEOUT
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def check_expiration_and_refresh_status(expires_on, refresh_window):
+    seconds_since_epoc = int(utc_now().timestamp())
+    is_expired = seconds_since_epoc >= expires_on
+    is_refresh_required = (expires_on - seconds_since_epoc) <= refresh_window
+    return is_expired, is_refresh_required
+
+
+def check_put_timeout_status(auth_timeout, token_put_time):
+    if auth_timeout > 0:
+        return (int(utc_now().timestamp()) - token_put_time) >= auth_timeout
+    else:
+        return False
+
+
+class CBSAuthenticator(object):
+    def __init__(
+        self,
+        session,
+        auth,
+        **kwargs
+    ):
+        self._session = session
+        self._connection = self._session._connection
+        self._mgmt_link = self._session.create_request_response_link_pair(
+            endpoint='$cbs',
+            on_amqp_management_open_complete=self._on_amqp_management_open_complete,
+            on_amqp_management_error=self._on_amqp_management_error,
+            status_code_field=b'status-code',
+            status_description_field=b'status-description'
+        )  # type: ManagementLink
+
+        if not auth.get_token or not callable(auth.get_token):
+            raise ValueError("get_token must be a callable object.")
+
+        self._auth = auth
+        self._encoding = 'UTF-8'
+        self._auth_timeout = kwargs.pop('auth_timeout', DEFAULT_AUTH_TIMEOUT)
+        self._token_put_time = None
+        self._expires_on = None
+        self._token = None
+        self._refresh_window = None
+
+        self._token_status_code = None
+        self._token_status_description = None
+
+        self.state = CbsState.CLOSED
+        self.auth_state = CbsAuthState.IDLE
+
+    def _put_token(self, token, token_type, audience, expires_on=None):
+        # type: (str, str, str, datetime) -> None
+        message = Message(
+            value=token,
+            properties=Properties(message_id=self._mgmt_link.next_message_id),
+            application_properties={
+                CBS_NAME: audience,
+                CBS_OPERATION: CBS_PUT_TOKEN,
+                CBS_TYPE: token_type,
+                CBS_EXPIRATION: expires_on
+            }
+        )
+        self._mgmt_link.execute_operation(
+            message,
+            self._on_execute_operation_complete,
+            timeout=self._auth_timeout,
+            operation=CBS_PUT_TOKEN,
+            type=token_type
+        )
+        self._mgmt_link.next_message_id += 1
+
+    def _on_amqp_management_open_complete(self, management_open_result):
+        if self.state in (CbsState.CLOSED, CbsState.ERROR):
+            _LOGGER.debug("CSB with status: %r encounters unexpected AMQP management open complete.", self.state)
+        elif self.state == CbsState.OPEN:
+            self.state = CbsState.ERROR
+            _LOGGER.info(
+                "Unexpected AMQP management open complete in OPEN, CBS error occurred on connection %r.",
+                self._connection._container_id
+            )
+        elif self.state == CbsState.OPENING:
+            self.state = CbsState.OPEN if management_open_result == ManagementOpenResult.OK else CbsState.CLOSED
+            _LOGGER.info("CBS for connection %r completed opening with status: %r",
+                         self._connection._container_id, management_open_result)
+
+    def _on_amqp_management_error(self):
+        if self.state == CbsState.CLOSED:
+            _LOGGER.info("Unexpected AMQP error in CLOSED state.")
+        elif self.state == CbsState.OPENING:
+            self.state = CbsState.ERROR
+            self._mgmt_link.close()
+            _LOGGER.info("CBS for connection %r failed to open with status: %r",
+                         self._connection._container_id, ManagementOpenResult.ERROR)
+        elif self.state == CbsState.OPEN:
+            self.state = CbsState.ERROR
+            _LOGGER.info("CBS error occurred on connection %r.", self._connection._container_id)
+
+    def _on_execute_operation_complete(
+            self,
+            execute_operation_result,
+            status_code,
+            status_description,
+            message,
+            error_condition=None
+    ):
+        _LOGGER.info("CBS Put token result (%r), status code: %s, status_description: %s.",
+                     execute_operation_result, status_code, status_description)
+        self._token_status_code = status_code
+        self._token_status_description = status_description
+
+        if execute_operation_result == ManagementExecuteOperationResult.OK:
+            self.auth_state = CbsAuthState.OK
+        elif execute_operation_result == ManagementExecuteOperationResult.ERROR:
+            self.auth_state = CbsAuthState.ERROR
+            # put-token-message sending failure, rejected
+            self._token_status_code = 0
+            self._token_status_description = "Auth message has been rejected."
+        elif execute_operation_result == ManagementExecuteOperationResult.FAILED_BAD_STATUS:
+            self.auth_state = CbsAuthState.ERROR
+
+    def _update_status(self):
+        if self.state == CbsAuthState.OK or self.state == CbsAuthState.REFRESH_REQUIRED:
+            is_expired, is_refresh_required = check_expiration_and_refresh_status(self._expires_on, self._refresh_window)
+            if is_expired:
+                self.state = CbsAuthState.EXPIRED
+            elif is_refresh_required:
+                self.state = CbsAuthState.REFRESH_REQUIRED
+        elif self.state == CbsAuthState.IN_PROGRESS:
+            put_timeout = check_put_timeout_status(self._auth_timeout, self._token_put_time)
+            if put_timeout:
+                self.state = CbsAuthState.TIMEOUT
+
+    def _cbs_link_ready(self):
+        if self.state == CbsState.OPEN:
+            return True
+        if self.state != CbsState.OPEN:
+            return False
+        if self.state in (CbsState.CLOSED, CbsState.ERROR):
+            # TODO: raise proper error type also should this be a ClientError?
+            #  Think how upper layer handle this exception + condition code
+            raise AuthenticationException(
+                condition=ErrorCondition.ClientError,
+                description="CBS authentication link is in broken status, please recreate the cbs link."
+            )
+
+    def open(self):
+        self.state = CbsState.OPENING
+        self._mgmt_link.open()
+
+    def close(self):
+        self._mgmt_link.close()
+        self.state = CbsState.CLOSED
+
+    def update_token(self):
+        self.auth_state = CbsAuthState.IN_PROGRESS
+        access_token = self._auth.get_token()
+        self._expires_on = access_token.expires_on
+        expires_in = self._expires_on - int(utc_now().timestamp())
+        self._refresh_window = int(float(expires_in) * 0.1)
+        try:
+            self._token = access_token.token.decode()
+        except AttributeError:
+            self._token = access_token.token
+        self._token_put_time = int(utc_now().timestamp())
+        self._put_token(self._token, self._auth.token_type, self._auth.audience, utc_from_timestamp(self._expires_on))
+
+    def handle_token(self):
+        if not self._cbs_link_ready():
+            return False
+        self._update_status()
+        if self.auth_state == CbsAuthState.IDLE:
+            self.update_token()
+            return False
+        elif self.auth_state == CbsAuthState.IN_PROGRESS:
+            return False
+        elif self.auth_state == CbsAuthState.OK:
+            return True
+        elif self.auth_state == CbsAuthState.REFRESH_REQUIRED:
+            _LOGGER.info("Token on connection %r will expire soon - attempting to refresh.",
+                         self._connection._container_id)
+            self.update_token()
+            return False
+        elif self.auth_state == CbsAuthState.FAILURE:
+            raise AuthenticationException(
+                condition=ErrorCondition.InternalError,
+                description="Failed to open CBS authentication link."
+            )
+        elif self.auth_state == CbsAuthState.ERROR:
+            raise TokenAuthFailure(
+                self._token_status_code,
+                self._token_status_description,
+                encoding=self._encoding  # TODO: drop off all the encodings
+            )
+        elif self.auth_state == CbsAuthState.TIMEOUT:
+            raise TimeoutError("Authentication attempt timed-out.")
+        elif self.auth_state == CbsAuthState.EXPIRED:
+            raise TokenExpired(
+                condition=ErrorCondition.InternalError,
+                description="CBS Authentication Expired."
+            )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -1,0 +1,756 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+# pylint: disable=too-many-lines
+
+import logging
+import time
+import uuid
+import certifi
+import queue
+from functools import partial
+
+from ._connection import Connection
+from .message import _MessageDelivery
+from .session import Session
+from .sender import SenderLink
+from .receiver import ReceiverLink
+from .sasl import SASLTransport
+from .endpoints import Source, Target
+from .error import (
+    AMQPConnectionError,
+    AMQPException,
+    ErrorResponse,
+    ErrorCondition,
+    MessageException,
+    MessageSendFailed,
+    RetryPolicy
+)
+
+from .constants import (
+    MessageDeliveryState,
+    SenderSettleMode,
+    ReceiverSettleMode,
+    LinkDeliverySettleReason,
+    TransportType,
+    SEND_DISPOSITION_ACCEPT,
+    SEND_DISPOSITION_REJECT,
+    AUTH_TYPE_CBS,
+    MAX_FRAME_SIZE_BYTES,
+    INCOMING_WINDOW,
+    OUTGOING_WIDNOW,
+    DEFAULT_AUTH_TIMEOUT,
+    MESSAGE_DELIVERY_DONE_STATES,
+)
+
+from .management_operation import ManagementOperation
+from .cbs import CBSAuthenticator
+from .authentication import _CBSAuth
+
+
+_logger = logging.getLogger(__name__)
+
+
+class AMQPClient(object):
+    """An AMQP client.
+
+    :param remote_address: The AMQP endpoint to connect to. This could be a send target
+     or a receive source.
+    :type remote_address: str, bytes or ~uamqp.address.Address
+    :param auth: Authentication for the connection. This should be one of the subclasses of
+     uamqp.authentication.AMQPAuth. Currently this includes:
+        - uamqp.authentication.SASLAnonymous
+        - uamqp.authentication.SASLPlain
+        - uamqp.authentication.SASTokenAuth
+     If no authentication is supplied, SASLAnnoymous will be used by default.
+    :type auth: ~uamqp.authentication.common.AMQPAuth
+    :param client_name: The name for the client, also known as the Container ID.
+     If no name is provided, a random GUID will be used.
+    :type client_name: str or bytes
+    :param debug: Whether to turn on network trace logs. If `True`, trace logs
+     will be logged at INFO level. Default is `False`.
+    :type debug: bool
+    :param retry_policy: A policy for parsing errors on link, connection and message
+     disposition to determine whether the error should be retryable.
+    :type retry_policy: ~uamqp.errors.RetryPolicy
+    :param keep_alive_interval: If set, a thread will be started to keep the connection
+     alive during periods of user inactivity. The value will determine how long the
+     thread will sleep (in seconds) between pinging the connection. If 0 or None, no
+     thread will be started.
+    :type keep_alive_interval: int
+    :param max_frame_size: Maximum AMQP frame size. Default is 63488 bytes.
+    :type max_frame_size: int
+    :param channel_max: Maximum number of Session channels in the Connection.
+    :type channel_max: int
+    :param idle_timeout: Timeout in seconds after which the Connection will close
+     if there is no further activity.
+    :type idle_timeout: int
+    :param auth_timeout: Timeout in seconds for CBS authentication. Otherwise this value will be ignored.
+     Default value is 60s.
+    :type auth_timeout: int
+    :param properties: Connection properties.
+    :type properties: dict
+    :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
+     idle time for Connections with no activity. Value must be between
+     0.0 and 1.0 inclusive. Default is 0.5.
+    :type remote_idle_timeout_empty_frame_send_ratio: float
+    :param incoming_window: The size of the allowed window for incoming messages.
+    :type incoming_window: int
+    :param outgoing_window: The size of the allowed window for outgoing messages.
+    :type outgoing_window: int
+    :param handle_max: The maximum number of concurrent link handles.
+    :type handle_max: int
+    :param on_attach: A callback function to be run on receipt of an ATTACH frame.
+     The function must take 4 arguments: source, target, properties and error.
+    :type on_attach: func[~uamqp.address.Source, ~uamqp.address.Target, dict, ~uamqp.errors.AMQPConnectionError]
+    :param send_settle_mode: The mode by which to settle message send
+     operations. If set to `Unsettled`, the client will wait for a confirmation
+     from the service that the message was successfully sent. If set to 'Settled',
+     the client will not wait for confirmation and assume success.
+    :type send_settle_mode: ~uamqp.constants.SenderSettleMode
+    :param receive_settle_mode: The mode by which to settle message receive
+     operations. If set to `PeekLock`, the receiver will lock a message once received until
+     the client accepts or rejects the message. If set to `ReceiveAndDelete`, the service
+     will assume successful receipt of the message and clear it from the queue. The
+     default is `PeekLock`.
+    :type receive_settle_mode: ~uamqp.constants.ReceiverSettleMode
+    :param encoding: The encoding to use for parameters supplied as strings.
+     Default is 'UTF-8'
+    :type encoding: str
+    """
+
+    def __init__(self, hostname, auth=None, **kwargs):
+        self._hostname = hostname
+        self._auth = auth
+        self._name = kwargs.pop("client_name", str(uuid.uuid4()))
+        self._shutdown = False
+        self._connection = None
+        self._session = None
+        self._link = None
+        self._socket_timeout = False
+        self._external_connection = False
+        self._cbs_authenticator = None
+        self._auth_timeout = kwargs.pop("auth_timeout", DEFAULT_AUTH_TIMEOUT)
+        self._mgmt_links = {}
+        self._retry_policy = kwargs.pop("retry_policy", RetryPolicy())
+
+        # Connection settings
+        self._max_frame_size = kwargs.pop('max_frame_size', None) or MAX_FRAME_SIZE_BYTES
+        self._channel_max = kwargs.pop('channel_max', None) or 65535
+        self._idle_timeout = kwargs.pop('idle_timeout', None)
+        self._properties = kwargs.pop('properties', None)
+        self._network_trace = kwargs.pop("network_trace", False)
+
+        # Session settings
+        self._outgoing_window = kwargs.pop('outgoing_window', None) or OUTGOING_WIDNOW
+        self._incoming_window = kwargs.pop('incoming_window', None) or INCOMING_WINDOW
+        self._handle_max = kwargs.pop('handle_max', None)
+
+        # Link settings
+        self._send_settle_mode = kwargs.pop('send_settle_mode', SenderSettleMode.Unsettled)
+        self._receive_settle_mode = kwargs.pop('receive_settle_mode', ReceiverSettleMode.Second)
+        self._desired_capabilities = kwargs.pop('desired_capabilities', None)
+
+        # transport
+        if kwargs.get('transport_type') is TransportType.Amqp and kwargs.get('http_proxy') is not None:
+            raise ValueError("Http proxy settings can't be passed if transport_type is explicitly set to Amqp")
+        self._transport_type = kwargs.pop('transport_type', TransportType.Amqp)
+        self._http_proxy = kwargs.pop('http_proxy', None)
+
+    def __enter__(self):
+        """Run Client in a context manager."""
+        self.open()
+        return self
+
+    def __exit__(self, *args):
+        """Close and destroy Client on exiting a context manager."""
+        self.close()
+
+    def _client_ready(self):  # pylint: disable=no-self-use
+        """Determine whether the client is ready to start sending and/or
+        receiving messages. To be ready, the connection must be open and
+        authentication complete.
+
+        :rtype: bool
+        """
+        return True
+
+    def _client_run(self, **kwargs):
+        """Perform a single Connection iteration."""
+        self._connection.listen(wait=self._socket_timeout)
+
+    def _close_link(self, **kwargs):
+        if self._link and not self._link._is_closed:
+            self._link.detach(close=True)
+            self._link = None
+
+    def _do_retryable_operation(self, operation, *args, **kwargs):
+        retry_settings = self._retry_policy.configure_retries()
+        retry_active = True
+        absolute_timeout = kwargs.pop("timeout", 0) or 0
+        start_time = time.time()
+        while retry_active:
+            try:
+                if absolute_timeout < 0:
+                    raise TimeoutError("Operation timed out.")
+                return operation(*args, timeout=absolute_timeout, **kwargs)
+            except AMQPException as exc:
+                if not self._retry_policy.is_retryable(exc):
+                    raise
+                if absolute_timeout >= 0:
+                    retry_active = self._retry_policy.increment(retry_settings, exc)
+                    if not retry_active:
+                        break
+                    time.sleep(self._retry_policy.get_backoff_time(retry_settings, exc))
+                    if exc.condition == ErrorCondition.LinkDetachForced:
+                        self._close_link()  # if link level error, close and open a new link
+                        # TODO: check if there's any other code that we want to close link?
+                    if exc.condition in (ErrorCondition.ConnectionCloseForced, ErrorCondition.SocketError):
+                        # if connection detach or socket error, close and open a new connection
+                        self.close()
+                        # TODO: check if there's any other code we want to close connection
+            except Exception:
+                raise
+            finally:
+                end_time = time.time()
+                if absolute_timeout > 0:
+                    absolute_timeout -= (end_time - start_time)
+        raise retry_settings['history'][-1]
+
+    def open(self):
+        """Open the client. The client can create a new Connection
+        or an existing Connection can be passed in. This existing Connection
+        may have an existing CBS authentication Session, which will be
+        used for this client as well. Otherwise a new Session will be
+        created.
+
+        :param connection: An existing Connection that may be shared between
+         multiple clients.
+        :type connetion: ~uamqp.Connection
+        """
+        # pylint: disable=protected-access
+        if self._session:
+            return  # already open.
+        _logger.debug("Opening client connection.")
+        if not self._connection:
+            self._connection = Connection(
+                "amqps://" + self._hostname,
+                sasl_credential=self._auth.sasl,
+                ssl={'ca_certs':certifi.where()},
+                container_id=self._name,
+                max_frame_size=self._max_frame_size,
+                channel_max=self._channel_max,
+                idle_timeout=self._idle_timeout,
+                properties=self._properties,
+                network_trace=self._network_trace,
+                transport_type=self._transport_type,
+                http_proxy=self._http_proxy
+            )
+            self._connection.open()
+        if not self._session:
+            self._session = self._connection.create_session(
+                incoming_window=self._incoming_window,
+                outgoing_window=self._outgoing_window
+            )
+            self._session.begin()
+        if self._auth.auth_type == AUTH_TYPE_CBS:
+            self._cbs_authenticator = CBSAuthenticator(
+                session=self._session,
+                auth=self._auth,
+                auth_timeout=self._auth_timeout
+            )
+            self._cbs_authenticator.open()
+        self._shutdown = False
+
+    def close(self):
+        """Close the client. This includes closing the Session
+        and CBS authentication layer as well as the Connection.
+        If the client was opened using an external Connection,
+        this will be left intact.
+
+        No further messages can be sent or received and the client
+        cannot be re-opened.
+
+        All pending, unsent messages will remain uncleared to allow
+        them to be inspected and queued to a new client.
+        """
+        self._shutdown = True
+        if not self._session:
+            return  # already closed.
+        self._close_link(close=True)
+        if self._cbs_authenticator:
+            self._cbs_authenticator.close()
+            self._cbs_authenticator = None
+        self._session.end()
+        self._session = None
+        if not self._external_connection:
+            self._connection.close()
+            self._connection = None
+
+    def auth_complete(self):
+        """Whether the authentication handshake is complete during
+        connection initialization.
+
+        :rtype: bool
+        """
+        if self._cbs_authenticator and not self._cbs_authenticator.handle_token():
+            self._connection.listen(wait=self._socket_timeout)
+            return False
+        return True
+
+    def client_ready(self):
+        """
+        Whether the handler has completed all start up processes such as
+        establishing the connection, session, link and authentication, and
+        is not ready to process messages.
+
+        :rtype: bool
+        """
+        if not self.auth_complete():
+            return False
+        if not self._client_ready():
+            try:
+                self._connection.listen(wait=self._socket_timeout)
+            except ValueError:
+                return True
+            return False
+        return True
+
+    def do_work(self, **kwargs):
+        """Run a single connection iteration.
+        This will return `True` if the connection is still open
+        and ready to be used for further work, or `False` if it needs
+        to be shut down.
+
+        :rtype: bool
+        :raises: TimeoutError or ~uamqp.errors.ClientTimeout if CBS authentication timeout reached.
+        """
+        if self._shutdown:
+            return False
+        if not self.client_ready():
+            return True
+        return self._client_run(**kwargs)
+
+    def mgmt_request(self, message, **kwargs):
+        """
+        :param message: The message to send in the management request.
+        :type message: ~uamqp.message.Message
+        :keyword str operation: The type of operation to be performed. This value will
+         be service-specific, but common values include READ, CREATE and UPDATE.
+         This value will be added as an application property on the message.
+        :keyword str operation_type: The type on which to carry out the operation. This will
+         be specific to the entities of the service. This value will be added as
+         an application property on the message.
+        :keyword str node: The target node. Default node is `$management`.
+        :keyword float timeout: Provide an optional timeout in seconds within which a response
+         to the management request must be received.
+        :rtype: ~uamqp.message.Message
+        """
+
+        # The method also takes "status_code_field" and "status_description_field"
+        # keyword arguments as alternate names for the status code and description
+        # in the response body. Those two keyword arguments are used in Azure services only.
+        operation = kwargs.pop("operation", None)
+        operation_type = kwargs.pop("operation_type", None)
+        node = kwargs.pop("node", "$management")
+        timeout = kwargs.pop('timeout', 0)
+        try:
+            mgmt_link = self._mgmt_links[node]
+        except KeyError:
+
+            mgmt_link = ManagementOperation(self._session, endpoint=node, **kwargs)
+            self._mgmt_links[node] = mgmt_link
+            mgmt_link.open()
+
+            while not mgmt_link.ready():
+                self._connection.listen(wait=False)
+
+        operation_type = operation_type or b'empty'
+        status, description, response = mgmt_link.execute(
+            message,
+            operation=operation,
+            operation_type=operation_type,
+            timeout=timeout
+        )
+        return response
+
+
+class SendClient(AMQPClient):
+    def __init__(self, hostname, target, auth=None, **kwargs):
+        self.target = target
+        # Sender and Link settings
+        self._max_message_size = kwargs.pop('max_message_size', None) or MAX_FRAME_SIZE_BYTES
+        self._link_properties = kwargs.pop('link_properties', None)
+        self._link_credit = kwargs.pop('link_credit', None)
+        super(SendClient, self).__init__(hostname, auth=auth, **kwargs)
+
+    def _client_ready(self):
+        """Determine whether the client is ready to start receiving messages.
+        To be ready, the connection must be open and authentication complete,
+        The Session, Link and MessageReceiver must be open and in non-errored
+        states.
+
+        :rtype: bool
+        :raises: ~uamqp.errors.MessageHandlerError if the MessageReceiver
+         goes into an error state.
+        """
+        # pylint: disable=protected-access
+        if not self._link:
+            self._link = self._session.create_sender_link(
+                target_address=self.target,
+                link_credit=self._link_credit,
+                send_settle_mode=self._send_settle_mode,
+                rcv_settle_mode=self._receive_settle_mode,
+                max_message_size=self._max_message_size,
+                properties=self._link_properties)
+            self._link.attach()
+            return False
+        if self._link.get_state().value != 3:  # ATTACHED
+            return False
+        return True
+
+    def _client_run(self, **kwargs):
+        """MessageSender Link is now open - perform message send
+        on all pending messages.
+        Will return True if operation successful and client can remain open for
+        further work.
+
+        :rtype: bool
+        """
+        try:
+            self._connection.listen(wait=self._socket_timeout, **kwargs)
+        except ValueError:
+            _logger.info("Timeout reached, closing sender.")
+            self._shutdown = True
+            return False
+        return True
+
+    def _transfer_message(self, message_delivery, timeout=0):
+        message_delivery.state = MessageDeliveryState.WaitingForSendAck
+        on_send_complete = partial(self._on_send_complete, message_delivery)
+        delivery = self._link.send_transfer(
+            message_delivery.message,
+            on_send_complete=on_send_complete,
+            timeout=timeout
+        )
+        if not delivery.sent:
+            raise RuntimeError("Message is not sent.")
+
+    @staticmethod
+    def _process_send_error(message_delivery, condition, description=None, info=None):
+        try:
+            amqp_condition = ErrorCondition(condition)
+        except ValueError:
+            error = MessageException(condition, description=description, info=info)
+        else:
+            error = MessageSendFailed(amqp_condition, description=description, info=info)
+        message_delivery.state = MessageDeliveryState.Error
+        message_delivery.error = error
+
+    def _on_send_complete(self, message_delivery, reason, state):
+        # TODO: check whether the callback would be called in case of message expiry or link going down
+        #  and if so handle the state in the callback
+        message_delivery.reason = reason
+        if reason == LinkDeliverySettleReason.DISPOSITION_RECEIVED:
+            if state and SEND_DISPOSITION_ACCEPT in state:
+                message_delivery.state = MessageDeliveryState.Ok
+            else:
+                try:
+                    error_info = state[SEND_DISPOSITION_REJECT]
+                    self._process_send_error(
+                        message_delivery,
+                        condition=error_info[0][0],
+                        description=error_info[0][1],
+                        info=error_info[0][2]
+                    )
+                except TypeError:
+                    self._process_send_error(
+                        message_delivery,
+                        condition=ErrorCondition.UnknownError
+                    )
+        elif reason == LinkDeliverySettleReason.SETTLED:
+            message_delivery.state = MessageDeliveryState.Ok
+        elif reason == LinkDeliverySettleReason.TIMEOUT:
+            message_delivery.state = MessageDeliveryState.Timeout
+            message_delivery.error = TimeoutError("Sending message timed out.")
+        else:
+            # NotDelivered and other unknown errors
+            self._process_send_error(
+                message_delivery,
+                condition=ErrorCondition.UnknownError
+            )
+
+    def _send_message_impl(self, message, **kwargs):
+        timeout = kwargs.pop("timeout", 0)
+        expire_time = (time.time() + timeout) if timeout else None
+        self.open()
+        message_delivery = _MessageDelivery(
+            message,
+            MessageDeliveryState.WaitingToBeSent,
+            expire_time
+        )
+
+        while not self.client_ready():
+            time.sleep(0.05)
+
+        self._transfer_message(message_delivery, timeout)
+
+        running = True
+        while running and message_delivery.state not in MESSAGE_DELIVERY_DONE_STATES:
+            running = self.do_work()
+            if message_delivery.expiry and time.time() > message_delivery.expiry:
+                self._on_send_complete(message_delivery, LinkDeliverySettleReason.TIMEOUT, None)
+
+        if message_delivery.state in (MessageDeliveryState.Error, MessageDeliveryState.Cancelled, MessageDeliveryState.Timeout):
+            try:
+                raise message_delivery.error
+            except TypeError:
+                # This is a default handler
+                raise MessageException(condition=ErrorCondition.UnknownError, description="Send failed.")
+
+    def send_message(self, message, **kwargs):
+        """
+        :param ~uamqp.message.Message message:
+        :keyword float timeout: timeout in seconds. If set to
+         0, the client will continue to wait until the message is sent or error happens. The
+         default is 0.
+        """
+        self._do_retryable_operation(self._send_message_impl, message=message, **kwargs)
+
+
+class ReceiveClient(AMQPClient):
+    """An AMQP client for receiving messages.
+
+    :param target: The source AMQP service endpoint. This can either be the URI as
+     a string or a ~uamqp.address.Source object.
+    :type target: str, bytes or ~uamqp.address.Source
+    :param auth: Authentication for the connection. This should be one of the subclasses of
+     uamqp.authentication.AMQPAuth. Currently this includes:
+        - uamqp.authentication.SASLAnonymous
+        - uamqp.authentication.SASLPlain
+        - uamqp.authentication.SASTokenAuth
+     If no authentication is supplied, SASLAnnoymous will be used by default.
+    :type auth: ~uamqp.authentication.common.AMQPAuth
+    :param client_name: The name for the client, also known as the Container ID.
+     If no name is provided, a random GUID will be used.
+    :type client_name: str or bytes
+    :param debug: Whether to turn on network trace logs. If `True`, trace logs
+     will be logged at INFO level. Default is `False`.
+    :type debug: bool
+    :param auto_complete: Whether to automatically settle message received via callback
+     or via iterator. If the message has not been explicitly settled after processing
+     the message will be accepted. Alternatively, when used with batch receive, this setting
+     will determine whether the messages are pre-emptively settled during batching, or otherwise
+     let to the user to be explicitly settled.
+    :type auto_complete: bool
+    :param retry_policy: A policy for parsing errors on link, connection and message
+     disposition to determine whether the error should be retryable.
+    :type retry_policy: ~uamqp.errors.RetryPolicy
+    :param keep_alive_interval: If set, a thread will be started to keep the connection
+     alive during periods of user inactivity. The value will determine how long the
+     thread will sleep (in seconds) between pinging the connection. If 0 or None, no
+     thread will be started.
+    :type keep_alive_interval: int
+    :param send_settle_mode: The mode by which to settle message send
+     operations. If set to `Unsettled`, the client will wait for a confirmation
+     from the service that the message was successfully sent. If set to 'Settled',
+     the client will not wait for confirmation and assume success.
+    :type send_settle_mode: ~uamqp.constants.SenderSettleMode
+    :param receive_settle_mode: The mode by which to settle message receive
+     operations. If set to `PeekLock`, the receiver will lock a message once received until
+     the client accepts or rejects the message. If set to `ReceiveAndDelete`, the service
+     will assume successful receipt of the message and clear it from the queue. The
+     default is `PeekLock`.
+    :type receive_settle_mode: ~uamqp.constants.ReceiverSettleMode
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint.
+     To create an desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
+    :param max_message_size: The maximum allowed message size negotiated for the Link.
+    :type max_message_size: int
+    :param link_properties: Metadata to be sent in the Link ATTACH frame.
+    :type link_properties: dict
+    :param prefetch: The receiver Link credit that determines how many
+     messages the Link will attempt to handle per connection iteration.
+     The default is 300.
+    :type prefetch: int
+    :param max_frame_size: Maximum AMQP frame size. Default is 63488 bytes.
+    :type max_frame_size: int
+    :param channel_max: Maximum number of Session channels in the Connection.
+    :type channel_max: int
+    :param idle_timeout: Timeout in seconds after which the Connection will close
+     if there is no further activity.
+    :type idle_timeout: int
+    :param properties: Connection properties.
+    :type properties: dict
+    :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
+     idle time for Connections with no activity. Value must be between
+     0.0 and 1.0 inclusive. Default is 0.5.
+    :type remote_idle_timeout_empty_frame_send_ratio: float
+    :param incoming_window: The size of the allowed window for incoming messages.
+    :type incoming_window: int
+    :param outgoing_window: The size of the allowed window for outgoing messages.
+    :type outgoing_window: int
+    :param handle_max: The maximum number of concurrent link handles.
+    :type handle_max: int
+    :param on_attach: A callback function to be run on receipt of an ATTACH frame.
+     The function must take 4 arguments: source, target, properties and error.
+    :type on_attach: func[~uamqp.address.Source, ~uamqp.address.Target, dict, ~uamqp.errors.AMQPConnectionError]
+    :param encoding: The encoding to use for parameters supplied as strings.
+     Default is 'UTF-8'
+    :type encoding: str
+    """
+
+    def __init__(self, hostname, source, auth=None, **kwargs):
+        self.source = source
+        self._streaming_receive = kwargs.pop("streaming_receive", False)  # TODO: whether public?
+        self._received_messages = queue.Queue()
+        self._message_received_callback = kwargs.pop("message_received_callback", None)  # TODO: whether public?
+
+        # Sender and Link settings
+        self._max_message_size = kwargs.pop('max_message_size', None) or MAX_FRAME_SIZE_BYTES
+        self._link_properties = kwargs.pop('link_properties', None)
+        self._link_credit = kwargs.pop('link_credit', 300)
+        super(ReceiveClient, self).__init__(hostname, auth=auth, **kwargs)
+
+    def _client_ready(self):
+        """Determine whether the client is ready to start receiving messages.
+        To be ready, the connection must be open and authentication complete,
+        The Session, Link and MessageReceiver must be open and in non-errored
+        states.
+
+        :rtype: bool
+        :raises: ~uamqp.errors.MessageHandlerError if the MessageReceiver
+         goes into an error state.
+        """
+        # pylint: disable=protected-access
+        if not self._link:
+            self._link = self._session.create_receiver_link(
+                source_address=self.source,
+                link_credit=self._link_credit,
+                send_settle_mode=self._send_settle_mode,
+                rcv_settle_mode=self._receive_settle_mode,
+                max_message_size=self._max_message_size,
+                on_message_received=self._message_received,
+                properties=self._link_properties,
+                desired_capabilities=self._desired_capabilities
+            )
+            self._link.attach()
+            return False
+        if self._link.get_state().value != 3:  # ATTACHED
+            return False
+        return True
+
+    def _client_run(self, **kwargs):
+        """MessageReceiver Link is now open - start receiving messages.
+        Will return True if operation successful and client can remain open for
+        further work.
+
+        :rtype: bool
+        """
+        try:
+            self._connection.listen(wait=self._socket_timeout, **kwargs)
+        except ValueError:
+            _logger.info("Timeout reached, closing receiver.")
+            self._shutdown = True
+            return False
+        return True
+
+    def _message_received(self, message):
+        """Callback run on receipt of every message. If there is
+        a user-defined callback, this will be called.
+        Additionally if the client is retrieving messages for a batch
+        or iterator, the message will be added to an internal queue.
+
+        :param message: Received message.
+        :type message: ~uamqp.message.Message
+        """
+        if self._message_received_callback:
+            self._message_received_callback(message)
+        if not self._streaming_receive:
+            self._received_messages.put(message)
+        # TODO: do we need settled property for a message?
+        #elif not message.settled:
+        #    # Message was received with callback processing and wasn't settled.
+        #    _logger.info("Message was not settled.")
+
+    def _receive_message_batch_impl(self, max_batch_size=None, on_message_received=None, timeout=0):
+        self._message_received_callback = on_message_received
+        max_batch_size = max_batch_size or self._link_credit
+        timeout = time.time() + timeout if timeout else 0
+        receiving = True
+        batch = []
+        self.open()
+        while len(batch) < max_batch_size:
+            try:
+                batch.append(self._received_messages.get_nowait())
+                self._received_messages.task_done()
+            except queue.Empty:
+                break
+        else:
+            return batch
+
+        to_receive_size = max_batch_size - len(batch)
+        before_queue_size = self._received_messages.qsize()
+
+        while receiving and to_receive_size > 0:
+            if timeout and time.time() > timeout:
+                break
+
+            receiving = self.do_work(batch=to_receive_size)
+            cur_queue_size = self._received_messages.qsize()
+            # after do_work, check how many new messages have been received since previous iteration
+            received = cur_queue_size - before_queue_size
+            if to_receive_size < max_batch_size and received == 0:
+                # there are already messages in the batch, and no message is received in the current cycle
+                # return what we have
+                break
+
+            to_receive_size -= received
+            before_queue_size = cur_queue_size
+
+        while len(batch) < max_batch_size:
+            try:
+                batch.append(self._received_messages.get_nowait())
+                self._received_messages.task_done()
+            except queue.Empty:
+                break
+        return batch
+
+    def close(self):
+        self._received_messages = queue.Queue()
+        super(ReceiveClient, self).close()
+
+    def receive_message_batch(self, **kwargs):
+        """Receive a batch of messages. Messages returned in the batch have already been
+        accepted - if you wish to add logic to accept or reject messages based on custom
+        criteria, pass in a callback. This method will return as soon as some messages are
+        available rather than waiting to achieve a specific batch size, and therefore the
+        number of messages returned per call will vary up to the maximum allowed.
+
+        If the receive client is configured with `auto_complete=True` then the messages received
+        in the batch returned by this function will already be settled. Alternatively, if
+        `auto_complete=False`, then each message will need to be explicitly settled before
+        it expires and is released.
+
+        :param max_batch_size: The maximum number of messages that can be returned in
+         one call. This value cannot be larger than the prefetch value, and if not specified,
+         the prefetch value will be used.
+        :type max_batch_size: int
+        :param on_message_received: A callback to process messages as they arrive from the
+         service. It takes a single argument, a ~uamqp.message.Message object.
+        :type on_message_received: callable[~uamqp.message.Message]
+        :param timeout: I timeout in milliseconds for which to wait to receive any messages.
+         If no messages are received in this time, an empty list will be returned. If set to
+         0, the client will continue to wait until at least one message is received. The
+         default is 0.
+        :type timeout: float
+        """
+        return self._do_retryable_operation(
+            self._receive_message_batch_impl,
+            **kwargs
+        )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -153,6 +153,7 @@ class AMQPClient(object):
         self._send_settle_mode = kwargs.pop('send_settle_mode', SenderSettleMode.Unsettled)
         self._receive_settle_mode = kwargs.pop('receive_settle_mode', ReceiverSettleMode.Second)
         self._desired_capabilities = kwargs.pop('desired_capabilities', None)
+        self._msg_timeout = kwargs.pop('msg_timeout', 30)
 
         # transport
         if kwargs.get('transport_type') is TransportType.Amqp and kwargs.get('http_proxy') is not None:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/constants.py
@@ -326,3 +326,13 @@ class TransportType(Enum):
     """
     Amqp = 1
     AmqpOverWebsocket = 2
+
+class MessageState(Enum):
+    WaitingToBeSent = 0
+    WaitingForSendAck = 1
+    SendComplete = 2
+    SendFailed = 3
+    ReceivedUnsettled = 4
+    ReceivedSettled = 5
+
+RECEIVE_STATES = (MessageState.ReceivedSettled, MessageState.ReceivedUnsettled)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/constants.py
@@ -1,0 +1,328 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+from collections import namedtuple
+from enum import Enum
+import struct
+
+_AS_BYTES = struct.Struct('>B')
+
+#: The IANA assigned port number for AMQP.The standard AMQP port number that has been assigned by IANA
+#: for TCP, UDP, and SCTP.There are currently no UDP or SCTP mappings defined for AMQP.
+#: The port number is reserved for future transport mappings to these protocols.
+PORT = 5672
+
+# default port for AMQP over Websocket
+WEBSOCKET_PORT = 443
+
+# subprotocol for AMQP over Websocket
+AMQP_WS_SUBPROTOCOL = 'AMQPWSB10'
+
+#: The IANA assigned port number for secure AMQP (amqps).The standard AMQP port number that has been assigned
+#: by IANA for secure TCP using TLS. Implementations listening on this port should NOT expect a protocol
+#: handshake before TLS is negotiated.
+SECURE_PORT = 5671
+
+
+# default port for AMQP over Websocket
+WEBSOCKET_PORT = 443
+
+
+# subprotocol for AMQP over Websocket
+AMQP_WS_SUBPROTOCOL = 'AMQPWSB10'
+
+
+MAJOR = 1  #: Major protocol version.
+MINOR = 0  #: Minor protocol version.
+REV = 0  #: Protocol revision.
+HEADER_FRAME = b"AMQP\x00" + _AS_BYTES.pack(MAJOR) + _AS_BYTES.pack(MINOR) + _AS_BYTES.pack(REV)
+
+
+TLS_MAJOR = 1  #: Major protocol version.
+TLS_MINOR = 0  #: Minor protocol version.
+TLS_REV = 0  #: Protocol revision.
+TLS_HEADER_FRAME = b"AMQP\x02" + _AS_BYTES.pack(TLS_MAJOR) + _AS_BYTES.pack(TLS_MINOR) + _AS_BYTES.pack(TLS_REV)
+
+SASL_MAJOR = 1  #: Major protocol version.
+SASL_MINOR = 0  #: Minor protocol version.
+SASL_REV = 0  #: Protocol revision.
+SASL_HEADER_FRAME = b"AMQP\x03" + _AS_BYTES.pack(SASL_MAJOR) + _AS_BYTES.pack(SASL_MINOR) + _AS_BYTES.pack(SASL_REV)
+
+EMPTY_FRAME = b'\x00\x00\x00\x08\x02\x00\x00\x00'
+
+#: The lower bound for the agreed maximum frame size (in bytes). During the initial Connection negotiation, the
+#: two peers must agree upon a maximum frame size. This constant defines the minimum value to which the maximum
+#: frame size can be set. By defining this value, the peers can guarantee that they can send frames of up to this
+#: size until they have agreed a definitive maximum frame size for that Connection.
+MIN_MAX_FRAME_SIZE = 512
+MAX_FRAME_SIZE_BYTES = 1024 * 1024
+MAX_CHANNELS = 65535
+INCOMING_WINDOW = 64 * 1024
+OUTGOING_WIDNOW = 64 * 1024
+
+DEFAULT_LINK_CREDIT = 10000
+
+FIELD = namedtuple('field', 'name, type, mandatory, default, multiple')
+
+
+DEFAULT_AUTH_TIMEOUT = 60
+AUTH_DEFAULT_EXPIRATION_SECONDS = 3600
+TOKEN_TYPE_JWT = "jwt"
+TOKEN_TYPE_SASTOKEN = "servicebus.windows.net:sastoken"
+CBS_PUT_TOKEN = "put-token"
+CBS_NAME = "name"
+CBS_OPERATION = "operation"
+CBS_TYPE = "type"
+CBS_EXPIRATION = "expiration"
+
+SEND_DISPOSITION_ACCEPT = "accepted"
+SEND_DISPOSITION_REJECT = "rejected"
+
+AUTH_TYPE_SASL_PLAIN = "AUTH_SASL_PLAIN"
+AUTH_TYPE_CBS = "AUTH_CBS"
+
+
+class ConnectionState(Enum):
+    #: In this state a Connection exists, but nothing has been sent or received. This is the state an
+    #: implementation would be in immediately after performing a socket connect or socket accept.
+    START = 0
+    #: In this state the Connection header has been received from our peer, but we have not yet sent anything.
+    HDR_RCVD = 1
+    #: In this state the Connection header has been sent to our peer, but we have not yet received anything.
+    HDR_SENT = 2
+    #: In this state we have sent and received the Connection header, but we have not yet sent or
+    #: received an open frame.
+    HDR_EXCH = 3
+    #: In this state we have sent both the Connection header and the open frame, but
+    #: we have not yet received anything.
+    OPEN_PIPE = 4
+    #: In this state we have sent the Connection header, the open frame, any pipelined Connection traffic,
+    #: and the close frame, but we have not yet received anything.
+    OC_PIPE = 5
+    #: In this state we have sent and received the Connection header, and received an open frame from
+    #: our peer, but have not yet sent an open frame.
+    OPEN_RCVD = 6
+    #: In this state we have sent and received the Connection header, and sent an open frame to our peer,
+    #: but have not yet received an open frame.
+    OPEN_SENT = 7
+    #: In this state we have send and received the Connection header, sent an open frame, any pipelined
+    #: Connection traffic, and the close frame, but we have not yet received an open frame.
+    CLOSE_PIPE = 8
+    #: In this state the Connection header and the open frame have both been sent and received.
+    OPENED = 9
+    #: In this state we have received a close frame indicating that our partner has initiated a close.
+    #: This means we will never have to read anything more from this Connection, however we can
+    #: continue to write frames onto the Connection. If desired, an implementation could do a TCP half-close
+    #: at this point to shutdown the read side of the Connection.
+    CLOSE_RCVD = 10
+    #: In this state we have sent a close frame to our partner. It is illegal to write anything more onto
+    #: the Connection, however there may still be incoming frames. If desired, an implementation could do
+    #: a TCP half-close at this point to shutdown the write side of the Connection.
+    CLOSE_SENT = 11
+    #: The DISCARDING state is a variant of the CLOSE_SENT state where the close is triggered by an error.
+    #: In this case any incoming frames on the connection MUST be silently discarded until the peer's close
+    #: frame is received.
+    DISCARDING = 12
+    #: In this state it is illegal for either endpoint to write anything more onto the Connection. The
+    #: Connection may be safely closed and discarded.
+    END = 13
+
+
+class SessionState(Enum):
+    #: In the UNMAPPED state, the Session endpoint is not mapped to any incoming or outgoing channels on the
+    #: Connection endpoint. In this state an endpoint cannot send or receive frames.
+    UNMAPPED = 0
+    #: In the BEGIN_SENT state, the Session endpoint is assigned an outgoing channel number, but there is no entry
+    #: in the incoming channel map. In this state the endpoint may send frames but cannot receive them.
+    BEGIN_SENT = 1
+    #: In the BEGIN_RCVD state, the Session endpoint has an entry in the incoming channel map, but has not yet
+    #: been assigned an outgoing channel number. The endpoint may receive frames, but cannot send them.
+    BEGIN_RCVD = 2
+    #: In the MAPPED state, the Session endpoint has both an outgoing channel number and an entry in the incoming
+    #: channel map. The endpoint may both send and receive frames.
+    MAPPED = 3
+    #: In the END_SENT state, the Session endpoint has an entry in the incoming channel map, but is no longer
+    #: assigned an outgoing channel number. The endpoint may receive frames, but cannot send them.
+    END_SENT = 4
+    #: In the END_RCVD state, the Session endpoint is assigned an outgoing channel number, but there is no entry in
+    #: the incoming channel map. The endpoint may send frames, but cannot receive them.
+    END_RCVD = 5
+    #: The DISCARDING state is a variant of the END_SENT state where the end is triggered by an error. In this
+    #: case any incoming frames on the session MUST be silently discarded until the peer's end frame is received.
+    DISCARDING = 6
+
+
+class SessionTransferState(Enum):
+
+    OKAY = 0
+    ERROR = 1
+    BUSY = 2
+
+
+class LinkDeliverySettleReason(Enum):
+
+    DISPOSITION_RECEIVED = 0
+    SETTLED = 1
+    NOT_DELIVERED = 2
+    TIMEOUT = 3
+    CANCELLED = 4
+
+
+class LinkState(Enum):
+
+    DETACHED = 0
+    ATTACH_SENT = 1
+    ATTACH_RCVD = 2
+    ATTACHED = 3
+    DETACH_SENT = 4
+    DETACH_RCVD = 5
+    ERROR = 6
+
+
+class ManagementLinkState(Enum):
+
+    IDLE = 0
+    OPENING = 1
+    CLOSING = 2
+    OPEN = 3
+    ERROR = 4
+
+
+class ManagementOpenResult(Enum):
+
+    OPENING = 0
+    OK = 1
+    ERROR = 2
+    CANCELLED = 3
+
+
+class ManagementExecuteOperationResult(Enum):
+
+    OK = 0
+    ERROR = 1
+    FAILED_BAD_STATUS = 2
+    LINK_CLOSED = 3
+
+
+class CbsState(Enum):
+    CLOSED = 0
+    OPENING = 1
+    OPEN = 2
+    ERROR = 3
+
+
+class CbsAuthState(Enum):
+    OK = 0
+    IDLE = 1
+    IN_PROGRESS = 2
+    TIMEOUT = 3
+    REFRESH_REQUIRED = 4
+    EXPIRED = 5
+    ERROR = 6  # Put token rejected or complete but fail authentication
+    FAILURE = 7  # Fail to open cbs links
+
+
+class Role(object):
+    """Link endpoint role.
+
+    Valid Values:
+        - False: Sender
+        - True: Receiver
+
+    <type name="role" class="restricted" source="boolean">
+        <choice name="sender" value="false"/>
+        <choice name="receiver" value="true"/>
+    </type>
+    """
+    Sender = False
+    Receiver = True
+
+
+class SenderSettleMode(object):
+    """Settlement policy for a Sender.
+
+    Valid Values:
+        - 0: The Sender will send all deliveries initially unsettled to the Receiver.
+        - 1: The Sender will send all deliveries settled to the Receiver.
+        - 2: The Sender may send a mixture of settled and unsettled deliveries to the Receiver.
+
+    <type name="sender-settle-mode" class="restricted" source="ubyte">
+        <choice name="unsettled" value="0"/>
+        <choice name="settled" value="1"/>
+        <choice name="mixed" value="2"/>
+    </type>
+    """
+    Unsettled = 0
+    Settled = 1
+    Mixed = 2
+
+
+class ReceiverSettleMode(object):
+    """Settlement policy for a Receiver.
+
+    Valid Values:
+        - 0: The Receiver will spontaneously settle all incoming transfers.
+        - 1: The Receiver will only settle after sending the disposition to the Sender and
+          receiving a disposition indicating settlement of the delivery from the sender.
+
+    <type name="receiver-settle-mode" class="restricted" source="ubyte">
+        <choice name="first" value="0"/>
+        <choice name="second" value="1"/>
+    </type>
+    """
+    First = 0
+    Second = 1
+
+
+class SASLCode(object):
+    """Codes to indicate the outcome of the sasl dialog.
+
+    <type name="sasl-code" class="restricted" source="ubyte">
+        <choice name="ok" value="0"/>
+        <choice name="auth" value="1"/>
+        <choice name="sys" value="2"/>
+        <choice name="sys-perm" value="3"/>
+        <choice name="sys-temp" value="4"/>
+    </type>
+    """
+    #: Connection authentication succeeded.
+    Ok = 0
+    #: Connection authentication failed due to an unspecified problem with the supplied credentials.
+    Auth = 1
+    #: Connection authentication failed due to a system error.
+    Sys = 2
+    #: Connection authentication failed due to a system error that is unlikely to be corrected without intervention.
+    SysPerm = 3
+    #: Connection authentication failed due to a transient system error.
+    SysTemp = 4
+
+
+class MessageDeliveryState(object):
+
+    WaitingToBeSent = 0
+    WaitingForSendAck = 1
+    Ok = 2
+    Error = 3
+    Timeout = 4
+    Cancelled = 5
+
+
+MESSAGE_DELIVERY_DONE_STATES = (
+    MessageDeliveryState.Ok,
+    MessageDeliveryState.Error,
+    MessageDeliveryState.Timeout,
+    MessageDeliveryState.Cancelled
+)
+
+
+class TransportType(Enum):
+    """Transport type
+    The underlying transport protocol type:
+     Amqp: AMQP over the default TCP transport protocol, it uses port 5671.
+     AmqpOverWebsocket: Amqp over the Web Sockets transport protocol, it uses
+     port 443.
+    """
+    Amqp = 1
+    AmqpOverWebsocket = 2

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/endpoints.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/endpoints.py
@@ -1,0 +1,277 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+# The messaging layer defines two concrete types (source and target) to be used as the source and target of a
+# link. These types are supplied in the source and target fields of the attach frame when establishing or
+# resuming link. The source is comprised of an address (which the container of the outgoing Link Endpoint will
+# resolve to a Node within that container) coupled with properties which determine:
+#
+#   - which messages from the sending Node will be sent on the Link
+#   - how sending the message affects the state of that message at the sending Node
+#   - the behavior of Messages which have been transferred on the Link, but have not yet reached a
+#     terminal state at the receiver, when the source is destroyed.
+
+from collections import namedtuple
+
+from .types import AMQPTypes, FieldDefinition, ObjDefinition
+from .constants import FIELD
+from .performatives import _CAN_ADD_DOCSTRING
+
+
+class TerminusDurability(object):
+    """Durability policy for a terminus.
+
+    <type name="terminus-durability" class="restricted" source="uint">
+        <choice name="none" value="0"/>
+        <choice name="configuration" value="1"/>
+        <choice name="unsettled-state" value="2"/>
+    </type>
+
+    Determines which state of the terminus is held durably.
+    """
+    #: No Terminus state is retained durably
+    NoDurability = 0
+    #: Only the existence and configuration of the Terminus is retained durably.
+    Configuration = 1
+    #: In addition to the existence and configuration of the Terminus, the unsettled state for durable
+    #: messages is retained durably.
+    UnsettledState = 2
+
+
+class ExpiryPolicy(object):
+    """Expiry policy for a terminus.
+
+    <type name="terminus-expiry-policy" class="restricted" source="symbol">
+        <choice name="link-detach" value="link-detach"/>
+        <choice name="session-end" value="session-end"/>
+        <choice name="connection-close" value="connection-close"/>
+        <choice name="never" value="never"/>
+    </type>
+
+    Determines when the expiry timer of a terminus starts counting down from the timeout
+    value. If the link is subsequently re-attached before the terminus is expired, then the
+    count down is aborted. If the conditions for the terminus-expiry-policy are subsequently
+    re-met, the expiry timer restarts from its originally configured timeout value.
+    """
+    #: The expiry timer starts when Terminus is detached.
+    LinkDetach = b"link-detach"
+    #: The expiry timer starts when the most recently associated session is ended.
+    SessionEnd = b"session-end"
+    #: The expiry timer starts when most recently associated connection is closed.
+    ConnectionClose = b"connection-close"
+    #: The Terminus never expires.
+    Never = b"never"
+
+
+class DistributionMode(object):
+    """Link distribution policy.
+
+    <type name="std-dist-mode" class="restricted" source="symbol" provides="distribution-mode">
+        <choice name="move" value="move"/>
+        <choice name="copy" value="copy"/>
+    </type>
+
+    Policies for distributing messages when multiple links are connected to the same node.
+    """
+    #: Once successfully transferred over the link, the message will no longer be available
+    #: to other links from the same node.
+    Move = b'move'
+    #: Once successfully transferred over the link, the message is still available for other
+    #: links from the same node.
+    Copy = b'copy'
+
+
+class LifeTimePolicy(object):
+    #: Lifetime of dynamic node scoped to lifetime of link which caused creation.
+    #: A node dynamically created with this lifetime policy will be deleted at the point that the link
+    #: which caused its creation ceases to exist.
+    DeleteOnClose = 0x0000002b
+    #: Lifetime of dynamic node scoped to existence of links to the node.
+    #: A node dynamically created with this lifetime policy will be deleted at the point that there remain
+    #: no links for which the node is either the source or target.
+    DeleteOnNoLinks = 0x0000002c
+    #: Lifetime of dynamic node scoped to existence of messages on the node.
+    #: A node dynamically created with this lifetime policy will be deleted at the point that the link which
+    #: caused its creation no longer exists and there remain no messages at the node.
+    DeleteOnNoMessages = 0x0000002d
+    #: Lifetime of node scoped to existence of messages on or links to the node.
+    #: A node dynamically created with this lifetime policy will be deleted at the point that the there are no
+    #: links which have this node as their source or target, and there remain no messages at the node.
+    DeleteOnNoLinksOrMessages = 0x0000002e
+
+
+class SupportedOutcomes(object):
+    #: Indicates successful processing at the receiver.
+    accepted = b"amqp:accepted:list"
+    #: Indicates an invalid and unprocessable message.
+    rejected = b"amqp:rejected:list"
+    #: Indicates that the message was not (and will not be) processed.
+    released = b"amqp:released:list"
+    #: Indicates that the message was modified, but not processed.
+    modified = b"amqp:modified:list"
+
+
+class ApacheFilters(object):
+    #: Exact match on subject - analogous to legacy AMQP direct exchange bindings.
+    legacy_amqp_direct_binding = b"apache.org:legacy-amqp-direct-binding:string"
+    #: Pattern match on subject - analogous to legacy AMQP topic exchange bindings.
+    legacy_amqp_topic_binding = b"apache.org:legacy-amqp-topic-binding:string"
+    #: Matching on message headers - analogous to legacy AMQP headers exchange bindings.
+    legacy_amqp_headers_binding = b"apache.org:legacy-amqp-headers-binding:map"
+    #: Filter out messages sent from the same connection as the link is currently associated with.
+    no_local_filter = b"apache.org:no-local-filter:list"
+    #: SQL-based filtering syntax.
+    selector_filter = b"apache.org:selector-filter:string"
+
+
+Source = namedtuple(
+    'source',
+    [
+        'address',
+        'durable',
+        'expiry_policy',
+        'timeout',
+        'dynamic',
+        'dynamic_node_properties',
+        'distribution_mode',
+        'filters',
+        'default_outcome',
+        'outcomes',
+        'capabilities'
+    ])
+Source.__new__.__defaults__ = (None,) * len(Source._fields)
+Source._code = 0x00000028
+Source._definition = (
+    FIELD("address", AMQPTypes.string, False, None, False),
+    FIELD("durable", AMQPTypes.uint, False, "none", False),
+    FIELD("expiry_policy", AMQPTypes.symbol, False, ExpiryPolicy.SessionEnd, False),
+    FIELD("timeout", AMQPTypes.uint, False, 0, False),
+    FIELD("dynamic", AMQPTypes.boolean, False, False, False),
+    FIELD("dynamic_node_properties", FieldDefinition.node_properties, False, None, False),
+    FIELD("distribution_mode", AMQPTypes.symbol, False, None, False),
+    FIELD("filters", FieldDefinition.filter_set, False, None, False),
+    FIELD("default_outcome", ObjDefinition.delivery_state, False, None, False),
+    FIELD("outcomes", AMQPTypes.symbol, False, None, True),
+    FIELD("capabilities", AMQPTypes.symbol, False, None, True))
+if _CAN_ADD_DOCSTRING:
+    Source.__doc__ = """
+    For containers which do not implement address resolution (and do not admit spontaneous link
+    attachment from their partners) but are instead only used as producers of messages, it is unnecessary to provide
+    spurious detail on the source. For this purpose it is possible to use a "minimal" source in which all the
+    fields are left unset.
+
+    :param str address: The address of the source.
+        The address of the source MUST NOT be set when sent on a attach frame sent by the receiving Link Endpoint
+        where the dynamic fiag is set to true (that is where the receiver is requesting the sender to create an
+        addressable node). The address of the source MUST be set when sent on a attach frame sent by the sending
+        Link Endpoint where the dynamic fiag is set to true (that is where the sender has created an addressable
+        node at the request of the receiver and is now communicating the address of that created node).
+        The generated name of the address SHOULD include the link name and the container-id of the remote container
+        to allow for ease of identification.
+    :param ~uamqp.endpoints.TerminusDurability durable: Indicates the durability of the terminus.
+        Indicates what state of the terminus will be retained durably: the state of durable messages, only
+        existence and configuration of the terminus, or no state at all.
+    :param ~uamqp.endpoints.ExpiryPolicy expiry_policy: The expiry policy of the Source.
+        Determines when the expiry timer of a Terminus starts counting down from the timeout value. If the link
+        is subsequently re-attached before the Terminus is expired, then the count down is aborted. If the
+        conditions for the terminus-expiry-policy are subsequently re-met, the expiry timer restarts from its
+        originally configured timeout value.
+    :param int timeout: Duration that an expiring Source will be retained in seconds.
+        The Source starts expiring as indicated by the expiry-policy.
+    :param bool dynamic: Request dynamic creation of a remote Node.
+        When set to true by the receiving Link endpoint, this field constitutes a request for the sending peer
+        to dynamically create a Node at the source. In this case the address field MUST NOT be set. When set to
+        true by the sending Link Endpoint this field indicates creation of a dynamically created Node. In this case
+        the address field will contain the address of the created Node. The generated address SHOULD include the
+        Link name and Session-name or client-id in some recognizable form for ease of traceability.
+    :param dict dynamic_node_properties: Properties of the dynamically created Node.
+        If the dynamic field is not set to true this field must be left unset. When set by the receiving Link
+        endpoint, this field contains the desired properties of the Node the receiver wishes to be created. When
+        set by the sending Link endpoint this field contains the actual properties of the dynamically created node.
+    :param uamqp.endpoints.DistributionMode distribution_mode: The distribution mode of the Link.
+        This field MUST be set by the sending end of the Link if the endpoint supports more than one
+        distribution-mode. This field MAY be set by the receiving end of the Link to indicate a preference when a
+        Node supports multiple distribution modes.
+    :param dict filters: A set of predicates to filter the Messages admitted onto the Link.
+        The receiving endpoint sets its desired filter, the sending endpoint sets the filter actually in place
+        (including any filters defaulted at the node). The receiving endpoint MUST check that the filter in place
+        meets its needs and take responsibility for detaching if it does not.
+         Common filter types, along with the capabilities they are associated with are registered
+         here: http://www.amqp.org/specification/1.0/filters.
+    :param ~uamqp.outcomes.DeliveryState default_outcome: Default outcome for unsettled transfers.
+        Indicates the outcome to be used for transfers that have not reached a terminal state at the receiver
+        when the transfer is settled, including when the Source is destroyed. The value MUST be a valid
+        outcome (e.g. Released or Rejected).
+    :param list(bytes) outcomes: Descriptors for the outcomes that can be chosen on this link.
+        The values in this field are the symbolic descriptors of the outcomes that can be chosen on this link.
+        This field MAY be empty, indicating that the default-outcome will be assumed for all message transfers
+        (if the default-outcome is not set, and no outcomes are provided, then the accepted outcome must be
+        supported by the source). When present, the values MUST be a symbolic descriptor of a valid outcome,
+        e.g. "amqp:accepted:list".
+    :param list(bytes) capabilities: The extension capabilities the sender supports/desires.
+        See http://www.amqp.org/specification/1.0/source-capabilities.
+    """
+
+
+Target = namedtuple(
+    'target',
+    [
+        'address',
+        'durable',
+        'expiry_policy',
+        'timeout',
+        'dynamic',
+        'dynamic_node_properties',
+        'capabilities'
+    ])
+Target._code = 0x00000029
+Target.__new__.__defaults__ = (None,) * len(Target._fields)
+Target._definition = (
+    FIELD("address", AMQPTypes.string, False, None, False),
+    FIELD("durable", AMQPTypes.uint, False, "none", False),
+    FIELD("expiry_policy", AMQPTypes.symbol, False, ExpiryPolicy.SessionEnd, False),
+    FIELD("timeout", AMQPTypes.uint, False, 0, False),
+    FIELD("dynamic", AMQPTypes.boolean, False, False, False),
+    FIELD("dynamic_node_properties", FieldDefinition.node_properties, False, None, False),
+    FIELD("capabilities", AMQPTypes.symbol, False, None, True))
+if _CAN_ADD_DOCSTRING:
+    Target.__doc__ = """
+    For containers which do not implement address resolution (and do not admit spontaneous link attachment
+    from their partners) but are instead only used as consumers of messages, it is unnecessary to provide spurious
+    detail on the source. For this purpose it is possible to use a 'minimal' target in which all the
+    fields are left unset.
+
+    :param str address: The address of the source.
+        The address of the source MUST NOT be set when sent on a attach frame sent by the receiving Link Endpoint
+        where the dynamic fiag is set to true (that is where the receiver is requesting the sender to create an
+        addressable node). The address of the source MUST be set when sent on a attach frame sent by the sending
+        Link Endpoint where the dynamic fiag is set to true (that is where the sender has created an addressable
+        node at the request of the receiver and is now communicating the address of that created node).
+        The generated name of the address SHOULD include the link name and the container-id of the remote container
+        to allow for ease of identification.
+    :param ~uamqp.endpoints.TerminusDurability durable: Indicates the durability of the terminus.
+        Indicates what state of the terminus will be retained durably: the state of durable messages, only
+        existence and configuration of the terminus, or no state at all.
+    :param ~uamqp.endpoints.ExpiryPolicy expiry_policy: The expiry policy of the Source.
+        Determines when the expiry timer of a Terminus starts counting down from the timeout value. If the link
+        is subsequently re-attached before the Terminus is expired, then the count down is aborted. If the
+        conditions for the terminus-expiry-policy are subsequently re-met, the expiry timer restarts from its
+        originally configured timeout value.
+    :param int timeout: Duration that an expiring Source will be retained in seconds.
+        The Source starts expiring as indicated by the expiry-policy.
+    :param bool dynamic: Request dynamic creation of a remote Node.
+        When set to true by the receiving Link endpoint, this field constitutes a request for the sending peer
+        to dynamically create a Node at the source. In this case the address field MUST NOT be set. When set to
+        true by the sending Link Endpoint this field indicates creation of a dynamically created Node. In this case
+        the address field will contain the address of the created Node. The generated address SHOULD include the
+        Link name and Session-name or client-id in some recognizable form for ease of traceability.
+    :param dict dynamic_node_properties: Properties of the dynamically created Node.
+        If the dynamic field is not set to true this field must be left unset. When set by the receiving Link
+        endpoint, this field contains the desired properties of the Node the receiver wishes to be created. When
+        set by the sending Link endpoint this field contains the actual properties of the dynamically created node.
+    :param list(bytes) capabilities: The extension capabilities the sender supports/desires.
+        See http://www.amqp.org/specification/1.0/source-capabilities.
+    """

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/error.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/error.py
@@ -1,0 +1,340 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+from enum import Enum
+from collections import namedtuple
+
+from .constants import SECURE_PORT, FIELD
+from .types import AMQPTypes, FieldDefinition
+
+
+class ErrorCondition(bytes, Enum):
+    # Shared error conditions:
+
+    #: An internal error occurred. Operator intervention may be required to resume normaloperation.
+    InternalError = b"amqp:internal-error"
+    #: A peer attempted to work with a remote entity that does not exist.
+    NotFound = b"amqp:not-found"
+    #: A peer attempted to work with a remote entity to which it has no access due tosecurity settings.
+    UnauthorizedAccess = b"amqp:unauthorized-access"
+    #: Data could not be decoded.
+    DecodeError = b"amqp:decode-error"
+    #: A peer exceeded its resource allocation.
+    ResourceLimitExceeded = b"amqp:resource-limit-exceeded"
+    #: The peer tried to use a frame in a manner that is inconsistent with the semantics defined in the specification.
+    NotAllowed = b"amqp:not-allowed"
+    #: An invalid field was passed in a frame body, and the operation could not proceed.
+    InvalidField = b"amqp:invalid-field"
+    #: The peer tried to use functionality that is not implemented in its partner.
+    NotImplemented = b"amqp:not-implemented"
+    #: The client attempted to work with a server entity to which it has no access
+    #: because another client is working with it.
+    ResourceLocked = b"amqp:resource-locked"
+    #: The client made a request that was not allowed because some precondition failed.
+    PreconditionFailed = b"amqp:precondition-failed"
+    #: A server entity the client is working with has been deleted.
+    ResourceDeleted = b"amqp:resource-deleted"
+    #: The peer sent a frame that is not permitted in the current state of the Session.
+    IllegalState = b"amqp:illegal-state"
+    #: The peer cannot send a frame because the smallest encoding of the performative with the currently
+    #: valid values would be too large to fit within a frame of the agreed maximum frame size.
+    FrameSizeTooSmall = b"amqp:frame-size-too-small"
+
+    # Symbols used to indicate connection error conditions:
+
+    #: An operator intervened to close the Connection for some reason. The client may retry at some later date.
+    ConnectionCloseForced = b"amqp:connection:forced"
+    #: A valid frame header cannot be formed from the incoming byte stream.
+    ConnectionFramingError = b"amqp:connection:framing-error"
+    #: The container is no longer available on the current connection. The peer should attempt reconnection
+    #: to the container using the details provided in the info map.
+    ConnectionRedirect = b"amqp:connection:redirect"
+
+    # Symbols used to indicate session error conditions:
+
+    #: The peer violated incoming window for the session.
+    SessionWindowViolation = b"amqp:session:window-violation"
+    #: Input was received for a link that was detached with an error.
+    SessionErrantLink = b"amqp:session:errant-link"
+    #: An attach was received using a handle that is already in use for an attached Link.
+    SessionHandleInUse = b"amqp:session:handle-in-use"
+    #: A frame (other than attach) was received referencing a handle which
+    #: is not currently in use of an attached Link.
+    SessionUnattachedHandle = b"amqp:session:unattached-handle"
+
+    # Symbols used to indicate link error conditions:
+
+    #: An operator intervened to detach for some reason.
+    LinkDetachForced = b"amqp:link:detach-forced"
+    #: The peer sent more Message transfers than currently allowed on the link.
+    LinkTransferLimitExceeded = b"amqp:link:transfer-limit-exceeded"
+    #: The peer sent a larger message than is supported on the link.
+    LinkMessageSizeExceeded = b"amqp:link:message-size-exceeded"
+    #: The address provided cannot be resolved to a terminus at the current container.
+    LinkRedirect = b"amqp:link:redirect"
+    #: The link has been attached elsewhere, causing the existing attachment to be forcibly closed.
+    LinkStolen = b"amqp:link:stolen"
+
+    # Customized symbols used to indicate client error conditions.
+    # TODO: check whether Client/Unknown/Vendor Error are exposed in EH/SB as users might be depending
+    #  on the code for error handling
+    ClientError = b"amqp:client-error"
+    UnknownError = b"amqp:unknown-error"
+    VendorError = b"amqp:vendor-error"
+    SocketError = b"amqp:socket-error"
+
+
+class RetryMode(str, Enum):
+    EXPONENTIAL = 'exponential'
+    FIXED = 'fixed'
+
+
+class RetryPolicy:
+
+    no_retry = [
+        ErrorCondition.DecodeError,
+        ErrorCondition.LinkMessageSizeExceeded,
+        ErrorCondition.NotFound,
+        ErrorCondition.NotImplemented,
+        ErrorCondition.LinkRedirect,
+        ErrorCondition.NotAllowed,
+        ErrorCondition.UnauthorizedAccess,
+        ErrorCondition.LinkStolen,
+        ErrorCondition.ResourceLimitExceeded,
+        ErrorCondition.ConnectionRedirect,
+        ErrorCondition.PreconditionFailed,
+        ErrorCondition.InvalidField,
+        ErrorCondition.ResourceDeleted,
+        ErrorCondition.IllegalState,
+        ErrorCondition.FrameSizeTooSmall,
+        ErrorCondition.ConnectionFramingError,
+        ErrorCondition.SessionUnattachedHandle,
+        ErrorCondition.SessionHandleInUse,
+        ErrorCondition.SessionErrantLink,
+        ErrorCondition.SessionWindowViolation
+    ]
+
+    def __init__(
+        self,
+        **kwargs
+    ):
+        """
+        keyword int retry_total:
+        keyword float retry_backoff_factor:
+        keyword float retry_backoff_max:
+        keyword RetryMode retry_mode:
+        keyword list no_retry:
+        keyword dict custom_retry_policy:
+        """
+        self.total_retries = kwargs.pop('retry_total', 3)
+        # TODO: A. consider letting retry_backoff_factor be either a float or a callback obj which returns a float
+        #  to give more extensibility on customization of retry backoff time, the callback could take the exception
+        #  as input.
+        self.backoff_factor = kwargs.pop('retry_backoff_factor', 0.8)
+        self.backoff_max = kwargs.pop('retry_backoff_max', 120)
+        self.retry_mode = kwargs.pop('retry_mode', RetryMode.EXPONENTIAL)
+        self.no_retry.extend(kwargs.get('no_retry', []))
+        self.custom_condition_backoff = kwargs.pop("custom_condition_backoff", None)
+        # TODO: B. As an alternative of option A, we could have a new kwarg serve the goal
+
+    def configure_retries(self, **kwargs):
+        return {
+            'total': kwargs.pop("retry_total", self.total_retries),
+            'backoff': kwargs.pop("retry_backoff_factor", self.backoff_factor),
+            'max_backoff': kwargs.pop("retry_backoff_max", self.backoff_max),
+            'retry_mode': kwargs.pop("retry_mode", self.retry_mode),
+            'history': []
+        }
+
+    def increment(self, settings, error):
+        settings['total'] -= 1
+        settings['history'].append(error)
+        if settings['total'] < 0:
+            return False
+        return True
+
+    def is_retryable(self, error):
+        try:
+            if error.condition in self.no_retry:
+                return False
+        except TypeError:
+            pass
+        return True
+
+    def get_backoff_time(self, settings, error):
+        try:
+            return self.custom_condition_backoff[error.condition]
+        except (KeyError, TypeError):
+            pass
+
+        consecutive_errors_len = len(settings['history'])
+        if consecutive_errors_len <= 1:
+            return 0
+
+        if self.retry_mode == RetryMode.FIXED:
+            backoff_value = settings['backoff']
+        else:
+            backoff_value = settings['backoff'] * (2 ** (consecutive_errors_len - 1))
+        return min(settings['max_backoff'], backoff_value)
+
+
+AMQPError = namedtuple('error', ['condition', 'description', 'info'])
+AMQPError.__new__.__defaults__ = (None,) * len(AMQPError._fields)
+AMQPError._code = 0x0000001d
+AMQPError._definition = (
+    FIELD('condition', AMQPTypes.symbol, True, None, False),
+    FIELD('description', AMQPTypes.string, False, None, False),
+    FIELD('info', FieldDefinition.fields, False, None, False),
+)
+
+
+class AMQPException(Exception):
+    """Base exception for all errors.
+
+    :param bytes condition: The error code.
+    :keyword str description: A description of the error.
+    :keyword dict info: A dictionary of additional data associated with the error.
+    """
+    def __init__(self, condition, **kwargs):
+        self.condition = condition or ErrorCondition.UnknownError
+        self.description = kwargs.get("description", None)
+        self.info = kwargs.get("info", None)
+        self.message = kwargs.get("message", None)
+        self.inner_error = kwargs.get("error", None)
+        message = self.message or "Error condition: {}".format(
+            str(condition) if isinstance(condition, ErrorCondition) else condition.decode()
+        )
+        if self.description:
+            try:
+                message += "\n Error Description: {}".format(self.description.decode())
+            except (TypeError, AttributeError):
+                message += "\n Error Description: {}".format(self.description)
+        super(AMQPException, self).__init__(message)
+
+
+class AMQPDecodeError(AMQPException):
+    """An error occurred while decoding an incoming frame.
+
+    """
+
+
+class AMQPConnectionError(AMQPException):
+    """Details of a Connection-level error.
+
+    """
+
+
+class AMQPConnectionRedirect(AMQPConnectionError):
+    """Details of a Connection-level redirect response.
+
+    The container is no longer available on the current connection.
+    The peer should attempt reconnection to the container using the details provided.
+
+    :param bytes condition: The error code.
+    :keyword str description: A description of the error.
+    :keyword dict info: A dictionary of additional data associated with the error.
+    """
+    def __init__(self, condition, description=None, info=None):
+        self.hostname = info.get(b'hostname', b'').decode('utf-8')
+        self.network_host = info.get(b'network-host', b'').decode('utf-8')
+        self.port = int(info.get(b'port', SECURE_PORT))
+        super(AMQPConnectionRedirect, self).__init__(condition, description=description, info=info)
+
+
+class AMQPSessionError(AMQPException):
+    """Details of a Session-level error.
+
+    :param bytes condition: The error code.
+    :keyword str description: A description of the error.
+    :keyword dict info: A dictionary of additional data associated with the error.
+    """
+
+
+class AMQPLinkError(AMQPException):
+    """
+
+    """
+
+
+class AMQPLinkRedirect(AMQPLinkError):
+    """Details of a Link-level redirect response.
+
+    The address provided cannot be resolved to a terminus at the current container.
+    The supplied information may allow the client to locate and attach to the terminus.
+
+    :param bytes condition: The error code.
+    :keyword str description: A description of the error.
+    :keyword dict info: A dictionary of additional data associated with the error.
+    """
+
+    def __init__(self, condition, description=None, info=None):
+        self.hostname = info.get(b'hostname', b'').decode('utf-8')
+        self.network_host = info.get(b'network-host', b'').decode('utf-8')
+        self.port = int(info.get(b'port', SECURE_PORT))
+        self.address = info.get(b'address', b'').decode('utf-8')
+        super(AMQPLinkError, self).__init__(condition, description=description, info=info)
+
+
+class AuthenticationException(AMQPException):
+    """
+
+    """
+
+
+class TokenExpired(AuthenticationException):
+    """
+
+    """
+
+
+class TokenAuthFailure(AuthenticationException):
+    """
+
+    """
+    def __init__(self, status_code, status_description, **kwargs):
+        encoding = kwargs.get("encoding", 'utf-8')
+        self.status_code = status_code
+        self.status_description = status_description
+        message = "CBS Token authentication failed.\nStatus code: {}".format(self.status_code)
+        if self.status_description:
+            try:
+                message += "\nDescription: {}".format(self.status_description.decode(encoding))
+            except (TypeError, AttributeError):
+                message += "\nDescription: {}".format(self.status_description)
+        super(TokenAuthFailure, self).__init__(condition=ErrorCondition.ClientError, message=message)
+
+
+class MessageException(AMQPException):
+    """
+
+    """
+
+
+class MessageSendFailed(MessageException):
+    """
+
+    """
+
+
+class ErrorResponse(object):
+    """
+    """
+    def __init__(self, **kwargs):
+        self.condition = kwargs.get("condition")
+        self.description = kwargs.get("description")
+
+        info = kwargs.get("info")
+        error_info = kwargs.get("error_info")
+        if isinstance(error_info, list) and len(error_info) >= 1:
+            if isinstance(error_info[0], list) and len(error_info[0]) >= 1:
+                self.condition = error_info[0][0]
+                if len(error_info[0]) >= 2:
+                    self.description = error_info[0][1]
+                if len(error_info[0]) >= 3:
+                    info = error_info[0][2]
+
+        self.info = info
+        self.error = error_info

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
@@ -1,0 +1,277 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import threading
+import struct
+import uuid
+import logging
+import time
+from enum import Enum
+from io import BytesIO
+from urllib.parse import urlparse
+
+from .endpoints import Source, Target
+from .constants import (
+    DEFAULT_LINK_CREDIT,
+    SessionState,
+    SessionTransferState,
+    LinkDeliverySettleReason,
+    LinkState,
+    Role,
+    SenderSettleMode,
+    ReceiverSettleMode
+)
+from .performatives import (
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame,
+    FlowFrame,
+)
+
+from .error import (
+    ErrorCondition,
+    AMQPLinkError,
+    AMQPLinkRedirect,
+    AMQPConnectionError
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Link(object):
+    """
+
+    """
+
+    def __init__(self, session, handle, name, role, **kwargs):
+        self.state = LinkState.DETACHED
+        self.name = name or str(uuid.uuid4())
+        self.handle = handle
+        self.remote_handle = None
+        self.role = role
+        source_address = kwargs['source_address']
+        target_address = kwargs["target_address"]
+        self.source = source_address if isinstance(source_address, Source) else Source(
+            address=kwargs['source_address'],
+            durable=kwargs.get('source_durable'),
+            expiry_policy=kwargs.get('source_expiry_policy'),
+            timeout=kwargs.get('source_timeout'),
+            dynamic=kwargs.get('source_dynamic'),
+            dynamic_node_properties=kwargs.get('source_dynamic_node_properties'),
+            distribution_mode=kwargs.get('source_distribution_mode'),
+            filters=kwargs.get('source_filters'),
+            default_outcome=kwargs.get('source_default_outcome'),
+            outcomes=kwargs.get('source_outcomes'),
+            capabilities=kwargs.get('source_capabilities')
+        )
+        self.target = target_address if isinstance(target_address,Target) else Target(
+            address=kwargs['target_address'],
+            durable=kwargs.get('target_durable'),
+            expiry_policy=kwargs.get('target_expiry_policy'),
+            timeout=kwargs.get('target_timeout'),
+            dynamic=kwargs.get('target_dynamic'),
+            dynamic_node_properties=kwargs.get('target_dynamic_node_properties'),
+            capabilities=kwargs.get('target_capabilities')
+        )
+        self.link_credit = kwargs.pop('link_credit', None) or DEFAULT_LINK_CREDIT
+        self.current_link_credit = self.link_credit
+        self.send_settle_mode = kwargs.pop('send_settle_mode', SenderSettleMode.Mixed)
+        self.rcv_settle_mode = kwargs.pop('rcv_settle_mode', ReceiverSettleMode.First)
+        self.unsettled = kwargs.pop('unsettled', None)
+        self.incomplete_unsettled = kwargs.pop('incomplete_unsettled', None)
+        self.initial_delivery_count = kwargs.pop('initial_delivery_count', 0)
+        self.delivery_count = self.initial_delivery_count
+        self.received_delivery_id = None
+        self.max_message_size = kwargs.pop('max_message_size', None)
+        self.remote_max_message_size = None
+        self.available = kwargs.pop('available', None)
+        self.properties = kwargs.pop('properties', None)
+        self.offered_capabilities = None
+        self.desired_capabilities = kwargs.pop('desired_capabilities', None)
+
+        self.network_trace = kwargs['network_trace']
+        self.network_trace_params = kwargs['network_trace_params']
+        self.network_trace_params['link'] = self.name
+        self._session = session
+        self._is_closed = False
+        self._send_links = {}
+        self._receive_links = {}
+        self._pending_deliveries = {}
+        self._received_payload = bytearray()
+        self._on_link_state_change = kwargs.get('on_link_state_change')
+        self._error = None
+
+    def __enter__(self):
+        self.attach()
+        return self
+
+    def __exit__(self, *args):
+        self.detach(close=True)
+
+    @classmethod
+    def from_incoming_frame(cls, session, handle, frame):
+        # check link_create_from_endpoint in C lib
+        raise NotImplementedError('Pending')  # TODO: Assuming we establish all links for now...
+
+    def get_state(self):
+        try:
+            raise self._error
+        except TypeError:
+            pass
+        return self.state
+
+    def _check_if_closed(self):
+        if self._is_closed:
+            try:
+                raise self._error
+            except TypeError:
+                raise AMQPConnectionError(
+                    condition=ErrorCondition.InternalError,
+                    description="Link already closed."
+                )
+
+    def _set_state(self, new_state):
+        # type: (LinkState) -> None
+        """Update the session state."""
+        if new_state is None:
+            return
+        previous_state = self.state
+        self.state = new_state
+        _LOGGER.info("Link state changed: %r -> %r", previous_state, new_state, extra=self.network_trace_params)
+        try:
+            self._on_link_state_change(previous_state, new_state)
+        except TypeError:
+            pass
+        except Exception as e:  # pylint: disable=broad-except
+            _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
+
+    def _remove_pending_deliveries(self):  # TODO: move to sender
+        for delivery in self._pending_deliveries.values():
+            delivery.on_settled(LinkDeliverySettleReason.NOT_DELIVERED, None)
+        self._pending_deliveries = {}
+    
+    def _on_session_state_change(self):
+        if self._session.state == SessionState.MAPPED:
+            if not self._is_closed and self.state == LinkState.DETACHED:
+                self._outgoing_attach()
+                self._set_state(LinkState.ATTACH_SENT)
+        elif self._session.state == SessionState.DISCARDING:
+            self._remove_pending_deliveries()
+            self._set_state(LinkState.DETACHED)
+
+    def _outgoing_attach(self):
+        self.delivery_count = self.initial_delivery_count
+        attach_frame = AttachFrame(
+            name=self.name,
+            handle=self.handle,
+            role=self.role,
+            send_settle_mode=self.send_settle_mode,
+            rcv_settle_mode=self.rcv_settle_mode,
+            source=self.source,
+            target=self.target,
+            unsettled=self.unsettled,
+            incomplete_unsettled=self.incomplete_unsettled,
+            initial_delivery_count=self.initial_delivery_count if self.role == Role.Sender else None,
+            max_message_size=self.max_message_size,
+            offered_capabilities=self.offered_capabilities if self.state == LinkState.ATTACH_RCVD else None,
+            desired_capabilities=self.desired_capabilities if self.state == LinkState.DETACHED else None,
+            properties=self.properties
+        )
+        if self.network_trace:
+            _LOGGER.info("-> %r", attach_frame, extra=self.network_trace_params)
+        self._session._outgoing_attach(attach_frame)
+
+    def _incoming_attach(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", AttachFrame(*frame), extra=self.network_trace_params)
+        if self._is_closed:
+            raise ValueError("Invalid link")
+        elif not frame[5] or not frame[6]:  # TODO: not sure if we should source + target check here
+            _LOGGER.info("Cannot get source or target. Detaching link")
+            self._remove_pending_deliveries()
+            self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+            raise ValueError("Invalid link")
+        self.remote_handle = frame[1]  # handle
+        self.remote_max_message_size = frame[10]  # max_message_size
+        self.offered_capabilities = frame[11]  # offered_capabilities
+        if self.properties:
+            self.properties.update(frame[13])  # properties
+        else:
+            self.properties = frame[13]
+        if self.state == LinkState.DETACHED:
+            self._set_state(LinkState.ATTACH_RCVD)
+        elif self.state == LinkState.ATTACH_SENT:
+            self._set_state(LinkState.ATTACHED)
+
+    def _outgoing_flow(self):
+        flow_frame = {
+            'handle': self.handle,
+            'delivery_count': self.delivery_count,
+            'link_credit': self.current_link_credit,
+            'available': None,
+            'drain': None,
+            'echo': None,
+            'properties': None
+        }
+        self._session._outgoing_flow(flow_frame)
+
+    def _incoming_flow(self, frame):
+        pass
+    
+    def _incoming_disposition(self, frame):
+        pass
+
+    def _outgoing_detach(self, close=False, error=None):
+        detach_frame = DetachFrame(handle=self.handle, closed=close, error=error)
+        if self.network_trace:
+            _LOGGER.info("-> %r", detach_frame, extra=self.network_trace_params)
+        self._session._outgoing_detach(detach_frame)
+        if close:
+            self._is_closed = True
+
+    def _incoming_detach(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", DetachFrame(*frame), extra=self.network_trace_params)
+        if self.state == LinkState.ATTACHED:
+            self._outgoing_detach(close=frame[1])  # closed
+        elif frame[1] and not self._is_closed and self.state in [LinkState.ATTACH_SENT, LinkState.ATTACH_RCVD]:
+            # Received a closing detach after we sent a non-closing detach.
+            # In this case, we MUST signal that we closed by reattaching and then sending a closing detach.
+            self._outgoing_attach()
+            self._outgoing_detach(close=True)
+        self._remove_pending_deliveries()
+        # TODO: on_detach_hook
+        if frame[2]:  # error
+            # frame[2][0] is condition, frame[2][1] is description, frame[2][2] is info
+            error_cls = AMQPLinkRedirect if frame[2][0] == ErrorCondition.LinkRedirect else AMQPLinkError
+            self._error = error_cls(condition=frame[2][0], description=frame[2][1], info=frame[2][2])
+            self._set_state(LinkState.ERROR)
+        else:
+            self._set_state(LinkState.DETACHED)
+
+    def attach(self):
+        if self._is_closed:
+            raise ValueError("Link already closed.")
+        self._outgoing_attach()
+        self._set_state(LinkState.ATTACH_SENT)
+        self._received_payload = bytearray()
+
+    def detach(self, close=False, error=None):
+        if self.state in (LinkState.DETACHED, LinkState.ERROR):
+            return
+        try:
+            self._check_if_closed()
+            self._remove_pending_deliveries()  # TODO: Keep?
+            if self.state in [LinkState.ATTACH_SENT, LinkState.ATTACH_RCVD]:
+                self._outgoing_detach(close=close, error=error)
+                self._set_state(LinkState.DETACHED)
+            elif self.state == LinkState.ATTACHED:
+                self._outgoing_detach(close=close, error=error)
+                self._set_state(LinkState.DETACH_SENT)
+        except Exception as exc:
+            _LOGGER.info("An error occurred when detaching the link: %r", exc)
+            self._set_state(LinkState.DETACHED)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/management_link.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/management_link.py
@@ -1,0 +1,246 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import time
+import logging
+from functools import partial
+from collections import namedtuple
+
+from .sender import SenderLink
+from .receiver import ReceiverLink
+from .constants import (
+    ManagementLinkState,
+    LinkState,
+    SenderSettleMode,
+    ReceiverSettleMode,
+    ManagementExecuteOperationResult,
+    ManagementOpenResult,
+    SEND_DISPOSITION_ACCEPT,
+    SEND_DISPOSITION_REJECT,
+    MessageDeliveryState
+)
+from .error import ErrorResponse, AMQPException, ErrorCondition
+from .message import Message, Properties, _MessageDelivery
+
+_LOGGER = logging.getLogger(__name__)
+
+PendingManagementOperation = namedtuple('PendingManagementOperation', ['message', 'on_execute_operation_complete'])
+
+
+class ManagementLink(object):
+    """
+
+    """
+    def __init__(self, session, endpoint, **kwargs):
+        self.next_message_id = 0
+        self.state = ManagementLinkState.IDLE
+        self._pending_operations = []
+        self._session = session
+        self._request_link: SenderLink = session.create_sender_link(
+            endpoint,
+            on_link_state_change=self._on_sender_state_change,
+            send_settle_mode=SenderSettleMode.Unsettled,
+            rcv_settle_mode=ReceiverSettleMode.First
+        )
+        self._response_link: ReceiverLink = session.create_receiver_link(
+            endpoint,
+            on_link_state_change=self._on_receiver_state_change,
+            on_message_received=self._on_message_received,
+            send_settle_mode=SenderSettleMode.Unsettled,
+            rcv_settle_mode=ReceiverSettleMode.First
+        )
+        self._on_amqp_management_error = kwargs.get('on_amqp_management_error')
+        self._on_amqp_management_open_complete = kwargs.get('on_amqp_management_open_complete')
+
+        self._status_code_field = kwargs.get('status_code_field', b'statusCode')
+        self._status_description_field = kwargs.get('status_description_field', b'statusDescription')
+
+        self._sender_connected = False
+        self._receiver_connected = False
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def _on_sender_state_change(self, previous_state, new_state):
+        _LOGGER.info("Management link sender state changed: %r -> %r", previous_state, new_state)
+        if new_state == previous_state:
+            return
+        if self.state == ManagementLinkState.OPENING:
+            if new_state == LinkState.ATTACHED:
+                self._sender_connected = True
+                if self._receiver_connected:
+                    self.state = ManagementLinkState.OPEN
+                    self._on_amqp_management_open_complete(ManagementOpenResult.OK)
+            elif new_state in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD, LinkState.ERROR]:
+                self.state = ManagementLinkState.IDLE
+                self._on_amqp_management_open_complete(ManagementOpenResult.ERROR)
+        elif self.state == ManagementLinkState.OPEN:
+            if new_state is not LinkState.ATTACHED:
+                self.state = ManagementLinkState.ERROR
+                self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.CLOSING:
+            if new_state not in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD]:
+                self.state = ManagementLinkState.ERROR
+                self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.ERROR:
+            # All state transitions shall be ignored.
+            return
+
+    def _on_receiver_state_change(self, previous_state, new_state):
+        _LOGGER.info("Management link receiver state changed: %r -> %r", previous_state, new_state)
+        if new_state == previous_state:
+            return
+        if self.state == ManagementLinkState.OPENING:
+            if new_state == LinkState.ATTACHED:
+                self._receiver_connected = True
+                if self._sender_connected:
+                    self.state = ManagementLinkState.OPEN
+                    self._on_amqp_management_open_complete(ManagementOpenResult.OK)
+            elif new_state in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD, LinkState.ERROR]:
+                self.state = ManagementLinkState.IDLE
+                self._on_amqp_management_open_complete(ManagementOpenResult.ERROR)
+        elif self.state == ManagementLinkState.OPEN:
+            if new_state is not LinkState.ATTACHED:
+                self.state = ManagementLinkState.ERROR
+                self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.CLOSING:
+            if new_state not in [LinkState.DETACHED, LinkState.DETACH_SENT, LinkState.DETACH_RCVD]:
+                self.state = ManagementLinkState.ERROR
+                self._on_amqp_management_error()
+        elif self.state == ManagementLinkState.ERROR:
+            # All state transitions shall be ignored.
+            return
+
+    def _on_message_received(self, message):
+        message_properties = message.properties
+        correlation_id = message_properties[5]
+        response_detail = message.application_properties
+
+        status_code = response_detail.get(self._status_code_field)
+        status_description = response_detail.get(self._status_description_field)
+
+        to_remove_operation = None
+        for operation in self._pending_operations:
+            if operation.message.properties.message_id == correlation_id:
+                to_remove_operation = operation
+                break
+        if to_remove_operation:
+            mgmt_result = ManagementExecuteOperationResult.OK \
+                if 200 <= status_code <= 299 else ManagementExecuteOperationResult.FAILED_BAD_STATUS
+            to_remove_operation.on_execute_operation_complete(
+                mgmt_result,
+                status_code,
+                status_description,
+                message,
+                response_detail.get(b'error-condition')
+            )
+            self._pending_operations.remove(to_remove_operation)
+
+    def _on_send_complete(self, message_delivery, reason, state):  # todo: reason is never used, should check spec
+        if SEND_DISPOSITION_REJECT in state:
+            # sample reject state: {'rejected': [[b'amqp:not-allowed', b"Invalid command 'RE1AD'.", None]]}
+            to_remove_operation = None
+            for operation in self._pending_operations:
+                if message_delivery.message == operation.message:
+                    to_remove_operation = operation
+                    break
+            self._pending_operations.remove(to_remove_operation)
+            # TODO: better error handling
+            #  AMQPException is too general? to be more specific: MessageReject(Error) or AMQPManagementError?
+            #  or should there an error mapping which maps the condition to the error type
+            to_remove_operation.on_execute_operation_complete(  # The callback is defined in management_operation.py
+                ManagementExecuteOperationResult.ERROR,
+                None,
+                None,
+                message_delivery.message,
+                error=AMQPException(
+                    condition=state[SEND_DISPOSITION_REJECT][0][0],  # 0 is error condition
+                    description=state[SEND_DISPOSITION_REJECT][0][1],  # 1 is error description
+                    info=state[SEND_DISPOSITION_REJECT][0][2],  # 2 is error info
+                )
+            )
+
+    def open(self):
+        if self.state != ManagementLinkState.IDLE:
+            raise ValueError("Management links are already open or opening.")
+        self.state = ManagementLinkState.OPENING
+        self._response_link.attach()
+        self._request_link.attach()
+
+    def execute_operation(
+        self,
+        message,
+        on_execute_operation_complete,
+        **kwargs
+    ):
+        """Execute a request and wait on a response.
+
+        :param message: The message to send in the management request.
+        :type message: ~uamqp.message.Message
+        :param on_execute_operation_complete: Callback to be called when the operation is complete.
+         The following value will be passed to the callback: operation_id, operation_result, status_code,
+         status_description, raw_message and error.
+        :type on_execute_operation_complete: Callable[[str, str, int, str, ~uamqp.message.Message, Exception], None]
+        :keyword operation: The type of operation to be performed. This value will
+         be service-specific, but common values include READ, CREATE and UPDATE.
+         This value will be added as an application property on the message.
+        :paramtype operation: bytes or str
+        :keyword type: The type on which to carry out the operation. This will
+         be specific to the entities of the service. This value will be added as
+         an application property on the message.
+        :paramtype type: bytes or str
+        :keyword str locales: A list of locales that the sending peer permits for incoming
+         informational text in response messages.
+        :keyword float timeout: Provide an optional timeout in seconds within which a response
+         to the management request must be received.
+        :rtype: None
+        """
+        timeout = kwargs.get("timeout")
+        message.application_properties["operation"] = kwargs.get("operation")
+        message.application_properties["type"] = kwargs.get("type")
+        message.application_properties["locales"] = kwargs.get("locales")
+        try:
+            # TODO: namedtuple is immutable, which may push us to re-think about the namedtuple approach for Message
+            new_properties = message.properties._replace(message_id=self.next_message_id)
+        except AttributeError:
+            new_properties = Properties(message_id=self.next_message_id)
+        message = message._replace(properties=new_properties)
+        expire_time = (time.time() + timeout) if timeout else None
+        message_delivery = _MessageDelivery(
+            message,
+            MessageDeliveryState.WaitingToBeSent,
+            expire_time
+        )
+
+        on_send_complete = partial(self._on_send_complete, message_delivery)
+
+        self._request_link.send_transfer(
+            message,
+            on_send_complete=on_send_complete,
+            timeout=timeout
+        )
+        self.next_message_id += 1
+        self._pending_operations.append(PendingManagementOperation(message, on_execute_operation_complete))
+
+    def close(self):
+        if self.state != ManagementLinkState.IDLE:
+            self.state = ManagementLinkState.CLOSING
+            self._response_link.detach(close=True)
+            self._request_link.detach(close=True)
+            for pending_operation in self._pending_operations:
+                pending_operation.on_execute_operation_complete(
+                    ManagementExecuteOperationResult.LINK_CLOSED,
+                    None,
+                    None,
+                    pending_operation.message,
+                    AMQPException(condition=ErrorCondition.ClientError, description="Management link already closed.")
+                )
+            self._pending_operations = []
+        self.state = ManagementLinkState.IDLE

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/management_operation.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/management_operation.py
@@ -1,0 +1,138 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+import logging
+import uuid
+import time
+from functools import partial
+
+from .management_link import ManagementLink
+from .message import Message
+from .error import (
+    AMQPException,
+    AMQPConnectionError,
+    AMQPLinkError,
+    ErrorCondition
+)
+
+from .constants import (
+    ManagementOpenResult,
+    ManagementExecuteOperationResult
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ManagementOperation(object):
+    def __init__(self, session, endpoint='$management', **kwargs):
+        self._mgmt_link_open_status = None
+
+        self._session = session
+        self._connection = self._session._connection
+        self._mgmt_link = self._session.create_request_response_link_pair(
+            endpoint=endpoint,
+            on_amqp_management_open_complete=self._on_amqp_management_open_complete,
+            on_amqp_management_error=self._on_amqp_management_error,
+            **kwargs
+        )  # type: ManagementLink
+        self._responses = {}
+        self._mgmt_error = None
+
+    def _on_amqp_management_open_complete(self, result):
+        """Callback run when the send/receive links are open and ready
+        to process messages.
+
+        :param result: Whether the link opening was successful.
+        :type result: int
+        """
+        self._mgmt_link_open_status = result
+
+    def _on_amqp_management_error(self):
+        """Callback run if an error occurs in the send/receive links."""
+        # TODO: This probably shouldn't be ValueError
+        self._mgmt_error = ValueError("Management Operation error occurred.")
+
+    def _on_execute_operation_complete(
+        self,
+        operation_id,
+        operation_result,
+        status_code,
+        status_description,
+        raw_message,
+        error=None
+    ):
+        _LOGGER.debug(
+            "mgmt operation completed, operation id: %r; operation_result: %r; status_code: %r; "
+            "status_description: %r, raw_message: %r, error: %r",
+            operation_id,
+            operation_result,
+            status_code,
+            status_description,
+            raw_message,
+            error
+        )
+
+        if operation_result in\
+                (ManagementExecuteOperationResult.ERROR, ManagementExecuteOperationResult.LINK_CLOSED):
+            self._mgmt_error = error
+            _LOGGER.error(
+                "Failed to complete mgmt operation due to error: %r. The management request message is: %r",
+                error, raw_message
+            )
+        else:
+            self._responses[operation_id] = (status_code, status_description, raw_message)
+
+    def execute(self, message, operation=None, operation_type=None, timeout=0):
+        start_time = time.time()
+        operation_id = str(uuid.uuid4())
+        self._responses[operation_id] = None
+        self._mgmt_error = None
+
+        self._mgmt_link.execute_operation(
+            message,
+            partial(self._on_execute_operation_complete, operation_id),
+            timeout=timeout,
+            operation=operation,
+            type=operation_type
+        )
+
+        while not self._responses[operation_id] and not self._mgmt_error:
+            if timeout > 0:
+                now = time.time()
+                if (now - start_time) >= timeout:
+                    raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
+            self._connection.listen()
+
+        if self._mgmt_error:
+            self._responses.pop(operation_id)
+            raise self._mgmt_error
+
+        response = self._responses.pop(operation_id)
+        return response
+
+    def open(self):
+        self._mgmt_link_open_status = ManagementOpenResult.OPENING
+        self._mgmt_link.open()
+
+    def ready(self):
+        try:
+            raise self._mgmt_error
+        except TypeError:
+            pass
+
+        if self._mgmt_link_open_status == ManagementOpenResult.OPENING:
+            return False
+        if self._mgmt_link_open_status == ManagementOpenResult.OK:
+            return True
+        # ManagementOpenResult.ERROR or CANCELLED
+        # TODO: update below with correct status code + info
+        raise AMQPLinkError(
+            condition=ErrorCondition.ClientError,
+            description="Failed to open mgmt link, management link status: {}".format(self._mgmt_link_open_status),
+            info=None
+        )
+
+    def close(self):
+        self._mgmt_link.close()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/message.py
@@ -7,8 +7,9 @@
 from collections import namedtuple
 
 from .types import AMQPTypes, FieldDefinition
-from .constants import FIELD, MessageDeliveryState
+from .constants import FIELD, MessageDeliveryState, MessageState, RECEIVE_STATES
 from .performatives import _CAN_ADD_DOCSTRING
+from .error import MessageAccepted, MessageRejected, MessageReleased, MessageModified
 
 
 Header = namedtuple(
@@ -89,7 +90,8 @@ Properties = namedtuple(
         'creation_time',
         'group_id',
         'group_sequence',
-        'reply_to_group_id'
+        'reply_to_group_id',
+        'settled'
     ])
 Properties._code = 0x00000073
 Properties.__new__.__defaults__ = (None,) * len(Properties._fields)
@@ -106,7 +108,8 @@ Properties._definition = (
     FIELD("creation_time", AMQPTypes.timestamp, False, None, False),
     FIELD("group_id", AMQPTypes.string, False, None, False),
     FIELD("group_sequence", AMQPTypes.uint, False, None, False),
-    FIELD("reply_to_group_id", AMQPTypes.string, False, None, False))
+    FIELD("reply_to_group_id", AMQPTypes.string, False, None, False),
+    FIELD("settled", AMQPTypes.boolean, False, None, False))
 if _CAN_ADD_DOCSTRING:
     Properties.__doc__ = """
     Immutable properties of the Message.
@@ -161,6 +164,7 @@ if _CAN_ADD_DOCSTRING:
         The relative position of this message within its group.
     :param str reply_to_group_id: The group the reply message belongs to.
         This is a client-specific id that is used so that client can send replies to this message to a specific group.
+    :param boolean settled Confirms whether or not the message has been settled
     """
 
 # TODO: should be a class, namedtuple or dataclass, immutability vs performance, need to collect performance data
@@ -251,7 +255,99 @@ if _CAN_ADD_DOCSTRING:
         signatures and encryption details). A registry of defined footers and their meanings can be found
         here: http://www.amqp.org/specification/1.0/footer.
     """
+    def accept(self):
+        """Send a response disposition to the service to indicate that
+        a received message has been accepted. If the client is running in PeekLock
+        mode, the service will wait on this disposition. Otherwise it will
+        be ignored. Returns `True` is message was accepted, or `False` if the message
+        was already settled.
+        :rtype: bool
+        :raises: TypeError if the message is being sent rather than received.
+        """
+        if self._can_settle_message():
+            self._response = MessageAccepted()
+            self._settler(self._response)
+            self.state = MessageState.ReceivedSettled
+            return True
+        return False
 
+    def reject(self, condition=None, description=None, info=None):
+        """Send a response disposition to the service to indicate that
+        a received message has been rejected. If the client is running in PeekLock
+        mode, the service will wait on this disposition. Otherwise it will
+        be ignored. A rejected message will increment the messages delivery count.
+        Returns `True` is message was rejected, or `False` if the message
+        was already settled.
+        :param condition: The AMQP rejection code. By default this is `amqp:internal-error`.
+        :type condition: bytes or str
+        :param description: A description/reason to accompany the rejection.
+        :type description: bytes or str
+        :param info: Information about the error condition.
+        :type info: dict
+        :rtype: bool
+        :raises: TypeError if the message is being sent rather than received.
+        """
+        if self._can_settle_message():
+            self._response = MessageRejected(
+                condition=condition,
+                description=description,
+                info=info,
+                encoding=self._encoding,
+            )
+            self._settler(self._response)
+            self.state = MessageState.ReceivedSettled
+            return True
+        return False
+
+    def release(self):
+        """Send a response disposition to the service to indicate that
+        a received message has been released. If the client is running in PeekLock
+        mode, the service will wait on this disposition. Otherwise it will
+        be ignored. A released message will not incremenet the messages
+        delivery count. Returns `True` is message was released, or `False` if the message
+        was already settled.
+        :rtype: bool
+        :raises: TypeError if the message is being sent rather than received.
+        """
+        if self._can_settle_message():
+            self._response = MessageReleased()
+            self._settler(self._response)
+            self.state = MessageState.ReceivedSettled
+            return True
+        return False
+
+    def modify(self, failed, deliverable, annotations=None):
+        """Send a response disposition to the service to indicate that
+        a received message has been modified. If the client is running in PeekLock
+        mode, the service will wait on this disposition. Otherwise it will
+        be ignored. Returns `True` is message was modified, or `False` if the message
+        was already settled.
+        :param failed: Whether this delivery of this message failed. This does not
+         indicate whether subsequence deliveries of this message would also fail.
+        :type failed: bool
+        :param deliverable: Whether this message will be deliverable to this client
+         on subsequent deliveries - i.e. whether delivery is retryable.
+        :type deliverable: bool
+        :param annotations: Annotations to attach to response.
+        :type annotations: dict
+        :rtype: bool
+        :raises: TypeError if the message is being sent rather than received.
+        """
+        if self._can_settle_message():
+            self._response = MessageModified(
+                failed, deliverable, annotations=annotations, encoding=self._encoding
+            )
+            self._settler(self._response)
+            self.state = MessageState.ReceivedSettled
+            return True
+        return False
+    
+    def _can_settle_message(self):
+        if self.state not in RECEIVE_STATES:
+            raise TypeError("Only received messages can be settled.")
+        if self.settled:
+            return False
+        return True
 
 class BatchMessage(Message):
     _code = 0x80013700

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/message.py
@@ -1,0 +1,267 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+from collections import namedtuple
+
+from .types import AMQPTypes, FieldDefinition
+from .constants import FIELD, MessageDeliveryState
+from .performatives import _CAN_ADD_DOCSTRING
+
+
+Header = namedtuple(
+    'header',
+    [
+        'durable',
+        'priority',
+        'ttl',
+        'first_acquirer',
+        'delivery_count'
+    ])
+Header._code = 0x00000070
+Header.__new__.__defaults__ = (None,) * len(Header._fields)
+Header._definition = (
+    FIELD("durable", AMQPTypes.boolean, False, None, False),
+    FIELD("priority", AMQPTypes.ubyte, False, None, False),
+    FIELD("ttl", AMQPTypes.uint, False, None, False),
+    FIELD("first_acquirer", AMQPTypes.boolean, False, None, False),
+    FIELD("delivery_count", AMQPTypes.uint, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    Header.__doc__ = """
+    Transport headers for a Message.
+
+    The header section carries standard delivery details about the transfer of a Message through the AMQP
+    network. If the header section is omitted the receiver MUST assume the appropriate default values for
+    the fields within the header unless other target or node specific defaults have otherwise been set.
+
+    :param bool durable: Specify durability requirements.
+        Durable Messages MUST NOT be lost even if an intermediary is unexpectedly terminated and restarted.
+        A target which is not capable of fulfilling this guarantee MUST NOT accept messages where the durable
+        header is set to true: if the source allows the rejected outcome then the message should be rejected
+        with the precondition-failed error, otherwise the link must be detached by the receiver with the same error.
+    :param int priority: Relative Message priority.
+        This field contains the relative Message priority. Higher numbers indicate higher priority Messages.
+        Messages with higher priorities MAY be delivered before those with lower priorities. An AMQP intermediary
+        implementing distinct priority levels MUST do so in the following manner:
+        
+            - If n distince priorities are implemented and n is less than 10 - priorities 0 to (5 - ceiling(n/2))
+              MUST be treated equivalently and MUST be the lowest effective priority. The priorities (4 + fioor(n/2))
+              and above MUST be treated equivalently and MUST be the highest effective priority. The priorities
+              (5 ceiling(n/2)) to (4 + fioor(n/2)) inclusive MUST be treated as distinct priorities.
+            - If n distinct priorities are implemented and n is 10 or greater - priorities 0 to (n - 1) MUST be
+              distinct, and priorities n and above MUST be equivalent to priority (n - 1). Thus, for example, if 2
+              distinct priorities are implemented, then levels 0 to 4 are equivalent, and levels 5 to 9 are equivalent
+              and levels 4 and 5 are distinct. If 3 distinct priorities are implements the 0 to 3 are equivalent,
+              5 to 9 are equivalent and 3, 4 and 5 are distinct. This scheme ensures that if two priorities are distinct
+              for a server which implements m separate priority levels they are also distinct for a server which
+              implements n different priority levels where n > m.
+
+    :param int ttl: Time to live in ms.
+        Duration in milliseconds for which the Message should be considered 'live'. If this is set then a message
+        expiration time will be computed based on the time of arrival at an intermediary. Messages that live longer
+        than their expiration time will be discarded (or dead lettered). When a message is transmitted by an
+        intermediary that was received with a ttl, the transmitted message's header should contain a ttl that is
+        computed as the difference between the current time and the formerly computed message expiration
+        time, i.e. the reduced ttl, so that messages will eventually die if they end up in a delivery loop.
+    :param bool first_acquirer: If this value is true, then this message has not been acquired by any other Link.
+        If this value is false, then this message may have previously been acquired by another Link or Links.
+    :param int delivery_count: The number of prior unsuccessful delivery attempts.
+        The number of unsuccessful previous attempts to deliver this message. If this value is non-zero it may
+        be taken as an indication that the delivery may be a duplicate. On first delivery, the value is zero.
+        It is incremented upon an outcome being settled at the sender, according to rules defined for each outcome.
+    """
+
+
+Properties = namedtuple(
+    'properties',
+    [
+        'message_id',
+        'user_id',
+        'to',
+        'subject',
+        'reply_to',
+        'correlation_id',
+        'content_type',
+        'content_encoding',
+        'absolute_expiry_time',
+        'creation_time',
+        'group_id',
+        'group_sequence',
+        'reply_to_group_id'
+    ])
+Properties._code = 0x00000073
+Properties.__new__.__defaults__ = (None,) * len(Properties._fields)
+Properties._definition = (
+    FIELD("message_id", FieldDefinition.message_id, False, None, False),
+    FIELD("user_id", AMQPTypes.binary, False, None, False),
+    FIELD("to", AMQPTypes.string, False, None, False),
+    FIELD("subject", AMQPTypes.string, False, None, False),
+    FIELD("reply_to", AMQPTypes.string, False, None, False),
+    FIELD("correlation_id", FieldDefinition.message_id, False, None, False),
+    FIELD("content_type", AMQPTypes.symbol, False, None, False),
+    FIELD("content_encoding", AMQPTypes.symbol, False, None, False),
+    FIELD("absolute_expiry_time", AMQPTypes.timestamp, False, None, False),
+    FIELD("creation_time", AMQPTypes.timestamp, False, None, False),
+    FIELD("group_id", AMQPTypes.string, False, None, False),
+    FIELD("group_sequence", AMQPTypes.uint, False, None, False),
+    FIELD("reply_to_group_id", AMQPTypes.string, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    Properties.__doc__ = """
+    Immutable properties of the Message.
+
+    The properties section is used for a defined set of standard properties of the message. The properties
+    section is part of the bare message and thus must, if retransmitted by an intermediary, remain completely
+    unaltered.
+
+    :param message_id: Application Message identifier.
+        Message-id is an optional property which uniquely identifies a Message within the Message system.
+        The Message producer is usually responsible for setting the message-id in such a way that it is assured
+        to be globally unique. A broker MAY discard a Message as a duplicate if the value of the message-id
+        matches that of a previously received Message sent to the same Node.
+    :param bytes user_id: Creating user id.
+        The identity of the user responsible for producing the Message. The client sets this value, and it MAY
+        be authenticated by intermediaries.
+    :param to: The address of the Node the Message is destined for.
+        The to field identifies the Node that is the intended destination of the Message. On any given transfer
+        this may not be the Node at the receiving end of the Link.
+    :param str subject: The subject of the message.
+        A common field for summary information about the Message content and purpose.
+    :param reply_to: The Node to send replies to.
+        The address of the Node to send replies to.
+    :param correlation_id: Application correlation identifier.
+        This is a client-specific id that may be used to mark or identify Messages between clients.
+    :param bytes content_type: MIME content type.
+        The RFC-2046 MIME type for the Message's application-data section (body). As per RFC-2046 this may contain
+        a charset parameter defining the character encoding used: e.g. 'text/plain; charset="utf-8"'.
+        For clarity, the correct MIME type for a truly opaque binary section is application/octet-stream.
+        When using an application-data section with a section code other than data, contenttype, if set, SHOULD
+        be set to a MIME type of message/x-amqp+?, where '?' is either data, map or list.
+    :param bytes content_encoding: MIME content type.
+        The Content-Encoding property is used as a modifier to the content-type. When present, its value indicates
+        what additional content encodings have been applied to the application-data, and thus what decoding
+        mechanisms must be applied in order to obtain the media-type referenced by the content-type header field.
+        Content-Encoding is primarily used to allow a document to be compressed without losing the identity of
+        its underlying content type. Content Encodings are to be interpreted as per Section 3.5 of RFC 2616.
+        Valid Content Encodings are registered at IANA as "Hypertext Transfer Protocol (HTTP) Parameters"
+        (http://www.iana.org/assignments/http-parameters/httpparameters.xml). Content-Encoding MUST not be set when
+        the application-data section is other than data. Implementations MUST NOT use the identity encoding.
+        Instead, implementations should not set this property. Implementations SHOULD NOT use the compress
+        encoding, except as to remain compatible with messages originally sent with other protocols,
+        e.g. HTTP or SMTP. Implementations SHOULD NOT specify multiple content encoding values except as to be
+        compatible with messages originally sent with other protocols, e.g. HTTP or SMTP.
+    :param datetime absolute_expiry_time: The time when this message is considered expired.
+        An absolute time when this message is considered to be expired.
+    :param datetime creation_time: The time when this message was created.
+        An absolute time when this message was created.
+    :param str group_id: The group this message belongs to.
+        Identifies the group the message belongs to.
+    :param int group_sequence: The sequence-no of this message within its group.
+        The relative position of this message within its group.
+    :param str reply_to_group_id: The group the reply message belongs to.
+        This is a client-specific id that is used so that client can send replies to this message to a specific group.
+    """
+
+# TODO: should be a class, namedtuple or dataclass, immutability vs performance, need to collect performance data
+Message = namedtuple(
+    'message',
+    [
+        'header',
+        'delivery_annotations',
+        'message_annotations',
+        'properties',
+        'application_properties',
+        'data',
+        'sequence',
+        'value',
+        'footer',
+    ])
+Message.__new__.__defaults__ = (None,) * len(Message._fields)
+Message._code = 0
+Message._definition = (
+    (0x00000070, FIELD("header", Header, False, None, False)),
+    (0x00000071, FIELD("delivery_annotations", FieldDefinition.annotations, False, None, False)),
+    (0x00000072, FIELD("message_annotations", FieldDefinition.annotations, False, None, False)),
+    (0x00000073, FIELD("properties", Properties, False, None, False)),
+    (0x00000074, FIELD("application_properties", AMQPTypes.map, False, None, False)),
+    (0x00000075, FIELD("data", AMQPTypes.binary, False, None, True)),
+    (0x00000076, FIELD("sequence", AMQPTypes.list, False, None, False)),
+    (0x00000077, FIELD("value", None, False, None, False)),
+    (0x00000078, FIELD("footer", FieldDefinition.annotations, False, None, False)))
+if _CAN_ADD_DOCSTRING:
+    Message.__doc__ = """
+    An annotated message consists of the bare message plus sections for annotation at the head and tail
+    of the bare message.
+
+    There are two classes of annotations: annotations that travel with the message indefinitely, and
+    annotations that are consumed by the next node.
+    The exact structure of a message, together with its encoding, is defined by the message format. This document
+    defines the structure and semantics of message format 0 (MESSAGE-FORMAT). Altogether a message consists of the
+    following sections:
+
+        - Zero or one header.
+        - Zero or one delivery-annotations.
+        - Zero or one message-annotations.
+        - Zero or one properties.
+        - Zero or one application-properties.
+        - The body consists of either: one or more data sections, one or more amqp-sequence sections,
+          or a single amqp-value section.
+        - Zero or one footer.
+
+    :param ~uamqp.message.Header header: Transport headers for a Message.
+        The header section carries standard delivery details about the transfer of a Message through the AMQP
+        network. If the header section is omitted the receiver MUST assume the appropriate default values for
+        the fields within the header unless other target or node specific defaults have otherwise been set.
+    :param dict delivery_annotations: The delivery-annotations section is used for delivery-specific non-standard
+        properties at the head of the message. Delivery annotations convey information from the sending peer to
+        the receiving peer. If the recipient does not understand the annotation it cannot be acted upon and its
+        effects (such as any implied propagation) cannot be acted upon. Annotations may be specific to one
+        implementation, or common to multiple implementations. The capabilities negotiated on link attach and on
+        the source and target should be used to establish which annotations a peer supports. A registry of defined
+        annotations and their meanings can be found here: http://www.amqp.org/specification/1.0/delivery-annotations.
+        If the delivery-annotations section is omitted, it is equivalent to a delivery-annotations section
+        containing an empty map of annotations.
+    :param dict message_annotations: The message-annotations section is used for properties of the message which
+        are aimed at the infrastructure and should be propagated across every delivery step. Message annotations
+        convey information about the message. Intermediaries MUST propagate the annotations unless the annotations
+        are explicitly augmented or modified (e.g. by the use of the modified outcome).
+        The capabilities negotiated on link attach and on the source and target may be used to establish which
+        annotations a peer understands, however it a network of AMQP intermediaries it may not be possible to know
+        if every intermediary will understand the annotation. Note that for some annotation it may not be necessary
+        for the intermediary to understand their purpose - they may be being used purely as an attribute which can be
+        filtered on. A registry of defined annotations and their meanings can be found here:
+        http://www.amqp.org/specification/1.0/message-annotations. If the message-annotations section is omitted,
+        it is equivalent to a message-annotations section containing an empty map of annotations.
+    :param ~uamqp.message.Properties: Immutable properties of the Message.
+        The properties section is used for a defined set of standard properties of the message. The properties
+        section is part of the bare message and thus must, if retransmitted by an intermediary, remain completely
+        unaltered.
+    :param dict application_properties: The application-properties section is a part of the bare message used
+        for structured application data. Intermediaries may use the data within this structure for the purposes
+        of filtering or routing. The keys of this map are restricted to be of type string (which excludes the
+        possibility of a null key) and the values are restricted to be of simple types only (that is excluding
+        map, list, and array types).
+    :param list(bytes) data_body: A data section contains opaque binary data.
+    :param list sequence_body: A sequence section contains an arbitrary number of structured data elements.
+    :param value_body: An amqp-value section contains a single AMQP value.
+    :param dict footer: Transport footers for a Message.
+        The footer section is used for details about the message or delivery which can only be calculated or
+        evaluated once the whole bare message has been constructed or seen (for example message hashes, HMACs,
+        signatures and encryption details). A registry of defined footers and their meanings can be found
+        here: http://www.amqp.org/specification/1.0/footer.
+    """
+
+
+class BatchMessage(Message):
+    _code = 0x80013700
+
+
+class _MessageDelivery:
+    def __init__(self, message, state=MessageDeliveryState.WaitingToBeSent, expiry=None):
+        self.message = message
+        self.state = state
+        self.expiry = expiry
+        self.reason = None
+        self.delivery = None
+        self.error = None

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/outcomes.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/outcomes.py
@@ -1,0 +1,157 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+# The Messaging layer defines a concrete set of delivery states which can be used (via the disposition frame)
+# to indicate the state of the message at the receiver.
+
+# Delivery states may be either terminal or non-terminal. Once a delivery reaches a terminal delivery-state,
+# the state for that delivery will no longer change. A terminal delivery-state is referred to as an outcome.
+
+# The following outcomes are formally defined by the messaging layer to indicate the result of processing at the
+# receiver:
+
+#     - accepted: indicates successful processing at the receiver
+#     - rejected: indicates an invalid and unprocessable message
+#     - released: indicates that the message was not (and will not be) processed
+#     - modified: indicates that the message was modified, but not processed
+
+# The following non-terminal delivery-state is formally defined by the messaging layer for use during link
+# recovery to allow the sender to resume the transfer of a large message without retransmitting all the
+# message data:
+
+#     - received: indicates partial message data seen by the receiver as well as the starting point for a
+#         resumed transfer
+
+from collections import namedtuple
+
+from .types import AMQPTypes, FieldDefinition, ObjDefinition
+from .constants import FIELD
+from .performatives import _CAN_ADD_DOCSTRING
+
+
+Received = namedtuple('received', ['section_number', 'section_offset'])
+Received._code = 0x00000023
+Received._definition = (
+    FIELD("section_number", AMQPTypes.uint, True, None, False),
+    FIELD("section_offset", AMQPTypes.ulong, True, None, False))
+if _CAN_ADD_DOCSTRING:
+    Received.__doc__ = """
+    At the target the received state indicates the furthest point in the payload of the message
+    which the target will not need to have resent if the link is resumed. At the source the received state represents
+    the earliest point in the payload which the Sender is able to resume transferring at in the case of link
+    resumption. When resuming a delivery, if this state is set on the first transfer performative it indicates
+    the offset in the payload at which the first resumed delivery is starting. The Sender MUST NOT send the
+    received state on transfer or disposition performatives except on the first transfer performative on a
+    resumed delivery.
+
+    :param int section_number:
+        When sent by the Sender this indicates the first section of the message (with sectionnumber 0 being the
+        first section) for which data can be resent. Data from sections prior to the given section cannot be
+        retransmitted for this delivery. When sent by the Receiver this indicates the first section of the message
+        for which all data may not yet have been received.
+    :param int section_offset:
+        When sent by the Sender this indicates the first byte of the encoded section data of the section given by
+        section-number for which data can be resent (with section-offset 0 being the first byte). Bytes from the
+        same section prior to the given offset section cannot be retransmitted for this delivery. When sent by the
+        Receiver this indicates the first byte of the given section which has not yet been received. Note that if
+        a receiver has received all of section number X (which contains N bytes of data), but none of section
+        number X + 1, then it may indicate this by sending either Received(section-number=X, section-offset=N) or
+        Received(section-number=X+1, section-offset=0). The state Received(sectionnumber=0, section-offset=0)
+        indicates that no message data at all has been transferred.
+    """
+
+
+Accepted = namedtuple('accepted', [])
+Accepted._code = 0x00000024
+Accepted._definition = ()
+if _CAN_ADD_DOCSTRING:
+    Accepted.__doc__ = """
+    The accepted outcome.
+
+    At the source the accepted state means that the message has been retired from the node, and transfer of
+    payload data will not be able to be resumed if the link becomes suspended. A delivery may become accepted at
+    the source even before all transfer frames have been sent, this does not imply that the remaining transfers
+    for the delivery will not be sent - only the aborted fiag on the transfer performative can be used to indicate
+    a premature termination of the transfer. At the target, the accepted outcome is used to indicate that an
+    incoming Message has been successfully processed, and that the receiver of the Message is expecting the sender
+    to transition the delivery to the accepted state at the source. The accepted outcome does not increment the
+    delivery-count in the header of the accepted Message.
+    """
+
+
+Rejected = namedtuple('rejected', ['error'])
+Rejected._code = 0x00000025
+Rejected._definition = (FIELD("error", ObjDefinition.error, False, None, False),)
+if _CAN_ADD_DOCSTRING:
+    Rejected.__doc__ = """
+    The rejected outcome.
+
+    At the target, the rejected outcome is used to indicate that an incoming Message is invalid and therefore
+    unprocessable. The rejected outcome when applied to a Message will cause the delivery-count to be incremented
+    in the header of the rejected Message. At the source, the rejected outcome means that the target has informed
+    the source that the message was rejected, and the source has taken the required action. The delivery SHOULD
+    NOT ever spontaneously attain the rejected state at the source.
+
+    :param ~uamqp.error.AMQPError error: The error that caused the message to be rejected.
+        The value supplied in this field will be placed in the delivery-annotations of the rejected Message
+        associated with the symbolic key "rejected".
+    """
+
+
+Released = namedtuple('released', [])
+Released._code = 0x00000026
+Released._definition = ()
+if _CAN_ADD_DOCSTRING:
+    Released.__doc__ = """
+    The released outcome.
+
+    At the source the released outcome means that the message is no longer acquired by the receiver, and has been
+    made available for (re-)delivery to the same or other targets receiving from the node. The message is unchanged
+    at the node (i.e. the delivery-count of the header of the released Message MUST NOT be incremented).
+    As released is a terminal outcome, transfer of payload data will not be able to be resumed if the link becomes
+    suspended. A delivery may become released at the source even before all transfer frames have been sent, this
+    does not imply that the remaining transfers for the delivery will not be sent. The source MAY spontaneously
+    attain the released outcome for a Message (for example the source may implement some sort of time bound
+    acquisition lock, after which the acquisition of a message at a node is revoked to allow for delivery to an
+    alternative consumer).
+
+    At the target, the released outcome is used to indicate that a given transfer was not and will not be acted upon.
+    """
+
+
+Modified = namedtuple('modified', ['delivery_failed', 'undeliverable_here', 'message_annotations'])
+Modified._code = 0x00000027
+Modified._definition = (
+    FIELD('delivery_failed', AMQPTypes.boolean, False, None, False),
+    FIELD('undeliverable_here', AMQPTypes.boolean, False, None, False),
+    FIELD('message_annotations', FieldDefinition.fields, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    Modified.__doc__ = """
+    The modified outcome.
+
+    At the source the modified outcome means that the message is no longer acquired by the receiver, and has been
+    made available for (re-)delivery to the same or other targets receiving from the node. The message has been
+    changed at the node in the ways indicated by the fields of the outcome. As modified is a terminal outcome,
+    transfer of payload data will not be able to be resumed if the link becomes suspended. A delivery may become
+    modified at the source even before all transfer frames have been sent, this does not imply that the remaining
+    transfers for the delivery will not be sent. The source MAY spontaneously attain the modified outcome for a
+    Message (for example the source may implement some sort of time bound acquisition lock, after which the
+    acquisition of a message at a node is revoked to allow for delivery to an alternative consumer with the
+    message modified in some way to denote the previous failed, e.g. with delivery-failed set to true).
+    At the target, the modified outcome is used to indicate that a given transfer was not and will not be acted
+    upon, and that the message should be modified in the specified ways at the node.
+
+    :param bool delivery_failed: Count the transfer as an unsuccessful delivery attempt.
+        If the delivery-failed fiag is set, any Messages modified MUST have their deliverycount incremented.
+    :param bool undeliverable_here: Prevent redelivery.
+        If the undeliverable-here is set, then any Messages released MUST NOT be redelivered to the modifying
+        Link Endpoint.
+    :param dict message_annotations: Message attributes.
+        Map containing attributes to combine with the existing message-annotations held in the Message's header
+        section. Where the existing message-annotations of the Message contain an entry with the same key as an
+        entry in this field, the value in this field associated with that key replaces the one in the existing
+        headers; where the existing message-annotations has no such value, the value in this map is added.
+    """

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/performatives.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/performatives.py
@@ -1,0 +1,633 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+from collections import namedtuple
+import sys
+
+from .types import AMQPTypes, FieldDefinition, ObjDefinition
+from .constants import FIELD
+
+_CAN_ADD_DOCSTRING = sys.version_info.major >= 3
+
+
+OpenFrame = namedtuple(
+    'open',
+    [
+        'container_id',
+        'hostname',
+        'max_frame_size',
+        'channel_max',
+        'idle_timeout',
+        'outgoing_locales',
+        'incoming_locales',
+        'offered_capabilities',
+        'desired_capabilities',
+        'properties'
+    ])
+OpenFrame._code = 0x00000010  # pylint:disable=protected-access
+OpenFrame._definition = (  # pylint:disable=protected-access
+    FIELD("container_id", AMQPTypes.string, True, None, False),
+    FIELD("hostname", AMQPTypes.string, False, None, False),
+    FIELD("max_frame_size", AMQPTypes.uint, False, 4294967295, False),
+    FIELD("channel_max", AMQPTypes.ushort, False, 65535, False),
+    FIELD("idle_timeout", AMQPTypes.uint, False, None, False),
+    FIELD("outgoing_locales", AMQPTypes.symbol, False, None, True),
+    FIELD("incoming_locales", AMQPTypes.symbol, False, None, True),
+    FIELD("offered_capabilities", AMQPTypes.symbol, False, None, True),
+    FIELD("desired_capabilities", AMQPTypes.symbol, False, None, True),
+    FIELD("properties", FieldDefinition.fields, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    OpenFrame.__doc__ = """
+    OPEN performative. Negotiate Connection parameters.
+
+    The first frame sent on a connection in either direction MUST contain an Open body.
+    (Note that theConnection header which is sent first on the Connection is *not* a frame.)
+    The fields indicate thecapabilities and limitations of the sending peer.
+
+    :param str container_id: The ID of the source container.
+    :param str hostname: The name of the target host.
+        The dns name of the host (either fully qualified or relative) to which the sendingpeer is connecting.
+        It is not mandatory to provide the hostname. If no hostname isprovided the receiving peer should select
+        a default based on its own configuration.This field can be used by AMQP proxies to determine the correct
+        back-end service toconnect the client to.This field may already have been specified by the sasl-init frame,
+        if a SASL layer is used, or, the server name indication extension as described in RFC-4366, if a TLSlayer
+        is used, in which case this field SHOULD be null or contain the same value. It is undefined what a different
+        value to those already specific means.
+    :param int max_frame_size: Proposed maximum frame size in bytes.
+        The largest frame size that the sending peer is able to accept on this Connection.
+        If this field is not set it means that the peer does not impose any specific limit. A peer MUST NOT send
+        frames larger than its partner can handle. A peer that receives an oversized frame MUST close the Connection
+        with the framing-error error-code. Both peers MUST accept frames of up to 512 (MIN-MAX-FRAME-SIZE)
+        octets large.
+    :param int channel_max: The maximum channel number that may be used on the Connection.
+        The channel-max value is the highest channel number that may be used on the Connection. This value plus one
+        is the maximum number of Sessions that can be simultaneously active on the Connection. A peer MUST not use
+        channel numbers outside the range that its partner can handle. A peer that receives a channel number
+        outside the supported range MUST close the Connection with the framing-error error-code.
+    :param int idle_timeout: Idle time-out in milliseconds.
+        The idle time-out required by the sender. A value of zero is the same as if it was not set (null). If the
+        receiver is unable or unwilling to support the idle time-out then it should close the connection with
+        an error explaining why (eg, because it is too small). If the value is not set, then the sender does not
+        have an idle time-out. However, senders doing this should be aware that implementations MAY choose to use
+        an internal default to efficiently manage a peer's resources.
+    :param list(str) outgoing_locales: Locales available for outgoing text.
+        A list of the locales that the peer supports for sending informational text. This includes Connection,
+        Session and Link error descriptions. A peer MUST support at least the en-US locale. Since this value
+        is always supported, it need not be supplied in the outgoing-locales. A null value or an empty list implies
+        that only en-US is supported.
+    :param list(str) incoming_locales: Desired locales for incoming text in decreasing level of preference.
+        A list of locales that the sending peer permits for incoming informational text. This list is ordered in
+        decreasing level of preference. The receiving partner will chose the first (most preferred) incoming locale
+        from those which it supports. If none of the requested locales are supported, en-US will be chosen. Note
+        that en-US need not be supplied in this list as it is always the fallback. A peer may determine which of the
+        permitted incoming locales is chosen by examining the partner's supported locales asspecified in the
+        outgoing_locales field. A null value or an empty list implies that only en-US is supported.
+    :param list(str) offered_capabilities: The extension capabilities the sender supports.
+        If the receiver of the offered-capabilities requires an extension capability which is not present in the
+        offered-capability list then it MUST close the connection. A list of commonly defined connection capabilities
+        and their meanings can be found here: http://www.amqp.org/specification/1.0/connection-capabilities.
+    :param list(str) required_capabilities: The extension capabilities the sender may use if the receiver supports
+        them. The desired-capability list defines which extension capabilities the sender MAY use if the receiver
+        offers them (i.e. they are in the offered-capabilities list received by the sender of the
+        desired-capabilities). If the receiver of the desired-capabilities offers extension capabilities which are
+        not present in the desired-capability list it received, then it can be sure those (undesired) capabilities
+        will not be used on the Connection.
+    :param dict properties: Connection properties.
+        The properties map contains a set of fields intended to indicate information about the connection and its
+        container. A list of commonly defined connection properties and their meanings can be found
+        here: http://www.amqp.org/specification/1.0/connection-properties.
+    """
+
+
+BeginFrame = namedtuple(
+    'begin',
+    [
+        'remote_channel',
+        'next_outgoing_id',
+        'incoming_window',
+        'outgoing_window',
+        'handle_max',
+        'offered_capabilities',
+        'desired_capabilities',
+        'properties'
+    ])
+BeginFrame._code = 0x00000011  # pylint:disable=protected-access
+BeginFrame._definition = (  # pylint:disable=protected-access
+    FIELD("remote_channel", AMQPTypes.ushort, False, None, False),
+    FIELD("next_outgoing_id", AMQPTypes.uint, True, None, False),
+    FIELD("incoming_window", AMQPTypes.uint, True, None, False),
+    FIELD("outgoing_window", AMQPTypes.uint, True, None, False),
+    FIELD("handle_max", AMQPTypes.uint, False, 4294967295, False),
+    FIELD("offered_capabilities", AMQPTypes.symbol, False, None, True),
+    FIELD("desired_capabilities", AMQPTypes.symbol, False, None, True),
+    FIELD("properties", FieldDefinition.fields, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    BeginFrame.__doc__ = """
+    BEGIN performative. Begin a Session on a channel.
+
+    Indicate that a Session has begun on the channel.
+
+    :param int remote_channel: The remote channel for this Session.
+        If a Session is locally initiated, the remote-channel MUST NOT be set. When an endpoint responds to a
+        remotely initiated Session, the remote-channel MUST be set to the channel on which the remote Session
+        sent the begin.
+    :param int next_outgoing_id: The transfer-id of the first transfer id the sender will send.
+        The next-outgoing-id is used to assign a unique transfer-id to all outgoing transfer frames on a given
+        session. The next-outgoing-id may be initialized to an arbitrary value and is incremented after each
+        successive transfer according to RFC-1982 serial number arithmetic.
+    :param int incoming_window: The initial incoming-window of the sender.
+        The incoming-window defines the maximum number of incoming transfer frames that the endpoint can currently
+        receive. This identifies a current maximum incoming transfer-id that can be computed by subtracting one
+        from the sum of incoming-window and next-incoming-id.
+    :param int outgoing_window: The initial outgoing-window of the sender.
+        The outgoing-window defines the maximum number of outgoing transfer frames that the endpoint can currently
+        send. This identifies a current maximum outgoing transfer-id that can be computed by subtracting one from
+        the sum of outgoing-window and next-outgoing-id.
+    :param int handle_max: The maximum handle value that may be used on the Session.
+        The handle-max value is the highest handle value that may be used on the Session. A peer MUST NOT attempt
+        to attach a Link using a handle value outside the range that its partner can handle. A peer that receives
+        a handle outside the supported range MUST close the Connection with the framing-error error-code.
+    :param list(str) offered_capabilities: The extension capabilities the sender supports.
+        A list of commonly defined session capabilities and their meanings can be found
+        here: http://www.amqp.org/specification/1.0/session-capabilities.
+    :param list(str) desired_capabilities: The extension capabilities the sender may use if the receiver
+        supports them.
+    :param dict properties: Session properties.
+        The properties map contains a set of fields intended to indicate information about the session and its
+        container. A list of commonly defined session properties and their meanings can be found
+        here: http://www.amqp.org/specification/1.0/session-properties.
+    """
+
+
+AttachFrame = namedtuple(
+    'attach',
+    [
+        'name',
+        'handle',
+        'role',
+        'send_settle_mode',
+        'rcv_settle_mode',
+        'source',
+        'target',
+        'unsettled',
+        'incomplete_unsettled',
+        'initial_delivery_count',
+        'max_message_size',
+        'offered_capabilities',
+        'desired_capabilities',
+        'properties'
+    ])
+AttachFrame._code = 0x00000012  # pylint:disable=protected-access
+AttachFrame._definition = (  # pylint:disable=protected-access
+    FIELD("name", AMQPTypes.string, True, None, False),
+    FIELD("handle", AMQPTypes.uint, True, None, False),
+    FIELD("role", AMQPTypes.boolean, True, None, False),
+    FIELD("send_settle_mode", AMQPTypes.ubyte, False, 2, False),
+    FIELD("rcv_settle_mode", AMQPTypes.ubyte, False, 0, False),
+    FIELD("source", ObjDefinition.source, False, None, False),
+    FIELD("target", ObjDefinition.target, False, None, False),
+    FIELD("unsettled", AMQPTypes.map, False, None, False),
+    FIELD("incomplete_unsettled", AMQPTypes.boolean, False, False, False),
+    FIELD("initial_delivery_count", AMQPTypes.uint, False, None, False),
+    FIELD("max_message_size", AMQPTypes.ulong, False, None, False),
+    FIELD("offered_capabilities", AMQPTypes.symbol, False, None, True),
+    FIELD("desired_capabilities", AMQPTypes.symbol, False, None, True),
+    FIELD("properties", FieldDefinition.fields, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    AttachFrame.__doc__ = """
+    ATTACH performative. Attach a Link to a Session.
+
+    The attach frame indicates that a Link Endpoint has been attached to the Session. The opening flag
+    is used to indicate that the Link Endpoint is newly created.
+
+    :param str name: The name of the link.
+        This name uniquely identifies the link from the container of the source to the container of the target
+        node, e.g. if the container of the source node is A, and the container of the target node is B, the link
+        may be globally identified by the (ordered) tuple(A,B,<name>).
+    :param int handle: The handle of the link.
+        The handle MUST NOT be used for other open Links. An attempt to attach using a handle which is already
+        associated with a Link MUST be responded to with an immediate close carrying a Handle-in-usesession-error.
+        To make it easier to monitor AMQP link attach frames, it is recommended that implementations always assign
+        the lowest available handle to this field.
+    :param bool role: The role of the link endpoint. Either Role.Sender (False) or Role.Receiver (True).
+    :param str send_settle_mode: The settlement mode for the Sender.
+        Determines the settlement policy for deliveries sent at the Sender. When set at the Receiver this indicates
+        the desired value for the settlement mode at the Sender. When set at the Sender this indicates the actual
+        settlement mode in use.
+    :param str rcv_settle_mode: The settlement mode of the Receiver.
+        Determines the settlement policy for unsettled deliveries received at the Receiver. When set at the Sender
+        this indicates the desired value for the settlement mode at the Receiver. When set at the Receiver this
+        indicates the actual settlement mode in use.
+    :param ~uamqp.messaging.Source source: The source for Messages.
+        If no source is specified on an outgoing Link, then there is no source currently attached to the Link.
+        A Link with no source will never produce outgoing Messages.
+    :param ~uamqp.messaging.Target target: The target for Messages.
+        If no target is specified on an incoming Link, then there is no target currently attached to the Link.
+        A Link with no target will never permit incoming Messages.
+    :param dict unsettled: Unsettled delivery state.
+        This is used to indicate any unsettled delivery states when a suspended link is resumed. The map is keyed
+        by delivery-tag with values indicating the delivery state. The local and remote delivery states for a given
+        delivery-tag MUST be compared to resolve any in-doubt deliveries. If necessary, deliveries MAY be resent,
+        or resumed based on the outcome of this comparison. If the local unsettled map is too large to be encoded
+        within a frame of the agreed maximum frame size then the session may be ended with the
+        frame-size-too-smallerror. The endpoint SHOULD make use of the ability to send an incomplete unsettled map
+        to avoid sending an error. The unsettled map MUST NOT contain null valued keys. When reattaching
+        (as opposed to resuming), the unsettled map MUST be null.
+    :param bool incomplete_unsettled:
+        If set to true this field indicates that the unsettled map provided is not complete. When the map is
+        incomplete the recipient of the map cannot take the absence of a delivery tag from the map as evidence of
+        settlement. On receipt of an incomplete unsettled map a sending endpoint MUST NOT send any new deliveries
+        (i.e. deliveries where resume is not set to true) to its partner (and a receiving endpoint which sent an
+        incomplete unsettled map MUST detach with an error on receiving a transfer which does not have the resume
+        flag set to true).
+    :param int initial_delivery_count: This MUST NOT be null if role is sender,
+        and it is ignored if the role is receiver.
+    :param int max_message_size: The maximum message size supported by the link endpoint.
+        This field indicates the maximum message size supported by the link endpoint. Any attempt to deliver a
+        message larger than this results in a message-size-exceeded link-error. If this field is zero or unset,
+        there is no maximum size imposed by the link endpoint.
+    :param list(str) offered_capabilities: The extension capabilities the sender supports.
+        A list of commonly defined session capabilities and their meanings can be found
+        here: http://www.amqp.org/specification/1.0/link-capabilities.
+    :param list(str) desired_capabilities: The extension capabilities the sender may use if the receiver
+        supports them.
+    :param dict properties: Link properties.
+        The properties map contains a set of fields intended to indicate information about the link and its
+        container. A list of commonly defined link properties and their meanings can be found
+        here: http://www.amqp.org/specification/1.0/link-properties.
+    """
+
+
+FlowFrame = namedtuple(
+    'flow',
+    [
+        'next_incoming_id',
+        'incoming_window',
+        'next_outgoing_id',
+        'outgoing_window',
+        'handle',
+        'delivery_count',
+        'link_credit',
+        'available',
+        'drain',
+        'echo',
+        'properties'
+    ])
+FlowFrame.__new__.__defaults__ = (None, None, None, None, None, None, None)
+FlowFrame._code = 0x00000013  # pylint:disable=protected-access
+FlowFrame._definition = (  # pylint:disable=protected-access
+    FIELD("next_incoming_id", AMQPTypes.uint, False, None, False),
+    FIELD("incoming_window", AMQPTypes.uint, True, None, False),
+    FIELD("next_outgoing_id", AMQPTypes.uint, True, None, False),
+    FIELD("outgoing_window", AMQPTypes.uint, True, None, False),
+    FIELD("handle", AMQPTypes.uint, False, None, False),
+    FIELD("delivery_count", AMQPTypes.uint, False, None, False),
+    FIELD("link_credit", AMQPTypes.uint, False, None, False),
+    FIELD("available", AMQPTypes.uint, False, None, False),
+    FIELD("drain", AMQPTypes.boolean, False, False, False),
+    FIELD("echo", AMQPTypes.boolean, False, False, False),
+    FIELD("properties", FieldDefinition.fields, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    FlowFrame.__doc__ = """
+    FLOW performative. Update link state.
+
+    Updates the flow state for the specified Link.
+
+    :param int next_incoming_id: Identifies the expected transfer-id of the next incoming transfer frame.
+        This value is not set if and only if the sender has not yet received the begin frame for the session.
+    :param int incoming_window: Defines the maximum number of incoming transfer frames that the endpoint
+        concurrently receive.
+    :param int next_outgoing_id: The transfer-id that will be assigned to the next outgoing transfer frame.
+    :param int outgoing_window: Defines the maximum number of outgoing transfer frames that the endpoint could
+        potentially currently send, if it was not constrained by restrictions imposed by its peer's incoming-window.
+    :param int handle: If set, indicates that the flow frame carries flow state information for the local Link
+        Endpoint associated with the given handle. If not set, the flow frame is carrying only information
+        pertaining to the Session Endpoint. If set to a handle that is not currently associated with an attached
+        Link, the recipient MUST respond by ending the session with an unattached-handle session error.
+    :param int delivery_count: The endpoint's delivery-count.
+        When the handle field is not set, this field MUST NOT be set. When the handle identifies that the flow
+        state is being sent from the Sender Link Endpoint to Receiver Link Endpoint this field MUST be set to the
+        current delivery-count of the Link Endpoint. When the flow state is being sent from the Receiver Endpoint
+        to the Sender Endpoint this field MUST be set to the last known value of the corresponding Sending Endpoint.
+        In the event that the Receiving Link Endpoint has not yet seen the initial attach frame from the Sender
+        this field MUST NOT be set.
+    :param int link_credit: The current maximum number of Messages that can be received.
+        The current maximum number of Messages that can be handled at the Receiver Endpoint of the Link. Only the
+        receiver endpoint can independently set this value. The sender endpoint sets this to the last known
+        value seen from the receiver. When the handle field is not set, this field MUST NOT be set.
+    :param int available: The number of available Messages.
+        The number of Messages awaiting credit at the link sender endpoint. Only the sender can independently set
+        this value. The receiver sets this to the last known value seen from the sender. When the handle field is
+        not set, this field MUST NOT be set.
+    :param bool drain: Indicates drain mode.
+        When flow state is sent from the sender to the receiver, this field contains the actual drain mode of the
+        sender. When flow state is sent from the receiver to the sender, this field contains the desired drain
+        mode of the receiver. When the handle field is not set, this field MUST NOT be set.
+    :param bool echo: Request link state from other endpoint.
+    :param dict properties: Link state properties.
+        A list of commonly defined link state properties and their meanings can be found
+        here: http://www.amqp.org/specification/1.0/link-state-properties.
+    """
+
+
+TransferFrame = namedtuple(
+    'transfer',
+    [
+        'handle',
+        'delivery_id',
+        'delivery_tag',
+        'message_format',
+        'settled',
+        'more',
+        'rcv_settle_mode',
+        'state',
+        'resume',
+        'aborted',
+        'batchable',
+        'payload'
+    ])
+TransferFrame._code = 0x00000014  # pylint:disable=protected-access
+TransferFrame._definition = (  # pylint:disable=protected-access
+    FIELD("handle", AMQPTypes.uint, True, None, False),
+    FIELD("delivery_id", AMQPTypes.uint, False, None, False),
+    FIELD("delivery_tag", AMQPTypes.binary, False, None, False),
+    FIELD("message_format", AMQPTypes.uint, False, 0, False),
+    FIELD("settled", AMQPTypes.boolean, False, None, False),
+    FIELD("more", AMQPTypes.boolean, False, False, False),
+    FIELD("rcv_settle_mode", AMQPTypes.ubyte, False, None, False),
+    FIELD("state", ObjDefinition.delivery_state, False, None, False),
+    FIELD("resume", AMQPTypes.boolean, False, False, False),
+    FIELD("aborted", AMQPTypes.boolean, False, False, False),
+    FIELD("batchable", AMQPTypes.boolean, False, False, False),  
+    None)
+if _CAN_ADD_DOCSTRING:
+    TransferFrame.__doc__ = """
+    TRANSFER performative. Transfer a Message.
+
+    The transfer frame is used to send Messages across a Link. Messages may be carried by a single transfer up
+    to the maximum negotiated frame size for the Connection. Larger Messages may be split across several
+    transfer frames.
+
+    :param int handle: Specifies the Link on which the Message is transferred.
+    :param int delivery_id: Alias for delivery-tag.
+        The delivery-id MUST be supplied on the first transfer of a multi-transfer delivery. On continuation
+        transfers the delivery-id MAY be omitted. It is an error if the delivery-id on a continuation transfer
+        differs from the delivery-id on the first transfer of a delivery.
+    :param bytes delivery_tag: Uniquely identifies the delivery attempt for a given Message on this Link.
+        This field MUST be specified for the first transfer of a multi transfer message and may only be
+        omitted for continuation transfers.
+    :param int message_format: Indicates the message format.
+        This field MUST be specified for the first transfer of a multi transfer message and may only be omitted
+        for continuation transfers.
+    :param bool settled: If not set on the first (or only) transfer for a delivery, then the settled flag MUST
+        be interpreted as being false. For subsequent transfers if the settled flag is left unset then it MUST be
+        interpreted as true if and only if the value of the settled flag on any of the preceding transfers was
+        true; if no preceding transfer was sent with settled being true then the value when unset MUST be taken
+        as false. If the negotiated value for snd-settle-mode at attachment is settled, then this field MUST be
+        true on at least one transfer frame for a delivery (i.e. the delivery must be settled at the Sender at
+        the point the delivery has been completely transferred). If the negotiated value for snd-settle-mode at
+        attachment is unsettled, then this field MUST be false (or unset) on every transfer frame for a delivery
+        (unless the delivery is aborted).
+    :param bool more: Indicates that the Message has more content.
+        Note that if both the more and aborted fields are set to true, the aborted flag takes precedence. That is
+        a receiver should ignore the value of the more field if the transfer is marked as aborted. A sender
+        SHOULD NOT set the more flag to true if it also sets the aborted flag to true.
+    :param str rcv_settle_mode: If first, this indicates that the Receiver MUST settle the delivery once it has
+        arrived without waiting for the Sender to settle first. If second, this indicates that the Receiver MUST
+        NOT settle until sending its disposition to the Sender and receiving a settled disposition from the sender.
+        If not set, this value is defaulted to the value negotiated on link attach. If the negotiated link value is
+        first, then it is illegal to set this field to second. If the message is being sent settled by the Sender,
+        the value of this field is ignored. The (implicit or explicit) value of this field does not form part of the
+        transfer state, and is not retained if a link is suspended and subsequently resumed.
+    :param bytes state: The state of the delivery at the sender.
+        When set this informs the receiver of the state of the delivery at the sender. This is particularly useful
+        when transfers of unsettled deliveries are resumed after a resuming a link. Setting the state on the
+        transfer can be thought of as being equivalent to sending a disposition immediately before the transfer
+        performative, i.e. it is the state of the delivery (not the transfer) that existed at the point the frame
+        was sent. Note that if the transfer performative (or an earlier disposition performative referring to the
+        delivery) indicates that the delivery has attained a terminal state, then no future transfer or disposition
+        sent by the sender can alter that terminal state.
+    :param bool resume: Indicates a resumed delivery.
+        If true, the resume flag indicates that the transfer is being used to reassociate an unsettled delivery
+        from a dissociated link endpoint. The receiver MUST ignore resumed deliveries that are not in its local
+        unsettled map. The sender MUST NOT send resumed transfers for deliveries not in its local unsettledmap.
+        If a resumed delivery spans more than one transfer performative, then the resume flag MUST be set to true
+        on the first transfer of the resumed delivery. For subsequent transfers for the same delivery the resume
+        flag may be set to true, or may be omitted. In the case where the exchange of unsettled maps makes clear
+        that all message data has been successfully transferred to the receiver, and that only the final state
+        (andpotentially settlement) at the sender needs to be conveyed, then a resumed delivery may carry no
+        payload and instead act solely as a vehicle for carrying the terminal state of the delivery at the sender.
+    :param bool aborted: Indicates that the Message is aborted.
+        Aborted Messages should be discarded by the recipient (any payload within the frame carrying the performative
+        MUST be ignored). An aborted Message is implicitly settled.
+    :param bool batchable: Batchable hint.
+        If true, then the issuer is hinting that there is no need for the peer to urgently communicate updated
+        delivery state. This hint may be used to artificially increase the amount of batching an implementation
+        uses when communicating delivery states, and thereby save bandwidth. If the message being delivered is too
+        large to fit within a single frame, then the setting of batchable to true on any of the transfer
+        performatives for the delivery is equivalent to setting batchable to true for all the transfer performatives
+        for the delivery. The batchable value does not form part of the transfer state, and is not retained if a
+        link is suspended and subsequently resumed.
+    """
+
+
+DispositionFrame = namedtuple(
+    'disposition',
+    [
+        'role',
+        'first',
+        'last',
+        'settled',
+        'state',
+        'batchable'
+    ])
+DispositionFrame._code = 0x00000015  # pylint:disable=protected-access
+DispositionFrame._definition = (  # pylint:disable=protected-access
+    FIELD("role", AMQPTypes.boolean, True, None, False),
+    FIELD("first", AMQPTypes.uint, True, None, False),
+    FIELD("last", AMQPTypes.uint, False, None, False),
+    FIELD("settled", AMQPTypes.boolean, False, False, False),
+    FIELD("state", ObjDefinition.delivery_state, False, None, False),
+    FIELD("batchable", AMQPTypes.boolean, False, False, False))
+if _CAN_ADD_DOCSTRING:
+    DispositionFrame.__doc__ = """
+    DISPOSITION performative. Inform remote peer of delivery state changes.
+
+    The disposition frame is used to inform the remote peer of local changes in the state of deliveries.
+    The disposition frame may reference deliveries from many different links associated with a session,
+    although all links MUST have the directionality indicated by the specified role. Note that it is possible
+    for a disposition sent from sender to receiver to refer to a delivery which has not yet completed
+    (i.e. a delivery which is spread over multiple frames and not all frames have yet been sent). The use of such
+    interleaving is discouraged in favor of carrying the modified state on the next transfer performative for
+    the delivery. The disposition performative may refer to deliveries on links that are no longer attached.
+    As long as the links have not been closed or detached with an error then the deliveries are still "live" and
+    the updated state MUST be applied.
+
+    :param str role: Directionality of disposition.
+        The role identifies whether the disposition frame contains information about sending link endpoints
+        or receiving link endpoints.
+    :param int first: Lower bound of deliveries.
+        Identifies the lower bound of delivery-ids for the deliveries in this set.
+    :param int last: Upper bound of deliveries.
+        Identifies the upper bound of delivery-ids for the deliveries in this set. If not set,
+        this is taken to be the same as first.
+    :param bool settled: Indicates deliveries are settled.
+        If true, indicates that the referenced deliveries are considered settled by the issuing endpoint.
+    :param bytes state: Indicates state of deliveries.
+        Communicates the state of all the deliveries referenced by this disposition.
+    :param bool batchable: Batchable hint.
+        If true, then the issuer is hinting that there is no need for the peer to urgently communicate the impact
+        of the updated delivery states. This hint may be used to artificially increase the amount of batching an
+        implementation uses when communicating delivery states, and thereby save bandwidth.
+    """
+
+DetachFrame = namedtuple('detach', ['handle', 'closed', 'error'])
+DetachFrame._code = 0x00000016  # pylint:disable=protected-access
+DetachFrame._definition = (  # pylint:disable=protected-access
+    FIELD("handle", AMQPTypes.uint, True, None, False),
+    FIELD("closed", AMQPTypes.boolean, False, False, False),
+    FIELD("error", ObjDefinition.error, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    DetachFrame.__doc__ = """
+    DETACH performative. Detach the Link Endpoint from the Session.
+
+    Detach the Link Endpoint from the Session. This un-maps the handle and makes it available for
+    use by other Links
+
+    :param int handle: The local handle of the link to be detached.
+    :param bool handle: If true then the sender has closed the link.
+    :param ~uamqp.error.AMQPError error: Error causing the detach.
+        If set, this field indicates that the Link is being detached due to an error condition.
+        The value of the field should contain details on the cause of the error.
+    """
+
+
+EndFrame = namedtuple('end', ['error'])
+EndFrame._code = 0x00000017  # pylint:disable=protected-access
+EndFrame._definition = (FIELD("error", ObjDefinition.error, False, None, False),)  # pylint:disable=protected-access
+if _CAN_ADD_DOCSTRING:
+    EndFrame.__doc__ = """
+    END performative. End the Session.
+
+    Indicates that the Session has ended.
+
+    :param ~uamqp.error.AMQPError error: Error causing the end.
+        If set, this field indicates that the Session is being ended due to an error condition.
+        The value of the field should contain details on the cause of the error.
+    """
+
+
+CloseFrame = namedtuple('close', ['error'])
+CloseFrame._code = 0x00000018  # pylint:disable=protected-access
+CloseFrame._definition = (FIELD("error", ObjDefinition.error, False, None, False),)  # pylint:disable=protected-access
+if _CAN_ADD_DOCSTRING:
+    CloseFrame.__doc__ = """
+    CLOSE performative. Signal a Connection close.
+
+    Sending a close signals that the sender will not be sending any more frames (or bytes of any other kind) on
+    the Connection. Orderly shutdown requires that this frame MUST be written by the sender. It is illegal to
+    send any more frames (or bytes of any other kind) after sending a close frame.
+
+    :param ~uamqp.error.AMQPError error: Error causing the close.
+        If set, this field indicates that the Connection is being closed due to an error condition.
+        The value of the field should contain details on the cause of the error.
+    """
+
+
+SASLMechanism = namedtuple('sasl_mechanism', ['sasl_server_mechanisms'])
+SASLMechanism._code = 0x00000040  # pylint:disable=protected-access
+SASLMechanism._definition = (FIELD('sasl_server_mechanisms', AMQPTypes.symbol, True, None, True),)  # pylint:disable=protected-access
+if _CAN_ADD_DOCSTRING:
+    SASLMechanism.__doc__ = """
+    Advertise available sasl mechanisms.
+
+    dvertises the available SASL mechanisms that may be used for authentication.
+
+    :param list(bytes) sasl_server_mechanisms: Supported sasl mechanisms.
+        A list of the sasl security mechanisms supported by the sending peer.
+        It is invalid for this list to be null or empty. If the sending peer does not require its partner to
+        authenticate with it, then it should send a list of one element with its value as the SASL mechanism
+        ANONYMOUS. The server mechanisms are ordered in decreasing level of preference.
+    """
+
+
+SASLInit = namedtuple('sasl_init', ['mechanism', 'initial_response', 'hostname'])
+SASLInit._code = 0x00000041  # pylint:disable=protected-access
+SASLInit._definition = (  # pylint:disable=protected-access
+    FIELD('mechanism', AMQPTypes.symbol, True, None, False),
+    FIELD('initial_response', AMQPTypes.binary, False, None, False),
+    FIELD('hostname', AMQPTypes.string, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    SASLInit.__doc__ = """
+    Initiate sasl exchange.
+
+    Selects the sasl mechanism and provides the initial response if needed.
+
+    :param bytes mechanism: Selected security mechanism.
+        The name of the SASL mechanism used for the SASL exchange. If the selected mechanism is not supported by
+        the receiving peer, it MUST close the Connection with the authentication-failure close-code. Each peer
+        MUST authenticate using the highest-level security profile it can handle from the list provided by the
+        partner.
+    :param bytes initial_response: Security response data.
+        A block of opaque data passed to the security mechanism. The contents of this data are defined by the
+        SASL security mechanism.
+    :param str hostname: The name of the target host.
+        The DNS name of the host (either fully qualified or relative) to which the sending peer is connecting. It
+        is not mandatory to provide the hostname. If no hostname is provided the receiving peer should select a
+        default based on its own configuration. This field can be used by AMQP proxies to determine the correct
+        back-end service to connect the client to, and to determine the domain to validate the client's credentials
+        against. This field may already have been specified by the server name indication extension as described
+        in RFC-4366, if a TLS layer is used, in which case this field SHOULD benull or contain the same value.
+        It is undefined what a different value to those already specific means.
+    """
+
+
+SASLChallenge = namedtuple('sasl_challenge', ['challenge'])
+SASLChallenge._code = 0x00000042  # pylint:disable=protected-access
+SASLChallenge._definition = (FIELD('challenge', AMQPTypes.binary, True, None, False),)  # pylint:disable=protected-access
+if _CAN_ADD_DOCSTRING:
+    SASLChallenge.__doc__ = """
+    Security mechanism challenge.
+
+    Send the SASL challenge data as defined by the SASL specification.
+
+    :param bytes challenge: Security challenge data.
+        Challenge information, a block of opaque binary data passed to the security mechanism.
+    """
+
+
+SASLResponse = namedtuple('sasl_response', ['response'])
+SASLResponse._code = 0x00000043  # pylint:disable=protected-access
+SASLResponse._definition = (FIELD('response', AMQPTypes.binary, True, None, False),)  # pylint:disable=protected-access
+if _CAN_ADD_DOCSTRING:
+    SASLResponse.__doc__ = """
+    Security mechanism response.
+
+    Send the SASL response data as defined by the SASL specification.
+
+    :param bytes response: Security response data.
+    """
+
+
+SASLOutcome = namedtuple('sasl_outcome', ['code', 'additional_data'])
+SASLOutcome._code = 0x00000044  # pylint:disable=protected-access
+SASLOutcome._definition = (  # pylint:disable=protected-access
+    FIELD('code', AMQPTypes.ubyte, True, None, False),
+    FIELD('additional_data', AMQPTypes.binary, False, None, False))
+if _CAN_ADD_DOCSTRING:
+    SASLOutcome.__doc__ = """
+    Indicates the outcome of the sasl dialog.
+
+    This frame indicates the outcome of the SASL dialog. Upon successful completion of the SASL dialog the
+    Security Layer has been established, and the peers must exchange protocol headers to either starta nested
+    Security Layer, or to establish the AMQP Connection.
+
+    :param int code: Indicates the outcome of the sasl dialog.
+        A reply-code indicating the outcome of the SASL dialog.
+    :param bytes additional_data: Additional data as specified in RFC-4422.
+        The additional-data field carries additional data on successful authentication outcomeas specified by
+        the SASL specification (RFC-4422). If the authentication is unsuccessful, this field is not set.
+    """

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -1,0 +1,107 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import uuid
+import logging
+from io import BytesIO
+
+from ._decode import decode_payload
+from .constants import DEFAULT_LINK_CREDIT, Role
+from .endpoints import Target
+from .link import Link
+from .message import Message, Properties, Header
+from .constants import (
+    DEFAULT_LINK_CREDIT,
+    SessionState,
+    SessionTransferState,
+    LinkDeliverySettleReason,
+    LinkState
+)
+from .performatives import (
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame,
+    FlowFrame,
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ReceiverLink(Link):
+
+    def __init__(self, session, handle, source_address, **kwargs):
+        name = kwargs.pop('name', None) or str(uuid.uuid4())
+        role = Role.Receiver
+        if 'target_address' not in kwargs:
+            kwargs['target_address'] = "receiver-link-{}".format(name)
+        super(ReceiverLink, self).__init__(session, handle, name, role, source_address=source_address, **kwargs)
+        self.on_message_received = kwargs.get('on_message_received')
+        self.on_transfer_received = kwargs.get('on_transfer_received')
+        if not self.on_message_received and not self.on_transfer_received:
+            raise ValueError("Must specify either a message or transfer handler.")
+
+    def _process_incoming_message(self, frame, message):
+        try:
+            if self.on_message_received:
+                return self.on_message_received(message)
+            elif self.on_transfer_received:
+                return self.on_transfer_received(frame, message)
+        except Exception as e:
+            _LOGGER.error("Handler function failed with error: %r", e)
+        return None
+
+    def _incoming_attach(self, frame):
+        super(ReceiverLink, self)._incoming_attach(frame)
+        if frame[9] is None:  # initial_delivery_count
+            _LOGGER.info("Cannot get initial-delivery-count. Detaching link")
+            self._remove_pending_deliveries()
+            self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+        self.delivery_count = frame[9]
+        self.current_link_credit = self.link_credit
+        self._outgoing_flow()
+
+    def _incoming_transfer(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", TransferFrame(*frame), extra=self.network_trace_params)
+        self.current_link_credit -= 1
+        self.delivery_count += 1
+        self.received_delivery_id = frame[1]  # delivery_id
+        if not self.received_delivery_id and not self._received_payload:
+            pass  # TODO: delivery error
+        if self._received_payload or frame[5]:  # more
+            self._received_payload.extend(frame[11])
+        if not frame[5]:
+            if self._received_payload:
+                message = decode_payload(memoryview(self._received_payload))
+                self._received_payload = bytearray()
+            else:
+                message = decode_payload(frame[11])
+            delivery_state = self._process_incoming_message(frame, message)
+            if not frame[4] and delivery_state:  # settled
+                self._outgoing_disposition(frame[1], delivery_state)
+        if self.current_link_credit <= 0:
+            self.current_link_credit = self.link_credit
+            self._outgoing_flow()
+
+    def _outgoing_disposition(self, delivery_id, delivery_state):
+        disposition_frame = DispositionFrame(
+            role=self.role,
+            first=delivery_id,
+            last=delivery_id,
+            settled=True,
+            state=delivery_state,
+            batchable=None
+        )
+        if self.network_trace:
+            _LOGGER.info("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
+        self._session._outgoing_disposition(disposition_frame)
+
+    def send_disposition(self, delivery_id, delivery_state=None):
+        if self._is_closed:
+            raise ValueError("Link already closed.")
+        self._outgoing_disposition(delivery_id, delivery_state)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/sasl.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/sasl.py
@@ -1,0 +1,152 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import struct
+from enum import Enum
+
+from ._transport import SSLTransport, WebSocketTransport, AMQPS_PORT
+from .types import AMQPTypes, TYPE, VALUE
+from .constants import FIELD, SASLCode, SASL_HEADER_FRAME, TransportType, WEBSOCKET_PORT
+from .performatives import (
+    SASLOutcome,
+    SASLResponse,
+    SASLChallenge,
+    SASLInit
+)
+
+
+_SASL_FRAME_TYPE = b'\x01'
+
+
+class SASLPlainCredential(object):
+    """PLAIN SASL authentication mechanism.
+    See https://tools.ietf.org/html/rfc4616 for details
+    """
+
+    mechanism = b'PLAIN'
+
+    def __init__(self, authcid, passwd, authzid=None):
+        self.authcid = authcid
+        self.passwd = passwd
+        self.authzid = authzid
+
+    def start(self):
+        if self.authzid:
+            login_response = self.authzid.encode('utf-8')
+        else:
+            login_response = b''
+        login_response += b'\0'
+        login_response += self.authcid.encode('utf-8')
+        login_response += b'\0'
+        login_response += self.passwd.encode('utf-8')
+        return login_response
+
+
+class SASLAnonymousCredential(object):
+    """ANONYMOUS SASL authentication mechanism.
+    See https://tools.ietf.org/html/rfc4505 for details
+    """
+
+    mechanism = b'ANONYMOUS'
+
+    def start(self):
+        return b''
+
+
+class SASLExternalCredential(object):
+    """EXTERNAL SASL mechanism.
+    Enables external authentication, i.e. not handled through this protocol.
+    Only passes 'EXTERNAL' as authentication mechanism, but no further
+    authentication data.
+    """
+
+    mechanism = b'EXTERNAL'
+
+    def start(self):
+        return b''
+
+class SASLTransportMixin():
+    def _negotiate(self):
+        self.write(SASL_HEADER_FRAME)
+        _, returned_header = self.receive_frame()
+        if returned_header[1] != SASL_HEADER_FRAME:
+            raise ValueError("Mismatching AMQP header protocol. Expected: {}, received: {}".format(
+                SASL_HEADER_FRAME, returned_header[1]))
+
+        _, supported_mechansisms = self.receive_frame(verify_frame_type=1)
+        if self.credential.mechanism not in supported_mechansisms[1][0]:  # sasl_server_mechanisms
+            raise ValueError("Unsupported SASL credential type: {}".format(self.credential.mechanism))
+        sasl_init = SASLInit(
+            mechanism=self.credential.mechanism,
+            initial_response=self.credential.start(),
+            hostname=self.host)
+        self.send_frame(0, sasl_init, frame_type=_SASL_FRAME_TYPE)
+
+        _, next_frame = self.receive_frame(verify_frame_type=1)
+        frame_type, fields = next_frame
+        if frame_type != 0x00000044:  # SASLOutcome
+            raise NotImplementedError("Unsupported SASL challenge")
+        if fields[0] == SASLCode.Ok:  # code
+            return
+        else:
+            raise ValueError("SASL negotiation failed.\nOutcome: {}\nDetails: {}".format(*fields))
+
+class SASLTransportMixin():
+    def _negotiate(self):
+        self.write(SASL_HEADER_FRAME)
+        _, returned_header = self.receive_frame()
+        if returned_header[1] != SASL_HEADER_FRAME:
+            raise ValueError("Mismatching AMQP header protocol. Expected: {}, received: {}".format(
+                SASL_HEADER_FRAME, returned_header[1]))
+
+        _, supported_mechansisms = self.receive_frame(verify_frame_type=1)
+        if self.credential.mechanism not in supported_mechansisms[1][0]:  # sasl_server_mechanisms
+            raise ValueError("Unsupported SASL credential type: {}".format(self.credential.mechanism))
+        sasl_init = SASLInit(
+            mechanism=self.credential.mechanism,
+            initial_response=self.credential.start(),
+            hostname=self.host)
+        self.send_frame(0, sasl_init, frame_type=_SASL_FRAME_TYPE)
+
+        _, next_frame = self.receive_frame(verify_frame_type=1)
+        frame_type, fields = next_frame
+        if frame_type != 0x00000044:  # SASLOutcome
+            raise NotImplementedError("Unsupported SASL challenge")
+        if fields[0] == SASLCode.Ok:  # code
+            return
+        else:
+            raise ValueError("SASL negotiation failed.\nOutcome: {}\nDetails: {}".format(*fields))
+
+
+class SASLTransport(SSLTransport, SASLTransportMixin):
+
+    def __init__(self, host, credential, port=AMQPS_PORT, connect_timeout=None, ssl=None, **kwargs):
+        self.credential = credential
+        ssl = ssl or True
+        super(SASLTransport, self).__init__(host, port=port, connect_timeout=connect_timeout, ssl=ssl, **kwargs)
+
+    def negotiate(self):
+        with self.block():
+            self._negotiate()
+
+class SASLWithWebSocket(WebSocketTransport, SASLTransportMixin):
+
+    def __init__(self, host, credential, port=WEBSOCKET_PORT, connect_timeout=None, ssl=None, **kwargs):
+        self.credential = credential
+        ssl = ssl or True
+        http_proxy = kwargs.pop('http_proxy', None)
+        self._transport = WebSocketTransport(
+            host,
+            port=port,
+            connect_timeout=connect_timeout,
+            ssl=ssl,
+            http_proxy=http_proxy,
+            **kwargs
+        )
+        super().__init__(host, port, connect_timeout, ssl, **kwargs)
+
+    def negotiate(self):
+        self._negotiate()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/sender.py
@@ -1,0 +1,185 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+import struct
+import uuid
+import logging
+import time
+
+from ._encode import encode_payload
+from .endpoints import Source
+from .link import Link
+from .constants import (
+    SessionState,
+    SessionTransferState,
+    LinkDeliverySettleReason,
+    LinkState,
+    Role,
+    SenderSettleMode
+)
+from .performatives import (
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame,
+    FlowFrame,
+)
+from .error import AMQPLinkError, ErrorCondition
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PendingDelivery(object):
+
+    def __init__(self, **kwargs):
+        self.message = kwargs.get('message')
+        self.sent = False
+        self.frame = None
+        self.on_delivery_settled = kwargs.get('on_delivery_settled')
+        self.link = kwargs.get('link')
+        self.start = time.time()
+        self.transfer_state = None
+        self.timeout = kwargs.get('timeout')
+        self.settled = kwargs.get('settled', False)
+    
+    def on_settled(self, reason, state):
+        if self.on_delivery_settled and not self.settled:
+            try:
+                self.on_delivery_settled(reason, state)
+            except Exception as e:
+                # TODO: this swallows every error in on_delivery_settled, which mean we
+                #  1. only handle errors we care about in the callback
+                #  2. ignore errors we don't care
+                #  We should revisit this:
+                #  -- "Errors should never pass silently." unless "Unless explicitly silenced."
+                _LOGGER.warning("Message 'on_send_complete' callback failed: %r", e)
+
+
+class SenderLink(Link):
+
+    def __init__(self, session, handle, target_address, **kwargs):
+        name = kwargs.pop('name', None) or str(uuid.uuid4())
+        role = Role.Sender
+        if 'source_address' not in kwargs:
+            kwargs['source_address'] = "sender-link-{}".format(name)
+        super(SenderLink, self).__init__(session, handle, name, role, target_address=target_address, **kwargs)
+        self._unsent_messages = []
+
+    def _incoming_attach(self, frame):
+        super(SenderLink, self)._incoming_attach(frame)
+        self.current_link_credit = self.link_credit
+        self._outgoing_flow()
+        self._update_pending_delivery_status()
+
+    def _incoming_flow(self, frame):
+        rcv_link_credit = frame[6]  # link_credit
+        rcv_delivery_count = frame[5]  # delivery_count
+        if frame[4] is not None:  # handle
+            if rcv_link_credit is None or rcv_delivery_count is None:
+                _LOGGER.info("Unable to get link-credit or delivery-count from incoming ATTACH. Detaching link.")
+                self._remove_pending_deliveries()
+                self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+            else:
+                self.current_link_credit = rcv_delivery_count + rcv_link_credit - self.delivery_count
+        if self.current_link_credit > 0:
+            self._send_unsent_messages()
+
+    def _outgoing_transfer(self, delivery):
+        output = bytearray()
+        encode_payload(output, delivery.message)
+        delivery_count = self.delivery_count + 1
+        delivery.frame = {
+            'handle': self.handle,
+            'delivery_tag': struct.pack('>I', abs(delivery_count)),
+            'message_format': delivery.message._code,
+            'settled': delivery.settled,
+            'more': False,
+            'rcv_settle_mode': None,
+            'state': None,
+            'resume': None,
+            'aborted': None,
+            'batchable': None,
+            'payload': output
+        }
+        if self.network_trace:
+            # TODO: whether we should move frame tracing into centralized place e.g. connection.py
+            _LOGGER.info("-> %r", TransferFrame(delivery_id='<pending>', **delivery.frame), extra=self.network_trace_params)
+        self._session._outgoing_transfer(delivery)
+        if delivery.transfer_state == SessionTransferState.OKAY:
+            self.delivery_count = delivery_count
+            self.current_link_credit -= 1
+            delivery.sent = True
+            if delivery.settled:
+                delivery.on_settled(LinkDeliverySettleReason.SETTLED, None)
+            else:
+                self._pending_deliveries[delivery.frame['delivery_id']] = delivery
+        elif delivery.transfer_state == SessionTransferState.ERROR:
+            raise ValueError("Message failed to send")
+        if self.current_link_credit <= 0:
+            self.current_link_credit = self.link_credit
+            self._outgoing_flow()
+
+    def _incoming_disposition(self, frame):
+        if not frame[3]:  # settled
+            return
+        range_end = (frame[2] or frame[1]) + 1  # first or last
+        settled_ids = [i for i in range(frame[1], range_end)]
+        for settled_id in settled_ids:
+            delivery = self._pending_deliveries.pop(settled_id, None)
+            if delivery:
+                delivery.on_settled(LinkDeliverySettleReason.DISPOSITION_RECEIVED, frame[4])  # state
+
+    def _update_pending_delivery_status(self):  # TODO
+        now = time.time()
+        expired = []
+        for delivery in self._pending_deliveries.values():
+            if delivery.timeout and (now - delivery.start) >= delivery.timeout:
+                expired.append(delivery.frame['delivery_id'])
+                delivery.on_settled(LinkDeliverySettleReason.TIMEOUT, None)
+        self._pending_deliveries = {i: d for i, d in self._pending_deliveries.items() if i not in expired}
+
+    def _send_unsent_messages(self):
+        unsent = []
+        for delivery in self._unsent_messages:
+            if not delivery.sent:
+                self._outgoing_transfer(delivery)
+                if not delivery.sent:
+                    unsent.append(delivery)
+        self._unsent_messages = unsent
+
+    def send_transfer(self, message, **kwargs):
+        self._check_if_closed()
+        if self.state != LinkState.ATTACHED:
+            raise AMQPLinkError(  # TODO: should we introduce MessageHandler to indicate the handler is in wrong state
+                condition=ErrorCondition.ClientError,  # TODO: should this be a ClientError?
+                description="Link is not attached."
+            )
+        settled = self.send_settle_mode == SenderSettleMode.Settled
+        if self.send_settle_mode == SenderSettleMode.Mixed:
+            settled = kwargs.pop('settled', True)
+        delivery = PendingDelivery(
+            on_delivery_settled=kwargs.get('on_send_complete'),
+            timeout=kwargs.get('timeout'),
+            link=self,
+            message=message,
+            settled=settled,
+        )
+        if self.current_link_credit == 0:
+            self._unsent_messages.append(delivery)
+        else:
+            self._outgoing_transfer(delivery)
+            if not delivery.sent:
+                self._unsent_messages.append(delivery)
+        return delivery
+
+    def cancel_transfer(self, delivery):
+        try:
+            delivery = self._pending_deliveries.pop(delivery.frame['delivery_id'])
+            delivery.on_settled(LinkDeliverySettleReason.CANCELLED, None)
+            return
+        except KeyError:
+            pass
+        # todo remove from unset messages
+        raise ValueError("No pending delivery with ID '{}' found.".format(delivery.frame['delivery_id']))

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
@@ -1,0 +1,379 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import uuid
+import logging
+from enum import Enum
+import time
+
+from .constants import (
+    INCOMING_WINDOW,
+    OUTGOING_WIDNOW,
+    ConnectionState,
+    SessionState,
+    SessionTransferState,
+    Role
+)
+from .endpoints import Source, Target
+from .sender import SenderLink
+from .receiver import ReceiverLink
+from .management_link import ManagementLink
+from .performatives import (
+    BeginFrame,
+    EndFrame,
+    FlowFrame,
+    AttachFrame,
+    DetachFrame,
+    TransferFrame,
+    DispositionFrame
+)
+from ._encode import encode_frame
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Session(object):
+    """
+    :param int remote_channel: The remote channel for this Session.
+    :param int next_outgoing_id: The transfer-id of the first transfer id the sender will send.
+    :param int incoming_window: The initial incoming-window of the sender.
+    :param int outgoing_window: The initial outgoing-window of the sender.
+    :param int handle_max: The maximum handle value that may be used on the Session.
+    :param list(str) offered_capabilities: The extension capabilities the sender supports.
+    :param list(str) desired_capabilities: The extension capabilities the sender may use if the receiver supports
+    :param dict properties: Session properties.
+    """
+
+    def __init__(self, connection, channel, **kwargs):
+        self.name = kwargs.pop('name', None) or str(uuid.uuid4())
+        self.state = SessionState.UNMAPPED
+        self.handle_max = kwargs.get('handle_max', 4294967295)
+        self.properties = kwargs.pop('properties', None)
+        self.channel = channel
+        self.remote_channel = None
+        self.next_outgoing_id = kwargs.pop('next_outgoing_id', 0)
+        self.next_incoming_id = None
+        self.incoming_window = kwargs.pop('incoming_window', 1)
+        self.outgoing_window = kwargs.pop('outgoing_window', 1)
+        self.target_incoming_window = self.incoming_window
+        self.remote_incoming_window = 0
+        self.remote_outgoing_window = 0
+        self.offered_capabilities = None
+        self.desired_capabilities = kwargs.pop('desired_capabilities', None)
+
+        self.allow_pipelined_open = kwargs.pop('allow_pipelined_open', True)
+        self.idle_wait_time = kwargs.get('idle_wait_time', 0.1)
+        self.network_trace = kwargs['network_trace']
+        self.network_trace_params = kwargs['network_trace_params']
+        self.network_trace_params['session'] = self.name
+
+        self.links = {}
+        self._connection = connection
+        self._output_handles = {}
+        self._input_handles = {}
+
+    def __enter__(self):
+        self.begin()
+        return self
+
+    def __exit__(self, *args):
+        self.end()
+
+    @classmethod
+    def from_incoming_frame(cls, connection, channel, frame):
+        # check session_create_from_endpoint in C lib
+        new_session = cls(connection, channel)
+        return new_session
+
+    def _set_state(self, new_state):
+        # type: (SessionState) -> None
+        """Update the session state."""
+        if new_state is None:
+            return
+        previous_state = self.state
+        self.state = new_state
+        _LOGGER.info("Session state changed: %r -> %r", previous_state, new_state, extra=self.network_trace_params)
+        for link in self.links.values():
+            link._on_session_state_change()
+
+    def _on_connection_state_change(self):
+        if self._connection.state in [ConnectionState.CLOSE_RCVD, ConnectionState.END]:
+            if self.state not in [SessionState.DISCARDING, SessionState.UNMAPPED]:
+                self._set_state(SessionState.DISCARDING)
+
+    def _get_next_output_handle(self):
+        # type: () -> int
+        """Get the next available outgoing handle number within the max handle limit.
+
+        :raises ValueError: If maximum handle has been reached.
+        :returns: The next available outgoing handle number.
+        :rtype: int
+        """
+        if len(self._output_handles) >= self.handle_max:
+            raise ValueError("Maximum number of handles ({}) has been reached.".format(self.handle_max))
+        next_handle = next(i for i in range(1, self.handle_max) if i not in self._output_handles)
+        return next_handle
+    
+    def _outgoing_begin(self):
+        begin_frame = BeginFrame(
+            remote_channel=self.remote_channel if self.state == SessionState.BEGIN_RCVD else None,
+            next_outgoing_id=self.next_outgoing_id,
+            outgoing_window=self.outgoing_window,
+            incoming_window=self.incoming_window,
+            handle_max=self.handle_max,
+            offered_capabilities=self.offered_capabilities if self.state == SessionState.BEGIN_RCVD else None,
+            desired_capabilities=self.desired_capabilities if self.state == SessionState.UNMAPPED else None,
+            properties=self.properties,
+        )
+        if self.network_trace:
+            _LOGGER.info("-> %r", begin_frame, extra=self.network_trace_params)
+        self._connection._process_outgoing_frame(self.channel, begin_frame)
+
+    def _incoming_begin(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", BeginFrame(*frame), extra=self.network_trace_params)
+        self.handle_max = frame[4]  # handle_max
+        self.next_incoming_id = frame[1]  # next_outgoing_id
+        self.remote_incoming_window = frame[2]  # incoming_window
+        self.remote_outgoing_window = frame[3]  # outgoing_window
+        if self.state == SessionState.BEGIN_SENT:
+            self.remote_channel = frame[0]  # remote_channel
+            self._set_state(SessionState.MAPPED)
+        elif self.state == SessionState.UNMAPPED:
+            self._set_state(SessionState.BEGIN_RCVD)
+            self._outgoing_begin()
+            self._set_state(SessionState.MAPPED)
+
+    def _outgoing_end(self, error=None):
+        end_frame = EndFrame(error=error)
+        if self.network_trace:
+            _LOGGER.info("-> %r", end_frame, extra=self.network_trace_params)
+        self._connection._process_outgoing_frame(self.channel, end_frame)
+
+    def _incoming_end(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", EndFrame(*frame), extra=self.network_trace_params)
+        if self.state not in [SessionState.END_RCVD, SessionState.END_SENT, SessionState.DISCARDING]:
+            self._set_state(SessionState.END_RCVD)
+            # TODO: Clean up all links
+            # TODO: handling error
+            self._outgoing_end()
+        self._set_state(SessionState.UNMAPPED)
+
+    def _outgoing_attach(self, frame):
+        self._connection._process_outgoing_frame(self.channel, frame)
+
+    def _incoming_attach(self, frame):
+        try:
+            self._input_handles[frame[1]] = self.links[frame[0].decode('utf-8')]  # name and handle
+            self._input_handles[frame[1]]._incoming_attach(frame)
+        except KeyError:
+            outgoing_handle = self._get_next_output_handle()  # TODO: catch max-handles error
+            if frame[2] == Role.Sender:  # role
+                new_link = ReceiverLink.from_incoming_frame(self, outgoing_handle, frame)
+            else:
+                new_link = SenderLink.from_incoming_frame(self, outgoing_handle, frame)
+            new_link._incoming_attach(frame)
+            self.links[frame[0]] = new_link
+            self._output_handles[outgoing_handle] = new_link
+            self._input_handles[frame[1]] = new_link
+        except ValueError:
+            pass  # TODO: Reject link
+    
+    def _outgoing_flow(self, frame=None):
+        link_flow = frame or {}
+        link_flow.update({
+            'next_incoming_id': self.next_incoming_id,
+            'incoming_window': self.incoming_window,
+            'next_outgoing_id': self.next_outgoing_id,
+            'outgoing_window': self.outgoing_window
+        })
+        flow_frame = FlowFrame(**link_flow)
+        if self.network_trace:
+            _LOGGER.info("-> %r", flow_frame, extra=self.network_trace_params)
+        self._connection._process_outgoing_frame(self.channel, flow_frame)
+
+    def _incoming_flow(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", FlowFrame(*frame), extra=self.network_trace_params)
+        self.next_incoming_id = frame[2]  # next_outgoing_id
+        remote_incoming_id = frame[0] or self.next_outgoing_id  #  next_incoming_id  TODO "initial-outgoing-id"
+        self.remote_incoming_window = remote_incoming_id + frame[1] - self.next_outgoing_id  # incoming_window
+        self.remote_outgoing_window = frame[3]  # outgoing_window
+        if frame[4] is not None:  # handle
+            self._input_handles[frame[4]]._incoming_flow(frame)
+        else:
+            for link in self._output_handles.values():
+                if self.remote_incoming_window > 0 and not link._is_closed:
+                    link._incoming_flow(frame)
+
+    def _outgoing_transfer(self, delivery):
+        if self.state != SessionState.MAPPED:
+            delivery.transfer_state = SessionTransferState.ERROR
+        if self.remote_incoming_window <= 0:
+            delivery.transfer_state = SessionTransferState.BUSY
+        else:
+            payload = delivery.frame['payload']
+            payload_size = len(payload)
+
+            delivery.frame['delivery_id'] = self.next_outgoing_id
+            # calculate the transfer frame encoding size excluding the payload
+            delivery.frame['payload'] = b""
+            # TODO: encoding a frame would be expensive, we might want to improve depending on the perf test results
+            encoded_frame = encode_frame(TransferFrame(**delivery.frame))[1]
+            transfer_overhead_size = len(encoded_frame)
+
+            # available size for payload per frame is calculated as following:
+            # remote max frame size - transfer overhead (calculated) - header (8 bytes)
+            available_frame_size = self._connection._remote_max_frame_size - transfer_overhead_size - 8
+
+            start_idx = 0
+            remaining_payload_cnt = payload_size
+            # encode n-1 frames if payload_size > available_frame_size
+            while remaining_payload_cnt > available_frame_size:
+                tmp_delivery_frame = {
+                    'handle': delivery.frame['handle'],
+                    'delivery_tag': delivery.frame['delivery_tag'],
+                    'message_format': delivery.frame['message_format'],
+                    'settled': delivery.frame['settled'],
+                    'more': True,
+                    'rcv_settle_mode': delivery.frame['rcv_settle_mode'],
+                    'state': delivery.frame['state'],
+                    'resume': delivery.frame['resume'],
+                    'aborted': delivery.frame['aborted'],
+                    'batchable': delivery.frame['batchable'],
+                    'payload': payload[start_idx:start_idx+available_frame_size],
+                    'delivery_id': self.next_outgoing_id
+                }
+                self._connection._process_outgoing_frame(self.channel, TransferFrame(**tmp_delivery_frame))
+                start_idx += available_frame_size
+                remaining_payload_cnt -= available_frame_size
+
+            # encode the last frame
+            tmp_delivery_frame = {
+                'handle': delivery.frame['handle'],
+                'delivery_tag': delivery.frame['delivery_tag'],
+                'message_format': delivery.frame['message_format'],
+                'settled': delivery.frame['settled'],
+                'more': False,
+                'rcv_settle_mode': delivery.frame['rcv_settle_mode'],
+                'state': delivery.frame['state'],
+                'resume': delivery.frame['resume'],
+                'aborted': delivery.frame['aborted'],
+                'batchable': delivery.frame['batchable'],
+                'payload': payload[start_idx:],
+                'delivery_id': self.next_outgoing_id
+            }
+            self._connection._process_outgoing_frame(self.channel, TransferFrame(**tmp_delivery_frame))
+            self.next_outgoing_id += 1
+            self.remote_incoming_window -= 1
+            self.outgoing_window -= 1
+            delivery.transfer_state = SessionTransferState.OKAY
+
+    def _incoming_transfer(self, frame):
+        self.next_incoming_id += 1
+        self.remote_outgoing_window -= 1
+        self.incoming_window -= 1
+        try:
+            self._input_handles[frame[0]]._incoming_transfer(frame)  # handle
+        except KeyError:
+            pass  #TODO: "unattached handle"
+        if self.incoming_window == 0:
+            self.incoming_window = self.target_incoming_window
+            self._outgoing_flow()
+
+    def _outgoing_disposition(self, frame):
+        self._connection._process_outgoing_frame(self.channel, frame)
+
+    def _incoming_disposition(self, frame):
+        if self.network_trace:
+            _LOGGER.info("<- %r", DispositionFrame(*frame), extra=self.network_trace_params)
+        for link in self._input_handles.values():
+            link._incoming_disposition(frame)
+
+    def _outgoing_detach(self, frame):
+        self._connection._process_outgoing_frame(self.channel, frame)
+
+    def _incoming_detach(self, frame):
+        try:
+            link = self._input_handles[frame[0]]  # handle
+            link._incoming_detach(frame)
+            # if link._is_closed:  TODO
+            #     self.links.pop(link.name, None)
+            #     self._input_handles.pop(link.remote_handle, None)
+            #     self._output_handles.pop(link.handle, None)
+        except KeyError:
+            pass  # TODO: close session with unattached-handle
+
+    def _wait_for_response(self, wait, end_state):
+        # type: (Union[bool, float], SessionState) -> None
+        if wait == True:
+            self._connection.listen(wait=False)
+            while self.state != end_state:
+                time.sleep(self.idle_wait_time)
+                self._connection.listen(wait=False)
+        elif wait:
+            self._connection.listen(wait=False)
+            timeout = time.time() + wait
+            while self.state != end_state:
+                if time.time() >= timeout:
+                    break
+                time.sleep(self.idle_wait_time)
+                self._connection.listen(wait=False)
+
+    def begin(self, wait=False):
+        self._outgoing_begin()
+        self._set_state(SessionState.BEGIN_SENT)
+        if wait:
+            self._wait_for_response(wait, SessionState.BEGIN_SENT)
+        elif not self.allow_pipelined_open:
+            raise ValueError("Connection has been configured to not allow piplined-open. Please set 'wait' parameter.")
+
+    def end(self, error=None, wait=False):
+        # type: (Optional[AMQPError]) -> None
+        try:
+            if self.state not in [SessionState.UNMAPPED, SessionState.DISCARDING]:
+                self._outgoing_end(error=error)
+            # TODO: destroy all links
+            new_state = SessionState.DISCARDING if error else SessionState.END_SENT
+            self._set_state(new_state)
+            self._wait_for_response(wait, SessionState.UNMAPPED)
+        except Exception as exc:
+            _LOGGER.info("An error occurred when ending the session: %r", exc)
+            self._set_state(SessionState.UNMAPPED)
+
+    def create_receiver_link(self, source_address, **kwargs):
+        assigned_handle = self._get_next_output_handle()
+        link = ReceiverLink(
+            self,
+            handle=assigned_handle,
+            source_address=source_address,
+            network_trace=kwargs.pop('network_trace', self.network_trace),
+            network_trace_params=dict(self.network_trace_params),
+            **kwargs)
+        self.links[link.name] = link
+        self._output_handles[assigned_handle] = link
+        return link
+
+    def create_sender_link(self, target_address, **kwargs):
+        assigned_handle = self._get_next_output_handle()
+        link = SenderLink(
+            self,
+            handle=assigned_handle,
+            target_address=target_address,
+            network_trace=kwargs.pop('network_trace', self.network_trace),
+            network_trace_params=dict(self.network_trace_params),
+            **kwargs)
+        self._output_handles[assigned_handle] = link
+        self.links[link.name] = link
+        return link
+    
+    def create_request_response_link_pair(self, endpoint, **kwargs):
+        return ManagementLink(
+            self,
+            endpoint,
+            network_trace=kwargs.pop('network_trace', self.network_trace),
+            **kwargs)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/types.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/types.py
@@ -1,0 +1,90 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+from enum import Enum
+
+
+TYPE = 'TYPE'
+VALUE = 'VALUE'
+
+
+class AMQPTypes(object):  # pylint: disable=no-init
+    null = 'NULL'
+    boolean = 'BOOL'
+    ubyte = 'UBYTE'
+    byte = 'BYTE'
+    ushort = 'USHORT'
+    short = 'SHORT'
+    uint = 'UINT'
+    int = 'INT'
+    ulong = 'ULONG'
+    long = 'LONG'
+    float = 'FLOAT'
+    double = 'DOUBLE'
+    timestamp = 'TIMESTAMP'
+    uuid = 'UUID'
+    binary = 'BINARY'
+    string = 'STRING'
+    symbol = 'SYMBOL'
+    list = 'LIST'
+    map = 'MAP'
+    array = 'ARRAY'
+    described = 'DESCRIBED'
+
+
+class FieldDefinition(Enum):
+    fields = "fields"
+    annotations = "annotations"
+    message_id = "message-id"
+    app_properties = "application-properties"
+    node_properties = "node-properties"
+    filter_set = "filter-set"
+
+
+class ObjDefinition(Enum):
+    source = "source"
+    target = "target"
+    delivery_state = "delivery-state"
+    error = "error"
+
+
+class ConstructorBytes(object):  # pylint: disable=no-init
+    null = b'\x40'
+    bool = b'\x56'
+    bool_true = b'\x41'
+    bool_false = b'\x42'
+    ubyte = b'\x50'
+    byte = b'\x51'
+    ushort = b'\x60'
+    short = b'\x61'
+    uint_0 = b'\x43'
+    uint_small = b'\x52'
+    int_small = b'\x54'
+    uint_large = b'\x70'
+    int_large = b'\x71'
+    ulong_0 = b'\x44'
+    ulong_small = b'\x53'
+    long_small = b'\x55'
+    ulong_large = b'\x80'
+    long_large = b'\x81'
+    float = b'\x72'
+    double = b'\x82'
+    timestamp = b'\x83'
+    uuid = b'\x98'
+    binary_small = b'\xA0'
+    binary_large = b'\xB0'
+    string_small = b'\xA1'
+    string_large = b'\xB1'
+    symbol_small = b'\xA3'
+    symbol_large = b'\xB3'
+    list_0 = b'\x45'
+    list_small = b'\xC0'
+    list_large = b'\xD0'
+    map_small = b'\xC1'
+    map_large = b'\xD1'
+    array_small = b'\xE0'
+    array_large = b'\xF0'
+    descriptor = b'\x00'

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/utils.py
@@ -1,0 +1,134 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import six
+import datetime
+from base64 import b64encode
+from hashlib import sha256
+from hmac import HMAC
+from urllib.parse import urlencode, quote_plus
+import time
+
+from .types import TYPE, VALUE, AMQPTypes
+from ._encode import encode_payload
+
+
+class UTC(datetime.tzinfo):
+    """Time Zone info for handling UTC"""
+
+    def utcoffset(self, dt):
+        """UTF offset for UTC is 0."""
+        return datetime.timedelta(0)
+
+    def tzname(self, dt):
+        """Timestamp representation."""
+        return "Z"
+
+    def dst(self, dt):
+        """No daylight saving for UTC."""
+        return datetime.timedelta(hours=1)
+
+
+try:
+    from datetime import timezone  # pylint: disable=ungrouped-imports
+
+    TZ_UTC = timezone.utc  # type: ignore
+except ImportError:
+    TZ_UTC = UTC()  # type: ignore
+
+
+def utc_from_timestamp(timestamp):
+    return datetime.datetime.fromtimestamp(timestamp, tz=TZ_UTC)
+
+
+def utc_now():
+    return datetime.datetime.now(tz=TZ_UTC)
+
+
+def encode(value, encoding='UTF-8'):
+    return value.encode(encoding) if isinstance(value, six.text_type) else value
+
+
+def generate_sas_token(audience, policy, key, expiry=None):
+    """
+    Generate a sas token according to the given audience, policy, key and expiry
+
+    :param str audience:
+    :param str policy:
+    :param str key:
+    :param int expiry: abs expiry time
+    :rtype: str
+    """
+    if not expiry:
+        expiry = int(time.time()) + 3600  # Default to 1 hour.
+
+    encoded_uri = quote_plus(audience)
+    encoded_policy = quote_plus(policy).encode("utf-8")
+    encoded_key = key.encode("utf-8")
+
+    ttl = int(expiry)
+    sign_key = '%s\n%d' % (encoded_uri, ttl)
+    signature = b64encode(HMAC(encoded_key, sign_key.encode('utf-8'), sha256).digest())
+    result = {
+        'sr': audience,
+        'sig': signature,
+        'se': str(ttl)
+    }
+    if policy:
+        result['skn'] = encoded_policy
+    return 'SharedAccessSignature ' + urlencode(result)
+
+
+def add_batch(batch, message):
+    # Add a message to a batch
+    output = bytearray()
+    encode_payload(output, message)
+    batch.data.append(output)
+
+
+def encode_str(data, encoding='utf-8'):
+    try:
+        return data.encode(encoding)
+    except AttributeError:
+        return data
+
+
+def normalized_data_body(data, **kwargs):
+    # A helper method to normalize input into AMQP Data Body format
+    encoding = kwargs.get("encoding", "utf-8")
+    if isinstance(data, list):
+        return [encode_str(item, encoding) for item in data]
+    else:
+        return [encode_str(data, encoding)]
+
+
+def normalized_sequence_body(sequence):
+    # A helper method to normalize input into AMQP Sequence Body format
+    if isinstance(sequence, list) and all([isinstance(b, list) for b in sequence]):
+        return sequence
+    elif isinstance(sequence, list):
+        return [sequence]
+
+
+def get_message_encoded_size(message):
+    output = bytearray()
+    encode_payload(output, message)
+    return len(output)
+
+
+def amqp_long_value(value):
+    # A helper method to wrap a Python int as AMQP long
+    # TODO: wrapping one line in a function is expensive, find if there's a better way to do it
+    return {TYPE: AMQPTypes.long, VALUE: value}
+
+
+def amqp_uint_value(value):
+    # A helper method to wrap a Python int as AMQP uint
+    return {TYPE: AMQPTypes.uint, VALUE: value}
+
+
+def amqp_string_value(value):
+    return {TYPE: AMQPTypes.string, VALUE: value}

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -7,7 +7,7 @@ import logging
 from weakref import WeakSet
 from typing_extensions import Literal
 
-import uamqp
+from ._pyamqp._connection import Connection
 
 from ._base_handler import (
     _parse_conn_str,
@@ -145,7 +145,7 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
 
     def _create_uamqp_connection(self):
         auth = create_authentication(self)
-        self._connection = uamqp.Connection(
+        self._connection = Connection(
             hostname=self.fully_qualified_namespace,
             sasl=auth,
             debug=self._config.logging_enable,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -430,6 +430,7 @@ class ServiceBusReceiver(
                 if timeout_ms
                 else 0
             )
+            # print("abs timeoit", abs_timeout_ms)
             batch = []  # type: List[Message]
             while not received_messages_queue.empty() and len(batch) < max_message_count:
                 batch.append(received_messages_queue.get())
@@ -447,6 +448,7 @@ class ServiceBusReceiver(
             receiving = True
             while receiving and not expired and len(batch) < max_message_count:
                 while receiving and received_messages_queue.qsize() < max_message_count:
+                    # print(f"Counter current ms: {amqp_receive_client._counter.get_current_ms()}")
                     if (
                         abs_timeout_ms
                         and amqp_receive_client._counter.get_current_ms() > abs_timeout_ms
@@ -456,6 +458,7 @@ class ServiceBusReceiver(
                     before = received_messages_queue.qsize()
                     receiving = amqp_receive_client.do_work()
                     received = received_messages_queue.qsize() - before
+                    # print(f"Received {received}")
                     if (
                         not first_message_received
                         and received_messages_queue.qsize() > 0
@@ -472,6 +475,7 @@ class ServiceBusReceiver(
                 ):
                     batch.append(received_messages_queue.get())
                     received_messages_queue.task_done()
+                    # print(f"my current timeout {abs_timeout_ms}")
 
             return [self._build_message(message) for message in batch]
         finally:
@@ -698,6 +702,8 @@ class ServiceBusReceiver(
             operation_requires_timeout=True,
         )
         links = get_receive_links(messages)
+        # print(f"My links {links}")
+        # print(f"My messages {len(messages)}")
         with receive_trace_context_manager(self, links=links):
             if (
                 self._auto_lock_renewer

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
@@ -6,12 +6,16 @@ import logging
 import time
 import uuid
 import datetime
+import functools
 import warnings
 from typing import Any, TYPE_CHECKING, Union, List, Optional, Mapping, cast
 
-import uamqp
-from uamqp import SendClient, types
-from uamqp.authentication.common import AMQPAuth
+from ._pyamqp import (
+    SendClient,
+    types,
+)
+from ._pyamqp.constants import MAX_FRAME_SIZE_BYTES
+from ._pyamqp.authentication import JWTTokenAuth
 
 from ._base_handler import BaseHandler
 from ._common import mgmt_handlers
@@ -40,6 +44,7 @@ from ._common.constants import (
     MGMT_REQUEST_MESSAGE_ID,
     MGMT_REQUEST_PARTITION_KEY,
     SPAN_NAME_SCHEDULE,
+    JWT_TOKEN_SCOPE
 )
 
 if TYPE_CHECKING:
@@ -60,6 +65,7 @@ if TYPE_CHECKING:
         ServiceBusMessageBatch,
         List[Union[ServiceBusMessage, AmqpAnnotatedMessage]],
     ]
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -230,35 +236,65 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         return cls(**constructor_args)
 
     def _create_handler(self, auth):
-        # type: (AMQPAuth) -> None
+        # type: (JWTTokenAuth) -> None
+        transport_type = self._config.transport_type
         self._handler = SendClient(
+            self.fully_qualified_namespace,
             self._entity_uri,
             auth=auth,
             debug=self._config.logging_enable,
             properties=self._properties,
-            error_policy=self._error_policy,
+            # error_policy=self._error_policy,
             client_name=self._name,
-            keep_alive_interval=self._config.keep_alive,
+            # keep_alive_interval=self._config.keep_alive,
             encoding=self._config.encoding,
+            transport_type=transport_type,
+            http_proxy=self._config.http_proxy
+        )
+
+    def _create_auth(self):
+        # type: () -> JWTTokenAuth
+        """
+        Create an ~uamqp.authentication.SASTokenAuth instance to authenticate
+        the session.
+        """
+        try:
+            # ignore mypy's warning because token_type is Optional
+            token_type = self._credential.token_type  # type: ignore
+        except AttributeError:
+            token_type = b"jwt"
+        if token_type == b"servicebus.windows.net:sastoken":
+            return JWTTokenAuth(
+                self._auth_uri,
+                self._auth_uri,
+                functools.partial(self._credential.get_token, self._auth_uri)
+            )
+        return JWTTokenAuth(
+            self._auth_uri,
+            self._auth_uri,
+            functools.partial(self._credential.get_token, JWT_TOKEN_SCOPE),
+            token_type=token_type,
+            timeout=self._config.auth_timeout,
+            custom_endpoint_hostname=self._config.custom_endpoint_hostname,
+            port=self._config.connection_port,
+            verify=self._config.connection_verify,
         )
 
     def _open(self):
         # pylint: disable=protected-access
-        if self._running:
-            return
-        if self._handler:
-            self._handler.close()
-
-        auth = None if self._connection else create_authentication(self)
+        if not self._running:
+            if self._handler:
+                self._handler.close()
+        auth = self._create_auth()
         self._create_handler(auth)
         try:
-            self._handler.open(connection=self._connection)
+            self._handler.open()
             while not self._handler.client_ready():
                 time.sleep(0.05)
             self._running = True
             self._max_message_size_on_link = (
-                self._handler.message_handler._link.peer_max_message_size
-                or uamqp.constants.MAX_MESSAGE_LENGTH_BYTES
+                # self._handler.message_handler._link.peer_max_message_size
+                MAX_FRAME_SIZE_BYTES
             )
         except:
             self._close_handler()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_amqp_message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_amqp_message.py
@@ -232,7 +232,8 @@ class AmqpAnnotatedMessage(object):
         ) if message.properties else None
         self._header = AmqpMessageHeader(
             delivery_count=message.header.delivery_count,
-            time_to_live=message.header.time_to_live,
+            # time_to_live=message.header.time_to_live,
+            time_to_live=message.header.ttl,
             first_acquirer=message.header.first_acquirer,
             durable=message.header.durable,
             priority=message.header.priority


### PR DESCRIPTION
Main thing on this branch:

- I ran send_queue.py (only the single_message() method, message batch I have not set up send_messages() for SB pyamqp yet)
- On running receive_queue.py, after the last outgoing_flow frame, we wait for Transfer frames back from the Service. These are never received. 

Tested Scenarios:

- send_queue.py running on pyamqp, confirm messages sent, then receive_queue.py on uamqp -> WORKS 
- send_queue.py running on uamqp,  confirm messages sent, then receive_queue.py on pyamqp -> DOESNT WORK
- send_queue.py running on pyamqp, confirm messages sent, then receive_queue.py on pyamqp -> DOESNT WORK
- send_queue.py running on uamqp, confirm messages sent, then receive_queue.py on uamqp -> WORKS

The issue seems to be solely on the receiving side of SB pyamqp. I am unsure where the messages are going because the Service shows that they are being sent out of the queue when requested, they are just not appearing on the Wireshark trace or being received by the socket.  

The interesting case here is:
If you run pyamqp receive_queue.py, and then simultaneously run send_queue.py on either pyamqp or uamqp you will receive the messages as expected.

Also, this branch is without message settlement right now, it is just trying to get the messages in order to settle them. 

Edit: We are receiving frames as expected, we just are running receive twice. Need to investigate why.