### PR TITLE
[Storage] Fix page blob tier on `upload_blob`

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
@@ -200,12 +200,14 @@ def upload_page_blob(
         if length % 512 != 0:
             raise ValueError("Invalid page blob size: {0}. "
                              "The size must be aligned to a 512-byte boundary.".format(length))
+        tier = None
         if kwargs.get('premium_page_blob_tier'):
             premium_page_blob_tier = kwargs.pop('premium_page_blob_tier')
             try:
-                headers['x-ms-access-tier'] = premium_page_blob_tier.value
+                tier = premium_page_blob_tier.value
             except AttributeError:
-                headers['x-ms-access-tier'] = premium_page_blob_tier
+                tier = premium_page_blob_tier
+
         if encryption_options and encryption_options.get('data'):
             headers['x-ms-meta-encryptiondata'] = encryption_options['data']
         blob_tags_string = kwargs.pop('blob_tags_string', None)
@@ -217,6 +219,7 @@ def upload_page_blob(
             blob_sequence_number=None,
             blob_http_headers=kwargs.pop('blob_headers', None),
             blob_tags_string=blob_tags_string,
+            tier=tier,
             cls=return_response_headers,
             headers=headers,
             **kwargs)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
@@ -174,12 +174,14 @@ async def upload_page_blob(
         if length % 512 != 0:
             raise ValueError("Invalid page blob size: {0}. "
                              "The size must be aligned to a 512-byte boundary.".format(length))
+        tier = None
         if kwargs.get('premium_page_blob_tier'):
             premium_page_blob_tier = kwargs.pop('premium_page_blob_tier')
             try:
-                headers['x-ms-access-tier'] = premium_page_blob_tier.value
+                tier = premium_page_blob_tier.value
             except AttributeError:
-                headers['x-ms-access-tier'] = premium_page_blob_tier
+                tier = premium_page_blob_tier
+
         if encryption_options and encryption_options.get('data'):
             headers['x-ms-meta-encryptiondata'] = encryption_options['data']
         blob_tags_string = kwargs.pop('blob_tags_string', None)
@@ -191,6 +193,7 @@ async def upload_page_blob(
             blob_sequence_number=None,
             blob_http_headers=kwargs.pop('blob_headers', None),
             blob_tags_string=blob_tags_string,
+            tier=tier,
             cls=return_response_headers,
             headers=headers,
             **kwargs)

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_page_blob.test_blob_tier_on_create.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_page_blob.test_blob_tier_on_create.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utcontainer3bb30fc9?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:08:18 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       etag:
-      - '"0x8D7597650D8C61B"'
+      - '"0x8DA48C6D8549630"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -41,7 +41,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -49,11 +49,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utcontainersource3bb30fc9?restype=container
   response:
@@ -63,15 +63,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:08:18 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       etag:
-      - '"0x8D7597650E15337"'
+      - '"0x8DA48C6D863D629"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -79,7 +79,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -87,11 +87,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9?restype=container
   response:
@@ -101,15 +101,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       etag:
-      - '"0x8D7597650FF4AC4"'
+      - '"0x8DA48C6D89B53F0"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -117,7 +117,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -125,7 +125,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - P4
       x-ms-blob-content-length:
@@ -133,9 +133,9 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9
   response:
@@ -145,17 +145,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       etag:
-      - '"0x8D7597651083A62"'
+      - '"0x8DA48C6D8A89E59"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -163,17 +163,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: HEAD
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9
   response:
@@ -187,11 +187,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       etag:
-      - '"0x8D7597651083A62"'
+      - '"0x8DA48C6D8A89E59"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
@@ -201,7 +201,7 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -209,7 +209,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -217,7 +217,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -225,7 +225,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - P6
       x-ms-blob-content-length:
@@ -233,9 +233,9 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:20 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9
   response:
@@ -245,17 +245,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       etag:
-      - '"0x8D759765117315A"'
+      - '"0x8DA48C6D8C23D13"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -263,7 +263,7 @@ interactions:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -273,17 +273,17 @@ interactions:
       Content-Type:
       - application/octet-stream
       If-Match:
-      - '"0x8D759765117315A"'
+      - '"0x8DA48C6D8C23D13"'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:20 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-page-write:
       - update
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9?comp=page
   response:
@@ -295,11 +295,11 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:49 GMT
       etag:
-      - '"0x8D75976511F9763"'
+      - '"0x8DA48C6D8D12F01"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-sequence-number:
@@ -307,7 +307,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -315,17 +315,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:20 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: HEAD
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9
   response:
@@ -339,11 +339,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       etag:
-      - '"0x8D75976511F9763"'
+      - '"0x8DA48C6D8D12F01"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
@@ -353,7 +353,7 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -361,7 +361,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -369,7 +369,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -377,7 +377,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - P10
       x-ms-blob-content-length:
@@ -385,9 +385,9 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:20 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9
   response:
@@ -397,17 +397,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       etag:
-      - '"0x8D75976512E6744"'
+      - '"0x8DA48C6D8EC542C"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -415,7 +415,7 @@ interactions:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -425,17 +425,17 @@ interactions:
       Content-Type:
       - application/octet-stream
       If-Match:
-      - '"0x8D75976512E6744"'
+      - '"0x8DA48C6D8EC542C"'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:20 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-page-write:
       - update
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9?comp=page
   response:
@@ -447,11 +447,11 @@ interactions:
       content-md5:
       - yaNM/IXZgmmMasifdgcavQ==
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       etag:
-      - '"0x8D7597651374293"'
+      - '"0x8DA48C6D8F94A8E"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-sequence-number:
@@ -459,7 +459,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 201
       message: Created
@@ -467,17 +467,17 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:20 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: HEAD
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9/blob3bb30fc9
   response:
@@ -491,11 +491,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       etag:
-      - '"0x8D7597651374293"'
+      - '"0x8DA48C6D8F94A8E"'
       last-modified:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
@@ -505,7 +505,7 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-creation-time:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -513,7 +513,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 200
       message: OK
@@ -521,7 +521,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/xml
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -529,11 +529,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:08:20 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: DELETE
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainer3bb30fc9?restype=container
   response:
@@ -543,11 +543,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 25 Oct 2019 18:08:19 GMT
+      - Tue, 07 Jun 2022 20:46:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_page_blob_async.test_blob_tier_on_create.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_page_blob_async.test_blob_tier_on_create.yaml
@@ -2,12 +2,14 @@ interactions:
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:55 GMT
+      - Tue, 07 Jun 2022 20:51:29 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utcontainera4df1246?restype=container
   response:
@@ -15,31 +17,26 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F58B8C13"'
-      last-modified: Fri, 25 Oct 2019 18:12:55 GMT
+      date: Tue, 07 Jun 2022 20:51:30 GMT
+      etag: '"0x8DA48C77F9A0BFD"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utcontainera4df1246
-        - restype=container
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utcontainera4df1246?restype=container
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utcontainersourcea4df1246?restype=container
   response:
@@ -47,31 +44,26 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F59922E8"'
-      last-modified: Fri, 25 Oct 2019 18:12:55 GMT
+      date: Tue, 07 Jun 2022 20:51:30 GMT
+      etag: '"0x8DA48C77FA63F36"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utcontainersourcea4df1246
-        - restype=container
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utcontainersourcea4df1246?restype=container
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246?restype=container
   response:
@@ -79,29 +71,24 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F5B31D41"'
-      last-modified: Fri, 25 Oct 2019 18:12:55 GMT
+      date: Tue, 07 Jun 2022 20:51:29 GMT
+      etag: '"0x8DA48C77FD2912D"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246
-        - restype=container
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246?restype=container
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - P4
       x-ms-blob-content-length:
@@ -109,9 +96,9 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
   response:
@@ -119,32 +106,27 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F5BC712B"'
-      last-modified: Fri, 25 Oct 2019 18:12:55 GMT
+      date: Tue, 07 Jun 2022 20:51:29 GMT
+      etag: '"0x8DA48C77FDEFBBA"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - ''
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: HEAD
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
   response:
@@ -154,36 +136,31 @@ interactions:
       accept-ranges: bytes
       content-length: '1024'
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F5BC712B"'
-      last-modified: Fri, 25 Oct 2019 18:12:55 GMT
+      date: Tue, 07 Jun 2022 20:51:29 GMT
+      etag: '"0x8DA48C77FDEFBBA"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier: P4
       x-ms-blob-sequence-number: '0'
       x-ms-blob-type: PageBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:12:56 GMT
+      x-ms-creation-time: Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - ''
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - P6
       x-ms-blob-content-length:
@@ -191,9 +168,9 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
   response:
@@ -201,42 +178,37 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F5E3D63C"'
-      last-modified: Fri, 25 Oct 2019 18:12:56 GMT
+      date: Tue, 07 Jun 2022 20:51:29 GMT
+      etag: '"0x8DA48C77FF602C6"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - ''
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
 - request:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '1024'
       Content-Type:
       - application/octet-stream
       If-Match:
-      - '"0x8D75976F5E3D63C"'
+      - '"0x8DA48C77FF602C6"'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-page-write:
       - update
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246?comp=page
   response:
@@ -245,33 +217,28 @@ interactions:
     headers:
       content-length: '0'
       content-md5: yaNM/IXZgmmMasifdgcavQ==
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F5EB51B9"'
-      last-modified: Fri, 25 Oct 2019 18:12:56 GMT
+      date: Tue, 07 Jun 2022 20:51:29 GMT
+      etag: '"0x8DA48C78001C0DF"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-sequence-number: '0'
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - comp=page
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246?comp=page
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: HEAD
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
   response:
@@ -281,36 +248,31 @@ interactions:
       accept-ranges: bytes
       content-length: '1024'
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F5EB51B9"'
-      last-modified: Fri, 25 Oct 2019 18:12:56 GMT
+      date: Tue, 07 Jun 2022 20:51:30 GMT
+      etag: '"0x8DA48C78001C0DF"'
+      last-modified: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier: P6
       x-ms-blob-sequence-number: '0'
       x-ms-blob-type: PageBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:12:56 GMT
+      x-ms-creation-time: Tue, 07 Jun 2022 20:51:30 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - ''
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-access-tier:
       - P10
       x-ms-blob-content-length:
@@ -318,9 +280,9 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:31 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
   response:
@@ -328,42 +290,37 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F609405B"'
-      last-modified: Fri, 25 Oct 2019 18:12:56 GMT
+      date: Tue, 07 Jun 2022 20:51:30 GMT
+      etag: '"0x8DA48C780196410"'
+      last-modified: Tue, 07 Jun 2022 20:51:31 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - ''
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
 - request:
     body: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     headers:
+      Accept:
+      - application/xml
       Content-Length:
       - '1024'
       Content-Type:
       - application/octet-stream
       If-Match:
-      - '"0x8D75976F609405B"'
+      - '"0x8DA48C780196410"'
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:31 GMT
       x-ms-page-write:
       - update
       x-ms-range:
       - bytes=0-1023
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: PUT
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246?comp=page
   response:
@@ -372,33 +329,28 @@ interactions:
     headers:
       content-length: '0'
       content-md5: yaNM/IXZgmmMasifdgcavQ==
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F610E232"'
-      last-modified: Fri, 25 Oct 2019 18:12:56 GMT
+      date: Tue, 07 Jun 2022 20:51:30 GMT
+      etag: '"0x8DA48C780252226"'
+      last-modified: Tue, 07 Jun 2022 20:51:31 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-sequence-number: '0'
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - comp=page
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246?comp=page
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:31 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: HEAD
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
   response:
@@ -408,38 +360,33 @@ interactions:
       accept-ranges: bytes
       content-length: '1024'
       content-type: application/octet-stream
-      date: Fri, 25 Oct 2019 18:12:55 GMT
-      etag: '"0x8D75976F610E232"'
-      last-modified: Fri, 25 Oct 2019 18:12:56 GMT
+      date: Tue, 07 Jun 2022 20:51:30 GMT
+      etag: '"0x8DA48C780252226"'
+      last-modified: Tue, 07 Jun 2022 20:51:31 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier: P10
       x-ms-blob-sequence-number: '0'
       x-ms-blob-type: PageBlob
-      x-ms-creation-time: Fri, 25 Oct 2019 18:12:56 GMT
+      x-ms-creation-time: Tue, 07 Jun 2022 20:51:31 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246/bloba4df1246
-        - ''
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246/bloba4df1246
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-storage-blob/12.13.0b1 Python/3.10.4 (Windows-10-10.0.17763-SP0)
       x-ms-date:
-      - Fri, 25 Oct 2019 18:12:56 GMT
+      - Tue, 07 Jun 2022 20:51:31 GMT
       x-ms-version:
-      - '2019-02-02'
+      - '2021-08-06'
     method: DELETE
     uri: https://pyacrstoragestorname.blob.core.windows.net/utpremiumcontainera4df1246?restype=container
   response:
@@ -447,18 +394,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Fri, 25 Oct 2019 18:12:56 GMT
+      date: Tue, 07 Jun 2022 20:51:30 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2019-02-02'
+      x-ms-version: '2021-08-06'
     status:
       code: 202
       message: Accepted
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - pyacrstoragemvvzd67g4hsm.blob.core.windows.net
-        - /utpremiumcontainera4df1246
-        - restype=container
-        - ''
+    url: https://jalauzonpremium.blob.core.windows.net/utpremiumcontainera4df1246?restype=container
 version: 1

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -1881,11 +1881,8 @@ class StoragePageBlobAsyncTest(AsyncStorageTestCase):
         # strip off protocol
         self.assertTrue(copy_blob.copy.source.endswith(sas_blob.url[5:]))
 
-    @pytest.mark.live_test_only
     @BlobPreparer()
     async def test_blob_tier_on_create(self, premium_storage_account_name, premium_storage_account_key):
-        # Test can only run live
-
         bsc = BlobServiceClient(self.account_url(premium_storage_account_name, "blob"), credential=premium_storage_account_key, connection_data_block_size=4 * 1024, max_page_size=4 * 1024, transport=AiohttpTestTransport())
         await self._setup(bsc)
         url = self.account_url(premium_storage_account_name, "blob")


### PR DESCRIPTION
The recent changes to the generated code as part of STG83 included a change to creating page blobs which requires that we no longer set the `x-ms-access-tier` header manually and instead pass it to the generated code. This was partly addressed in #24668 but `upload_blob` was missed in that change. This change applies the same fix to `upload_blob`.