### PR TITLE
[Datalake] Fix connection string parsing

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -402,7 +402,8 @@ def parse_connection_str(conn_str, credential, service):
             raise ValueError("Connection string missing required connection details.")
     if service == "dfs":
         primary = primary.replace(".blob.", ".dfs.")
-        secondary = secondary.replace(".blob.", ".dfs.")
+        if secondary:
+            secondary = secondary.replace(".blob.", ".dfs.")
     return primary, secondary, credential
 
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
@@ -401,7 +401,8 @@ def parse_connection_str(conn_str, credential, service):
             raise ValueError("Connection string missing required connection details.")
     if service == "dfs":
         primary = primary.replace(".blob.", ".dfs.")
-        secondary = secondary.replace(".blob.", ".dfs.")
+        if secondary:
+            secondary = secondary.replace(".blob.", ".dfs.")
     return primary, secondary, credential
 
 

--- a/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client.py
@@ -321,3 +321,10 @@ class DatalakeServiceTest(StorageTestCase):
         # Assert
         received_props = self.dsc.get_service_properties()
         self._assert_cors_equal(received_props['cors'], cors)
+
+    def test_connectionstring_without_secondary(self):
+        test_conn_str = "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=bar"
+        client = DataLakeServiceClient.from_connection_string(test_conn_str)
+        assert client.url == 'https://foo.dfs.core.windows.net/'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname

--- a/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client.py
@@ -10,7 +10,12 @@ import unittest
 from azure.core.exceptions import HttpResponseError
 
 
-from azure.storage.filedatalake import DataLakeServiceClient
+from azure.storage.filedatalake import (
+    DataLakeServiceClient,
+    FileSystemClient,
+    DataLakeFileClient,
+    DataLakeDirectoryClient
+)
 
 from settings.testcase import DataLakePreparer
 from devtools_testutils.storage import StorageTestCase
@@ -326,5 +331,20 @@ class DatalakeServiceTest(StorageTestCase):
         test_conn_str = "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=bar"
         client = DataLakeServiceClient.from_connection_string(test_conn_str)
         assert client.url == 'https://foo.dfs.core.windows.net/'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname
+
+        client = FileSystemClient.from_connection_string(test_conn_str, "fsname")
+        assert client.url == 'https://foo.dfs.core.windows.net/fsname'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname
+
+        client = DataLakeFileClient.from_connection_string(test_conn_str, "fsname", "fpath")
+        assert client.url == 'https://foo.dfs.core.windows.net/fsname/fpath'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname
+
+        client = DataLakeDirectoryClient.from_connection_string(test_conn_str, "fsname", "dname")
+        assert client.url == 'https://foo.dfs.core.windows.net/fsname/dname'
         assert client.primary_hostname == 'foo.dfs.core.windows.net'
         assert not client.secondary_hostname

--- a/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client_async.py
@@ -316,3 +316,10 @@ class DatalakeServiceTest(StorageTestCase):
         # Assert
         received_props = await self.dsc.get_service_properties()
         self._assert_cors_equal(received_props['cors'], cors)
+
+    async def test_connectionstring_without_secondary(self):
+        test_conn_str = "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=bar"
+        client = DataLakeServiceClient.from_connection_string(test_conn_str)
+        assert client.url == 'https://foo.dfs.core.windows.net/'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname

--- a/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client_async.py
@@ -11,7 +11,12 @@ import unittest
 from azure.core.exceptions import HttpResponseError
 
 
-from azure.storage.filedatalake.aio import DataLakeServiceClient
+from azure.storage.filedatalake.aio import (
+    DataLakeServiceClient,
+    FileSystemClient,
+    DataLakeFileClient,
+    DataLakeDirectoryClient
+)
 from devtools_testutils.storage.aio import AsyncStorageTestCase as StorageTestCase
 from settings.testcase import DataLakePreparer
 
@@ -321,5 +326,20 @@ class DatalakeServiceTest(StorageTestCase):
         test_conn_str = "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=bar"
         client = DataLakeServiceClient.from_connection_string(test_conn_str)
         assert client.url == 'https://foo.dfs.core.windows.net/'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname
+
+        client = FileSystemClient.from_connection_string(test_conn_str, "fsname")
+        assert client.url == 'https://foo.dfs.core.windows.net/fsname'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname
+
+        client = DataLakeFileClient.from_connection_string(test_conn_str, "fsname", "fpath")
+        assert client.url == 'https://foo.dfs.core.windows.net/fsname/fpath'
+        assert client.primary_hostname == 'foo.dfs.core.windows.net'
+        assert not client.secondary_hostname
+
+        client = DataLakeDirectoryClient.from_connection_string(test_conn_str, "fsname", "dname")
+        assert client.url == 'https://foo.dfs.core.windows.net/fsname/dname'
         assert client.primary_hostname == 'foo.dfs.core.windows.net'
         assert not client.secondary_hostname

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -401,7 +401,8 @@ def parse_connection_str(conn_str, credential, service):
             raise ValueError("Connection string missing required connection details.")
     if service == "dfs":
         primary = primary.replace(".blob.", ".dfs.")
-        secondary = secondary.replace(".blob.", ".dfs.")
+        if secondary:
+            secondary = secondary.replace(".blob.", ".dfs.")
     return primary, secondary, credential
 
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -401,7 +401,8 @@ def parse_connection_str(conn_str, credential, service):
             raise ValueError("Connection string missing required connection details.")
     if service == "dfs":
         primary = primary.replace(".blob.", ".dfs.")
-        secondary = secondary.replace(".blob.", ".dfs.")
+        if secondary:
+            secondary = secondary.replace(".blob.", ".dfs.")
     return primary, secondary, credential
 
 


### PR DESCRIPTION
Hi @jalauzon-msft, @vincenttran-msft 
It looks like the secondary host name that is parsed from the connection string for datalake is always ignored, as can be seen in the various client constructors:
- [DataLakeServiceClient](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_service_client.py#L158)
- [DataLakeDirectoryClient](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py#L108)
- [DataLakeFileClient](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py#L118)

Should this be interpreted to mean that a secondary host name is **never** supported for DataLake, and therefore should **never** be parsed from the connection string?

We hit an issue in one of our pipelines that was tripping up on this line in the shared `base_client` code:
https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py#L404
As is described in this issue: #24757 

I have proposed a 'soft fix' here in this PR that should unblock the error - however I will depend on your service expertise to determine whether we should go further and either remove this line or replace it with `secondary = None` or similar.

Will add a unittest for this as well.
