### PR TITLE
[Tables] Reraise an error with no response

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_error.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_error.py
@@ -204,6 +204,8 @@ def _reraise_error(decoded_error):
 
 
 def _process_table_error(storage_error, table_name=None):
+    if not storage_error.response:
+        _reraise_error(storage_error)
     decoded_error = _decode_error(storage_error.response, storage_error.message)
     if table_name:
         _validate_tablename_error(decoded_error, table_name)


### PR DESCRIPTION
Hi @YalinLi0312 - I believe this is a potential fix for #21416 
Would you be able to try and construct a test case for a scenario where `HttpResponseError.response is None`
It might be worth checking with McCoy to see where this azure-identity AuthenticationError is being raised, and why it has an empty `.response` attribute.