### PR TITLE
[Test Proxy] Properly wrap recording decorators

### DIFF
--- a/sdk/advisor/azure-mgmt-advisor/tests/test_mgmt_advisor.py
+++ b/sdk/advisor/azure-mgmt-advisor/tests/test_mgmt_advisor.py
@@ -164,7 +164,8 @@ class TestMgmtAdvisor(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_configurations_resourcegroup(self, resource_group):
+    def test_configurations_resourcegroup(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         resourceGroupName = resource_group.name
         configurationName = "default"
 

--- a/sdk/authorization/azure-mgmt-authorization/tests/test_cli_mgmt_authorization.py
+++ b/sdk/authorization/azure-mgmt-authorization/tests/test_cli_mgmt_authorization.py
@@ -56,7 +56,8 @@ class TestMgmtAuthorization(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_deny_assignment(self, resource_group):
+    def test_deny_assignment(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -100,7 +101,8 @@ class TestMgmtAuthorization(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_role_assignment_by_id(self, resource_group):
+    def test_role_assignment_by_id(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -133,7 +135,8 @@ class TestMgmtAuthorization(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_list_by_resource(self, resource_group):
+    def test_list_by_resource(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_NAME = "resourcexxx"
@@ -179,7 +182,8 @@ class TestMgmtAuthorization(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_role_assignment(self, resource_group):
+    def test_role_assignment(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/automation/azure-mgmt-automation/tests/test_cli_mgmt_automation.py
+++ b/sdk/automation/azure-mgmt-automation/tests/test_cli_mgmt_automation.py
@@ -35,7 +35,8 @@ class TestMgmtAutomationClient(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_automation(self, resource_group):
+    def test_automation(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         AUTOMATION_ACCOUNT_NAME = 'myAutomationAccount9'
 

--- a/sdk/batch/azure-mgmt-batch/tests/test_mgmt_batch.py
+++ b/sdk/batch/azure-mgmt-batch/tests/test_mgmt_batch.py
@@ -124,7 +124,9 @@ class TestMgmtBatch(AzureMgmtRecordedTestCase):
     # @KeyVaultPreparer(location=AZURE_LOCATION)
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_mgmt_batch_byos_account(self, resource_group, location):
+    def test_mgmt_batch_byos_account(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         # if self.is_live:
         #     keyvault = keyvault.result()
         batch_account = models.BatchAccountCreateParameters(
@@ -153,7 +155,9 @@ class TestMgmtBatch(AzureMgmtRecordedTestCase):
     @pytest.mark.skip('hard to test')
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_mgmt_batch_account(self, resource_group, location):
+    def test_mgmt_batch_account(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         batch_account = models.BatchAccountCreateParameters(
             location=location,
         )
@@ -207,7 +211,11 @@ class TestMgmtBatch(AzureMgmtRecordedTestCase):
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @StorageAccountPreparer(name_prefix='batch', location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_mgmt_batch_applications(self, resource_group, location, storage_account, storage_account_key):
+    def test_mgmt_batch_applications(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
+        storage_account = kwargs.pop("storage_account")
+        storage_account_key = kwargs.pop("storage_account_key")
         # Test Create Account with Auto-Storage 
         storage_resource = '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Storage/storageAccounts/{}'.format(
             self.get_settings_value("SUBSCRIPTION_ID"),
@@ -314,7 +322,10 @@ class TestMgmtBatch(AzureMgmtRecordedTestCase):
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @SimpleBatchPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_mgmt_batch_certificates(self, resource_group, location, batch_account):
+    def test_mgmt_batch_certificates(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
+        batch_account = kwargs.pop("batch_account")
         # Test Add Certificate
         parameters = models.CertificateCreateOrUpdateParameters(
             thumbprint='cff2ab63c8c955aaf71989efa641b906558d9fb7',
@@ -358,7 +369,10 @@ class TestMgmtBatch(AzureMgmtRecordedTestCase):
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @SimpleBatchPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_mgmt_batch_pools(self, resource_group, location, batch_account):
+    def test_mgmt_batch_pools(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
+        batch_account = kwargs.pop("batch_account")
         # Test create PAAS pool
         paas_pool = "test_paas_pool"
         parameters = models.Pool(
@@ -464,7 +478,9 @@ class TestMgmtBatch(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('yes', 'true'), reason='only run live test')
     @ResourceGroupPreparer(location=AZURE_LOCATION, random_name_enabled=True)
     @recorded_by_proxy
-    def test_mgmt_batch_account_advanced(self, resource_group, location):
+    def test_mgmt_batch_account_advanced(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         batch_account_name = self.get_resource_name('batchpendpoint')
         vnet_name = self.get_resource_name('vnet')
         subnet_name = self.get_resource_name('subnet')

--- a/sdk/cdn/azure-mgmt-cdn/tests/test_cli_mgmt_cdn.py
+++ b/sdk/cdn/azure-mgmt-cdn/tests/test_cli_mgmt_cdn.py
@@ -33,7 +33,8 @@ class TestMgmtCdn(AzureMgmtRecordedTestCase):
     
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_cdn(self, resource_group):
+    def test_cdn(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = None
         if self.is_live:

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute.py
@@ -113,7 +113,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute(self, resource_group):
+    def test_compute(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         # List operations (TODO: need swagger file)
         result = self.mgmt_client.operations.list()
@@ -127,7 +128,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_availability_sets(self, resource_group):
+    def test_compute_availability_sets(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         AVAILABILITY_SET_NAME = self.get_resource_name("availabilitysets")
 
         # Create an availability set.[put]
@@ -163,7 +165,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_proximity_placement_groups(self, resource_group):
+    def test_compute_proximity_placement_groups(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         PROXIMITY_PLACEMENT_GROUP_NAME = self.get_resource_name("proximiityplacementgroups")
         
         # Create or Update a proximity placement group.[put]
@@ -195,7 +198,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_log_analytics(self, resource_group):
+    def test_compute_log_analytics(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         RESOURCE_GROUP = resource_group.name
         STORAGE_ACCOUNT_NAME = self.get_resource_name("accountxyz")
         LOG_ANALYTIC_NAME = self.get_resource_name("loganalyticx")

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_base_async.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_base_async.py
@@ -74,7 +74,8 @@ class TestMgmtCompute(AzureMgmtAsyncTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vm(self, resource_group):
+    def test_compute_vm(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.settings.SUBSCRIPTION_ID
         RESOURCE_GROUP = resource_group.name

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_dedicated_hosts.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_dedicated_hosts.py
@@ -27,7 +27,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_dedicated_hosts(self, resource_group):
+    def test_dedicated_hosts(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         HOST_GROUP_NAME = self.get_resource_name("hostgroup")
         HOST_NAME = self.get_resource_name("hostname")
 

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_disks.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_disks.py
@@ -65,7 +65,8 @@ class TestMgmtComputeMultiVersion(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_disks_multi(self, resource_group):
+    def test_compute_disks_multi(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         DISK_NAME = self.get_resource_name("disknamex")
 
@@ -198,7 +199,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @unittest.skip("The KEY_VAULT_NAME need artificially generated,skip for now")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_disk_encryption(self, resource_group):
+    def test_compute_disk_encryption(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         TENANT_ID = self.settings.TENANT_ID
         CLIENT_OID = self.settings.CLIENT_OID if self.is_live else "000"
@@ -260,7 +262,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_shot(self, resource_group):
+    def test_compute_shot(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         DISK_NAME = self.get_resource_name("disknamex")
@@ -373,7 +376,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_disks(self, resource_group):
+    def test_compute_disks(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         DISK_NAME = self.get_resource_name("disknamex")
 

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_galleries.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_galleries.py
@@ -72,7 +72,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_galleries(self, resource_group):
+    def test_compute_galleries(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         GALLERY_NAME = self.get_resource_name("galleryname")

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vm.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vm.py
@@ -83,7 +83,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vm(self, resource_group):
+    def test_compute_vm(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -295,7 +296,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vm_2(self, resource_group):
+    def test_compute_vm_2(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -392,7 +394,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vm_image(self, resource_group):
+    def test_compute_vm_image(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         PUBLISHER_NAME = "MicrosoftWindowsServer"
         OFFER = "WindowsServer"
         SKUS = "2019-Datacenter"
@@ -416,7 +419,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vm_extension_image(self, resource_group):
+    def test_compute_vm_extension_image(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         EXTENSION_PUBLISHER_NAME = "Microsoft.Compute"
         EXTENSION_IMAGE_TYPE = "VMAccessAgent"
         EXTENSION_IMAGE_VERSION = "1.0.2"

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vmss.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vmss.py
@@ -167,7 +167,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @unittest.skip("skip temporary")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vmss_rolling_upgrades(self, resource_group):
+    def test_compute_vmss_rolling_upgrades(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         VIRTUAL_MACHINE_SCALE_SET_NAME = self.get_resource_name("virtualmachinescaleset")
@@ -264,7 +265,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @unittest.skip("The entity was not found in this Azure location.")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vmss_extension(self, resource_group):
+    def test_compute_vmss_extension(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         VIRTUAL_MACHINE_SCALE_SET_NAME = self.get_resource_name("virtualmachinescaleset")
@@ -396,7 +398,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vmss_vm(self, resource_group):
+    def test_compute_vmss_vm(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -553,7 +556,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vmss_vm_2(self, resource_group):
+    def test_compute_vmss_vm_2(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         VIRTUAL_MACHINE_SCALE_SET_NAME = self.get_resource_name("virtualmachinescaleset")
@@ -665,7 +669,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @unittest.skip("The (VMRedeployment) need artificially generated,skip for now")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute(self, resource_group):
+    def test_compute(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -856,7 +861,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vmss_base_2(self, resource_group):
+    def test_compute_vmss_base_2(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -989,7 +995,8 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_compute_vmss_perform_maintenance(self, resource_group):
+    def test_compute_vmss_perform_maintenance(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         VIRTUAL_MACHINE_SCALE_SET_NAME = self.get_resource_name("virtualmachinescaleset")

--- a/sdk/consumption/azure-mgmt-consumption/tests/test_budgets.py
+++ b/sdk/consumption/azure-mgmt-consumption/tests/test_budgets.py
@@ -22,7 +22,8 @@ class TestMgmtConsumption(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_budgets(self, resource_group):
+    def test_budgets(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value('SUBSCRIPTION_ID')
         SCOPE = '/subscriptions/{}/resourceGroups/{}'.format(SUBSCRIPTION_ID, resource_group.name)
         BUDGET_NAME = self.get_resource_name('budget')

--- a/sdk/devtestlabs/azure-mgmt-devtestlabs/tests/test_mgmt_devtestlabs.py
+++ b/sdk/devtestlabs/azure-mgmt-devtestlabs/tests/test_mgmt_devtestlabs.py
@@ -20,7 +20,9 @@ class TestMgmtDevTestLabs(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_devtestlabs(self, resource_group, location):
+    def test_devtestlabs(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         lab_name = self.get_resource_name('pylab')
 
         async_lab = self.client.labs.begin_create_or_update(

--- a/sdk/eventgrid/azure-eventgrid/tests/test_cncf_events.py
+++ b/sdk/eventgrid/azure-eventgrid/tests/test_cncf_events.py
@@ -18,7 +18,9 @@ class TestEventGridPublisherClientCncf(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_dict(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_dict(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         attributes = {
             "type": "com.example.sampletype1",
@@ -37,7 +39,9 @@ class TestEventGridPublisherClientCncf(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_base64_using_data(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_base64_using_data(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         attributes = {
             "type": "com.example.sampletype1",
@@ -54,7 +58,9 @@ class TestEventGridPublisherClientCncf(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_none(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_none(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         attributes = {
             "type": "com.example.sampletype1",
@@ -66,7 +72,9 @@ class TestEventGridPublisherClientCncf(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_str(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_str(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         attributes = {
             "type": "com.example.sampletype1",
@@ -82,7 +90,9 @@ class TestEventGridPublisherClientCncf(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_as_list(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_as_list(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         attributes = {
             "type": "com.example.sampletype1",
@@ -94,7 +104,9 @@ class TestEventGridPublisherClientCncf(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_with_extensions(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_with_extensions(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         attributes = {
             "type": "com.example.sampletype1",

--- a/sdk/eventgrid/azure-eventgrid/tests/test_eg_publisher_client.py
+++ b/sdk/eventgrid/azure-eventgrid/tests/test_eg_publisher_client.py
@@ -39,7 +39,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_event_grid_event_data_dict(self, variables, eventgrid_topic_endpoint):
+    def test_send_event_grid_event_data_dict(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_topic_endpoint)
         eg_event = EventGridEvent(
                 subject="sample", 
@@ -51,7 +53,10 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_event_grid_event_fails_without_full_url(self, variables, eventgrid_topic_key, eventgrid_topic_endpoint):
+    def test_send_event_grid_event_fails_without_full_url(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_key = kwargs.pop("eventgrid_topic_key")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         akc_credential = AzureKeyCredential(eventgrid_topic_key)
         parsed_url = urlparse(eventgrid_topic_endpoint)
         client = EventGridPublisherClient(parsed_url.netloc, akc_credential)
@@ -66,7 +71,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_event_grid_event_data_as_list(self, variables, eventgrid_topic_endpoint):
+    def test_send_event_grid_event_data_as_list(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_topic_endpoint)
         eg_event1 = EventGridEvent(
                 subject="sample", 
@@ -84,7 +91,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_event_grid_event_data_str(self, variables, eventgrid_topic_endpoint):
+    def test_send_event_grid_event_data_str(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_topic_endpoint)
         eg_event = EventGridEvent(
                 subject="sample", 
@@ -96,7 +105,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_event_grid_event_data_bytes(self, variables, eventgrid_topic_endpoint):
+    def test_send_event_grid_event_data_bytes(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_topic_endpoint)
         eg_event = EventGridEvent(
                 subject="sample", 
@@ -109,7 +120,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_event_grid_event_dict_data_bytes(self, variables, eventgrid_topic_endpoint):
+    def test_send_event_grid_event_dict_data_bytes(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_topic_endpoint)
         eg_event = {
                 "subject":"sample", 
@@ -124,7 +137,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_event_grid_event_dict_data_dict(self, variables, eventgrid_topic_endpoint):
+    def test_send_event_grid_event_dict_data_dict(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_topic_endpoint)
         eg_event = {
                 "subject":"sample", 
@@ -141,7 +156,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_dict(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_dict(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -153,7 +170,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
     @pytest.mark.skip("https://github.com/Azure/azure-sdk-for-python/issues/16993")
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_NULL(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_NULL(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -169,7 +188,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_base64_using_data(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_base64_using_data(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -195,7 +216,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_none(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_none(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -206,7 +229,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_str(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_str(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -217,7 +242,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_bytes(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_bytes(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -228,7 +255,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_as_list(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_as_list(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -239,7 +268,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_data_with_extensions(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_data_with_extensions(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event = CloudEvent(
                 source = "http://samplesource.dev",
@@ -258,7 +289,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_cloud_event_dict(self, variables, eventgrid_cloud_event_topic_endpoint):
+    def test_send_cloud_event_dict(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_cloud_event_topic_endpoint = kwargs.pop("eventgrid_cloud_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_cloud_event_topic_endpoint)
         cloud_event1 = {
                 "id": "1234",
@@ -271,7 +304,10 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_signature_credential(self, variables, eventgrid_topic_key, eventgrid_topic_endpoint):
+    def test_send_signature_credential(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_key = kwargs.pop("eventgrid_topic_key")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         expiration_date_utc = dt.datetime.now(UTC()) + timedelta(hours=1)
         signature = generate_sas(eventgrid_topic_endpoint, eventgrid_topic_key, expiration_date_utc)
         credential = AzureSasCredential(signature)
@@ -286,13 +322,17 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_NONE_credential(self, variables, eventgrid_topic_endpoint):
+    def test_send_NONE_credential(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         with pytest.raises(ValueError, match="Parameter 'self._credential' must not be None."):
             client = EventGridPublisherClient(eventgrid_topic_endpoint, None)
         
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_custom_schema_event(self, variables, eventgrid_custom_event_topic_endpoint):
+    def test_send_custom_schema_event(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_custom_event_topic_endpoint = kwargs.pop("eventgrid_custom_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_custom_event_topic_endpoint)
         custom_event = {
                     "customSubject": "sample",
@@ -306,7 +346,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_custom_schema_event_as_list(self, variables, eventgrid_custom_event_topic_endpoint):
+    def test_send_custom_schema_event_as_list(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_custom_event_topic_endpoint = kwargs.pop("eventgrid_custom_event_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_custom_event_topic_endpoint)
         custom_event1 = {
                     "customSubject": "sample",
@@ -334,7 +376,9 @@ class TestEventGridPublisherClient(AzureRecordedTestCase):
     @pytest.mark.live_test_only
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_send_token_credential(self, variables, eventgrid_topic_endpoint):
+    def test_send_token_credential(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         credential = self.get_credential(EventGridPublisherClient)
         client = EventGridPublisherClient(eventgrid_topic_endpoint, credential)
         eg_event = EventGridEvent(

--- a/sdk/eventgrid/azure-eventgrid/tests/test_exceptions.py
+++ b/sdk/eventgrid/azure-eventgrid/tests/test_exceptions.py
@@ -45,7 +45,9 @@ class TestEventGridPublisherClientExceptions(AzureMgmtRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_raise_on_auth_error(self, variables, eventgrid_topic_endpoint):
+    def test_raise_on_auth_error(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         akc_credential = AzureKeyCredential("bad credential")
         client = EventGridPublisherClient(eventgrid_topic_endpoint, akc_credential)
         eg_event = EventGridEvent(
@@ -59,7 +61,9 @@ class TestEventGridPublisherClientExceptions(AzureMgmtRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_raise_on_bad_resource(self, variables, eventgrid_topic_key):
+    def test_raise_on_bad_resource(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_key = kwargs.pop("eventgrid_topic_key")
         akc_credential = AzureKeyCredential(eventgrid_topic_key)
         client = EventGridPublisherClient("https://bad-resource.westus-1.eventgrid.azure.net/api/events", akc_credential)
         eg_event = EventGridEvent(
@@ -73,7 +77,9 @@ class TestEventGridPublisherClientExceptions(AzureMgmtRecordedTestCase):
 
     @EventGridPreparer()
     @recorded_by_proxy
-    def test_raise_on_large_payload(self, variables, eventgrid_topic_endpoint):
+    def test_raise_on_large_payload(self, **kwargs):
+        variables = kwargs.pop("variables")
+        eventgrid_topic_endpoint = kwargs.pop("eventgrid_topic_endpoint")
         client = self.create_eg_publisher_client(eventgrid_topic_endpoint)
 
         path  = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "./large_data.json"))

--- a/sdk/eventgrid/azure-mgmt-eventgrid/tests/test_azure_mgmt_eventgrid.py
+++ b/sdk/eventgrid/azure-mgmt-eventgrid/tests/test_azure_mgmt_eventgrid.py
@@ -39,14 +39,18 @@ class TestMgmtEventGrid(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_topic_types(self, resource_group, location):
+    def test_topic_types(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         # List all topic types
         for result in self.eventgrid_client.topic_types.list():
             self.process(result)
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_user_topics(self, resource_group, location):
+    def test_user_topics(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         topic_name = "kalspython1"
         eventsubscription_name = "kalspythonEventSubscription2"
 
@@ -80,7 +84,9 @@ class TestMgmtEventGrid(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_input_mappings_and_queue_destination(self, resource_group, location):
+    def test_input_mappings_and_queue_destination(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         topic_name = "kalspython2"
         eventsubscription_name = "kalspythonEventSubscription3"
 
@@ -129,7 +135,9 @@ class TestMgmtEventGrid(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_domains_and_advanced_filter(self, resource_group, location):
+    def test_domains_and_advanced_filter(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         domain_name = "kalspythond1"
         eventsubscription_name = "kalspythonEventSubscription2"
 

--- a/sdk/eventgrid/azure-mgmt-eventgrid/tests/test_domain.py
+++ b/sdk/eventgrid/azure-mgmt-eventgrid/tests/test_domain.py
@@ -19,7 +19,9 @@ class TestMgmtEventGrid(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location="eastus2euap")
     @recorded_by_proxy
-    def test_domain(self, resource_group, location):
+    def test_domain(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         # create
         DOMAIN_NAME = self.get_resource_name('domain')
         BODY = {

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
@@ -40,7 +40,9 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_custom_document_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_custom_document_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -89,7 +91,9 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_custom_document_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
+    def test_custom_document_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url = kwargs.pop("formrecognizer_multipage_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -137,7 +141,9 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
+    def test_custom_document_selection_mark(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_selection_mark_storage_container_sas_url = kwargs.pop("formrecognizer_selection_mark_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -185,7 +191,9 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -206,7 +214,9 @@ class TestDACAnalyzeCustomModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_custom_document_signature_field(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_custom_document_signature_field(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         set_bodiless_matcher()
         da_client = client.get_document_analysis_client()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
@@ -46,7 +46,9 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_document_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_custom_document_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -97,7 +99,9 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_document_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
+    async def test_custom_document_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url = kwargs.pop("formrecognizer_multipage_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -147,7 +151,9 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
+    async def test_custom_document_selection_mark(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_selection_mark_storage_container_sas_url = kwargs.pop("formrecognizer_selection_mark_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -195,7 +201,9 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -218,7 +226,9 @@ class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_document_signature_field(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_custom_document_signature_field(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         set_bodiless_matcher()
         da_client = client.get_document_analysis_client()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
@@ -40,7 +40,9 @@ class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
+    def test_custom_document_selection_mark(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_selection_mark_storage_container_sas_url = kwargs.pop("formrecognizer_selection_mark_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -85,7 +87,9 @@ class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_label_tables_variable_rows(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
+    def test_label_tables_variable_rows(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_variable_rows_container_sas_url = kwargs.pop("formrecognizer_table_variable_rows_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -129,7 +133,9 @@ class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_label_tables_fixed_rows(self, client, formrecognizer_table_fixed_rows_container_sas_url, **kwargs):
+    def test_label_tables_fixed_rows(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_fixed_rows_container_sas_url = kwargs.pop("formrecognizer_table_fixed_rows_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
@@ -44,7 +44,9 @@ class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_document_selection_mark(self, client, formrecognizer_selection_mark_storage_container_sas_url, **kwargs):
+    async def test_custom_document_selection_mark(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_selection_mark_storage_container_sas_url = kwargs.pop("formrecognizer_selection_mark_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -91,7 +93,9 @@ class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_label_tables_variable_rows(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
+    async def test_label_tables_variable_rows(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_variable_rows_container_sas_url = kwargs.pop("formrecognizer_table_variable_rows_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -138,7 +142,9 @@ class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_label_tables_fixed_rows(self, client, formrecognizer_table_fixed_rows_container_sas_url, **kwargs):
+    async def test_label_tables_fixed_rows(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_fixed_rows_container_sas_url = kwargs.pop("formrecognizer_table_fixed_rows_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document.py
@@ -26,7 +26,8 @@ class TestDACAnalyzeDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_stream_transform_pdf(self, client):
+    def test_document_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -60,7 +61,8 @@ class TestDACAnalyzeDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_stream_transform_jpg(self, client):
+    def test_document_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             document = fd.read()
 
@@ -95,7 +97,8 @@ class TestDACAnalyzeDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_multipage_transform(self, client):
+    def test_document_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -130,7 +133,8 @@ class TestDACAnalyzeDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_multipage_table_span_pdf(self, client):
+    def test_document_multipage_table_span_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_table_pdf, "rb") as fd:
             my_file = fd.read()
         poller = client.begin_analyze_document("prebuilt-document", my_file)
@@ -146,7 +150,8 @@ class TestDACAnalyzeDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_specify_pages(self, client):
+    def test_document_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document_async.py
@@ -26,7 +26,8 @@ class TestDACAnalyzeDocumentAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_stream_transform_pdf(self, client):
+    async def test_document_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -61,7 +62,8 @@ class TestDACAnalyzeDocumentAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_stream_transform_jpg(self, client):
+    async def test_document_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             document = fd.read()
 
@@ -97,7 +99,8 @@ class TestDACAnalyzeDocumentAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_multipage_transform(self, client):
+    async def test_document_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -133,8 +136,9 @@ class TestDACAnalyzeDocumentAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_multipage_table_span_pdf(self, client, **kwargs):
-
+    async def test_document_multipage_table_span_pdf(self, **kwargs):
+        client = kwargs.pop("client")
+        
         with open(self.multipage_table_pdf, "rb") as fd:
             my_file = fd.read()
         async with client:
@@ -151,7 +155,8 @@ class TestDACAnalyzeDocumentAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_specify_pages(self, client):
+    async def test_document_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout.py
@@ -26,7 +26,8 @@ class TestDACAnalyzeLayout(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_layout_stream_transform_pdf(self, client):
+    def test_layout_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -60,7 +61,8 @@ class TestDACAnalyzeLayout(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_layout_stream_transform_jpg(self, client):
+    def test_layout_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             document = fd.read()
 
@@ -94,7 +96,8 @@ class TestDACAnalyzeLayout(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_layout_multipage_transform(self, client):
+    def test_layout_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -129,7 +132,8 @@ class TestDACAnalyzeLayout(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_layout_multipage_table_span_pdf(self, client):
+    def test_layout_multipage_table_span_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_table_pdf, "rb") as fd:
             my_file = fd.read()
         poller = client.begin_analyze_document("prebuilt-layout", my_file)
@@ -145,7 +149,8 @@ class TestDACAnalyzeLayout(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_layout_specify_pages(self, client):
+    def test_layout_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout_async.py
@@ -26,7 +26,8 @@ class TestDACAnalyzeLayoutAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_layout_stream_transform_pdf(self, client):
+    async def test_layout_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -61,7 +62,8 @@ class TestDACAnalyzeLayoutAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_layout_stream_transform_jpg(self, client):
+    async def test_layout_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             document = fd.read()
 
@@ -96,7 +98,8 @@ class TestDACAnalyzeLayoutAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_layout_multipage_transform(self, client):
+    async def test_layout_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -132,7 +135,8 @@ class TestDACAnalyzeLayoutAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_layout_multipage_table_span_pdf(self, client):
+    async def test_layout_multipage_table_span_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_table_pdf, "rb") as fd:
             my_file = fd.read()
         async with client:
@@ -149,7 +153,8 @@ class TestDACAnalyzeLayoutAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_layout_specify_pages(self, client):
+    async def test_layout_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             document = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
@@ -26,7 +26,8 @@ class TestDACAnalyzeRead(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_read_stream_languages(self, client):
+    def test_document_read_stream_languages(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -62,7 +63,8 @@ class TestDACAnalyzeRead(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_read_stream_docx(self, client, **kwargs):
+    def test_document_read_stream_docx(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_docx, "rb") as fd:
             document = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
@@ -26,7 +26,8 @@ class TestDACAnalyzeReadAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_read_stream_languages(self, client):
+    async def test_document_read_stream_languages(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -63,7 +64,8 @@ class TestDACAnalyzeReadAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_read_stream_docx(self, client, **kwargs):
+    async def test_document_read_stream_docx(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_docx, "rb") as fd:
             document = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts.py
@@ -31,7 +31,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_business_card_multipage_pdf(self, client):
+    def test_business_card_multipage_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.business_card_multipage_pdf, "rb") as fd:
             business_card = fd.read()
 
@@ -92,7 +93,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_w2_png_value_address(self, client):
+    def test_w2_png_value_address(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.w2_png, "rb") as fd:
             document = fd.read()
 
@@ -134,7 +136,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_jpg_passport(self, client):
+    def test_identity_document_jpg_passport(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_passport_jpg, "rb") as fd:
             id_document = fd.read()
 
@@ -157,7 +160,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_jpg(self, client):
+    def test_identity_document_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
 
@@ -180,7 +184,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_invoice_stream_transform_tiff(self, client):
+    def test_invoice_stream_transform_tiff(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -219,7 +224,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_invoice_jpg(self, client, **kwargs):
+    def test_invoice_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_jpg, "rb") as fd:
             invoice = fd.read()
         poller = client.begin_analyze_document("prebuilt-invoice", invoice)
@@ -286,7 +292,9 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @pytest.mark.skip("TODO check if the error type changed")
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_receipt_bad_endpoint(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_receipt_bad_endpoint(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         with open(self.receipt_jpg, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(ServiceRequestError):
@@ -295,7 +303,9 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_authentication_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_authentication_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentAnalysisClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             poller = client.begin_analyze_document("prebuilt-receipt", b"xx")
@@ -303,7 +313,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_damaged_file_passed_as_bytes(self, client):
+    def test_damaged_file_passed_as_bytes(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x25\x50\x44\x46\x55\x55\x55"  # still has correct bytes to be recognized as PDF
         with pytest.raises(HttpResponseError):
             poller = client.begin_analyze_document(
@@ -314,7 +325,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_damaged_file_passed_as_bytes_io(self, client):
+    def test_damaged_file_passed_as_bytes_io(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x25\x50\x44\x46\x55\x55\x55")  # still has correct bytes to be recognized as PDF
         with pytest.raises(HttpResponseError):
             poller = client.begin_analyze_document(
@@ -325,7 +337,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_blank_page(self, client):
+    def test_blank_page(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.blank_pdf, "rb") as fd:
             blank = fd.read()
@@ -339,7 +352,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_auto_detect_unsupported_stream_content(self, client):
+    def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.unsupported_content_py, "rb") as fd:
             my_file = fd.read()
@@ -354,7 +368,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_stream_transform_png(self, client):
+    def test_receipt_stream_transform_png(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -393,7 +408,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_stream_transform_jpg(self, client):
+    def test_receipt_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -433,7 +449,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_png(self, client):
+    def test_receipt_png(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.receipt_png, "rb") as stream:
             poller = client.begin_analyze_document("prebuilt-receipt", stream)
@@ -455,7 +472,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_multipage(self, client):
+    def test_receipt_multipage(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.multipage_receipt_pdf, "rb") as fd:
             receipt = fd.read()
@@ -494,7 +512,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_multipage_transform(self, client):
+    def test_receipt_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
 
         responses = []
 
@@ -551,7 +570,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_locale_specified(self, client):
+    def test_receipt_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         poller = client.begin_analyze_document("prebuilt-receipt", receipt, locale="en-IN")
@@ -562,7 +582,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_locale_error(self, client):
+    def test_receipt_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         with pytest.raises(HttpResponseError) as e:
@@ -572,7 +593,8 @@ class TestDACAnalyzePrebuilts(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_async.py
@@ -31,7 +31,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_damaged_file_passed_as_bytes(self, client):
+    async def test_damaged_file_passed_as_bytes(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x25\x50\x44\x46\x55\x55\x55"  # still has correct bytes to be recognized as PDF
         with pytest.raises(HttpResponseError):
             async with client:
@@ -44,7 +45,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_damaged_file_passed_as_bytes_io(self, client):
+    async def test_damaged_file_passed_as_bytes_io(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = BytesIO(b"\x25\x50\x44\x46\x55\x55\x55")  # still has correct bytes to be recognized as PDF
         with pytest.raises(HttpResponseError):
             async with client:
@@ -57,7 +59,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_blank_page(self, client):
+    async def test_blank_page(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.blank_pdf, "rb") as fd:
             blank = fd.read()
@@ -81,7 +84,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_auto_detect_unsupported_stream_content(self, client):
+    async def test_auto_detect_unsupported_stream_content(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.unsupported_content_py, "rb") as fd:
             my_file = fd.read()
 
@@ -97,7 +101,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_stream_transform_png(self, client):
+    async def test_receipt_stream_transform_png(self, **kwargs):
+        client = kwargs.pop("client")
 
         responses = []
 
@@ -138,7 +143,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_stream_transform_jpg(self, client):
+    async def test_receipt_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -179,7 +185,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_png(self, client):
+    async def test_receipt_png(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_png, "rb") as fd:
             receipt = fd.read()
 
@@ -202,7 +209,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_multipage(self, client):
+    async def test_receipt_multipage(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_receipt_pdf, "rb") as fd:
             receipt = fd.read()
         async with client:
@@ -240,7 +248,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_multipage_transform(self, client):
+    async def test_receipt_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -298,7 +307,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_locale_specified(self, client):
+    async def test_receipt_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         async with client:
@@ -310,7 +320,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_locale_error(self, client):
+    async def test_receipt_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         with pytest.raises(HttpResponseError) as e:
@@ -321,7 +332,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         async with client:
@@ -333,7 +345,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_business_card_multipage_pdf(self, client):
+    async def test_business_card_multipage_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.business_card_multipage_pdf, "rb") as fd:
             business_card = fd.read()
 
@@ -395,7 +408,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_jpg_passport(self, client):
+    async def test_identity_document_jpg_passport(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_passport_jpg, "rb") as fd:
             id_document = fd.read()
 
@@ -419,7 +433,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_jpg(self, client):
+    async def test_identity_document_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
 
@@ -443,7 +458,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_stream_transform_tiff(self, client):
+    async def test_invoice_stream_transform_tiff(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -483,7 +499,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_w2_png_value_address(self, client):
+    async def test_w2_png_value_address(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.w2_png, "rb") as fd:
             document = fd.read()
 
@@ -526,7 +543,8 @@ class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_jpg(self, client, **kwargs):
+    async def test_invoice_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_jpg, "rb") as fd:
             invoice = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
@@ -28,7 +28,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_business_card_multipage_pdf(self, client):
+    def test_business_card_multipage_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -91,7 +92,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_jpg_passport(self, client):
+    def test_identity_document_jpg_passport(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -116,7 +118,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_jpg(self, client):
+    def test_identity_document_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -141,7 +144,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_invoice_tiff(self, client, **kwargs):
+    def test_invoice_tiff(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -166,7 +170,9 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_polling_interval(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -194,7 +200,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipts_encoded_url(self, client):
+    def test_receipts_encoded_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -207,7 +214,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @pytest.mark.skip("TODO check if the error changed")
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_receipt_url_bad_endpoint(self, formrecognizer_test_api_key, **kwargs):
+    def test_receipt_url_bad_endpoint(self, **kwargs):
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -218,7 +226,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_receipt_url_auth_bad_key(self, formrecognizer_test_endpoint, **kwargs):
+    def test_receipt_url_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -230,7 +239,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_bad_url(self, client):
+    def test_receipt_bad_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -242,7 +252,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_url_pass_stream(self, client, **kwargs):
+    def test_receipt_url_pass_stream(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -254,7 +265,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_url_transform_jpg(self, client):
+    def test_receipt_url_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -294,7 +306,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_url_png(self, client):
+    def test_receipt_url_png(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -319,7 +332,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_multipage_url(self, client):
+    def test_receipt_multipage_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -356,7 +370,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_multipage_transform_url(self, client, **kwargs):
+    def test_receipt_multipage_transform_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -410,7 +425,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_locale_specified(self, client):
+    def test_receipt_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -423,7 +439,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_receipt_locale_error(self, client):
+    def test_receipt_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -435,7 +452,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
@@ -30,7 +30,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_business_card_multipage_pdf(self, client):
+    async def test_business_card_multipage_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -95,7 +96,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_jpg_passport(self, client):
+    async def test_identity_document_jpg_passport(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -121,7 +123,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_jpg(self, client):
+    async def test_identity_document_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -147,7 +150,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_tiff(self, client, **kwargs):
+    async def test_invoice_tiff(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -173,7 +177,9 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_polling_interval(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -207,7 +213,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipts_encoded_url(self, client):
+    async def test_receipts_encoded_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -220,7 +227,9 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_url_bad_endpoint(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_receipt_url_bad_endpoint(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -236,7 +245,9 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_receipt_url_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -253,7 +264,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_bad_url(self, client):
+    async def test_receipt_bad_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -266,7 +278,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_url_pass_stream(self, client):
+    async def test_receipt_url_pass_stream(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -283,7 +296,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_url_transform_jpg(self, client):
+    async def test_receipt_url_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -325,7 +339,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_url_png(self, client):
+    async def test_receipt_url_png(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -351,7 +366,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_multipage_url(self, client):
+    async def test_receipt_multipage_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -388,7 +404,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_multipage_transform_url(self, client):
+    async def test_receipt_multipage_transform_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -444,7 +461,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_locale_specified(self, client):
+    async def test_receipt_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -458,7 +476,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_locale_error(self, client):
+    async def test_receipt_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -471,7 +490,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
@@ -25,7 +25,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_compose_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_compose_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -59,7 +61,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_compose_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_compose_model_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -114,7 +118,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
@@ -26,7 +26,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_compose_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_compose_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -61,7 +63,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_compose_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_compose_model_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -118,7 +122,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model.py
@@ -38,8 +38,10 @@ class TestCopyModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy
-    def test_copy_model_successful(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-
+    def test_copy_model_successful(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
+        
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model = poller.result()
 
@@ -63,8 +65,10 @@ class TestCopyModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy
-    def test_copy_model_with_model_id_and_desc(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-
+    def test_copy_model_with_model_id_and_desc(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
+        
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model = poller.result()
 
@@ -90,8 +94,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_copy_model_fail_bad_model_id(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-
+    def test_copy_model_fail_bad_model_id(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
+        
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model = poller.result()
 
@@ -106,8 +112,10 @@ class TestCopyModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy
-    def test_copy_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-
+    def test_copy_model_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
+        
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model = poller.result()
 
@@ -132,8 +140,11 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_copy_authorization(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
-
+    def test_copy_authorization(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
+        
         target = client.get_copy_authorization()
 
         assert target["targetResourceId"] == formrecognizer_resource_id
@@ -147,8 +158,10 @@ class TestCopyModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy
-    def test_copy_model_with_composed_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-
+    def test_copy_model_with_composed_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
+        
         poller_1 = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model_1 = poller_1.result()
 
@@ -199,7 +212,9 @@ class TestCopyModel(FormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy
-    def test_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         poller = client.begin_build_model(formrecognizer_storage_container_sas_url)
         model = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_copy_model_async.py
@@ -41,7 +41,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy_async
-    async def test_copy_model_successful(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_copy_model_successful(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             training_poller = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             model = await training_poller.result()
@@ -66,7 +68,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy_async
-    async def test_copy_model_with_model_id_and_desc(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_copy_model_with_model_id_and_desc(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             model = await poller.result()
@@ -93,7 +97,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_copy_model_fail_bad_model_id(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_copy_model_fail_bad_model_id(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             model = await poller.result()
@@ -109,7 +115,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy_async
-    async def test_copy_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_copy_model_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         raw_response = []
 
         def callback(response, _, headers):
@@ -134,7 +142,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_copy_authorization(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_authorization(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         async with client:
             target = await client.get_copy_authorization()
 
@@ -149,7 +160,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy_async
-    async def test_copy_model_with_composed_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_copy_model_with_composed_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             poller_1 = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             model_1 = await poller_1.result()
@@ -202,7 +215,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @DocumentModelAdministrationClientPreparer()
     @pytest.mark.skip()
     @recorded_by_proxy_async
-    async def test_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         async with client:
             poller = await client.begin_build_model(formrecognizer_storage_container_sas_url)
             model = await poller.result()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
@@ -41,7 +41,9 @@ class TestManagement(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_dmac_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_dmac_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             result = client.get_account_info()
@@ -77,7 +79,8 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_account_info(self, client):
+    def test_account_info(self, **kwargs):
+        client = kwargs.pop("client")
         info = client.get_account_info()
 
         assert info.document_model_limit
@@ -86,7 +89,8 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_get_model_prebuilt(self, client, **kwargs):
+    def test_get_model_prebuilt(self, **kwargs):
+        client = kwargs.pop("client")
         model = client.get_model("prebuilt-invoice")
         assert model.model_id == "prebuilt-invoice"
         assert model.description is not None
@@ -104,7 +108,9 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_mgmt_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_mgmt_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -138,7 +144,8 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_get_list_operations(self, client, **kwargs):
+    def test_get_list_operations(self, **kwargs):
+        client = kwargs.pop("client")
         operations = client.list_operations()
         successful_op = None
         failed_op = None
@@ -203,7 +210,9 @@ class TestManagement(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_get_document_analysis_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_get_document_analysis_client(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
@@ -43,7 +43,9 @@ class TestManagementAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_dmac_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_dmac_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = DocumentModelAdministrationClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             async with client:
@@ -84,7 +86,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_account_info(self, client):
+    async def test_account_info(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             info = await client.get_account_info()
 
@@ -94,7 +97,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_get_model_prebuilt(self, client):
+    async def test_get_model_prebuilt(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             model = await client.get_model("prebuilt-invoice")
             assert model.model_id == "prebuilt-invoice"
@@ -111,7 +115,9 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_mgmt_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_mgmt_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -146,7 +152,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_get_list_operations(self, client):
+    async def test_get_list_operations(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             operations = client.list_operations()
             successful_op = None
@@ -208,7 +215,9 @@ class TestManagementAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_get_document_analysis_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_get_document_analysis_client(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
@@ -27,7 +27,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_polling_interval(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_build_model_polling_interval(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -49,7 +51,8 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_encoded_url(self, client):
+    def test_build_model_encoded_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -63,7 +66,9 @@ class TestDMACTraining(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_build_model_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_build_model_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -75,7 +80,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_build_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -107,7 +114,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_multipage(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
+    def test_build_model_multipage(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url = kwargs.pop("formrecognizer_multipage_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -132,7 +141,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_nested_schema(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
+    def test_build_model_nested_schema(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_variable_rows_container_sas_url = kwargs.pop("formrecognizer_table_variable_rows_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -154,7 +165,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_build_model_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -184,7 +197,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
+    def test_build_model_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url = kwargs.pop("formrecognizer_multipage_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -209,7 +224,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_nested_schema_transform(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
+    def test_build_model_nested_schema_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_variable_rows_container_sas_url = kwargs.pop("formrecognizer_table_variable_rows_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -240,7 +257,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_azure_blob_path_filter(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_build_model_azure_blob_path_filter(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         set_bodiless_matcher()
         with pytest.raises(HttpResponseError) as e:
             poller = client.begin_build_model(formrecognizer_storage_container_sas_url, "template", prefix="testfolder")
@@ -262,7 +281,9 @@ class TestDMACTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy
-    def test_build_model_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    def test_build_model_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
@@ -30,7 +30,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_polling_interval(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_build_model_polling_interval(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -52,7 +54,8 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_encoded_url(self, client):
+    async def test_build_model_encoded_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -68,7 +71,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_build_model_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -82,7 +87,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_build_model(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -115,7 +122,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_multipage(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
+    async def test_build_model_multipage(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url = kwargs.pop("formrecognizer_multipage_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -140,7 +149,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_nested_schema(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
+    async def test_build_model_nested_schema(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_variable_rows_container_sas_url = kwargs.pop("formrecognizer_table_variable_rows_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -162,8 +173,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_transform(self, client, formrecognizer_storage_container_sas_url, **kwargs):
-
+    async def test_build_model_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
+        
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -193,8 +206,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_multipage_transform(self, client, formrecognizer_multipage_storage_container_sas_url, **kwargs):
-
+    async def test_build_model_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url = kwargs.pop("formrecognizer_multipage_storage_container_sas_url")
+        
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -219,8 +234,10 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_nested_schema_transform(self, client, formrecognizer_table_variable_rows_container_sas_url, **kwargs):
-
+    async def test_build_model_nested_schema_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_table_variable_rows_container_sas_url = kwargs.pop("formrecognizer_table_variable_rows_container_sas_url")
+        
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -251,7 +268,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_azure_blob_path_filter(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_build_model_azure_blob_path_filter(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         set_bodiless_matcher()
         with pytest.raises(HttpResponseError) as e:
             async with client:
@@ -275,7 +294,9 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
-    async def test_build_model_poller_metadata(self, client, formrecognizer_storage_container_sas_url, **kwargs):
+    async def test_build_model_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url = kwargs.pop("formrecognizer_storage_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
@@ -26,7 +26,8 @@ class TestBusinessCard(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_passing_enum_content_type(self, client):
+    def test_passing_enum_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -75,7 +76,8 @@ class TestBusinessCard(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_business_card_multipage_pdf(self, client):
+    def test_business_card_multipage_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -141,7 +143,8 @@ class TestBusinessCard(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_business_card_jpg_include_field_elements(self, client):
+    def test_business_card_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
@@ -26,7 +26,8 @@ class TestBusinessCardAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_enum_content_type(self, client):
+    async def test_passing_enum_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.business_card_png, "rb") as fd:
             my_file = fd.read()
         async with client:
@@ -77,7 +78,8 @@ class TestBusinessCardAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_business_card_jpg_include_field_elements(self, client):
+    async def test_business_card_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.business_card_jpg, "rb") as fd:
             business_card = fd.read()
         async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
@@ -24,7 +24,8 @@ class TestBusinessCardFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_business_card_jpg_include_field_elements(self, client):
+    def test_business_card_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
@@ -25,7 +25,8 @@ class TestBusinessCardFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_business_card_jpg_include_field_elements(self, client):
+    async def test_business_card_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
@@ -28,7 +28,9 @@ class TestContentFromStream(FormRecognizerTest):
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_content_bad_endpoint(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_content_bad_endpoint(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(ServiceRequestError):
@@ -37,7 +39,9 @@ class TestContentFromStream(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_content_authentication_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_content_authentication_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             poller = client.begin_recognize_content(b"xx", content_type="application/pdf")
@@ -45,7 +49,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_passing_enum_content_type(self, client):
+    def test_passing_enum_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         poller = client.begin_recognize_content(
@@ -58,7 +63,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_damaged_file_passed_as_bytes(self, client):
+    def test_damaged_file_passed_as_bytes(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x25\x50\x44\x46\x55\x55\x55"  # still has correct bytes to be recognized as PDF
         with pytest.raises(HttpResponseError):
             poller = client.begin_recognize_content(
@@ -92,7 +98,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_stream_transform_pdf(self, client):
+    def test_content_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             form = fd.read()
 
@@ -117,7 +124,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_reading_order(self, client):
+    def test_content_reading_order(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             form = fd.read()
 
@@ -130,7 +138,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_stream_transform_jpg(self, client):
+    def test_content_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             form = fd.read()
 
@@ -155,7 +164,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_stream_jpg(self, client):
+    def test_content_stream_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as stream:
             poller = client.begin_recognize_content(stream)
         result = poller.result()
@@ -173,7 +183,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_multipage(self, client):
+    def test_content_multipage(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             invoice = fd.read()
         poller = client.begin_recognize_content(invoice)
@@ -185,7 +196,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_multipage_transform(self, client):
+    def test_content_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             form = fd.read()
 
@@ -226,7 +238,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_multipage_table_span_transform(self, client):
+    def test_content_multipage_table_span_transform(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_table_pdf, "rb") as fd:
             form = fd.read()
 
@@ -251,7 +264,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_selection_marks(self, client):
+    def test_content_selection_marks(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.selection_form_pdf, "rb") as fd:
             form = fd.read()
 
@@ -265,7 +279,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy
-    def test_content_selection_marks_v2(self, client):
+    def test_content_selection_marks_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.selection_form_pdf, "rb") as fd:
             form = fd.read()
 
@@ -279,7 +294,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_specify_pages(self, client):
+    def test_content_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.multipage_invoice_pdf, "rb") as fd:
             form = fd.read()
@@ -303,7 +319,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_language_specified(self, client):
+    def test_content_language_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             my_file = fd.read()
         poller = client.begin_recognize_content(my_file, language="de")
@@ -314,7 +331,8 @@ class TestContentFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_language_error(self, client):
+    def test_content_language_error(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(HttpResponseError) as e:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
@@ -30,7 +30,9 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_content_bad_endpoint(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_content_bad_endpoint(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(ServiceRequestError):
@@ -41,7 +43,9 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_content_authentication_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_content_authentication_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         client = FormRecognizerClient(formrecognizer_test_endpoint, AzureKeyCredential("xxxx"))
         with pytest.raises(ClientAuthenticationError):
             async with client:
@@ -52,7 +56,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_enum_content_type(self, client):
+    async def test_passing_enum_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         async with client:
@@ -67,7 +72,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_damaged_file_passed_as_bytes(self, client):
+    async def test_damaged_file_passed_as_bytes(self, **kwargs):
+        client = kwargs.pop("client")
         damaged_pdf = b"\x25\x50\x44\x46\x55\x55\x55"  # still has correct bytes to be recognized as PDF
         with pytest.raises(HttpResponseError):
             async with client:
@@ -108,7 +114,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_stream_transform_pdf(self, client):
+    async def test_content_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             form = fd.read()
 
@@ -135,7 +142,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_stream_transform_jpg(self, client):
+    async def test_content_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             form = fd.read()
 
@@ -162,7 +170,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_stream_jpg(self, client):
+    async def test_content_stream_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             form = fd.read()
 
@@ -184,7 +193,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_multipage(self, client):
+    async def test_content_multipage(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             invoice = fd.read()
         async with client:
@@ -198,7 +208,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_multipage_transform(self, client):
+    async def test_content_multipage_transform(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             form = fd.read()
 
@@ -241,7 +252,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_multipage_table_span_pdf(self, client):
+    async def test_content_multipage_table_span_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_table_pdf, "rb") as fd:
             my_file = fd.read()
         async with client:
@@ -269,7 +281,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_selection_marks(self, client):
+    async def test_content_selection_marks(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.selection_form_pdf, "rb") as fd:
             form = fd.read()
 
@@ -286,7 +299,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy_async
-    async def test_content_selection_marks_v2(self, client):
+    async def test_content_selection_marks_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.selection_form_pdf, "rb") as fd:
             form = fd.read()
 
@@ -302,7 +316,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_specify_pages(self, client):
+    async def test_content_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.multipage_invoice_pdf, "rb") as fd:
             form = fd.read()
 
@@ -327,7 +342,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_reading_order(self, client):
+    async def test_content_reading_order(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             form = fd.read()
 
@@ -342,7 +358,8 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_language_specified(self, client):
+    async def test_content_language_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.form_jpg, "rb") as fd:
             my_file = fd.read()
         async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
@@ -27,7 +27,9 @@ class TestContentFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_content_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_content_url_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -39,7 +41,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_url_pass_stream(self, client):
+    def test_content_url_pass_stream(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -51,7 +54,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_url_transform_pdf(self, client):
+    def test_content_url_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -77,7 +81,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_url_pdf(self, client):
+    def test_content_url_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -95,7 +100,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_url_transform_jpg(self, client):
+    def test_content_url_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -121,7 +127,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_url_jpg(self, client):
+    def test_content_url_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -142,7 +149,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_multipage_url(self, client):
+    def test_content_multipage_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -156,7 +164,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_multipage_transform_url(self, client):
+    def test_content_multipage_transform_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -195,7 +204,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_multipage_table_span_pdf(self, client):
+    def test_content_multipage_table_span_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -223,7 +233,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_selection_marks(self, client):
+    def test_content_selection_marks(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -238,7 +249,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy
-    def test_content_selection_marks_v2(self, client):
+    def test_content_selection_marks_v2(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -253,7 +265,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_specify_pages(self, client):
+    def test_content_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -277,7 +290,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_reading_order(self, client):
+    def test_content_reading_order(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -291,7 +305,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_language_specified(self, client):
+    def test_content_language_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -304,7 +319,8 @@ class TestContentFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_content_language_error(self, client):
+    def test_content_language_error(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
@@ -29,7 +29,9 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_content_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_content_url_auth_bad_key(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -43,7 +45,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_url_pass_stream(self, client):
+    async def test_content_url_pass_stream(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -59,7 +62,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_url_transform_pdf(self, client):
+    async def test_content_url_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -86,7 +90,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_url_pdf(self, client):
+    async def test_content_url_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -105,7 +110,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_multipage_url(self, client):
+    async def test_content_multipage_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -119,7 +125,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_multipage_transform_url(self, client):
+    async def test_content_multipage_transform_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -160,7 +167,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_multipage_table_span_pdf(self, client):
+    async def test_content_multipage_table_span_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -189,7 +197,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_selection_marks(self, client):
+    async def test_content_selection_marks(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -205,7 +214,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy_async
-    async def test_content_selection_marks_v2(self, client):
+    async def test_content_selection_marks_v2(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -221,7 +231,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_specify_pages(self, client):
+    async def test_content_specify_pages(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -246,7 +257,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_reading_order(self, client):
+    async def test_content_reading_order(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -261,7 +273,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_language_specified(self, client):
+    async def test_content_language_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -275,7 +288,8 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_content_language_error(self, client):
+    async def test_content_language_error(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
@@ -25,7 +25,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_unlabeled(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_unlabeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -49,7 +51,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_multipage_unlabeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -76,7 +80,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_labeled(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_labeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -102,7 +108,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_multipage_labeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -132,7 +140,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_unlabeled_transform(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -190,7 +200,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_multipage_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -263,7 +275,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    def test_custom_form_multipage_vendor_set_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -308,7 +322,9 @@ class TestCustomForms(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    def test_custom_form_multipage_vendor_set_labeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
@@ -28,7 +28,9 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_unlabeled(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_custom_form_unlabeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -51,7 +53,9 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_custom_form_multipage_unlabeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -81,7 +85,9 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_custom_form_multipage_labeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -112,7 +118,9 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_forms_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_custom_forms_multipage_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -191,7 +199,9 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    async def test_custom_form_multipage_vendor_set_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -238,7 +248,9 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    async def test_custom_form_multipage_vendor_set_labeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
@@ -25,7 +25,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_form_multipage_unlabeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -51,7 +53,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_form_multipage_labeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -78,7 +82,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_multipage_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -120,7 +126,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_custom_form_multipage_labeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -189,7 +197,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    def test_custom_form_multipage_vendor_set_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -231,7 +241,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    def test_custom_form_multipage_vendor_set_labeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -274,7 +286,9 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client, formrecognizer_testing_data_container_sas_url, **kwargs):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_testing_data_container_sas_url = kwargs.pop("formrecognizer_testing_data_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
@@ -27,7 +27,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_multipage_unlabeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_custom_form_multipage_unlabeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -54,7 +56,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_form_multipage_labeled(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_form_multipage_labeled(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -82,7 +86,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_multipage_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_multipage_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -127,7 +133,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_multipage_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_multipage_labeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -200,7 +208,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_multipage_vendor_set_unlabeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    async def test_custom_form_multipage_vendor_set_unlabeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -243,7 +253,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_custom_form_multipage_vendor_set_labeled_transform(self, client, formrecognizer_multipage_storage_container_sas_url_2_v2, **kwargs):
+    async def test_custom_form_multipage_vendor_set_labeled_transform(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_2_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_2_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -288,7 +300,9 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client, formrecognizer_testing_data_container_sas_url, **kwargs):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_testing_data_container_sas_url = kwargs.pop("formrecognizer_testing_data_container_sas_url")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
@@ -28,7 +28,8 @@ class TestIdDocument(FormRecognizerTest):
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_identity_document_bad_endpoint(self, formrecognizer_test_api_key, **kwargs):
+    def test_identity_document_bad_endpoint(self, **kwargs):
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         with open(self.identity_document_license_jpg, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(ServiceRequestError):
@@ -82,7 +83,8 @@ class TestIdDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_stream_transform_jpg(self, client):
+    def test_identity_document_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -121,7 +123,8 @@ class TestIdDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_jpg_include_field_elements(self, client):
+    def test_identity_document_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
         poller = client.begin_recognize_identity_documents(id_document, include_field_elements=True)
@@ -169,7 +172,8 @@ class TestIdDocument(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
         poller = client.begin_recognize_identity_documents(id_document, pages=["1"])

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
@@ -29,7 +29,9 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_bad_endpoint(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_identity_document_bad_endpoint(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         with open(self.identity_document_license_jpg, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(ServiceRequestError):
@@ -88,7 +90,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_stream_transform_jpg(self, client):
+    async def test_identity_document_stream_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -128,7 +131,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_jpg_include_field_elements(self, client):
+    async def test_identity_document_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
         async with client:
@@ -178,7 +182,8 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.identity_document_license_jpg, "rb") as fd:
             id_document = fd.read()
         async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
@@ -26,7 +26,9 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_polling_interval(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -44,7 +46,8 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_url_transform_jpg(self, client):
+    def test_identity_document_url_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -84,7 +87,8 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_identity_document_jpg_include_field_elements(self, client):
+    def test_identity_document_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -129,7 +133,8 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
@@ -27,7 +27,9 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_polling_interval(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -46,7 +48,8 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_url_transform_jpg(self, client):
+    async def test_identity_document_url_transform_jpg(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -87,7 +90,8 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_identity_document_jpg_include_field_elements(self, client):
+    async def test_identity_document_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -135,7 +139,8 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
@@ -29,7 +29,8 @@ class TestInvoice(FormRecognizerTest):
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_invoice_bad_endpoint(self, formrecognizer_test_api_key, **kwargs):
+    def test_invoice_bad_endpoint(self, **kwargs):
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(ServiceRequestError):
@@ -39,7 +40,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_passing_enum_content_type(self, client):
+    def test_passing_enum_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         poller = client.begin_recognize_invoices(
@@ -97,7 +99,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_stream_transform_pdf(self, client):
+    def test_invoice_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -137,7 +140,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_stream_multipage_transform_pdf(self, client):
+    def test_invoice_stream_multipage_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -181,7 +185,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_tiff(self, client):
+    def test_invoice_tiff(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.invoice_tiff, "rb") as stream:
             poller = client.begin_recognize_invoices(stream)
@@ -205,7 +210,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_multipage_pdf(self, client):
+    def test_invoice_multipage_pdf(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.multipage_vendor_pdf, "rb") as fd:
             invoice = fd.read()
@@ -233,7 +239,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_jpg_include_field_elements(self, client):
+    def test_invoice_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_jpg, "rb") as fd:
             invoice = fd.read()
         poller = client.begin_recognize_invoices(invoice, include_field_elements=True)
@@ -311,7 +318,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_locale_specified(self, client):
+    def test_invoice_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_tiff, "rb") as fd:
             invoice = fd.read()
         poller = client.begin_recognize_invoices(invoice, locale="en-US")
@@ -322,7 +330,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_locale_error(self, client):
+    def test_invoice_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             invoice = fd.read()
         with pytest.raises(HttpResponseError) as e:
@@ -332,7 +341,8 @@ class TestInvoice(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             invoice = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
@@ -31,7 +31,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_bad_endpoint(self, formrecognizer_test_api_key, **kwargs):
+    async def test_invoice_bad_endpoint(self, **kwargs):
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         with pytest.raises(ServiceRequestError):
@@ -42,7 +43,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_enum_content_type(self, client):
+    async def test_passing_enum_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             my_file = fd.read()
         async with client:
@@ -105,7 +107,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_stream_transform_pdf(self, client):
+    async def test_invoice_stream_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -146,7 +149,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_stream_multipage_transform_pdf(self, client):
+    async def test_invoice_stream_multipage_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         responses = []
 
         def callback(raw_response, _, headers):
@@ -191,7 +195,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_tiff(self, client):
+    async def test_invoice_tiff(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.invoice_tiff, "rb") as fd:
             stream = fd.read()
@@ -217,7 +222,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_multipage_pdf(self, client):
+    async def test_invoice_multipage_pdf(self, **kwargs):
+        client = kwargs.pop("client")
 
         with open(self.multipage_vendor_pdf, "rb") as fd:
             invoice = fd.read()
@@ -247,7 +253,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_jpg_include_field_elements(self, client):
+    async def test_invoice_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_jpg, "rb") as fd:
             invoice = fd.read()
 
@@ -327,7 +334,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_locale_specified(self, client):
+    async def test_invoice_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_tiff, "rb") as fd:
             invoice = fd.read()
         async with client:
@@ -339,7 +347,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_locale_error(self, client):
+    async def test_invoice_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             invoice = fd.read()
         with pytest.raises(HttpResponseError) as e:
@@ -350,7 +359,8 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             invoice = fd.read()
         async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
@@ -26,7 +26,9 @@ class TestInvoiceFromUrl(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_polling_interval(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -44,7 +46,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_bad_url(self, client):
+    def test_invoice_bad_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -55,7 +58,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_url_multipage_transform_pdf(self, client):
+    def test_invoice_url_multipage_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -121,7 +125,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_locale_specified(self, client):
+    def test_invoice_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -134,7 +139,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_locale_error(self, client):
+    def test_invoice_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -146,7 +152,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_pages_kwarg_specified(self, client):
+    def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -159,7 +166,8 @@ class TestInvoiceFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_invoice_no_sub_line_items(self, client):
+    def test_invoice_no_sub_line_items(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
@@ -29,7 +29,9 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_polling_interval(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -48,7 +50,8 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_bad_url(self, client):
+    async def test_invoice_bad_url(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -60,7 +63,8 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_url_multipage_transform_pdf(self, client):
+    async def test_invoice_url_multipage_transform_pdf(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -128,7 +132,8 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_locale_specified(self, client):
+    async def test_invoice_locale_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -142,7 +147,8 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_invoice_locale_error(self, client):
+    async def test_invoice_locale_error(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -155,7 +161,8 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_pages_kwarg_specified(self, client):
+    async def test_pages_kwarg_specified(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
@@ -25,7 +25,8 @@ class TestReceiptFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_passing_enum_content_type_v2(self, client):
+    def test_passing_enum_content_type_v2(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_png, "rb") as fd:
             my_file = fd.read()
         poller = client.begin_recognize_receipts(
@@ -81,7 +82,8 @@ class TestReceiptFromStream(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_receipt_jpg_include_field_elements(self, client):
+    def test_receipt_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         poller = client.begin_recognize_receipts(receipt, include_field_elements=True)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
@@ -28,7 +28,8 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_enum_content_type(self, client):
+    async def test_passing_enum_content_type(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_png, "rb") as fd:
             my_file = fd.read()
         async with client:
@@ -81,7 +82,8 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_jpg_include_field_elements(self, client):
+    async def test_receipt_jpg_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.receipt_jpg, "rb") as fd:
             receipt = fd.read()
         async with client:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
@@ -25,7 +25,8 @@ class TestReceiptFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_receipt_url_transform_png(self, client):
+    def test_receipt_url_transform_png(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -66,7 +67,8 @@ class TestReceiptFromUrl(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
-    def test_receipt_url_include_field_elements(self, client):
+    def test_receipt_url_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
@@ -27,7 +27,8 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_url_transform_png(self, client):
+    async def test_receipt_url_transform_png(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -68,7 +69,8 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
-    async def test_receipt_url_include_field_elements(self, client):
+    async def test_receipt_url_include_field_elements(self, **kwargs):
+        client = kwargs.pop("client")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
@@ -25,7 +25,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_compose_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_compose_model_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -48,7 +50,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_compose_model_invalid_unlabeled_models_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_compose_model_invalid_unlabeled_models_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
@@ -27,7 +27,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_compose_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_compose_model_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -50,7 +52,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_compose_model_invalid_unlabeled_models_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_compose_model_invalid_unlabeled_models_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
@@ -25,7 +25,11 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
-    def test_copy_model_successful_v2(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_model_successful_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -51,7 +55,11 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_copy_model_with_labeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_model_with_labeled_model_name_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -78,7 +86,11 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_copy_model_with_unlabeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_model_with_unlabeled_model_name_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -105,7 +117,11 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_copy_model_fail_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_model_fail_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -126,7 +142,11 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_copy_model_case_insensitive_region_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_model_case_insensitive_region_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -150,7 +170,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
-    def test_copy_authorization_v2(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_authorization_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -167,7 +190,10 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_copy_authorization_v21(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_authorization_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -184,7 +210,11 @@ class TestCopyModel(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_copy_model_with_composed_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    def test_copy_model_with_composed_model_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
@@ -27,7 +27,11 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
-    async def test_copy_model_successful_v2(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_model_successful_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -53,7 +57,11 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_copy_model_with_labeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_model_with_labeled_model_name_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -80,7 +88,11 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_copy_model_with_unlabeled_model_name_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_model_with_unlabeled_model_name_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -107,7 +119,11 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_copy_model_fail_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_model_fail_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -128,7 +144,11 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_copy_model_case_insensitive_region_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_model_case_insensitive_region_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -152,7 +172,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
-    async def test_copy_authorization_v2(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_authorization_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -169,7 +192,10 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_copy_authorization_v21(self, client, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_authorization_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -186,7 +212,11 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_copy_model_with_composed_model_v21(self, client, formrecognizer_storage_container_sas_url_v2, formrecognizer_region, formrecognizer_resource_id, **kwargs):
+    async def test_copy_model_with_composed_model_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        formrecognizer_region = kwargs.pop("formrecognizer_region")
+        formrecognizer_resource_id = kwargs.pop("formrecognizer_resource_id")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
@@ -29,7 +29,8 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_account_properties_v2(self, client):
+    def test_account_properties_v2(self, **kwargs):
+        client = kwargs.pop("client")
         properties = client.get_account_properties()
 
         assert properties.custom_model_limit
@@ -39,8 +40,10 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_mgmt_model_labeled_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-
+    def test_mgmt_model_labeled_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
         labeled_model_from_train = poller.result()
 
@@ -77,8 +80,10 @@ class TestManagement(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_mgmt_model_unlabeled_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
-
+    def test_mgmt_model_unlabeled_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
+        
         poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
         unlabeled_model_from_train = poller.result()
 
@@ -112,7 +117,9 @@ class TestManagement(FormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy
-    def test_get_form_recognizer_client_v2(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    def test_get_form_recognizer_client_v2(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
@@ -29,7 +29,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_account_properties_v2(self, client):
+    async def test_account_properties_v2(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             properties = await client.get_account_properties()
 
@@ -40,7 +41,9 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_mgmt_model_labeled_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_mgmt_model_labeled_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True)
             labeled_model_from_train = await poller.result()
@@ -78,7 +81,9 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_mgmt_model_unlabeled_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_mgmt_model_unlabeled_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         async with client:
             poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=False)
             unlabeled_model_from_train = await poller.result()
@@ -113,7 +118,9 @@ class TestManagementAsync(AsyncFormRecognizerTest):
 
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
-    async def test_get_form_recognizer_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
+    async def test_get_form_recognizer_client(self, **kwargs):
+        formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")
+        formrecognizer_test_api_key = kwargs.pop("formrecognizer_test_api_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
@@ -24,7 +24,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
-    def test_training_with_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_training_with_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -56,7 +58,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
-    def test_training_multipage_with_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_training_multipage_with_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -86,7 +90,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
-    def test_training_without_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_training_without_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -118,7 +124,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
-    def test_training_multipage_without_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_training_multipage_without_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -147,7 +155,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
-    def test_training_with_files_filter_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_training_with_files_filter_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -172,7 +182,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_training_with_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_training_with_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -205,7 +217,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_training_multipage_with_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_training_multipage_with_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -234,7 +248,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_training_without_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_training_without_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -267,7 +283,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_training_multipage_without_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    def test_training_multipage_without_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -296,7 +314,9 @@ class TestTraining(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
-    def test_training_with_files_filter_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_training_with_files_filter_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
@@ -27,7 +27,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
-    async def test_training_with_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_training_with_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -59,7 +61,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
-    async def test_training_multipage_with_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_training_multipage_with_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -89,7 +93,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
-    async def test_training_without_labels_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_training_without_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -121,7 +127,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
-    async def test_training_multipage_without_labels_v2(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_training_multipage_without_labels_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -150,7 +158,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
-    async def test_training_with_files_filter_v2(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_training_with_files_filter_v2(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -175,7 +185,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_training_with_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_training_with_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -208,7 +220,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_training_multipage_with_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_training_multipage_with_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -237,7 +251,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_training_without_labels_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_training_without_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -270,7 +286,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_training_multipage_without_labels_v21(self, client, formrecognizer_multipage_storage_container_sas_url_v2, **kwargs):
+    async def test_training_multipage_without_labels_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_multipage_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_multipage_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -299,7 +317,9 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
-    async def test_training_with_files_filter_v21(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_training_with_files_filter_v21(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
@@ -24,7 +24,8 @@ class TestGetChildren(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_line_get_words(self, client, **kwargs):
+    def test_document_line_get_words(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 
@@ -38,7 +39,8 @@ class TestGetChildren(FormRecognizerTest):
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
-    def test_document_line_get_words_error(self, client, **kwargs):
+    def test_document_line_get_words_error(self, **kwargs):
+        client = kwargs.pop("client")
         with open(self.invoice_pdf, "rb") as fd:
             document = fd.read()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
@@ -140,7 +140,9 @@ class TestMultiapi(FormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy
-    def test_v2_0_compatibility(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    def test_v2_0_compatibility(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # test that the addition of new attributes in v2.1 does not break v2.0
 
         label_poller = client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
@@ -139,7 +139,9 @@ class TestMultiapi(AsyncFormRecognizerTest):
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy_async
-    async def test_v2_0_compatibility(self, client, formrecognizer_storage_container_sas_url_v2, **kwargs):
+    async def test_v2_0_compatibility(self, **kwargs):
+        client = kwargs.pop("client")
+        formrecognizer_storage_container_sas_url_v2 = kwargs.pop("formrecognizer_storage_container_sas_url_v2")
         # test that the addition of new attributes in v2.1 does not break v2.0
         async with client:
             label_poller = await client.begin_training(formrecognizer_storage_container_sas_url_v2, use_training_labels=True)

--- a/sdk/iothub/azure-mgmt-iothub/tests/test_mgmt_iothub.py
+++ b/sdk/iothub/azure-mgmt-iothub/tests/test_mgmt_iothub.py
@@ -20,7 +20,9 @@ class TestMgmtIoTHub(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_iothub(self, resource_group, location):
+    def test_iothub(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         account_name = self.get_resource_name('iot')
         
         is_available = self.iothub_client.iot_hub_resource.check_name_availability(
@@ -99,7 +101,9 @@ class TestMgmtIoTHub(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_iothub_consumer_group(self, resource_group, location):
+    def test_iothub_consumer_group(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         account_name = self.get_resource_name('iot')
 
         async_iot_hub = self.iothub_client.iot_hub_resource.begin_create_or_update(

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_access_control.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_access_control.py
@@ -33,7 +33,8 @@ class TestAccessControl(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultAccessControlClientPreparer()
     @recorded_by_proxy
-    def test_role_definitions(self, client, **kwargs):
+    def test_role_definitions(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         # list initial role definitions
         scope = KeyVaultRoleScope.GLOBAL
@@ -92,7 +93,8 @@ class TestAccessControl(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultAccessControlClientPreparer()
     @recorded_by_proxy
-    def test_role_assignment(self, client, **kwargs):
+    def test_role_assignment(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         scope = KeyVaultRoleScope.GLOBAL
         definitions = [d for d in client.list_role_definitions(scope)]

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_access_control_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_access_control_async.py
@@ -36,7 +36,8 @@ class TestAccessControl(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultAccessControlClientPreparer()
     @recorded_by_proxy_async
-    async def test_role_definitions(self, client, **kwargs):
+    async def test_role_definitions(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         # list initial role definitions
         scope = KeyVaultRoleScope.GLOBAL
@@ -103,7 +104,8 @@ class TestAccessControl(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultAccessControlClientPreparer()
     @recorded_by_proxy_async
-    async def test_role_assignment(self, client, **kwargs):
+    async def test_role_assignment(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         scope = KeyVaultRoleScope.GLOBAL
         definitions = []

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
@@ -26,7 +26,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
-    def test_full_backup_and_restore(self, client, **kwargs):
+    def test_full_backup_and_restore(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         # backup the vault
         container_uri = kwargs.pop("container_uri")
@@ -44,7 +45,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
-    def test_full_backup_and_restore_rehydration(self, client, **kwargs):
+    def test_full_backup_and_restore_rehydration(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         container_uri = kwargs.pop("container_uri")
         sas_token = kwargs.pop("sas_token")
@@ -76,7 +78,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
-    def test_selective_key_restore(self, client, **kwargs):
+    def test_selective_key_restore(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         # create a key to selectively restore
         managed_hsm_url = kwargs.pop("managed_hsm_url")
@@ -106,7 +109,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
-    def test_backup_client_polling(self, client, **kwargs):
+    def test_backup_client_polling(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         # if not self.is_live:
         #     pytest.skip("Poller requests are incompatible with vcrpy in playback")

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client_async.py
@@ -25,7 +25,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
-    async def test_full_backup_and_restore(self, client, **kwargs):
+    async def test_full_backup_and_restore(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         # backup the vault
         container_uri = kwargs.pop("container_uri")
@@ -44,7 +45,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
-    async def test_full_backup_and_restore_rehydration(self, client, **kwargs):
+    async def test_full_backup_and_restore_rehydration(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
 
         # backup the vault
@@ -77,7 +79,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
-    async def test_selective_key_restore(self, client, **kwargs):
+    async def test_selective_key_restore(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         # create a key to selectively restore
         managed_hsm_url = kwargs.pop("managed_hsm_url")
@@ -105,7 +108,8 @@ class TestBackupClientTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
-    async def test_backup_client_polling(self, client, **kwargs):
+    async def test_backup_client_polling(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
 
         # backup the vault

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration.py
@@ -22,7 +22,8 @@ class TestExamplesTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
-    def test_example_backup_and_restore(self, client, **kwargs):
+    def test_example_backup_and_restore(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         backup_client = client
         container_uri = kwargs.pop("container_uri")
@@ -59,7 +60,8 @@ class TestExamplesTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
-    def test_example_selective_key_restore(self, client,**kwargs):
+    def test_example_selective_key_restore(self, **kwargs):
+        client,**kwargs = kwargs.pop("client,**kwargs")
         set_bodiless_matcher()
         # create a key to selectively restore
         managed_hsm_url = kwargs.pop("managed_hsm_url")

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration_async.py
@@ -24,7 +24,8 @@ class TestExamplesTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_backup_and_restore(self, client, **kwargs):
+    async def test_example_backup_and_restore(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         backup_client = client
         container_uri = kwargs.pop("container_uri")
@@ -62,7 +63,8 @@ class TestExamplesTests(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_selective_key_restore(self, client, **kwargs):
+    async def test_example_selective_key_restore(self, **kwargs):
+        client = kwargs.pop("client")
         # create a key to selectively restore
         set_bodiless_matcher()
         managed_hsm_url = kwargs.pop("managed_hsm_url")

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -171,7 +171,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_crud_operations(self, client, **kwargs):
+    def test_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("cert")
         lifetime_actions = [LifetimeAction(lifetime_percentage=80, action=CertificatePolicyAction.auto_renew)]
         cert_policy = CertificatePolicy(
@@ -225,7 +226,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_import_certificate_not_password_encoded_no_policy(self, client, **kwargs):
+    def test_import_certificate_not_password_encoded_no_policy(self, **kwargs):
+        client = kwargs.pop("client")
         # If a certificate is not password encoded, we can import the certificate
         # without passing in 'password'
         certificate = client.import_certificate(
@@ -237,7 +239,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_import_certificate_password_encoded_no_policy(self, client, **kwargs):
+    def test_import_certificate_password_encoded_no_policy(self, **kwargs):
+        client = kwargs.pop("client")
         # If a certificate is password encoded, we have to pass in 'password'
         # when importing the certificate
         certificate = client.import_certificate(
@@ -250,7 +253,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_list(self, client, **kwargs):
+    def test_list(self, **kwargs):
+        client = kwargs.pop("client")
         max_certificates = LIST_TEST_SIZE
         expected = {}
 
@@ -279,7 +283,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_list_certificate_versions(self, client, **kwargs):
+    def test_list_certificate_versions(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("certver")
 
         max_certificates = LIST_TEST_SIZE
@@ -310,7 +315,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_crud_contacts(self, client, **kwargs):
+    def test_crud_contacts(self, **kwargs):
+        client = kwargs.pop("client")
         contact_list = [
             CertificateContact(email="admin@contoso.com", name="John Doe", phone="1111111111"),
             CertificateContact(email="admin2@contoso.com", name="John Doe2", phone="2222222222"),
@@ -339,7 +345,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_recover_and_purge(self, client, **kwargs):
+    def test_recover_and_purge(self, **kwargs):
+        client = kwargs.pop("client")
         certs = {}
         # create certificates to recover
         for i in range(LIST_TEST_SIZE):
@@ -382,7 +389,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_async_request_cancellation_and_deletion(self, client, **kwargs):
+    def test_async_request_cancellation_and_deletion(self, **kwargs):
+        client = kwargs.pop("client")
         if self.is_live:
             pytest.skip("Skipping by default because of pipeline test flakiness: https://github.com/Azure/azure-sdk-for-python/issues/16333")
 
@@ -437,7 +445,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", exclude_2016_10_01)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_policy(self, client, **kwargs):
+    def test_policy(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("policyCertificate")
         cert_policy = CertificatePolicy(
             issuer_name="Self",
@@ -473,7 +482,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_get_pending_certificate_signing_request(self, client, **kwargs):
+    def test_get_pending_certificate_signing_request(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("unknownIssuerCert")
 
         # get pending certificate signing request
@@ -487,7 +497,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", exclude_2016_10_01)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_backup_restore(self, client, **kwargs):
+    def test_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
         policy = CertificatePolicy.get_default()
         policy._san_user_principal_names = ["john.doe@domain.com"]
         cert_name = self.get_resource_name("cert")
@@ -512,7 +523,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_crud_issuer(self, client, **kwargs):
+    def test_crud_issuer(self, **kwargs):
+        client = kwargs.pop("client")
         issuer_name = self.get_resource_name("issuer")
         admin_contacts = [
             AdministratorContact(first_name="John", last_name="Doe", email="admin@microsoft.com", phone="4255555555")
@@ -592,7 +604,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy
-    def test_logging_enabled(self, client, **kwargs):
+    def test_logging_enabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -626,7 +639,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer(logging_enable = False)
     @recorded_by_proxy
-    def test_logging_disabled(self, client, **kwargs):
+    def test_logging_disabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -660,7 +674,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", only_2016_10_01)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_models(self, client, **kwargs):
+    def test_models(self, **kwargs):
+        client = kwargs.pop("client")
         """The client should correctly deserialize version 2016-10-01 models"""
 
         cert_name = self.get_resource_name("cert")
@@ -673,7 +688,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_get_certificate_version(self, client, **kwargs):
+    def test_get_certificate_version(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("cert")
         for _ in range(LIST_TEST_SIZE):
             client.begin_create_certificate(cert_name, CertificatePolicy.get_default()).wait()
@@ -699,7 +715,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", only_2016_10_01)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_list_properties_of_certificates(self, client, **kwargs):
+    def test_list_properties_of_certificates(self, **kwargs):
+        client = kwargs.pop("client")
         """Tests API version v2016_10_01"""
 
         [_ for _ in client.list_properties_of_certificates()]
@@ -712,7 +729,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", only_2016_10_01)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_list_deleted_certificates(self, client, **kwargs):
+    def test_list_deleted_certificates(self, **kwargs):
+        client = kwargs.pop("client")
         """Tests API version v2016_10_01"""
         
         [_ for _ in client.list_deleted_certificates()]

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
@@ -171,7 +171,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_crud_operations(self, client, **kwargs):
+    async def test_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("cert")
         lifetime_actions = [LifetimeAction(lifetime_percentage=80, action=CertificatePolicyAction.auto_renew)]
         cert_policy = CertificatePolicy(
@@ -225,7 +226,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_import_certificate_not_password_encoded_no_policy(self, client, **kwargs):
+    async def test_import_certificate_not_password_encoded_no_policy(self, **kwargs):
+        client = kwargs.pop("client")
         # If a certificate is not password encoded, we can import the certificate
         # without passing in 'password'
         certificate = await client.import_certificate(
@@ -238,7 +240,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_import_certificate_password_encoded_no_policy(self, client, **kwargs):
+    async def test_import_certificate_password_encoded_no_policy(self, **kwargs):
+        client = kwargs.pop("client")
         # If a certificate is password encoded, we have to pass in 'password'
         # when importing the certificate
         certificate = await client.import_certificate(
@@ -252,7 +255,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_list(self, client, **kwargs):
+    async def test_list(self, **kwargs):
+        client = kwargs.pop("client")
         max_certificates = LIST_TEST_SIZE
         expected = {}
 
@@ -282,7 +286,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_list_certificate_versions(self, client, **kwargs):
+    async def test_list_certificate_versions(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("certver")
 
         max_certificates = LIST_TEST_SIZE
@@ -316,7 +321,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_crud_contacts(self, client, **kwargs):
+    async def test_crud_contacts(self, **kwargs):
+        client = kwargs.pop("client")
         contact_list = [
             CertificateContact(email="admin@contoso.com", name="John Doe", phone="1111111111"),
             CertificateContact(email="admin2@contoso.com", name="John Doe2", phone="2222222222"),
@@ -346,7 +352,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_recover_and_purge(self, client, **kwargs):
+    async def test_recover_and_purge(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         certs = {}
         # create certificates to recover
@@ -400,7 +407,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.skip("Skipping because service doesn't allow cancellation of certificates with issuer 'Unknown'")
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_async_request_cancellation_and_deletion(self, client, **kwargs):
+    async def test_async_request_cancellation_and_deletion(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("asyncCanceledDeletedCert")
         cert_policy = CertificatePolicy.get_default()
 
@@ -460,7 +468,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", exclude_2016_10_01)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_policy(self, client, **kwargs):
+    async def test_policy(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("policyCertificate")
         cert_policy = CertificatePolicy(
             issuer_name="Self",
@@ -498,7 +507,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_get_pending_certificate_signing_request(self, client, **kwargs):
+    async def test_get_pending_certificate_signing_request(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("unknownIssuerCert")
 
         # get pending certificate signing request
@@ -511,7 +521,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", exclude_2016_10_01)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_backup_restore(self, client, **kwargs):
+    async def test_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("cert")
         policy = CertificatePolicy.get_default()
         policy._san_user_principal_names = ["john.doe@domain.com"]
@@ -539,7 +550,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer()
     @recorded_by_proxy_async
-    async def test_crud_issuer(self, client, **kwargs):
+    async def test_crud_issuer(self, **kwargs):
+        client = kwargs.pop("client")
         issuer_name = self.get_resource_name("issuer")
         admin_contacts = [
             AdministratorContact(first_name="John", last_name="Doe", email="admin@microsoft.com", phone="4255555555")
@@ -620,7 +632,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_logging_enabled(self, client, **kwargs):
+    async def test_logging_enabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -655,7 +668,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = False)
     @recorded_by_proxy_async
-    async def test_logging_disabled(self, client, **kwargs):
+    async def test_logging_disabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -689,7 +703,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_get_certificate_version(self, client, **kwargs):
+    async def test_get_certificate_version(self, **kwargs):
+        client = kwargs.pop("client")
         cert_name = self.get_resource_name("cert")
         policy = CertificatePolicy.get_default()
         for _ in range(LIST_TEST_SIZE):
@@ -717,7 +732,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", only_2016_10_01)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_list_properties_of_certificates(self, client, **kwargs):
+    async def test_list_properties_of_certificates(self, **kwargs):
+        client = kwargs.pop("client")
         """Tests API version v2016_10_01"""
 
         certs = client.list_properties_of_certificates()
@@ -736,7 +752,8 @@ class TestCertificateClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", only_2016_10_01)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_list_deleted_certificates_2016_10_01(self, client, **kwargs):
+    async def test_list_deleted_certificates_2016_10_01(self, **kwargs):
+        client = kwargs.pop("client")
         """Tests API version v2016_10_01"""
 
         certs = client.list_deleted_certificates()

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
@@ -38,7 +38,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_example_certificate_crud_operations(self, certificate_client, **kwargs):
+    def test_example_certificate_crud_operations(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         cert_name = self.get_resource_name("cert-name")
 
         # [START create_certificate]
@@ -121,7 +122,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_example_certificate_list_operations(self, certificate_client, **kwargs):
+    def test_example_certificate_list_operations(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -180,7 +182,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", exclude_2016_10_01)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_example_certificate_backup_restore(self, certificate_client, **kwargs):
+    def test_example_certificate_backup_restore(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -223,7 +226,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_example_certificate_recover(self, certificate_client, **kwargs):
+    def test_example_certificate_recover(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -266,7 +270,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_example_contacts(self, certificate_client, **kwargs):
+    def test_example_contacts(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # [START set_contacts]
         from azure.keyvault.certificates import CertificateContact
 
@@ -305,7 +310,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_example_issuers(self, certificate_client, **kwargs):
+    def test_example_issuers(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # [START create_issuer]
         from azure.keyvault.certificates import AdministratorContact
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
@@ -44,7 +44,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_example_certificate_crud_operations(self, certificate_client, **kwargs):
+    async def test_example_certificate_crud_operations(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         cert_name = self.get_resource_name("cert-name")
 
         # [START create_certificate]
@@ -117,7 +118,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_example_certificate_list_operations(self, certificate_client, **kwargs):
+    async def test_example_certificate_list_operations(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -177,7 +179,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", exclude_2016_10_01)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_example_certificate_backup_restore(self, certificate_client, **kwargs):
+    async def test_example_certificate_backup_restore(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -224,7 +227,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_example_certificate_recover(self, certificate_client, **kwargs):
+    async def test_example_certificate_recover(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -263,7 +267,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_example_contacts(self, certificate_client, **kwargs):
+    async def test_example_contacts(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # [START set_contacts]
         from azure.keyvault.certificates import CertificateContact
 
@@ -303,7 +308,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_example_issuers(self, certificate_client, **kwargs):
+    async def test_example_issuers(self, **kwargs):
+        certificate_client = kwargs.pop("certificate_client")
         # [START create_issuer]
         from azure.keyvault.certificates import AdministratorContact
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate.py
@@ -20,7 +20,8 @@ class TestMergeCertificate(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @CertificatesClientPreparer()
     @recorded_by_proxy
-    def test_merge_certificate(self, client, **kwargs):
+    def test_merge_certificate(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         cert_name = self.get_resource_name("mergeCertificate")
         cert_policy = CertificatePolicy(

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
@@ -22,7 +22,8 @@ class TestMergeCertificate(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions)
     @AsyncCertificatesClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_merge_certificate(self, client, **kwargs):
+    async def test_merge_certificate(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         cert_name = self.get_resource_name("mergeCertificate")
         cert_policy = CertificatePolicy(

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_parse_id.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_parse_id.py
@@ -17,7 +17,8 @@ class TestParseId(KeyVaultTestCase):
 
     @PowerShellPreparer("keyvault", azure_keyvault_url="https://vaultname.vault.azure.net")
     @recorded_by_proxy
-    def test_parse_certificate_id_with_version(self, azure_keyvault_url):
+    def test_parse_certificate_id_with_version(self, **kwargs):
+        azure_keyvault_url = kwargs.pop("azure_keyvault_url")
         client = self.create_client(azure_keyvault_url)
 
         cert_name = self.get_resource_name("cert")

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -40,7 +40,9 @@ class TestChallengeAuth(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", only_default_version)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_multitenant_authentication(self, client, is_hsm, **kwargs):
+    def test_multitenant_authentication(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         if not self.is_live:
             pytest.skip("This test is incompatible with test proxy in playback")
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -38,7 +38,9 @@ class TestChallengeAuth(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_default_version)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_multitenant_authentication(self, client, is_hsm, **kwargs):
+    async def test_multitenant_authentication(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         if not self.is_live:
             pytest.skip("This test is incompatible with vcrpy in playback")
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -139,7 +139,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_ec_key_id(self, key_client, is_hsm, **kwargs):
+    def test_ec_key_id(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
         set_bodiless_matcher()
         key = self._create_ec_key(key_client, self.get_resource_name("eckey"), hardware_protected=is_hsm)
@@ -156,7 +158,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_rsa_key_id(self, key_client, is_hsm, **kwargs):
+    def test_rsa_key_id(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
         key = self._create_rsa_key(key_client, self.get_resource_name("rsakey"), hardware_protected=is_hsm)
 
@@ -174,7 +178,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", no_get)
     @KeysClientPreparer(permissions=NO_GET)
     @recorded_by_proxy
-    def test_encrypt_and_decrypt(self, key_client, is_hsm, **kwargs):
+    def test_encrypt_and_decrypt(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         key_name = self.get_resource_name("keycrypt")
 
@@ -192,7 +198,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", no_get)
     @KeysClientPreparer(permissions=NO_GET)
     @recorded_by_proxy
-    def test_sign_and_verify(self, key_client, is_hsm, **kwargs):
+    def test_sign_and_verify(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         key_name = self.get_resource_name("keysign")
 
         md = hashlib.sha256()
@@ -213,7 +221,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", no_get)
     @KeysClientPreparer(permissions=NO_GET)
     @recorded_by_proxy
-    def test_wrap_and_unwrap(self, key_client, is_hsm, **kwargs):
+    def test_wrap_and_unwrap(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         key_name = self.get_resource_name("keywrap")
 
@@ -232,7 +242,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_symmetric_encrypt_and_decrypt(self, key_client, **kwargs):
+    def test_symmetric_encrypt_and_decrypt(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         """Encrypt and decrypt with the service"""
         key_name = self.get_resource_name("symmetric-encrypt")
 
@@ -279,7 +290,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_symmetric_wrap_and_unwrap(self, key_client, **kwargs):
+    def test_symmetric_wrap_and_unwrap(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("symmetric-kw")
 
         imported_key = self._import_symmetric_test_key(key_client, key_name)
@@ -295,7 +307,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_encrypt_local(self, key_client, is_hsm, **kwargs):
+    def test_encrypt_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         """Encrypt locally, decrypt with Key Vault"""
         key_name = self.get_resource_name("encrypt-local")
@@ -313,7 +327,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_encrypt_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    def test_encrypt_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         """Encrypt locally, decrypt with Key Vault"""
         key_name = self.get_resource_name("encrypt-local")
@@ -332,7 +348,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_symmetric_encrypt_local(self, key_client, **kwargs):
+    def test_symmetric_encrypt_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         """Encrypt locally, decrypt with the service"""
         key_name = self.get_resource_name("symmetric-encrypt")
 
@@ -362,7 +379,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", only_hsm)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_symmetric_decrypt_local(self, key_client, **kwargs):
+    def test_symmetric_decrypt_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         """Encrypt with the service, decrypt locally"""
         key_name = self.get_resource_name("symmetric-encrypt")
 
@@ -393,7 +411,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_wrap_local(self, key_client, is_hsm, **kwargs):
+    def test_wrap_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         """Wrap locally, unwrap with Key Vault"""
         key_name = self.get_resource_name("wrap-local")
@@ -410,7 +430,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_wrap_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    def test_wrap_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Wrap locally, unwrap with Key Vault"""
         set_bodiless_matcher()
         key_name = self.get_resource_name("wrap-local")
@@ -428,7 +450,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_rsa_verify_local(self, key_client, is_hsm, **kwargs):
+    def test_rsa_verify_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
             key_name = self.get_resource_name("rsa-verify-{}".format(size))
@@ -453,7 +477,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_rsa_verify_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    def test_rsa_verify_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
             key_name = self.get_resource_name("rsa-verify-{}".format(size))
@@ -479,7 +505,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_ec_verify_local(self, key_client, is_hsm, **kwargs):
+    def test_ec_verify_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         matrix = {
             KeyCurveName.p_256: (SignatureAlgorithm.es256, hashlib.sha256),
@@ -504,7 +532,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_ec_verify_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    def test_ec_verify_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         matrix = {
             KeyCurveName.p_256: (SignatureAlgorithm.es256, hashlib.sha256),
@@ -530,7 +560,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_local_validity_period_enforcement(self, key_client, is_hsm, **kwargs):
+    def test_local_validity_period_enforcement(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Local crypto operations should respect a key's nbf and exp properties"""
         def test_operations(key, expected_error_substrings, encrypt_algorithms, wrap_algorithms):
             crypto_client = self.create_crypto_client(key, api_version=key_client.api_version)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -137,7 +137,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_ec_key_id(self, key_client, is_hsm, **kwargs):
+    async def test_ec_key_id(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
         key = await self._create_ec_key(key_client, self.get_resource_name("eckey"), hardware_protected=is_hsm)
 
@@ -154,7 +156,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_rsa_key_id(self, key_client, is_hsm, **kwargs):
+    async def test_rsa_key_id(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
         key = await self._create_rsa_key(key_client, self.get_resource_name("rsakey"), hardware_protected=is_hsm)
 
@@ -173,7 +177,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",no_get)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_encrypt_and_decrypt(self, key_client, is_hsm, **kwargs):
+    async def test_encrypt_and_decrypt(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         key_name = self.get_resource_name("keycrypt")
 
@@ -192,7 +198,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",no_get)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_sign_and_verify(self, key_client, is_hsm, **kwargs):
+    async def test_sign_and_verify(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         key_name = self.get_resource_name("keysign")
 
         md = hashlib.sha256()
@@ -214,7 +222,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",no_get)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_wrap_and_unwrap(self, key_client, is_hsm, **kwargs):
+    async def test_wrap_and_unwrap(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         key_name = self.get_resource_name("keywrap")
 
@@ -234,7 +244,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_symmetric_encrypt_and_decrypt(self, key_client, **kwargs):
+    async def test_symmetric_encrypt_and_decrypt(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         """Encrypt and decrypt with the service"""
         key_name = self.get_resource_name("symmetric-encrypt")
 
@@ -279,7 +290,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_symmetric_wrap_and_unwrap(self, key_client, **kwargs):
+    async def test_symmetric_wrap_and_unwrap(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("symmetric-kw")
 
         imported_key = await self._import_symmetric_test_key(key_client, key_name)
@@ -296,7 +308,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_encrypt_local(self, key_client, is_hsm, **kwargs):
+    async def test_encrypt_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         """Encrypt locally, decrypt with Key Vault"""
         key_name = self.get_resource_name("encrypt-local")
@@ -315,7 +329,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_encrypt_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    async def test_encrypt_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         """Encrypt locally, decrypt with Key Vault"""
         key_name = self.get_resource_name("encrypt-local")
@@ -335,7 +351,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_symmetric_encrypt_local(self, key_client, **kwargs):
+    async def test_symmetric_encrypt_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         """Encrypt locally, decrypt with the service"""
         key_name = self.get_resource_name("symmetric-encrypt")
 
@@ -366,7 +383,8 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_symmetric_decrypt_local(self, key_client, **kwargs):
+    async def test_symmetric_decrypt_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         """Encrypt with the service, decrypt locally"""
         key_name = self.get_resource_name("symmetric-encrypt")
 
@@ -398,7 +416,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_wrap_local(self, key_client, is_hsm, **kwargs):
+    async def test_wrap_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         """Wrap locally, unwrap with Key Vault"""
         key_name = self.get_resource_name("wrap-local")
@@ -416,7 +436,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_wrap_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    async def test_wrap_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         """Wrap locally, unwrap with Key Vault"""
         key_name = self.get_resource_name("wrap-local")
@@ -435,7 +457,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_rsa_verify_local(self, key_client, is_hsm, **kwargs):
+    async def test_rsa_verify_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
             key_name = self.get_resource_name("rsa-verify-{}".format(size))
@@ -461,7 +485,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_rsa_verify_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    async def test_rsa_verify_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
             key_name = self.get_resource_name("rsa-verify-{}".format(size))
@@ -488,7 +514,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_ec_verify_local(self, key_client, is_hsm, **kwargs):
+    async def test_ec_verify_local(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         matrix = {
             KeyCurveName.p_256: (SignatureAlgorithm.es256, hashlib.sha256),
@@ -514,7 +542,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_ec_verify_local_from_jwk(self, key_client, is_hsm, **kwargs):
+    async def test_ec_verify_local_from_jwk(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Sign with Key Vault, verify locally"""
         matrix = {
             KeyCurveName.p_256: (SignatureAlgorithm.es256, hashlib.sha256),
@@ -541,7 +571,9 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",no_get)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_local_validity_period_enforcement(self, key_client, is_hsm, **kwargs):
+    async def test_local_validity_period_enforcement(self, **kwargs):
+        key_client = kwargs.pop("key_client")
+        is_hsm = kwargs.pop("is_hsm")
         """Local crypto operations should respect a key's nbf and exp properties"""
         async def test_operations(key, expected_error_substrings, encrypt_algorithms, wrap_algorithms):
             crypto_client = self.create_crypto_client(key, is_async=True, api_version=key_client.api_version)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
@@ -16,7 +16,8 @@ class TestCryptoExamples(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_encrypt_decrypt(self, key_client, **kwargs):
+    def test_encrypt_decrypt(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         set_bodiless_matcher()
         credential = self.get_credential(CryptographyClient)
         key_name = self.get_resource_name("crypto-test-encrypt-key")
@@ -54,7 +55,8 @@ class TestCryptoExamples(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_wrap_unwrap(self, key_client, **kwargs):
+    def test_wrap_unwrap(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         set_bodiless_matcher()
         credential = self.get_credential(CryptographyClient)
         key_name = self.get_resource_name("crypto-test-wrapping-key")
@@ -83,7 +85,8 @@ class TestCryptoExamples(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm", all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_sign_verify(self, key_client, **kwargs):
+    def test_sign_verify(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         set_bodiless_matcher()
         credential = self.get_credential(CryptographyClient)
         key_name = self.get_resource_name("crypto-test-wrapping-key")

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
@@ -18,7 +18,8 @@ class TestCryptoExamples(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_encrypt_decrypt_async(self, key_client, **kwargs):
+    async def test_encrypt_decrypt_async(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         set_bodiless_matcher()
         credential = self.get_credential(CryptographyClient, is_async=True)
         key_name = self.get_resource_name("crypto-test-encrypt-key")
@@ -62,7 +63,8 @@ class TestCryptoExamples(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_wrap_unwrap_async(self, key_client, **kwargs):
+    async def test_wrap_unwrap_async(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         set_bodiless_matcher()
         credential = self.get_credential(CryptographyClient, is_async=True)
         key_name = self.get_resource_name("crypto-test-wrapping-key")
@@ -91,7 +93,8 @@ class TestCryptoExamples(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_sign_verify_async(self, key_client, **kwargs):
+    async def test_sign_verify_async(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         credential = self.get_credential(CryptographyClient, is_async=True)
         key_name = self.get_resource_name("crypto-test-wrapping-key")
         key = await key_client.create_rsa_key(key_name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -178,7 +178,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_crud_operations(self, client, is_hsm, **kwargs):
+    def test_key_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         assert client is not None
 
@@ -243,7 +245,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_rsa_public_exponent(self, client, **kwargs):
+    def test_rsa_public_exponent(self, **kwargs):
+        client = kwargs.pop("client")
         """The public exponent of a Managed HSM RSA key can be specified during creation"""
         set_bodiless_matcher()
         assert client is not None
@@ -256,7 +259,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_backup_restore(self, client, is_hsm, **kwargs):
+    def test_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         assert client is not None
 
@@ -283,7 +288,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_list(self, client, is_hsm, **kwargs):
+    def test_key_list(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
 
         assert client is not None
@@ -308,7 +315,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_list_versions(self, client, is_hsm, **kwargs):
+    def test_list_versions(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         key_name = self.get_resource_name("testKey")
@@ -334,7 +343,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_list_deleted_keys(self, client, is_hsm, **kwargs):
+    def test_list_deleted_keys(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         assert client is not None
 
@@ -365,7 +376,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_recover(self, client, is_hsm, **kwargs):
+    def test_recover(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         assert client is not None
 
@@ -392,7 +405,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_purge(self, client, is_hsm, **kwargs):
+    def test_purge(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         set_bodiless_matcher()
         assert client is not None
 
@@ -424,7 +439,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",logging_enabled)
     @KeysClientPreparer(logging_enable = True)
     @recorded_by_proxy
-    def test_logging_enabled(self, client, is_hsm, **kwargs):
+    def test_logging_enabled(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -459,7 +476,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",logging_enabled)
     @KeysClientPreparer(logging_enable = False)
     @recorded_by_proxy
-    def test_logging_disabled(self, client, is_hsm, **kwargs):
+    def test_logging_disabled(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -493,7 +512,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_get_random_bytes(self, client, **kwargs):
+    def test_get_random_bytes(self, **kwargs):
+        client = kwargs.pop("client")
         assert client
 
         generated_random_bytes = []
@@ -509,7 +529,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_release(self, client, **kwargs):
+    def test_key_release(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         attestation = get_attestation_token(attestation_uri)
@@ -529,7 +550,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_imported_key_release(self, client, **kwargs):
+    def test_imported_key_release(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         attestation = get_attestation_token(attestation_uri)
@@ -549,7 +571,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_update_release_policy(self, client, **kwargs):
+    def test_update_release_policy(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri)
@@ -591,7 +614,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_immutable_release_policy(self, client, **kwargs):
+    def test_immutable_release_policy(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri, immutable=True)
@@ -625,7 +649,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_rotation(self, client, **kwargs):
+    def test_key_rotation(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
@@ -642,7 +667,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_rotation_policy(self, client, **kwargs):
+    def test_key_rotation_policy(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
@@ -710,7 +736,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_get_cryptography_client(self, client, is_hsm, **kwargs):
+    def test_get_cryptography_client(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         key_name = self.get_resource_name("key-name")
         key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -176,7 +176,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_key_crud_operations(self, client, is_hsm, **kwargs):
+    async def test_key_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         # create ec key
@@ -243,7 +245,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_rsa_public_exponent(self, client, **kwargs):
+    async def test_rsa_public_exponent(self, **kwargs):
+        client = kwargs.pop("client")
         """The public exponent of a Managed HSM RSA key can be specified during creation"""
         assert client is not None
 
@@ -256,7 +259,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_backup_restore(self, client, is_hsm, **kwargs):
+    async def test_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         key_name = self.get_resource_name("keybak")
@@ -284,7 +289,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_key_list(self, client, is_hsm, **kwargs):
+    async def test_key_list(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         max_keys = LIST_TEST_SIZE
@@ -308,7 +315,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_list_versions(self, client, is_hsm, **kwargs):
+    async def test_list_versions(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         key_name = self.get_resource_name("testKey")
@@ -335,7 +344,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_list_deleted_keys(self, client, is_hsm, **kwargs):
+    async def test_list_deleted_keys(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         expected = {}
@@ -367,7 +378,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_recover(self, client, is_hsm, **kwargs):
+    async def test_recover(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         # create keys
@@ -398,7 +411,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_purge(self, client, is_hsm, **kwargs):
+    async def test_purge(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         assert client is not None
 
         # create keys
@@ -426,7 +441,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",logging_enabled)
     @AsyncKeysClientPreparer(logging_enable = True)
     @recorded_by_proxy_async
-    async def test_logging_enabled(self, client, is_hsm, **kwargs):
+    async def test_logging_enabled(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -462,7 +479,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",logging_disabled)
     @AsyncKeysClientPreparer(logging_enable = False)
     @recorded_by_proxy_async
-    async def test_logging_disabled(self, client, is_hsm, **kwargs):
+    async def test_logging_disabled(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -497,7 +516,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_get_random_bytes(self, client, **kwargs):
+    async def test_get_random_bytes(self, **kwargs):
+        client = kwargs.pop("client")
         assert client
 
         generated_random_bytes = []
@@ -514,7 +534,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_key_release(self, client, **kwargs):
+    async def test_key_release(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         attestation = await get_attestation_token(attestation_uri)
@@ -535,7 +556,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_imported_key_release(self, client, **kwargs):
+    async def test_imported_key_release(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         attestation = await get_attestation_token(attestation_uri)
@@ -556,7 +578,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_update_release_policy(self, client, **kwargs):
+    async def test_update_release_policy(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri)
@@ -599,7 +622,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_immutable_release_policy(self, client, **kwargs):
+    async def test_immutable_release_policy(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri, immutable=True)
@@ -634,7 +658,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_key_rotation(self, client, **kwargs):
+    async def test_key_rotation(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
@@ -652,7 +677,8 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_key_rotation_policy(self, client, **kwargs):
+    async def test_key_rotation_policy(self, **kwargs):
+        client = kwargs.pop("client")
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
@@ -725,7 +751,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_get_cryptography_client(self, client, is_hsm, **kwargs):
+    async def test_get_cryptography_client(self, **kwargs):
+        client = kwargs.pop("client")
+        is_hsm = kwargs.pop("is_hsm")
         key_name = self.get_resource_name("key-name")
         key = await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_parse_id.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_parse_id.py
@@ -18,7 +18,8 @@ class TestParseId(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_vault)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_parse_key_id_with_version(self, client, **kwargs):
+    def test_parse_key_id_with_version(self, **kwargs):
+        client = kwargs.pop("client")
         key_name = self.get_resource_name("key")
         # create key
         created_key = client.create_rsa_key(key_name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -40,7 +40,8 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_example_key_crud_operations(self, key_client, **kwargs):
+    def test_example_key_crud_operations(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
             pytest.skip("This test not supprot in usgov/china region. Follow up with service team")
 
@@ -135,7 +136,8 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_example_create_oct_key(self, key_client, **kwargs):
+    def test_example_create_oct_key(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("key")
 
         # [START create_oct_key]
@@ -149,7 +151,8 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_example_key_list_operations(self, key_client, **kwargs):
+    def test_example_key_list_operations(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         for i in range(4):
             key_name = self.get_resource_name("key{}".format(i))
             key_client.create_ec_key(key_name)
@@ -190,7 +193,8 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_example_keys_backup_restore(self, key_client, **kwargs):
+    def test_example_keys_backup_restore(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("keyrec")
         key_client.create_key(key_name, "RSA")
         # [START backup_key]
@@ -223,7 +227,8 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_example_keys_recover(self, key_client, **kwargs):
+    def test_example_keys_recover(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("key-name")
         created_key = key_client.create_key(key_name, "RSA")
         key_client.begin_delete_key(created_key.name).wait()

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -44,7 +44,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_key_crud_operations(self, key_client, **kwargs):
+    async def test_example_key_crud_operations(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
             pytest.skip("This test not supprot in usgov/china region. Follow up with service team")
 
@@ -134,7 +135,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",only_hsm)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_create_oct_key(self, key_client, **kwargs):
+    async def test_example_create_oct_key(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("key")
 
         # [START create_oct_key]
@@ -149,7 +151,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_key_list_operations(self, key_client, **kwargs):
+    async def test_example_key_list_operations(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         for i in range(4):
             key_name = self.get_resource_name("key{}".format(i))
             await key_client.create_ec_key(key_name)
@@ -196,7 +199,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_keys_backup_restore(self, key_client, **kwargs):
+    async def test_example_keys_backup_restore(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("key-name")
         await key_client.create_key(key_name, "RSA")
         # [START backup_key]
@@ -231,7 +235,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_keys_recover(self, key_client, **kwargs):
+    async def test_example_keys_recover(self, **kwargs):
+        key_client = kwargs.pop("key_client")
         key_name = self.get_resource_name("key-name")
         created_key = await key_client.create_key(key_name, "RSA")
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_parse_id.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_parse_id.py
@@ -16,7 +16,8 @@ class TestParseId(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", [(DEFAULT_VERSION)])
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_parse_secret_id_with_version(self, client, **kwargs):
+    def test_parse_secret_id_with_version(self, **kwargs):
+        client = kwargs.pop("client")
         secret_name = self.get_resource_name("secret")
         secret_value = "secret_value"
         # create secret

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -36,7 +36,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_example_secret_crud_operations(self, client, **kwargs):
+    def test_example_secret_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
         secret_client = client
         secret_name = self.get_resource_name("secret-name")
 
@@ -101,7 +102,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_example_secret_list_operations(self, client, **kwargs):
+    def test_example_secret_list_operations(self, **kwargs):
+        client = kwargs.pop("client")
         secret_client = client
 
         for i in range(7):
@@ -148,7 +150,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_example_secrets_backup_restore(self, client, **kwargs):
+    def test_example_secrets_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
         secret_client = client
         secret_name = self.get_resource_name("secret-name")
         secret_client.set_secret(secret_name, "secret-value")
@@ -176,7 +179,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_example_secrets_recover(self, client, **kwargs):
+    def test_example_secrets_recover(self, **kwargs):
+        client = kwargs.pop("client")
         secret_client = client
         secret_name = self.get_resource_name("secret-name")
         secret_client.set_secret(secret_name, "secret-value")

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -45,7 +45,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_secret_crud_operations(self, client, **kwargs):
+    async def test_example_secret_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
         secret_client = client
         secret_name = self.get_resource_name("secret-name")
 
@@ -108,7 +109,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_secret_list_operations(self, client, **kwargs):
+    async def test_example_secret_list_operations(self, **kwargs):
+        client = kwargs.pop("client")
         if not is_live():
             set_custom_default_matcher(excluded_headers="Authorization")
         secret_client = client
@@ -156,7 +158,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_secrets_backup_restore(self, client, **kwargs):
+    async def test_example_secrets_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
         secret_client = client
         secret_name = self.get_resource_name("secret-name")
         async with secret_client:
@@ -186,7 +189,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_example_secrets_recover(self, client, **kwargs):
+    async def test_example_secrets_recover(self, **kwargs):
+        client = kwargs.pop("client")
         secret_client = client
         secret_name = self.get_resource_name("secret-name")
         async with client:

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -70,7 +70,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_secret_crud_operations(self, client, **kwargs):
+    async def test_secret_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
         secret_name = self.get_resource_name("crud-secret")
         secret_value = "crud_secret_value"
 
@@ -137,8 +138,9 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_secret_list(self, client, **kwargs):
-
+    async def test_secret_list(self, **kwargs):
+        client = kwargs.pop("client")
+        
         max_secrets = list_test_size
         expected = {}
 
@@ -159,7 +161,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_list_deleted_secrets(self, client, **kwargs):
+    async def test_list_deleted_secrets(self, **kwargs):
+        client = kwargs.pop("client")
         expected = {}
 
         async with client:
@@ -186,7 +189,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_list_versions(self, client, **kwargs):
+    async def test_list_versions(self, **kwargs):
+        client = kwargs.pop("client")
         secret_name = self.get_resource_name("sec")
         secret_value = "secVal"
 
@@ -216,7 +220,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_backup_restore(self, client, **kwargs):
+    async def test_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
         secret_name = self.get_resource_name("secbak")
         secret_value = "secVal"
 
@@ -245,7 +250,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_recover(self, client, **kwargs):
+    async def test_recover(self, **kwargs):
+        client = kwargs.pop("client")
         secrets = {}
 
         async with client:
@@ -278,7 +284,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
-    async def test_purge(self, client, **kwargs):
+    async def test_purge(self, **kwargs):
+        client = kwargs.pop("client")
         secrets = {}
         async with client:
             # create secrets to purge
@@ -305,7 +312,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer(logging_enable=True)
     @recorded_by_proxy_async
-    async def test_logging_enabled(self, client, **kwargs):
+    async def test_logging_enabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
         logger = logging.getLogger("azure")
         logger.addHandler(mock_handler)
@@ -342,7 +350,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @AsyncSecretsClientPreparer(logging_enable=False)
     @recorded_by_proxy_async
-    async def test_logging_disabled(self, client, **kwargs):
+    async def test_logging_disabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
         logger = logging.getLogger("azure")
         logger.addHandler(mock_handler)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -72,7 +72,8 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_secret_crud_operations(self, client, **kwargs):
+    def test_secret_crud_operations(self, **kwargs):
+        client = kwargs.pop("client")
         secret_name = self.get_resource_name("crud-secret")
         secret_value = "crud_secret_value"
 
@@ -141,7 +142,8 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_secret_list(self, client, **kwargs):
+    def test_secret_list(self, **kwargs):
+        client = kwargs.pop("client")
         max_secrets = list_test_size
         expected = {}
 
@@ -161,8 +163,9 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_list_versions(self, client, **kwargs):
-
+    def test_list_versions(self, **kwargs):
+        client = kwargs.pop("client")
+        
         secret_name = self.get_resource_name("secVer")
         secret_value = "secVal"
 
@@ -189,7 +192,8 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_list_deleted_secrets(self, client, **kwargs):
+    def test_list_deleted_secrets(self, **kwargs):
+        client = kwargs.pop("client")
         expected = {}
 
         # create secrets
@@ -214,8 +218,9 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_backup_restore(self, client, **kwargs):
-
+    def test_backup_restore(self, **kwargs):
+        client = kwargs.pop("client")
+        
         secret_name = self.get_resource_name("secbak")
         secret_value = "secVal"
 
@@ -240,8 +245,9 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_recover(self, client, **kwargs):
-
+    def test_recover(self, **kwargs):
+        client = kwargs.pop("client")
+        
         secrets = {}
 
         # create secrets to recover
@@ -270,8 +276,9 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer()
     @recorded_by_proxy
-    def test_purge(self, client, **kwargs):
-
+    def test_purge(self, **kwargs):
+        client = kwargs.pop("client")
+        
         secrets = {}
 
         # create secrets to purge
@@ -300,7 +307,8 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer(logging_enable=True)
     @recorded_by_proxy
-    def test_logging_enabled(self, client, **kwargs):
+    def test_logging_enabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -334,7 +342,8 @@ class TestSecretClient(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", all_api_versions, ids=all_api_versions)
     @SecretsClientPreparer(logging_enable=False)
     @recorded_by_proxy
-    def test_logging_disabled(self, client, **kwargs):
+    def test_logging_disabled(self, **kwargs):
+        client = kwargs.pop("client")
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")

--- a/sdk/keyvault/azure-mgmt-keyvault/tests/disable_test_cli_mgmt_keyvault_async.py
+++ b/sdk/keyvault/azure-mgmt-keyvault/tests/disable_test_cli_mgmt_keyvault_async.py
@@ -36,7 +36,8 @@ class TestMgmtKeyVault(AzureMgmtAsyncTestCase):
     @pytest.mark.skip('skip aio test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_keyvault(self, resource_group):
+    def test_keyvault(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         TENANT_ID = self.get_settings_value("TENANT_ID") # self.settings.TENANT_ID

--- a/sdk/keyvault/azure-mgmt-keyvault/tests/test_cli_mgmt_keyvault.py
+++ b/sdk/keyvault/azure-mgmt-keyvault/tests/test_cli_mgmt_keyvault.py
@@ -32,7 +32,8 @@ class TestMgmtKeyVault(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_keyvault(self, resource_group):
+    def test_keyvault(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47" # self.settings.TENANT_ID

--- a/sdk/loganalytics/azure-mgmt-loganalytics/tests/test_workspace.py
+++ b/sdk/loganalytics/azure-mgmt-loganalytics/tests/test_workspace.py
@@ -11,7 +11,9 @@ class TestMgmtLogAnalyticsWorkspace(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_loganalytics_workspace(self, resource_group, location):
+    def test_loganalytics_workspace(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         workspace_name = 'WorkspaceName'
         workspace_result = self.client.workspaces.begin_create_or_update(
             resource_group.name,

--- a/sdk/logic/azure-mgmt-logic/tests/test_mgmt_apps.py
+++ b/sdk/logic/azure-mgmt-logic/tests/test_mgmt_apps.py
@@ -20,7 +20,9 @@ class TestMgmtApps(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer(location="West US")
     @recorded_by_proxy
-    def test_logic(self, resource_group, location):
+    def test_logic(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         workflow_name = '12HourHeartBeat'
         # workflow_name1 = workflow_name+'1'
         workflow=azure.mgmt.logic.models.Workflow(

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_alert_config_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_alert_config_async.py
@@ -30,7 +30,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_top_n_alert_dir_both(self, client, variables):
+    async def test_create_alert_config_top_n_alert_dir_both(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -92,7 +94,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_top_n_alert_dir_down(self, client, variables):
+    async def test_create_alert_config_top_n_alert_dir_down(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -146,7 +150,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_top_n_alert_dir_up(self, client, variables):
+    async def test_create_alert_config_top_n_alert_dir_up(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -200,7 +206,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_top_n_severity_condition(self, client, variables):
+    async def test_create_alert_config_top_n_severity_condition(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -250,7 +258,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_snooze_condition(self, client, variables):
+    async def test_create_alert_config_snooze_condition(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -299,7 +309,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_conf_whole_series_dir_both(self, client, variables):
+    async def test_create_alert_conf_whole_series_dir_both(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -345,7 +357,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_conf_whole_series_dir_down(self, client, variables):
+    async def test_create_alert_conf_whole_series_dir_down(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -390,7 +404,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_whole_series_alert_dir_up(self, client, variables):
+    async def test_create_alert_config_whole_series_alert_dir_up(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -435,7 +451,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_whole_series_sev_cond(self, client, variables):
+    async def test_create_alert_config_whole_series_sev_cond(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -476,7 +494,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_conf_series_group_dir_both(self, client, variables):
+    async def test_create_alert_conf_series_group_dir_both(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -524,7 +544,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_conf_series_group_dir_down(self, client, variables):
+    async def test_create_alert_conf_series_group_dir_down(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -571,7 +593,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_series_group_alert_dir_up(self, client, variables):
+    async def test_create_alert_config_series_group_alert_dir_up(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -618,7 +642,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_conf_series_group_sev_cond(self, client, variables):
+    async def test_create_alert_conf_series_group_sev_cond(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -661,7 +687,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_create_alert_config_multiple_configurations(self, client, variables):
+    async def test_create_alert_config_multiple_configurations(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -747,7 +775,8 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_alert_configs(self, client):
+    async def test_list_alert_configs(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             configs = client.list_alert_configurations(
                 detection_configuration_id=self.anomaly_detection_configuration_id
@@ -761,7 +790,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy_async
-    async def test_update_alert_config_with_model(self, client, variables):
+    async def test_update_alert_config_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -808,7 +839,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy_async
-    async def test_update_alert_config_with_kwargs(self, client, variables):
+    async def test_update_alert_config_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -898,7 +931,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy_async
-    async def test_update_alert_config_with_model_and_kwargs(self, client, variables):
+    async def test_update_alert_config_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -994,7 +1029,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy_async
-    async def test_update_anomaly_alert_by_resetting_properties(self, client, variables):
+    async def test_update_anomaly_alert_by_resetting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_credential_entities_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_credential_entities_async.py
@@ -26,7 +26,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_datasource_sql_connection_string(self, client, variables):
+    async def test_create_datasource_sql_connection_string(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testsqlcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -52,7 +54,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_datasource_datalake_gen2_shared_key(self, client, variables):
+    async def test_datasource_datalake_gen2_shared_key(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testdatalakecredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -78,7 +82,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_datasource_service_principal(self, client, variables):
+    async def test_datasource_service_principal(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -106,7 +112,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_datasource_service_principal_in_kv(self, client, variables):
+    async def test_datasource_service_principal_in_kv(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -137,7 +145,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_datasource_credentials(self, client, variables):
+    async def test_list_datasource_credentials(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testsqlcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -166,7 +176,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_update_datasource_sql_connection_string(self, client, variables):
+    async def test_update_datasource_sql_connection_string(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testsqlcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -193,7 +205,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_update_datasource_datalake_gen2_shared_key(self, client, variables):
+    async def test_update_datasource_datalake_gen2_shared_key(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testdatalakecredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -220,7 +234,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_update_datasource_service_principal(self, client, variables):
+    async def test_update_datasource_service_principal(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -251,7 +267,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_update_datasource_service_principal_in_kv(self, client, variables):
+    async def test_update_datasource_service_principal_in_kv(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_data_feed_ingestion_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_data_feed_ingestion_async.py
@@ -22,7 +22,8 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_get_data_feed_ingestion_progress(self, client):
+    async def test_get_data_feed_ingestion_progress(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             ingestion = await client.get_data_feed_ingestion_progress(
                 data_feed_id=self.data_feed_id
@@ -34,7 +35,8 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feed_ingestion_status(self, client):
+    async def test_list_data_feed_ingestion_status(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             ingestions = client.list_data_feed_ingestion_status(
                 data_feed_id=self.data_feed_id,
@@ -50,7 +52,8 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feed_ingest_status_skip(self, client):
+    async def test_list_data_feed_ingest_status_skip(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             ingestions = client.list_data_feed_ingestion_status(
                 data_feed_id=self.data_feed_id,
@@ -78,7 +81,8 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_refresh_data_feed_ingestion(self, client):
+    async def test_refresh_data_feed_ingestion(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             await client.refresh_data_feed_ingestion(
                 self.data_feed_id,

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_data_feeds_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_data_feeds_async.py
@@ -44,7 +44,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_simple_data_feed(self, client, variables):
+    async def test_create_simple_data_feed(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         data_feed_name = self.create_random_name("testfeed")
         if self.is_live:
             variables["data_feed_name"] = data_feed_name
@@ -80,7 +82,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_from_sql_server(self, client, variables):
+    async def test_create_data_feed_from_sql_server(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         data_feed_name = self.create_random_name("testfeed")
         if self.is_live:
@@ -174,7 +178,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_from_sql_server_with_custom_values(self, client, variables):
+    async def test_create_data_feed_from_sql_server_with_custom_values(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         data_feed_name = self.create_random_name("testfeed")
         if self.is_live:
@@ -272,7 +278,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_azure_table(self, client, variables):
+    async def test_create_data_feed_with_azure_table(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("tablefeed")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -319,7 +327,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_azure_blob(self, client, variables):
+    async def test_create_data_feed_with_azure_blob(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("blobfeed")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -366,7 +376,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_azure_cosmos_db(self, client, variables):
+    async def test_create_data_feed_with_azure_cosmos_db(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("cosmosfeed")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -415,7 +427,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_application_insights(self, client, variables):
+    async def test_create_data_feed_with_application_insights(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("applicationinsights")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -467,7 +481,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_data_explorer(self, client, variables):
+    async def test_create_data_feed_with_data_explorer(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("azuredataexplorer")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -514,7 +530,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_influxdb(self, client, variables):
+    async def test_create_data_feed_with_influxdb(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("influxdb")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -565,7 +583,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_datalake(self, client, variables):
+    async def test_create_data_feed_with_datalake(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("datalake")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -616,7 +636,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_mongodb(self, client, variables):
+    async def test_create_data_feed_with_mongodb(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("mongodb")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -663,7 +685,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_mysql(self, client, variables):
+    async def test_create_data_feed_with_mysql(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("mysql")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -708,7 +732,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_data_feed_with_postgresql(self, client, variables):
+    async def test_create_data_feed_with_postgresql(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("postgresql")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -753,7 +779,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feeds(self, client):
+    async def test_list_data_feeds(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             feeds = client.list_data_feeds()
             feeds_list = []
@@ -765,7 +792,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feeds_with_data_feed_name(self, client):
+    async def test_list_data_feeds_with_data_feed_name(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             feeds = client.list_data_feeds(data_feed_name="azureSqlDatafeed")
             feeds_list = []
@@ -777,7 +805,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feeds_with_skip(self, client):
+    async def test_list_data_feeds_with_skip(self, **kwargs):
+        client = kwargs.pop("client")
         all_feeds = client.list_data_feeds()
         skipped_feeds = client.list_data_feeds(skip=10)
         all_feeds_list = []
@@ -792,7 +821,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feeds_with_status(self, client):
+    async def test_list_data_feeds_with_status(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             feeds = client.list_data_feeds(status="Active")
             feeds_list = []
@@ -804,7 +834,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feeds_with_source_type(self, client):
+    async def test_list_data_feeds_with_source_type(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             feeds = client.list_data_feeds(data_source_type="SqlServer")
             feeds_list = []
@@ -816,7 +847,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_data_feeds_with_granularity_type(self, client):
+    async def test_list_data_feeds_with_granularity_type(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             feeds = client.list_data_feeds(granularity_type="Daily")
             feeds_list = []
@@ -828,7 +860,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy_async
-    async def test_update_data_feed_with_model(self, client, variables):
+    async def test_update_data_feed_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -884,7 +918,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy_async
-    async def test_update_data_feed_with_kwargs(self, client, variables):
+    async def test_update_data_feed_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 data_feed = await client.get_data_feed(variables["data_feed_id"])
@@ -943,7 +979,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy_async
-    async def test_update_data_feed_with_model_and_kwargs(self, client, variables):
+    async def test_update_data_feed_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -1022,7 +1060,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy_async
-    async def test_update_data_feed_by_reseting_properties(self, client, variables):
+    async def test_update_data_feed_by_reseting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 data_feed = await client.get_data_feed(variables["data_feed_id"])

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_detection_config_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_detection_config_async.py
@@ -31,7 +31,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy_async
-    async def test_create_ad_config_whole_series_detection(self, client, variables):
+    async def test_create_ad_config_whole_series_detection(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         detection_config_name = self.create_random_name("testdetectionconfig")
         if self.is_live:
             variables["detection_config_name"] = detection_config_name
@@ -110,7 +112,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy_async
-    async def test_create_ad_conf_series_and_group_cond(self, client, variables):
+    async def test_create_ad_conf_series_and_group_cond(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         detection_config_name = self.create_random_name("testdetectionconfig")
         if self.is_live:
             variables["detection_config_name"] = detection_config_name
@@ -213,7 +217,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy_async
-    async def test_create_ad_conf_series_and_group_conds(self, client, variables):
+    async def test_create_ad_conf_series_and_group_conds(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         detection_config_name = self.create_random_name("testdetectionconfig")
         if self.is_live:
             variables["detection_config_name"] = detection_config_name
@@ -424,7 +430,8 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_detection_configs(self, client):
+    async def test_list_detection_configs(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             configs = client.list_detection_configurations(metric_id=self.metric_id)
             configs_list = []
@@ -436,7 +443,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_update_detection_config_with_model(self, client, variables):
+    async def test_update_detection_config_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 detection_config = await client.get_detection_configuration(variables["detection_config_id"])
@@ -543,7 +552,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_update_detection_config_with_kwargs(self, client, variables):
+    async def test_update_detection_config_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 change_threshold_condition = ChangeThresholdCondition(
@@ -660,7 +671,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_update_ad_conf_model_and_kwargs(self, client, variables):
+    async def test_update_ad_conf_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 detection_config = await client.get_detection_configuration(variables["detection_config_id"])
@@ -778,7 +791,9 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy_async
-    async def test_update_ad_conf_by_reset_props(self, client, variables):
+    async def test_update_ad_conf_by_reset_props(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_hooks_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_hooks_async.py
@@ -27,7 +27,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_email_hook(self, client, variables):
+    async def test_create_email_hook(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         email_hook_name = self.create_random_name("testemailhook")
         if self.is_live:
             variables["email_hook_name"] = email_hook_name
@@ -62,7 +64,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_create_web_hook(self, client, variables):
+    async def test_create_web_hook(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         web_hook_name = self.create_random_name("testwebhook")
         if self.is_live:
             variables["web_hook_name"] = web_hook_name
@@ -97,7 +101,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_hooks(self, client):
+    async def test_list_hooks(self, **kwargs):
+        client = kwargs.pop("client")
         hooks = client.list_hooks()
         hooks_list = []
         async for hook in hooks:
@@ -108,7 +113,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy_async
-    async def test_update_email_hook_with_model(self, client, variables):
+    async def test_update_email_hook_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         hook = await client.get_hook(variables["email_hook_id"])
         async with client:
             try:
@@ -136,7 +143,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy_async
-    async def test_update_email_hook_with_kwargs(self, client, variables):
+    async def test_update_email_hook_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -164,7 +173,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy_async
-    async def test_update_email_hook_with_model_and_kwargs(self, client, variables):
+    async def test_update_email_hook_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -196,7 +207,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy_async
-    async def test_update_email_hook_by_resetting_properties(self, client, variables):
+    async def test_update_email_hook_by_resetting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -224,7 +237,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy_async
-    async def test_update_web_hook_with_model(self, client, variables):
+    async def test_update_web_hook_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -252,7 +267,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy_async
-    async def test_update_web_hook_with_kwargs(self, client, variables):
+    async def test_update_web_hook_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -282,7 +299,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy_async
-    async def test_update_web_hook_with_model_and_kwargs(self, client, variables):
+    async def test_update_web_hook_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())
@@ -317,7 +336,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy_async
-    async def test_update_web_hook_by_resetting_properties(self, client, variables):
+    async def test_update_web_hook_by_resetting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         async with client:
             try:
                 update_name = "update" + str(uuid.uuid4())

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_metrics_advisor_client_live_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_metrics_advisor_client_live_async.py
@@ -28,7 +28,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_anomalies_for_detection_configuration(self, client):
+    async def test_list_anomalies_for_detection_configuration(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_anomalies(
                 detection_configuration_id=self.anomaly_detection_configuration_id,
@@ -44,7 +45,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_anomaly_dimension_values(self, client):
+    async def test_list_anomaly_dimension_values(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_anomaly_dimension_values(
                 detection_configuration_id=self.anomaly_detection_configuration_id,
@@ -61,7 +63,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_incidents_for_detection_configuration(self, client):
+    async def test_list_incidents_for_detection_configuration(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_incidents(
                 detection_configuration_id=self.anomaly_detection_configuration_id,
@@ -77,7 +80,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_metric_dimension_values(self, client):
+    async def test_list_metric_dimension_values(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_metric_dimension_values(
                 metric_id=self.metric_id,
@@ -92,7 +96,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_incident_root_cause(self, client):
+    async def test_list_incident_root_cause(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_incident_root_causes(
                 detection_configuration_id=self.anomaly_detection_configuration_id,
@@ -107,7 +112,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_metric_enriched_series_data(self, client):
+    async def test_list_metric_enriched_series_data(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             series_identity = {"region": "Los Angeles"}
             results = client.list_metric_enriched_series_data(
@@ -125,7 +131,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_metric_enrichment_status(self, client):
+    async def test_list_metric_enrichment_status(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_metric_enrichment_status(
                 metric_id=self.metric_id,
@@ -141,7 +148,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_alerts(self, client):
+    async def test_list_alerts(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_alerts(
                 alert_configuration_id=self.anomaly_alert_configuration_id,
@@ -158,7 +166,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_metrics_series_data(self, client):
+    async def test_list_metrics_series_data(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_metric_series_data(
                 metric_id=self.metric_id,
@@ -177,7 +186,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_metric_series_definitions(self, client):
+    async def test_list_metric_series_definitions(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_metric_series_definitions(
                 metric_id=self.metric_id,
@@ -192,7 +202,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_add_anomaly_feedback(self, client):
+    async def test_add_anomaly_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         anomaly_feedback = AnomalyFeedback(metric_id=self.metric_id,
                                            dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                            start_time=datetime.datetime(2021, 8, 5),
@@ -205,7 +216,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_add_change_point_feedback(self, client):
+    async def test_add_change_point_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         change_point_feedback = ChangePointFeedback(metric_id=self.metric_id,
                                                     dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                                     start_time=datetime.datetime(2021, 8, 5),
@@ -218,7 +230,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_add_comment_feedback(self, client):
+    async def test_add_comment_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         comment_feedback = CommentFeedback(metric_id=self.metric_id,
                                            dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                            start_time=datetime.datetime(2021, 8, 5),
@@ -231,7 +244,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_add_period_feedback(self, client):
+    async def test_add_period_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         period_feedback = PeriodFeedback(metric_id=self.metric_id,
                                          dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                          start_time=datetime.datetime(2021, 8, 5),
@@ -245,7 +259,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_feedback(self, client):
+    async def test_list_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_feedback(
                 metric_id=self.metric_id,
@@ -262,7 +277,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_get_feedback(self, client):
+    async def test_get_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             result = await client.get_feedback(feedback_id=self.feedback_id)
             assert result
@@ -272,7 +288,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_anomalies_for_alert(self, client):
+    async def test_list_anomalies_for_alert(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_anomalies(
                 alert_configuration_id=self.anomaly_alert_configuration_id,
@@ -287,7 +304,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy_async
-    async def test_list_incidents_for_alert(self, client):
+    async def test_list_incidents_for_alert(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             results = client.list_incidents(
                 alert_configuration_id=self.anomaly_alert_configuration_id,

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_alert_config.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_alert_config.py
@@ -29,7 +29,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_top_n_alert_direction_both(self, client, variables):
+    def test_create_alert_config_top_n_alert_direction_both(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -91,7 +93,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_top_n_alert_direction_down(self, client, variables):
+    def test_create_alert_config_top_n_alert_direction_down(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -144,7 +148,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_top_n_alert_direction_up(self, client, variables):
+    def test_create_alert_config_top_n_alert_direction_up(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -197,7 +203,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_top_n_severity_condition(self, client, variables):
+    def test_create_alert_config_top_n_severity_condition(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -246,7 +254,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_snooze_condition(self, client, variables):
+    def test_create_alert_config_snooze_condition(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -295,7 +305,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_conf_whole_series_dir_both(self, client, variables):
+    def test_create_alert_conf_whole_series_dir_both(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -341,7 +353,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_conf_whole_series_dir_down(self, client, variables):
+    def test_create_alert_conf_whole_series_dir_down(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -386,7 +400,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_whole_series_alert_direction_up(self, client, variables):
+    def test_create_alert_config_whole_series_alert_direction_up(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -431,7 +447,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_whole_series_sev_cond(self, client, variables):
+    def test_create_alert_config_whole_series_sev_cond(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -472,7 +490,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_conf_series_group_dir_both(self, client, variables):
+    def test_create_alert_conf_series_group_dir_both(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -520,7 +540,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_conf_series_group_dir_down(self, client, variables):
+    def test_create_alert_conf_series_group_dir_down(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -567,7 +589,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_series_group_alert_direction_up(self, client, variables):
+    def test_create_alert_config_series_group_alert_direction_up(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -614,7 +638,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_conf_series_group_sev_cond(self, client, variables):
+    def test_create_alert_conf_series_group_sev_cond(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -657,7 +683,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_create_alert_config_multiple_configurations(self, client, variables):
+    def test_create_alert_config_multiple_configurations(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config_name = self.create_random_name("alertconfig")
         if self.is_live:
             variables["alert_config_name"] = alert_config_name
@@ -743,7 +771,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_alert_configs(self, client):
+    def test_list_alert_configs(self, **kwargs):
+        client = kwargs.pop("client")
 
         configs = client.list_alert_configurations(
             detection_configuration_id=self.anomaly_detection_configuration_id
@@ -753,7 +782,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy
-    def test_update_alert_config_with_model(self, client, variables):
+    def test_update_alert_config_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         alert_config = client.get_alert_configuration(variables["alert_config_id"])
         try:
@@ -800,7 +831,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy
-    def test_update_alert_config_with_kwargs(self, client, variables):
+    def test_update_alert_config_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         try:
             update_name = "update" + str(uuid.uuid4())
@@ -889,7 +922,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy
-    def test_update_alert_config_with_model_and_kwargs(self, client, variables):
+    def test_update_alert_config_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         alert_config = client.get_alert_configuration(variables["alert_config_id"])
 
         try:
@@ -984,7 +1019,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True, alert_config=True)
     @recorded_by_proxy
-    def test_update_anomaly_alert_by_resetting_properties(self, client, variables):
+    def test_update_anomaly_alert_by_resetting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         try:
             update_name = "update" + str(uuid.uuid4())

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_credential_entities.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_credential_entities.py
@@ -24,7 +24,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_datasource_sql_connection_string(self, client, variables):
+    def test_create_datasource_sql_connection_string(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testsqlcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -49,7 +51,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_datasource_datalake_gen2_shared_key(self, client, variables):
+    def test_datasource_datalake_gen2_shared_key(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testdatalakecredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -74,7 +78,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_datasource_service_principal(self, client, variables):
+    def test_datasource_service_principal(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -100,7 +106,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_datasource_service_principal_in_kv(self, client, variables):
+    def test_datasource_service_principal_in_kv(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -129,7 +137,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_datasource_credentials(self, client, variables):
+    def test_list_datasource_credentials(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testsqlcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -152,7 +162,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_update_datasource_sql_connection_string(self, client, variables):
+    def test_update_datasource_sql_connection_string(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testsqlcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -177,7 +189,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_update_datasource_datalake_gen2_shared_key(self, client, variables):
+    def test_update_datasource_datalake_gen2_shared_key(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testdatalakecredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -202,7 +216,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_update_datasource_service_principal(self, client, variables):
+    def test_update_datasource_service_principal(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name
@@ -231,7 +247,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_update_datasource_service_principal_in_kv(self, client, variables):
+    def test_update_datasource_service_principal_in_kv(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         credential_name = self.create_random_name("testserviceprincipalcredential")
         if self.is_live:
             variables["credential_name"] = credential_name

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_data_feed_ingestion.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_data_feed_ingestion.py
@@ -20,7 +20,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_get_data_feed_ingestion_progress(self, client):
+    def test_get_data_feed_ingestion_progress(self, **kwargs):
+        client = kwargs.pop("client")
 
         ingestion = client.get_data_feed_ingestion_progress(
             data_feed_id=self.data_feed_id
@@ -31,7 +32,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feed_ingestion_status(self, client):
+    def test_list_data_feed_ingestion_status(self, **kwargs):
+        client = kwargs.pop("client")
 
         ingestions = client.list_data_feed_ingestion_status(
             data_feed_id=self.data_feed_id,
@@ -43,7 +45,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feed_ingest_status_skip(self, client):
+    def test_list_data_feed_ingest_status_skip(self, **kwargs):
+        client = kwargs.pop("client")
 
         ingestions = client.list_data_feed_ingestion_status(
             data_feed_id=self.data_feed_id,
@@ -64,7 +67,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_refresh_data_feed_ingestion(self, client):
+    def test_refresh_data_feed_ingestion(self, **kwargs):
+        client = kwargs.pop("client")
         client.refresh_data_feed_ingestion(
             self.data_feed_id,
             start_time=datetime.datetime(2021, 10, 1, tzinfo=tzutc()),

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_data_feeds.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_data_feeds.py
@@ -42,7 +42,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_simple_data_feed(self, client, variables):
+    def test_create_simple_data_feed(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         data_feed_name = self.create_random_name("testfeeds")
         if self.is_live:
             variables["data_feed_name"] = data_feed_name
@@ -75,7 +77,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_from_sql_server(self, client, variables):
+    def test_create_data_feed_from_sql_server(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         data_feed_name = self.create_random_name("testfeed")
         if self.is_live:
@@ -168,7 +172,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_from_sql_server_with_custom_values(self, client, variables):
+    def test_create_data_feed_from_sql_server_with_custom_values(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         data_feed_name = self.create_random_name("testfeed")
         if self.is_live:
@@ -265,7 +271,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_azure_table(self, client, variables):
+    def test_create_data_feed_with_azure_table(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("tablefeed")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -311,7 +319,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_azure_blob(self, client, variables):
+    def test_create_data_feed_with_azure_blob(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("blobfeed")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -357,7 +367,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_azure_cosmos_db(self, client, variables):
+    def test_create_data_feed_with_azure_cosmos_db(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("cosmosfeed")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -405,7 +417,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_application_insights(self, client, variables):
+    def test_create_data_feed_with_application_insights(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("applicationinsights")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -456,7 +470,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_data_explorer(self, client, variables):
+    def test_create_data_feed_with_data_explorer(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("azuredataexplorer")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -502,7 +518,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_influxdb(self, client, variables):
+    def test_create_data_feed_with_influxdb(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("influxdb")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -551,7 +569,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_datalake(self, client, variables):
+    def test_create_data_feed_with_datalake(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("datalake")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -601,7 +621,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_mongodb(self, client, variables):
+    def test_create_data_feed_with_mongodb(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("mongodb")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -647,7 +669,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_mysql(self, client, variables):
+    def test_create_data_feed_with_mysql(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("mysql")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -691,7 +715,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_data_feed_with_postgresql(self, client, variables):
+    def test_create_data_feed_with_postgresql(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         name = self.create_random_name("postgresql")
         if self.is_live:
             variables["data_feed_name"] = name
@@ -735,14 +761,16 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feeds(self, client):
+    def test_list_data_feeds(self, **kwargs):
+        client = kwargs.pop("client")
         feeds = client.list_data_feeds()
         assert len(list(feeds)) > 0
 
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feeds_with_data_feed_name(self, client):
+    def test_list_data_feeds_with_data_feed_name(self, **kwargs):
+        client = kwargs.pop("client")
         feeds = client.list_data_feeds(data_feed_name="azureSqlDatafeed")
         feed_list = list(feeds)
         assert len(feed_list) == 1
@@ -750,7 +778,8 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feeds_with_skip(self, client):
+    def test_list_data_feeds_with_skip(self, **kwargs):
+        client = kwargs.pop("client")
         all_feeds = client.list_data_feeds()
         skipped_feeds = client.list_data_feeds(skip=10)
         all_feeds_list = list(all_feeds)
@@ -760,28 +789,33 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feeds_with_status(self, client):
+    def test_list_data_feeds_with_status(self, **kwargs):
+        client = kwargs.pop("client")
         feeds = client.list_data_feeds(status="Active")
         assert len(list(feeds)) > 0
 
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feeds_with_source_type(self, client):
+    def test_list_data_feeds_with_source_type(self, **kwargs):
+        client = kwargs.pop("client")
         feeds = client.list_data_feeds(data_source_type="SqlServer")
         assert len(list(feeds)) > 0
 
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_data_feeds_with_granularity_type(self, client):
+    def test_list_data_feeds_with_granularity_type(self, **kwargs):
+        client = kwargs.pop("client")
         feeds = client.list_data_feeds(granularity_type="Daily")
         assert len(list(feeds)) > 0
 
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy
-    def test_update_data_feed_with_model(self, client, variables):
+    def test_update_data_feed_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         data_feed = client.get_data_feed(variables["data_feed_id"])
         try:
             update_name = "update" + str(uuid.uuid4())
@@ -835,7 +869,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy
-    def test_update_data_feed_with_kwargs(self, client, variables):
+    def test_update_data_feed_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         data_feed = client.get_data_feed(variables["data_feed_id"])
         try:
@@ -893,7 +929,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy
-    def test_update_data_feed_with_model_and_kwargs(self, client, variables):
+    def test_update_data_feed_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         data_feed = client.get_data_feed(variables["data_feed_id"])
         try:
@@ -971,7 +1009,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy
-    def test_update_data_feed_by_reseting_properties(self, client, variables):
+    def test_update_data_feed_by_reseting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
 
         data_feed = client.get_data_feed(variables["data_feed_id"])
         try:

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_detection_config.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_detection_config.py
@@ -30,7 +30,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy
-    def test_create_ad_config_whole_series_detection(self, client, variables):
+    def test_create_ad_config_whole_series_detection(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         detection_config_name = self.create_random_name("testdetectionconfig")
         if self.is_live:
             variables["detection_config_name"] = detection_config_name
@@ -106,7 +108,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy
-    def test_create_ad_conf_series_and_group_cond(self, client, variables):
+    def test_create_ad_conf_series_and_group_cond(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         detection_config_name = self.create_random_name("testdetectionconfig")
         if self.is_live:
             variables["detection_config_name"] = detection_config_name
@@ -206,7 +210,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True)
     @recorded_by_proxy
-    def test_create_ad_conf_series_and_group_conds(self, client, variables):
+    def test_create_ad_conf_series_and_group_conds(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         detection_config_name = self.create_random_name("testdetectionconfig")
         if self.is_live:
             variables["detection_config_name"] = detection_config_name
@@ -415,14 +421,17 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_detection_configs(self, client):
+    def test_list_detection_configs(self, **kwargs):
+        client = kwargs.pop("client")
         configs = client.list_detection_configurations(metric_id=self.metric_id)
         assert len(list(configs)) > 0
 
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_update_detection_config_with_model(self, client, variables):
+    def test_update_detection_config_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             detection_config = client.get_detection_configuration(variables["detection_config_id"])
             update_name = "update" + str(uuid.uuid4())
@@ -528,7 +537,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_update_detection_config_with_kwargs(self, client, variables):
+    def test_update_detection_config_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             change_threshold_condition = ChangeThresholdCondition(
                 anomaly_detector_direction="Both",
@@ -643,7 +654,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_update_ad_conf_model_and_kwargs(self, client, variables):
+    def test_update_ad_conf_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             detection_config = client.get_detection_configuration(variables["detection_config_id"])
             change_threshold_condition = ChangeThresholdCondition(
@@ -759,7 +772,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(data_feed=True, detection_config=True)
     @recorded_by_proxy
-    def test_update_ad_conf_by_reset_props(self, client, variables):
+    def test_update_ad_conf_by_reset_props(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_hooks.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_hooks.py
@@ -25,7 +25,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_email_hook(self, client, variables):
+    def test_create_email_hook(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         email_hook_name = self.create_random_name("testemailhook")
         if self.is_live:
             variables["email_hook_name"] = email_hook_name
@@ -58,7 +60,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_create_web_hook(self, client, variables):
+    def test_create_web_hook(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         web_hook_name = self.create_random_name("testwebhook")
         if self.is_live:
             variables["web_hook_name"] = web_hook_name
@@ -90,14 +94,17 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_hooks(self, client):
+    def test_list_hooks(self, **kwargs):
+        client = kwargs.pop("client")
         hooks = client.list_hooks()
         assert len(list(hooks)) > 0
 
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy
-    def test_update_email_hook_with_model(self, client, variables):
+    def test_update_email_hook_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         hook = client.get_hook(variables["email_hook_id"])
         try:
             update_name = "update" + str(uuid.uuid4())
@@ -123,7 +130,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy
-    def test_update_email_hook_with_kwargs(self, client, variables):
+    def test_update_email_hook_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:
@@ -149,7 +158,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy
-    def test_update_email_hook_with_model_and_kwargs(self, client, variables):
+    def test_update_email_hook_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:
@@ -179,7 +190,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(email_hook=True)
     @recorded_by_proxy
-    def test_update_email_hook_by_resetting_properties(self, client, variables):
+    def test_update_email_hook_by_resetting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:
@@ -205,7 +218,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy
-    def test_update_web_hook_with_model(self, client, variables):
+    def test_update_web_hook_with_model(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:
@@ -231,7 +246,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy
-    def test_update_web_hook_with_kwargs(self, client, variables):
+    def test_update_web_hook_with_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:
@@ -259,7 +276,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy
-    def test_update_web_hook_with_model_and_kwargs(self, client, variables):
+    def test_update_web_hook_with_model_and_kwargs(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:
@@ -292,7 +311,9 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer(web_hook=True)
     @recorded_by_proxy
-    def test_update_web_hook_by_resetting_properties(self, client, variables):
+    def test_update_web_hook_by_resetting_properties(self, **kwargs):
+        client = kwargs.pop("client")
+        variables = kwargs.pop("variables")
         try:
             update_name = "update" + str(uuid.uuid4())
             if self.is_live:

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_metrics_advisor_client_live.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_metrics_advisor_client_live.py
@@ -26,7 +26,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_anomalies_for_detection_configuration(self, client):
+    def test_list_anomalies_for_detection_configuration(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_anomalies(
             detection_configuration_id=self.anomaly_detection_configuration_id,
             start_time=datetime.datetime(2021, 1, 1),
@@ -37,7 +38,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_anomaly_dimension_values(self, client):
+    def test_list_anomaly_dimension_values(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_anomaly_dimension_values(
             detection_configuration_id=self.anomaly_detection_configuration_id,
             dimension_name="region",
@@ -49,7 +51,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_incidents_for_detection_configuration(self, client):
+    def test_list_incidents_for_detection_configuration(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_incidents(
             detection_configuration_id=self.anomaly_detection_configuration_id,
             start_time=datetime.datetime(2021, 1, 1),
@@ -60,7 +63,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_metric_dimension_values(self, client):
+    def test_list_metric_dimension_values(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_metric_dimension_values(
             metric_id=self.metric_id,
             dimension_name="region",
@@ -70,7 +74,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_incident_root_cause(self, client):
+    def test_list_incident_root_cause(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_incident_root_causes(
             detection_configuration_id=self.anomaly_detection_configuration_id,
             incident_id=self.incident_id,
@@ -80,7 +85,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_metric_enriched_series_data(self, client):
+    def test_list_metric_enriched_series_data(self, **kwargs):
+        client = kwargs.pop("client")
         series_identity = {"region": "Los Angeles"}
         results = list(client.list_metric_enriched_series_data(
             detection_configuration_id=self.anomaly_detection_configuration_id,
@@ -93,7 +99,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_metric_enrichment_status(self, client):
+    def test_list_metric_enrichment_status(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_metric_enrichment_status(
             metric_id=self.metric_id,
             start_time=datetime.datetime(2021, 1, 1),
@@ -104,7 +111,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_alerts(self, client):
+    def test_list_alerts(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_alerts(
             alert_configuration_id=self.anomaly_alert_configuration_id,
             start_time=datetime.datetime(2021, 1, 1),
@@ -116,7 +124,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_metrics_series_data(self, client):
+    def test_list_metrics_series_data(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_metric_series_data(
             metric_id=self.metric_id,
             start_time=datetime.datetime(2021, 1, 1),
@@ -130,7 +139,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_metric_series_definitions(self, client):
+    def test_list_metric_series_definitions(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_metric_series_definitions(
             metric_id=self.metric_id,
             active_since=datetime.datetime(2021, 1, 1),
@@ -140,7 +150,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_add_anomaly_feedback(self, client):
+    def test_add_anomaly_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         anomaly_feedback = AnomalyFeedback(metric_id=self.metric_id,
                                            dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                            start_time=datetime.datetime(2021, 8, 5),
@@ -151,7 +162,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_add_change_point_feedback(self, client):
+    def test_add_change_point_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         change_point_feedback = ChangePointFeedback(metric_id=self.metric_id,
                                                     dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                                     start_time=datetime.datetime(2021, 8, 5),
@@ -162,7 +174,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_add_comment_feedback(self, client):
+    def test_add_comment_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         comment_feedback = CommentFeedback(metric_id=self.metric_id,
                                            dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                            start_time=datetime.datetime(2021, 8, 5),
@@ -173,7 +186,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)  # only using API key for now since service issue with AAD
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_add_period_feedback(self, client):
+    def test_add_period_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         period_feedback = PeriodFeedback(metric_id=self.metric_id,
                                          dimension_key={"category": "Shoes Handbags & Sunglasses"},
                                          start_time=datetime.datetime(2021, 8, 5),
@@ -185,7 +199,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_feedback(self, client):
+    def test_list_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_feedback(
             metric_id=self.metric_id,
             start_time=datetime.datetime(2021, 9, 1),
@@ -197,14 +212,16 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_get_feedback(self, client):
+    def test_get_feedback(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.get_feedback(feedback_id=self.feedback_id)
         assert result
 
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_anomalies_for_alert(self, client):
+    def test_list_anomalies_for_alert(self, **kwargs):
+        client = kwargs.pop("client")
         result = list(client.list_anomalies(
             alert_configuration_id=self.anomaly_alert_configuration_id,
             alert_id=self.alert_id,
@@ -214,7 +231,8 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
     @pytest.mark.parametrize("credential", CREDENTIALS, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
-    def test_list_incidents_for_alert(self, client):
+    def test_list_incidents_for_alert(self, **kwargs):
+        client = kwargs.pop("client")
         results = list(client.list_incidents(
             alert_configuration_id=self.anomaly_alert_configuration_id,
             alert_id=self.alert_id,

--- a/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor.py
@@ -442,7 +442,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_monitor_diagnostic_settings(self, resource_group):
+    def test_monitor_diagnostic_settings(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         # RESOURCE_URI = "subscriptions/{}/resourcegroups/{}".format(SUBSCRIPTION_ID, RESOURCE_GROUP)
@@ -522,7 +523,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_log_profiles(self, resource_group):
+    def test_log_profiles(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         LOGPROFILE_NAME  = self.get_resource_name("logprofilex")
@@ -587,7 +589,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @unittest.skip("cannot create or modify classic metric alerts")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_alert_rule(self, resource_group):
+    def test_alert_rule(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -688,7 +691,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_metric_alerts(self, resource_group):
+    def test_metric_alerts(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         METRIC_ALERT_NAME = "metricnamexx"
@@ -857,7 +861,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_action_groups(self, resource_group):
+    def test_action_groups(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         ACTION_GROUP_NAME = self.get_resource_name("actiongroup")
         
@@ -916,7 +921,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_activity_log_alerts(self, resource_group):
+    def test_activity_log_alerts(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         ACTIVITY_LOG_ALERT_NAME = self.get_resource_name("activitylogalertx")
 
@@ -989,7 +995,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_autoscale_settings(self, resource_group):
+    def test_autoscale_settings(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -1090,7 +1097,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @pytest.mark.skipif(os.getenv('AZURE_TEST_RUN_LIVE') not in ('true', 'yes'), reason='only run live test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_scheduled_query_rules(self, resource_group):
+    def test_scheduled_query_rules(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         RESOURCE_GROUP = resource_group.name
         WORKSPACE_NAME = self.get_resource_name("workspacex")
         SCHEDULED_QUERY_RULE_NAME = self.get_resource_name("scheduledqueryrule")
@@ -1162,7 +1170,8 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
     @unittest.skip("(InvalidResourceType) The resource type could not be found in the namespace 'microsoft.insights' for api version '2018-06-01-preview'.")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_guest_diagnostics_settings(self, resource_group):
+    def test_guest_diagnostics_settings(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         DIAGNOSTIC_SETTINGS_NAME = self.get_resource_name("diagnosticsettings")
 
         BODY = {

--- a/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor_async.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor_async.py
@@ -284,7 +284,8 @@ class TestMgmtMonitorClient(AzureMgmtAsyncTestCase):
     @pytest.mark.skip("https://github.com/Azure/azure-sdk-for-python/issues/19389")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_monitor_diagnostic_settings(self, resource_group):
+    def test_monitor_diagnostic_settings(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
         # RESOURCE_URI = "subscriptions/{}/resourcegroups/{}".format(SUBSCRIPTION_ID, RESOURCE_GROUP)

--- a/sdk/network/azure-mgmt-dns/tests/test_mgmt_dns.py
+++ b/sdk/network/azure-mgmt-dns/tests/test_mgmt_dns.py
@@ -81,7 +81,9 @@ class TestMgmtDns(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_public_zone(self, resource_group, location):
+    def test_public_zone(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         zone_name = self.get_resource_name('pydns.com')
 
         # Zones are a 'global' resource.
@@ -183,7 +185,11 @@ class TestMgmtDns(AzureMgmtRecordedTestCase):
     @ResourceGroupPreparer()
     @VirtualNetworkPreparer()
     @recorded_by_proxy
-    def test_private_zone(self, resource_group, location, registration_virtual_network, resolution_virtual_network):
+    def test_private_zone(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
+        registration_virtual_network = kwargs.pop("registration_virtual_network")
+        resolution_virtual_network = kwargs.pop("resolution_virtual_network")
         zone_name = self.get_resource_name('pydns.com')
 
         # Zones are a 'global' resource.

--- a/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_ddos.py
+++ b/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_ddos.py
@@ -171,7 +171,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     @unittest.skip('skip test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_express_route.py
+++ b/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_express_route.py
@@ -51,7 +51,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     @unittest.skip('skip test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_interface.py
+++ b/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_interface.py
@@ -145,7 +145,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     @unittest.skip('skip test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_available.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_available.py
@@ -37,7 +37,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         LOCATION_NAME = AZURE_LOCATION
 

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_base.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_base.py
@@ -87,7 +87,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
    
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SERVICE_NAME = "myapimrndxyz"
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_base_async.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_base_async.py
@@ -32,7 +32,8 @@ class TestMgmtNetwork(AzureMgmtRecordedAsyncTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SERVICE_NAME = "myapimrndxyz"
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_endpoint.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_endpoint.py
@@ -122,7 +122,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_endpoint_policy.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_endpoint_policy.py
@@ -38,7 +38,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_firewall.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_firewall.py
@@ -83,7 +83,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_firewall_policy.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_firewall_policy.py
@@ -38,7 +38,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_ip.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_ip.py
@@ -53,7 +53,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_ip_addresses.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_ip_addresses.py
@@ -39,7 +39,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SERVICE_NAME = "myapimrndxyz"
         PUBLIC_IPPREFIX_NAME = self.get_resource_name("publicipprefix")

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_load_balancer.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_load_balancer.py
@@ -82,7 +82,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_nat.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_nat.py
@@ -66,7 +66,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_operation.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_operation.py
@@ -38,7 +38,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_route_filter.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_route_filter.py
@@ -40,7 +40,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_route_table.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_route_table.py
@@ -38,7 +38,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_wan_hub.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_wan_hub.py
@@ -51,7 +51,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_watcher.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_watcher.py
@@ -289,7 +289,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network_watcher_troubleshoot(self, resource_group):
+    def test_network_watcher_troubleshoot(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
 
@@ -342,7 +343,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     @unittest.skip("NsgsNotAppliedOnNic")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network_watcher_ip_flow(self, resource_group):
+    def test_network_watcher_ip_flow(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -386,7 +388,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
  
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network_watcher_flow_log(self, resource_group):
+    def test_network_watcher_flow_log(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
 
@@ -468,7 +471,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network_watcher_monitor(self, resource_group):
+    def test_network_watcher_monitor(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -614,7 +618,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network_watcher_packet_capture(self, resource_group):
+    def test_network_watcher_packet_capture(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -680,7 +685,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network_watcher(self, resource_group):
+    def test_network_watcher(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name
@@ -816,7 +822,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_web_application_firewall_policy.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_web_application_firewall_policy.py
@@ -37,7 +37,8 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_network(self, resource_group):
+    def test_network(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         RESOURCE_GROUP = resource_group.name

--- a/sdk/notificationhubs/azure-mgmt-notificationhubs/tests/test_mgmt_notificationhubs.py
+++ b/sdk/notificationhubs/azure-mgmt-notificationhubs/tests/test_mgmt_notificationhubs.py
@@ -23,7 +23,8 @@ class TestMgmtNotificationHubs(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_notification_hubs(self, resource_group):
+    def test_notification_hubs(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         GROUP_NAME = resource_group.name
         namespace_name = "namespacexxz"
         notification_hub_name = "notificationhubxxzx"
@@ -71,7 +72,8 @@ class TestMgmtNotificationHubs(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_namespaces(self, resource_group):
+    def test_namespaces(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
         GROUP_NAME = resource_group.name
         namespace_name = "namespacexxx"
 

--- a/sdk/relay/azure-mgmt-relay/tests/test_azure_mgmt_hybridconnection.py
+++ b/sdk/relay/azure-mgmt-relay/tests/test_azure_mgmt_hybridconnection.py
@@ -23,7 +23,9 @@ class TestMgmtHybridConnection(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_hybridconnetion_curd(self, resource_group, location):
+    def test_hybridconnetion_curd(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
 
         resource_group_name = resource_group.name
 

--- a/sdk/relay/azure-mgmt-relay/tests/test_azure_mgmt_relay_namespace.py
+++ b/sdk/relay/azure-mgmt-relay/tests/test_azure_mgmt_relay_namespace.py
@@ -22,7 +22,9 @@ class TestMgmtRelayNamespace(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_relay_namespace_curd(self, resource_group, location):
+    def test_relay_namespace_curd(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
 
         resource_group_name = resource_group.name
 

--- a/sdk/relay/azure-mgmt-relay/tests/test_azure_mgmt_wcfrelay.py
+++ b/sdk/relay/azure-mgmt-relay/tests/test_azure_mgmt_wcfrelay.py
@@ -23,7 +23,9 @@ class TestMgmtWcfRelay(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_wcfrelay_curd(self, resource_group, location):
+    def test_wcfrelay_curd(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
 
         resource_group_name = resource_group.name
 

--- a/sdk/resources/azure-mgmt-resource/tests/test_mgmt_resource_deployment_scripts.py
+++ b/sdk/resources/azure-mgmt-resource/tests/test_mgmt_resource_deployment_scripts.py
@@ -31,7 +31,9 @@ class TestMgmtResourceDeploymentScript(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer()
     @recorded_by_proxy
-    def test_deployment_scripts(self, resource_group, location):
+    def test_deployment_scripts(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         SUBSCRIPTION = self.get_settings_value("SUBSCRIPTION_ID")
         script_name = "scripttest"
         identity_name = "uai"

--- a/sdk/resources/azure-mgmt-resource/tests/test_mgmt_resource_links.py
+++ b/sdk/resources/azure-mgmt-resource/tests/test_mgmt_resource_links.py
@@ -27,7 +27,9 @@ class TestMgmtResourceLinks(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer()
     @recorded_by_proxy
-    def test_links(self, resource_group, location):
+    def test_links(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         resource_name = self.get_resource_name("pytestavset")
         if not self.is_playback():
             create_result = self.resource_client.resources.begin_create_or_update(

--- a/sdk/resources/azure-mgmt-resource/tests/test_mgmt_resource_locks.py
+++ b/sdk/resources/azure-mgmt-resource/tests/test_mgmt_resource_locks.py
@@ -50,7 +50,9 @@ class TestMgmtResourceLocks(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer()
     @recorded_by_proxy
-    def test_locks_by_scope(self, resource_group, location):
+    def test_locks_by_scope(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         lock_name = "pylockrg"
         SUBSCRIPTION_ID = self.get_settings_value("SUBSCRIPTION_ID")
         resource_name = self.get_resource_name("pytestavset")
@@ -99,7 +101,9 @@ class TestMgmtResourceLocks(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer()
     @recorded_by_proxy
-    def test_locks_at_resource_level(self, resource_group, location):
+    def test_locks_at_resource_level(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         lock_name = 'pylockrg'
         resource_name = self.get_resource_name("pytestavset")
 
@@ -167,7 +171,9 @@ class TestMgmtResourceLocks(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer()
     @recorded_by_proxy
-    def test_locks_at_resource_group_level(self, resource_group, location):
+    def test_locks_at_resource_group_level(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         lock_name = 'pylockrg'
 
         lock = self.locks_client.management_locks.create_or_update_at_resource_group_level(

--- a/sdk/scheduler/azure-mgmt-scheduler/tests/disable_test_mgmt_scheduler.py
+++ b/sdk/scheduler/azure-mgmt-scheduler/tests/disable_test_mgmt_scheduler.py
@@ -24,7 +24,9 @@ class TestMgmtScheduler(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_scheduler(self, resource_group, location):
+    def test_scheduler(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         jobcollection_name = "myjobcollection"
         self.scheduler_client.job_collections.create_or_update(
             resource_group.name,
@@ -46,7 +48,9 @@ class TestMgmtScheduler(AzureMgmtRecordedTestCase):
     @unittest.skip("(BadRequest) Malformed Job Object")
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_scheduler_job_custom_time(self, resource_group, location):
+    def test_scheduler_job_custom_time(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         jobcollection_name = "myjobcollection"
         self.scheduler_client.job_collections.create_or_update(
             resource_group.name,

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
@@ -91,7 +91,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_basic_sr_avro_encoder_with_auto_register_schemas(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -185,7 +185,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_basic_sr_avro_encoder_without_auto_register_schemas(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group)
@@ -213,7 +213,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_basic_sr_avro_encoder_decode_readers_schema(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -265,7 +265,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_basic_sr_avro_encoder_with_request_options(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -293,7 +293,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_parse_invalid_json_string(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -312,7 +312,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_parse_primitive_types(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -326,7 +326,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_parse_fixed_types(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -356,7 +356,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_parse_invalid_type(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -383,7 +383,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_parse_record_name(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -461,7 +461,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_parse_error_schema_as_record(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -481,7 +481,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_parse_record_fields(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -564,7 +564,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_encode_primitive(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -576,7 +576,7 @@ class TestAvroEncoder(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_encode_record(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder_async.py
@@ -54,7 +54,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
     @pytest.mark.asyncio
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_basic_sr_avro_encoder_with_auto_register_schemas(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_basic_sr_avro_encoder_with_auto_register_schemas(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -147,7 +149,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
     @pytest.mark.asyncio
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_basic_sr_avro_encoder_without_auto_register_schemas(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_basic_sr_avro_encoder_without_auto_register_schemas(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -175,7 +179,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
     @pytest.mark.asyncio
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_basic_sr_avro_encoder_decode_readers_schema(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_basic_sr_avro_encoder_decode_readers_schema(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -227,7 +233,7 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
     async def test_basic_sr_avro_encoder_with_request_options(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
@@ -253,7 +259,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_parse_invalid_json_string(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_parse_invalid_json_string(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
         invalid_schema = {
@@ -270,7 +278,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_parse_primitive_types(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_parse_primitive_types(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -282,7 +292,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_parse_fixed_types(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_parse_fixed_types(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -310,7 +322,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_parse_invalid_type(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_parse_invalid_type(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -335,7 +349,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_parse_record_name(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_parse_record_name(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -410,7 +426,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_parse_error_schema_as_record(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_parse_error_schema_as_record(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -428,7 +446,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_parse_record_fields(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_parse_record_fields(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -509,7 +529,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_encode_primitive(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_encode_primitive(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 
@@ -519,7 +541,9 @@ class TestAvroEncoderAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_encode_record(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_encode_record(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         sr_client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         sr_avro_encoder = AvroEncoder(client=sr_client, group_name=schemaregistry_group, auto_register=True)
 

--- a/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
@@ -42,7 +42,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_schema_basic_async(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_schema_basic_async(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         async with client:
             name = self.get_resource_name('test-schema-basic-async')
@@ -71,7 +73,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_schema_update_async(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_schema_update_async(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         async with client:
             name = self.get_resource_name('test-schema-update-async')
@@ -103,7 +107,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_schema_same_twice_async(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_schema_same_twice_async(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = self.get_resource_name('test-schema-twice-async')
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"age","type":["int","null"]},{"name":"city","type":["string","null"]}]}"""
@@ -116,7 +122,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_schema_negative_wrong_credential_async(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_schema_negative_wrong_credential_async(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         credential = ClientSecretCredential(tenant_id="fake", client_id="fake", client_secret="fake")
         client = SchemaRegistryClient(fully_qualified_namespace=schemaregistry_fully_qualified_namespace, credential=credential)
         async with client, credential:
@@ -130,7 +138,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
     @pytest.mark.live_test_only
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_schema_negative_wrong_endpoint_async(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_schema_negative_wrong_endpoint_async(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace="fake.servicebus.windows.net")
         async with client:
             name = self.get_resource_name('test-schema-nonexist-async')
@@ -147,7 +157,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_schema_negative_no_schema_async(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_schema_negative_no_schema_async(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         async with client:
             with pytest.raises(HttpResponseError):
@@ -159,7 +171,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_register_schema_errors(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_register_schema_errors(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = 'test-schema'
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"age","type":["int","null"]},{"name":"city","type":["string","null"]}]}"""
@@ -189,7 +203,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
     
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_get_schema_properties_errors(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_get_schema_properties_errors(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = 'test-schema'
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"age","type":["int","null"]},{"name":"city","type":["string","null"]}]}"""
@@ -225,7 +241,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy_async
-    async def test_get_schema_errors(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    async def test_get_schema_errors(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         async with client:
             with pytest.raises(ValueError) as e:

--- a/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
@@ -39,7 +39,7 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_schema_basic(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = self.get_resource_name('test-schema-basic')
@@ -68,7 +68,7 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_schema_update(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = self.get_resource_name('test-schema-update')
@@ -99,7 +99,7 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_schema_same_twice(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = self.get_resource_name('test-schema-twice')
@@ -112,7 +112,7 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_schema_negative_wrong_credential(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         print(schemaregistry_fully_qualified_namespace)
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         credential = ClientSecretCredential(tenant_id="fake", client_id="fake", client_secret="fake")
@@ -128,7 +128,7 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_schema_negative_wrong_endpoint(self, **kwargs):
-        schemaregistry_group = kwargs.pop("schemaregistry_group")
+                schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace="fake.servicebus.windows.net")
         name = self.get_resource_name('test-schema-nonexist')
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"favorite_number","type":["int","null"]},{"name":"favorite_color","type":["string","null"]}]}"""
@@ -143,7 +143,7 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
     def test_schema_negative_no_schema(self, **kwargs):
-        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+                schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
         schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         with pytest.raises(HttpResponseError):
@@ -154,7 +154,9 @@ class TestSchemaRegistry(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
-    def test_register_schema_errors(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    def test_register_schema_errors(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = 'test-schema'
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"age","type":["int","null"]},{"name":"city","type":["string","null"]}]}"""
@@ -184,7 +186,9 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
-    def test_get_schema_properties_errors(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    def test_get_schema_properties_errors(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         name = 'test-schema'
         schema_str = """{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string"},{"name":"age","type":["int","null"]},{"name":"city","type":["string","null"]}]}"""
@@ -219,7 +223,9 @@ class TestSchemaRegistry(AzureRecordedTestCase):
 
     @SchemaRegistryEnvironmentVariableLoader()
     @recorded_by_proxy
-    def test_get_schema_errors(self, schemaregistry_fully_qualified_namespace, schemaregistry_group, **kwargs):
+    def test_get_schema_errors(self, **kwargs):
+        schemaregistry_fully_qualified_namespace = kwargs.pop("schemaregistry_fully_qualified_namespace")
+        schemaregistry_group = kwargs.pop("schemaregistry_group")
         client = self.create_client(fully_qualified_namespace=schemaregistry_fully_qualified_namespace)
         with pytest.raises(ValueError) as e:
             client.get_schema(None)

--- a/sdk/search/azure-mgmt-search/tests/test_mgmt_search.py
+++ b/sdk/search/azure-mgmt-search/tests/test_mgmt_search.py
@@ -20,7 +20,9 @@ class TestMgmtSearch(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_search_services(self, resource_group, location):
+    def test_search_services(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         account_name = 'ptvstestsearch'
 
         availability = self.client.services.check_name_availability(account_name)
@@ -61,7 +63,9 @@ class TestMgmtSearch(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_search_query_keys(self, resource_group, location):
+    def test_search_query_keys(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         account_name = 'ptvstestquerykeysxxy'
         key_name = 'testkey'
 
@@ -102,7 +106,9 @@ class TestMgmtSearch(AzureMgmtRecordedTestCase):
 
     @ResourceGroupPreparer()
     @recorded_by_proxy
-    def test_search_admin_keys(self, resource_group, location):
+    def test_search_admin_keys(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
+        location = kwargs.pop("location")
         account_name = 'ptvstestquerykeys'
 
         service = self.client.services.begin_create_or_update(

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_basic_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_basic_live_async.py
@@ -17,7 +17,10 @@ class TestSearchClientAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_get_document_count(self, endpoint, api_key, index_name):
+    async def test_get_document_count(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         async with client:
             assert await client.get_document_count() == 10
@@ -25,7 +28,11 @@ class TestSearchClientAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_get_document(self, endpoint, api_key, index_name, index_batch):
+    async def test_get_document(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
+        index_batch = kwargs.pop("index_batch")
         client = SearchClient(endpoint, index_name, api_key)
         async with client:
             for hotel_id in range(1, 11):
@@ -38,7 +45,10 @@ class TestSearchClientAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_get_document_missing(self, endpoint, api_key, index_name):
+    async def test_get_document_missing(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         async with client:
             with pytest.raises(HttpResponseError):

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_buffered_sender_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_buffered_sender_live_async.py
@@ -21,7 +21,10 @@ class TestSearchIndexingBufferedSenderAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_search_client_index_buffered_sender(self, endpoint, api_key, index_name):
+    async def test_search_client_index_buffered_sender(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         batch_client = SearchIndexingBufferedSender(endpoint, index_name, api_key)
         try:

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_index_document_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_index_document_live_async.py
@@ -21,7 +21,10 @@ class TestSearchClientDocumentsAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_search_client_index_document(self, endpoint, api_key, index_name):
+    async def test_search_client_index_document(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         doc_count = 10
         async with client:

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
@@ -18,7 +18,10 @@ class TestClientTestAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_search_client(self, endpoint, api_key, index_name):
+    async def test_search_client(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         async with client:
             await self._test_get_search_simple(client)
@@ -152,7 +155,10 @@ class TestClientTestAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_large.json")
     @recorded_by_proxy_async
-    async def test_search_client_large(self, endpoint, api_key, index_name):
+    async def test_search_client_large(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         async with client:
             await self._test_get_search_simple_large(client)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_alias_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_alias_live_async.py
@@ -29,7 +29,9 @@ class TestSearchClientAlias(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_alias(self, endpoint, api_key):
+    async def test_alias(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         client = SearchIndexClient(endpoint, api_key)
         aliases = ["resort", "motel"]
 

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_data_source_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_data_source_live_async.py
@@ -33,7 +33,9 @@ class TestSearchClientDataSourcesAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_data_source(self, endpoint, api_key, **kwargs):
+    async def test_data_source(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         storage_cs = kwargs.get("search_storage_connection_string")
         client = SearchIndexerClient(endpoint, api_key)
         async with client:

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_live_async.py
@@ -26,7 +26,10 @@ class TestSearchIndexClientAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema=None, index_batch=None)
     @recorded_by_proxy_async
-    async def test_search_index_client(self, api_key, endpoint, index_name):
+    async def test_search_index_client(self, **kwargs):
+        api_key = kwargs.pop("api_key")
+        endpoint = kwargs.pop("endpoint")
+        index_name = kwargs.pop("index_name")
         client = SearchIndexClient(endpoint, api_key)
         index_name = "hotels"
         async with client:

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_skillset_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_skillset_live_async.py
@@ -28,7 +28,9 @@ class TestSearchClientSkillsets(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_skillset_crud(self, api_key, endpoint):
+    async def test_skillset_crud(self, **kwargs):
+        api_key = kwargs.pop("api_key")
+        endpoint = kwargs.pop("endpoint")
         client = SearchIndexerClient(endpoint, api_key)
         async with client:
             await self._test_create_skillset(client)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_synonym_map_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_synonym_map_live_async.py
@@ -21,7 +21,9 @@ class TestSearchClientSynonymMaps(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_synonym_map(self, endpoint, api_key):
+    async def test_synonym_map(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         client = SearchIndexClient(endpoint, api_key)
         async with client:
             await self._test_create_synonym_map(client)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_indexer_client_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_indexer_client_live_async.py
@@ -22,7 +22,9 @@ class TestSearchIndexerClientTestAsync(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
-    async def test_search_indexers(self, endpoint, api_key, **kwargs):
+    async def test_search_indexers(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         storage_cs = kwargs.get("search_storage_connection_string")
         container_name = kwargs.get("search_storage_container_name")
         client = SearchIndexerClient(endpoint, api_key)

--- a/sdk/search/azure-search-documents/tests/test_search_client_basic_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_basic_live.py
@@ -17,14 +17,21 @@ class TestSearchClient(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_get_document_count(self, endpoint, api_key, index_name):
+    def test_get_document_count(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         assert client.get_document_count() == 10
 
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_get_document(self, endpoint, api_key, index_name, index_batch):
+    def test_get_document(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
+        index_batch = kwargs.pop("index_batch")
         client = SearchClient(endpoint, index_name, api_key)
         for hotel_id in range(1, 11):
             result = client.get_document(key=str(hotel_id))
@@ -36,7 +43,10 @@ class TestSearchClient(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_get_document_missing(self, endpoint, api_key, index_name):
+    def test_get_document_missing(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         with pytest.raises(HttpResponseError):
             client.get_document(key="1000")

--- a/sdk/search/azure-search-documents/tests/test_search_client_buffered_sender_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_buffered_sender_live.py
@@ -20,7 +20,10 @@ class TestSearchIndexingBufferedSender(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_search_client_index_buffered_sender(self, endpoint, api_key, index_name):
+    def test_search_client_index_buffered_sender(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         batch_client = SearchIndexingBufferedSender(endpoint, index_name, api_key)
         try:

--- a/sdk/search/azure-search-documents/tests/test_search_client_index_document_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_index_document_live.py
@@ -18,7 +18,10 @@ class TestSearchClientIndexDocument(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_search_client_index_document(self, endpoint, api_key, index_name):
+    def test_search_client_index_document(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         doc_count = 10
         doc_count = self._test_upload_documents_new(client, doc_count)

--- a/sdk/search/azure-search-documents/tests/test_search_client_search_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_search_live.py
@@ -15,7 +15,10 @@ class TestSearchClient(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_search_client(self, endpoint, api_key, index_name):
+    def test_search_client(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
+        index_name = kwargs.pop("index_name")
         client = SearchClient(endpoint, index_name, api_key)
         self._test_get_search_simple(client)
         self._test_get_search_simple_with_top(client)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_alias_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_alias_live.py
@@ -28,7 +28,9 @@ class TestSearchClientAlias(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_alias(self, endpoint, api_key):
+    def test_alias(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         client = SearchIndexClient(endpoint, api_key)
         aliases = ["resort", "motel"]
         index_name = next(client.list_index_names())

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_data_source_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_data_source_live.py
@@ -32,7 +32,9 @@ class TestSearchClientDataSources(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_data_source(self, endpoint, api_key, **kwargs):
+    def test_data_source(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         storage_cs = kwargs.get("search_storage_connection_string")
         client = SearchIndexerClient(endpoint, api_key)
         self._test_create_datasource(client, storage_cs)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_live.py
@@ -25,7 +25,10 @@ class TestSearchIndexClient(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema=None, index_batch=None)
     @recorded_by_proxy
-    def test_search_index_client(self, api_key, endpoint, index_name):
+    def test_search_index_client(self, **kwargs):
+        api_key = kwargs.pop("api_key")
+        endpoint = kwargs.pop("endpoint")
+        index_name = kwargs.pop("index_name")
         client = SearchIndexClient(endpoint, api_key)
         index_name = "hotels"
         self._test_get_service_statistics(client)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_skillset_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_skillset_live.py
@@ -28,7 +28,9 @@ class TestSearchSkillset(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_skillset_crud(self, api_key, endpoint):
+    def test_skillset_crud(self, **kwargs):
+        api_key = kwargs.pop("api_key")
+        endpoint = kwargs.pop("endpoint")
         client = SearchIndexerClient(endpoint, api_key)
         self._test_create_skillset_validation()
         self._test_create_skillset(client)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_synonym_map_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_synonym_map_live.py
@@ -20,7 +20,9 @@ class TestSearchClientSynonymMaps(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_synonym_map(self, endpoint, api_key):
+    def test_synonym_map(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         client = SearchIndexClient(endpoint, api_key)
         self._test_create_synonym_map(client)
         self._test_delete_synonym_map(client)

--- a/sdk/search/azure-search-documents/tests/test_search_indexer_client_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_indexer_client_live.py
@@ -21,7 +21,9 @@ class TestSearchIndexerClientTest(AzureRecordedTestCase):
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
-    def test_search_indexers(self, endpoint, api_key, **kwargs):
+    def test_search_indexers(self, **kwargs):
+        endpoint = kwargs.pop("endpoint")
+        api_key = kwargs.pop("api_key")
         storage_cs = kwargs.get("search_storage_connection_string")
         container_name = kwargs.get("search_storage_container_name")
         client = SearchIndexerClient(endpoint, api_key)

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/disable_test_cli_mgmt_servicebus_namespace.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/disable_test_cli_mgmt_servicebus_namespace.py
@@ -69,7 +69,8 @@ class TestMgmtServiceBus(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_namespace(self, resource_group):
+    def test_namespace(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         SUBSCRIPTION_ID = self.settings.SUBSCRIPTION_ID
         RESOURCE_GROUP = resource_group.name
@@ -257,7 +258,8 @@ class TestMgmtServiceBus(AzureMgmtRecordedTestCase):
     @unittest.skip('hard to test')
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_migration_configs(self, resource_group):
+    def test_migration_configs(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         RESOURCE_GROUP = resource_group.name
         NAMESPACE_NAME = "myNamespacexxyyzzxyyma"
@@ -385,7 +387,8 @@ class TestMgmtServiceBus(AzureMgmtRecordedTestCase):
     @unittest.skip("unsupport.")
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_disaster_recovery_configs(self, resource_group):
+    def test_disaster_recovery_configs(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         RESOURCE_GROUP = resource_group.name
         NAMESPACE_NAME = "myNamespacexxyyzzxyyab"

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/test_cli_mgmt_servicebus_queue.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/test_cli_mgmt_servicebus_queue.py
@@ -25,7 +25,8 @@ class TestMgmtServiceBus(AzureMgmtRecordedTestCase):
     
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_queue(self, resource_group):
+    def test_queue(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         RESOURCE_GROUP = resource_group.name
         NAMESPACE_NAME = "myNamespacexxyyzzybx"

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/test_cli_mgmt_servicebus_topic.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/test_cli_mgmt_servicebus_topic.py
@@ -27,7 +27,8 @@ class TestMgmtServiceBus(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_subscrpition_and_rule(self, resource_group):
+    def test_subscrpition_and_rule(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         RESOURCE_GROUP = resource_group.name
         NAMESPACE_NAME = "myNamespacexxyyzzxyye"
@@ -117,7 +118,8 @@ class TestMgmtServiceBus(AzureMgmtRecordedTestCase):
 
     @RandomNameResourceGroupPreparer(location=AZURE_LOCATION)
     @recorded_by_proxy
-    def test_topic(self, resource_group):
+    def test_topic(self, **kwargs):
+        resource_group = kwargs.pop("resource_group")
 
         RESOURCE_GROUP = resource_group.name
         NAMESPACE_NAME = "myNamespacexxyyzzxyyf"

--- a/sdk/tables/azure-data-tables/tests/test_challenge_auth.py
+++ b/sdk/tables/azure-data-tables/tests/test_challenge_auth.py
@@ -30,7 +30,8 @@ except ModuleNotFoundError:
 class TestTableChallengeAuth(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
-    def test_challenge_auth_supported_version(self, tables_storage_account_name):
+    def test_challenge_auth_supported_version(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         """This test requires a client that uses an API version that supports 401 challenge responses.
 
         Recorded using an incorrect tenant for the credential provided to our client. To run this live, ensure that the
@@ -52,7 +53,8 @@ class TestTableChallengeAuth(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_challenge_auth_unsupported_version(self, tables_storage_account_name):
+    def test_challenge_auth_unsupported_version(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         """This test requires a client that uses an API version that doesn't support 401 challenge responses.
 
         Recorded using an incorrect tenant for the credential provided to our client. To run this live, ensure that the

--- a/sdk/tables/azure-data-tables/tests/test_challenge_auth_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_challenge_auth_async.py
@@ -32,7 +32,8 @@ except ModuleNotFoundError:
 class TestTableChallengeAuthAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_challenge_auth_supported_version(self, tables_storage_account_name):
+    async def test_challenge_auth_supported_version(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         """This test requires a client that uses an API version that supports 401 challenge responses.
 
         Recorded using an incorrect tenant for the credential provided to our client. To run this live, ensure that the
@@ -54,7 +55,8 @@ class TestTableChallengeAuthAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_challenge_auth_unsupported_version(self, tables_storage_account_name):
+    async def test_challenge_auth_unsupported_version(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         """This test requires a client that uses an API version that doesn't support 401 challenge responses.
 
         Recorded using an incorrect tenant for the credential provided to our client. To run this live, ensure that the

--- a/sdk/tables/azure-data-tables/tests/test_retry.py
+++ b/sdk/tables/azure-data-tables/tests/test_retry.py
@@ -70,7 +70,9 @@ class TestStorageRetry(AzureRecordedTestCase, TableTestCase):
     # --Test Cases --------------------------------------------
     @tables_decorator
     @recorded_by_proxy
-    def test_retry_on_server_error(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_retry_on_server_error(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key, default_table=False)
         try:
             callback = ResponseCallback(status=201, new_status=500).override_status
@@ -86,7 +88,9 @@ class TestStorageRetry(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_retry_on_timeout(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_retry_on_timeout(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(
             tables_storage_account_name,
             tables_primary_storage_account_key,
@@ -125,7 +129,9 @@ class TestStorageRetry(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_no_retry(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_no_retry(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key, retry_total=0, default_table=False)
 
         new_table_name = self.get_resource_name('uttable')

--- a/sdk/tables/azure-data-tables/tests/test_retry_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_retry_async.py
@@ -59,7 +59,9 @@ class TestStorageRetryAsync(AzureRecordedTestCase, AsyncTableTestCase):
     # --Test Cases --------------------------------------------
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_retry_on_server_error_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_retry_on_server_error_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key, default_table=False)
         try:
             callback = ResponseCallback(status=201, new_status=500).override_status
@@ -75,7 +77,9 @@ class TestStorageRetryAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_retry_on_timeout_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_retry_on_timeout_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(
             tables_storage_account_name,
             tables_primary_storage_account_key,
@@ -114,7 +118,9 @@ class TestStorageRetryAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_no_retry_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_no_retry_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key, retry_total=0, default_table=False)
 
         new_table_name = self.get_resource_name('uttable')

--- a/sdk/tables/azure-data-tables/tests/test_table.py
+++ b/sdk/tables/azure-data-tables/tests/test_table.py
@@ -34,7 +34,9 @@ from preparers import tables_decorator, tables_decorator
 class TestTable(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
-    def test_create_properties(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_create_properties(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -63,7 +65,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_create_table(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_create_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -80,7 +84,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_create_table_fail_on_exist(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_create_table_fail_on_exist(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -100,7 +106,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_tables_per_page(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_tables_per_page(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -129,7 +137,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_create_table_if_exists(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_create_table_if_exists(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
         table_name = self._get_table_reference()
@@ -144,7 +154,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_create_table_if_exists_new_table(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_create_table_if_exists_new_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
         table_name = self._get_table_reference()
@@ -157,7 +169,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_tables(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_tables(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -178,7 +192,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_tables_with_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_tables_with_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -200,7 +216,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_tables_with_num_results(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_tables_with_num_results(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         prefix = 'listtable'
         account_url = self.account_url(tables_storage_account_name, "table")
@@ -227,7 +245,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_tables_with_marker(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_tables_with_marker(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -255,7 +275,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_table_with_existing_table(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_table_with_existing_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -271,7 +293,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_table_with_non_existing_table_fail_not_exist(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_table_with_non_existing_table_fail_not_exist(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -280,7 +304,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_table_acl(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_table_acl(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         account_url = self.account_url(tables_storage_account_name, "table")
@@ -298,7 +324,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_set_table_acl_with_empty_signed_identifiers(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_table_acl_with_empty_signed_identifiers(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
 
@@ -318,7 +346,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_set_table_acl_with_empty_signed_identifier(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_table_acl_with_empty_signed_identifier(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
 
@@ -367,7 +397,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_set_table_acl_with_signed_identifiers(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_table_acl_with_signed_identifiers(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
 
@@ -395,7 +427,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_set_table_acl_too_many_ids(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_table_acl_too_many_ids(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
 
@@ -416,7 +450,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_account_sas(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_account_sas(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
 
@@ -459,7 +495,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
     
     @tables_decorator
     @recorded_by_proxy
-    def test_unicode_create_table_unicode_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_unicode_create_table_unicode_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(account_url, credential=tables_primary_storage_account_key)
         invalid_table_name = u'啊齄丂狛狜'
@@ -471,7 +509,9 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
     
     @tables_decorator
     @recorded_by_proxy
-    def test_create_table_invalid_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_create_table_invalid_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(account_url, credential=tables_primary_storage_account_key)
         invalid_table_name = "my_table"

--- a/sdk/tables/azure-data-tables/tests/test_table_aad.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_aad.py
@@ -34,7 +34,8 @@ from preparers import tables_decorator, tables_decorator
 class TestTableAAD(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_create_table(self, tables_storage_account_name):
+    def test_aad_create_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -53,7 +54,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_query_list_tables(self, tables_storage_account_name):
+    def test_aad_query_list_tables(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -85,7 +87,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_create_table_tc(self, tables_storage_account_name):
+    def test_aad_create_table_tc(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -107,7 +110,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_service_properties(self, tables_storage_account_name):
+    def test_aad_service_properties(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -133,7 +137,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_table_service_stats(self, tables_storage_account_name):
+    def test_aad_table_service_stats(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         tsc = TableServiceClient(
             self.account_url(tables_storage_account_name, "table"), credential=self.get_token_credential()
         )
@@ -142,7 +147,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_insert_entity_dictionary(self, tables_storage_account_name):
+    def test_aad_insert_entity_dictionary(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
 
         self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
@@ -156,7 +162,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_query_user_filter(self, tables_storage_account_name):
+    def test_aad_query_user_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
 
         self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
@@ -177,7 +184,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_batch_all_operations_together(self, tables_storage_account_name):
+    def test_aad_batch_all_operations_together(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -249,7 +257,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_access_policy_error(self, tables_storage_account_name):
+    def test_aad_access_policy_error(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         account_url = self.account_url(tables_storage_account_name, "table")
         table_name = self._get_table_reference()
         table_client = TableClient(credential=self.get_token_credential(), endpoint=account_url, table_name=table_name)
@@ -262,7 +271,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_delete_entities(self, tables_storage_account_name):
+    def test_aad_delete_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
             entity, _ = self._insert_random_entity()
@@ -276,7 +286,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_query_user_filter(self, tables_storage_account_name):
+    def test_aad_query_user_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
 
         self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
@@ -296,7 +307,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_aad_list_entities(self, tables_storage_account_name):
+    def test_aad_list_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
 
         self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
@@ -312,7 +324,8 @@ class TestTableAAD(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_merge_entity(self, tables_storage_account_name):
+    def test_merge_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
             entity, _ = self._insert_random_entity()

--- a/sdk/tables/azure-data-tables/tests/test_table_aad_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_aad_async.py
@@ -33,7 +33,8 @@ from async_preparers import tables_decorator_async
 class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_create_table(self, tables_storage_account_name):
+    async def test_aad_create_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -52,7 +53,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_query_list_tables(self, tables_storage_account_name):
+    async def test_aad_query_list_tables(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -84,7 +86,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_create_table_tc(self, tables_storage_account_name):
+    async def test_aad_create_table_tc(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -106,7 +109,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_service_properties(self, tables_storage_account_name):
+    async def test_aad_service_properties(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         try:
             account_url = self.account_url(tables_storage_account_name, "table")
             ts = TableServiceClient(credential=self.get_token_credential(), endpoint=account_url)
@@ -132,7 +136,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_table_service_stats(self, tables_storage_account_name):
+    async def test_aad_table_service_stats(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         tsc = TableServiceClient(
             self.account_url(tables_storage_account_name, "table"), credential=self.get_token_credential()
         )
@@ -141,7 +146,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_insert_entity_dictionary(self, tables_storage_account_name):
+    async def test_aad_insert_entity_dictionary(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
 
         await self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
@@ -154,7 +160,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_query_user_filter(self, tables_storage_account_name):
+    async def test_aad_query_user_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
 
         await self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
@@ -175,7 +182,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_batch_all_operations_together(self, tables_storage_account_name):
+    async def test_aad_batch_all_operations_together(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -249,7 +257,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_access_policy_error(self, tables_storage_account_name):
+    async def test_aad_access_policy_error(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         account_url = self.account_url(tables_storage_account_name, "table")
         table_name = self._get_table_reference()
         table_client = TableClient(credential=self.get_token_credential(), endpoint=account_url, table_name=table_name)
@@ -262,7 +271,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_delete_entities(self, tables_storage_account_name):
+    async def test_aad_delete_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         await self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
             entity, _ = await self._insert_random_entity()
@@ -276,7 +286,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_query_user_filter(self, tables_storage_account_name):
+    async def test_aad_query_user_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
 
         await self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
@@ -296,7 +307,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_aad_list_entities(self, tables_storage_account_name):
+    async def test_aad_list_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         await self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
             table = await self._create_query_table(2)
@@ -313,7 +325,8 @@ class TestTableAADAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity(self, tables_storage_account_name):
+    async def test_merge_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
         await self._set_up(tables_storage_account_name, self.get_token_credential())
         try:
             entity, _ = await self._insert_random_entity()

--- a/sdk/tables/azure-data-tables/tests/test_table_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_async.py
@@ -29,7 +29,9 @@ from async_preparers import tables_decorator_async
 class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_create_table(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_create_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -46,7 +48,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_create_table_fail_on_exist(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_create_table_fail_on_exist(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -66,7 +70,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_tables_per_page(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_tables_per_page(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -96,7 +102,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_list_tables(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_list_tables(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -118,7 +126,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_tables_with_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_tables_with_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -140,7 +150,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_list_tables_with_num_results(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_list_tables_with_num_results(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         prefix = 'listtable'
         account_url = self.account_url(tables_storage_account_name, "table")
@@ -168,7 +180,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_list_tables_with_marker(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_list_tables_with_marker(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -202,7 +216,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_table_with_existing_table(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_table_with_existing_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -219,8 +235,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_table_with_non_existing_table_fail_not_exist(self, tables_storage_account_name,
-                                                                       tables_primary_storage_account_key):
+    async def test_delete_table_with_non_existing_table_fail_not_exist(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -231,7 +248,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_table_acl(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_table_acl(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
 
@@ -248,7 +267,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_table_acl_with_empty_signed_identifiers(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_table_acl_with_empty_signed_identifiers(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         account_url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
@@ -267,7 +288,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_table_acl_with_empty_signed_identifier(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_table_acl_with_empty_signed_identifier(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -314,7 +337,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_table_acl_with_signed_identifiers(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_table_acl_with_signed_identifiers(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -341,7 +366,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_table_acl_too_many_ids(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_table_acl_too_many_ids(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         ts = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -360,7 +387,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_account_sas(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_account_sas(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
 
@@ -405,7 +434,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
     
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_unicode_create_table_unicode_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_unicode_create_table_unicode_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(account_url, credential=tables_primary_storage_account_key)
         invalid_table_name = u'啊齄丂狛狜'
@@ -418,7 +449,9 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
     
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_create_table_invalid_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_create_table_invalid_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         account_url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(account_url, credential=tables_primary_storage_account_key)
         invalid_table_name = "my_table"

--- a/sdk/tables/azure-data-tables/tests/test_table_batch.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch.py
@@ -47,7 +47,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_single_insert(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_single_insert(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -84,7 +86,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_single_update(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_single_update(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -125,7 +129,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_update(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_update(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -168,7 +174,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_merge(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -213,7 +221,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_update_if_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_update_if_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -247,7 +257,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_update_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_update_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -281,7 +293,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_single_op_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_single_op_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -331,7 +345,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_insert_replace(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_insert_replace(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -367,7 +383,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_insert_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_insert_merge(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -403,7 +421,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_delete(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_delete(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -441,7 +461,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_inserts(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_inserts(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -482,7 +504,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_all_operations_together(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_all_operations_together(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -558,7 +582,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_reuse(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_reuse(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -603,7 +629,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_same_row_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_same_row_operations_fail(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -637,7 +665,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_different_partition_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_different_partition_operations_fail(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -668,7 +698,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_too_many_ops(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_too_many_ops(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -697,7 +729,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_different_partition_keys(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_different_partition_keys(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -720,7 +754,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_new_non_existent_table(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_new_non_existent_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -744,7 +780,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_new_invalid_key(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_new_invalid_key(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -767,7 +805,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_new_delete_nonexistent_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_new_delete_nonexistent_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -789,7 +829,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_batch_with_bad_kwarg(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_batch_with_bad_kwarg(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -908,7 +950,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_with_mode(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_with_mode(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -958,7 +1002,9 @@ class TestTableBatch(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator
     @recorded_by_proxy
-    def test_batch_with_specialchar_partitionkey(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_batch_with_specialchar_partitionkey(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
@@ -43,7 +43,9 @@ from async_preparers import tables_decorator_async
 class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_single_insert(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_single_insert(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -79,7 +81,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_single_update(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_single_update(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -120,7 +124,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_update(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_update(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -160,7 +166,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_merge(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -204,7 +212,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_update_if_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_update_if_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -237,7 +247,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_update_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_update_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -271,7 +283,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_insert_replace(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_insert_replace(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -306,7 +320,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_insert_merge(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_insert_merge(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -341,7 +357,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_delete(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_delete(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -379,7 +397,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_inserts(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_inserts(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -422,7 +442,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_all_operations_together(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_all_operations_together(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -500,7 +522,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_same_row_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_same_row_operations_fail(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -531,7 +555,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_different_partition_operations_fail(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_different_partition_operations_fail(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -562,7 +588,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_too_many_ops(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_too_many_ops(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -590,7 +618,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_new_non_existent_table(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_new_non_existent_table(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -613,7 +643,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_new_invalid_key(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_new_invalid_key(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -634,7 +666,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_new_delete_nonexistent_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_new_delete_nonexistent_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -737,7 +771,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_batch_with_bad_kwarg(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_batch_with_bad_kwarg(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -771,7 +807,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_with_mode(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_with_mode(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -821,7 +859,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_with_specialchar_partitionkey(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_batch_with_specialchar_partitionkey(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -885,7 +925,9 @@ class TestTableBatchAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_async_batch_inserts(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_async_batch_inserts(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
@@ -38,7 +38,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_insert(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_insert(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -74,7 +76,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_update(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -115,7 +119,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_merge(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -160,7 +166,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_update_if_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_update_if_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -194,7 +202,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_update_if_doesnt_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_update_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -228,7 +238,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_insert_replace(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_insert_replace(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -264,7 +276,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_insert_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_insert_merge(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -300,7 +314,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_delete(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_delete(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -338,7 +354,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_inserts(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_inserts(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -379,7 +397,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_all_operations_together(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_all_operations_together(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -455,7 +475,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_different_partition_operations_fail(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_different_partition_operations_fail(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -486,7 +508,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_new_non_existent_table(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_new_non_existent_table(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -510,7 +534,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_new_delete_nonexistent_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_new_delete_nonexistent_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -531,7 +557,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_batch_with_bad_kwarg(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_batch_with_bad_kwarg(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -648,7 +676,9 @@ class TestTableBatchCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_batch_with_specialchar_partitionkey(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_batch_with_specialchar_partitionkey(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
@@ -43,7 +43,9 @@ TEST_TABLE_PREFIX = 'table'
 class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_single_insert(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_single_insert(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -80,7 +82,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_single_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_single_update(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -121,7 +125,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_update(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -161,7 +167,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_merge(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -205,7 +213,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_update_if_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_update_if_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -238,7 +248,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_update_if_doesnt_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_update_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -273,7 +285,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_insert_replace(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_insert_replace(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -308,7 +322,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_insert_merge(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_insert_merge(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -343,7 +359,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_delete(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_delete(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -380,7 +398,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_inserts(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_inserts(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -423,7 +443,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_all_operations_together(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_all_operations_together(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -501,7 +523,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_different_partition_operations_fail(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_different_partition_operations_fail(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -532,7 +556,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_new_non_existent_table(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_new_non_existent_table(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -571,7 +597,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_new_delete_nonexistent_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_new_delete_nonexistent_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -621,7 +649,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_batch_with_bad_kwarg(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_delete_batch_with_bad_kwarg(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -707,7 +737,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_batch_with_specialchar_partitionkey(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_batch_with_specialchar_partitionkey(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"
@@ -771,7 +803,9 @@ class TestTableBatchCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_async_batch_inserts(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_async_batch_inserts(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # this can be reverted to set_bodiless_matcher() after tests are re-recorded and don't contain these headers
         set_custom_default_matcher(
             compare_bodies=False, excluded_headers="Authorization,Content-Length,x-ms-client-request-id,x-ms-request-id"

--- a/sdk/tables/azure-data-tables/tests/test_table_client.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client.py
@@ -34,7 +34,9 @@ _CONNECTION_ENDPOINTS_SECONDARY = {'table': 'TableSecondaryEndpoint', 'cosmos': 
 class TestTableClient(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
-    def test_user_agent_custom(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_user_agent_custom(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         custom_app = "TestApp/v1.0"
         service = TableServiceClient(
             self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key, user_agent=custom_app)
@@ -71,7 +73,9 @@ class TestTableClient(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_user_agent_append(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_user_agent_append(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         service = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 
         def callback(response):
@@ -88,7 +92,9 @@ class TestTableClient(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_user_agent_default(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_user_agent_default(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         service = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 
         def callback(response):
@@ -109,7 +115,9 @@ class TestTableClient(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.live_test_only
     @tables_decorator
     @recorded_by_proxy
-    def test_table_name_errors(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_table_name_errors(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         endpoint = self.account_url(tables_storage_account_name, "table")
 
         # storage table names must be alphanumeric, cannot begin with a number, and must be between 3 and 63 chars long.       

--- a/sdk/tables/azure-data-tables/tests/test_table_client_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_async.py
@@ -33,7 +33,9 @@ class TestTableClientAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_user_agent_default_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_user_agent_default_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         service = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 
         def callback(response):
@@ -53,7 +55,9 @@ class TestTableClientAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_user_agent_custom_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_user_agent_custom_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         custom_app = "TestApp/v1.0"
         service = TableServiceClient(
             self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key, user_agent=custom_app)
@@ -90,7 +94,9 @@ class TestTableClientAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_user_agent_append(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_user_agent_append(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         service = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 
         def callback(response):
@@ -108,7 +114,9 @@ class TestTableClientAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.live_test_only
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_table_name_errors(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_table_name_errors(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         endpoint = self.account_url(tables_storage_account_name, "table")
 
         # storage table names must be alphanumeric, cannot begin with a number, and must be between 3 and 63 chars long.       

--- a/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
@@ -35,7 +35,9 @@ class TestTableClientCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="Malformed string")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_user_agent_default(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_user_agent_default(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         service = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
 
         def callback(response):
@@ -55,7 +57,9 @@ class TestTableClientCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_user_agent_custom(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_user_agent_custom(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         custom_app = "TestApp/v1.0"
         service = TableServiceClient(
             self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key, user_agent=custom_app)
@@ -93,7 +97,9 @@ class TestTableClientCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_user_agent_append(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_user_agent_append(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         service = TableServiceClient(
             self.account_url(tables_cosmos_account_name, "cosmos"),
             credential=tables_primary_cosmos_account_key)
@@ -113,7 +119,9 @@ class TestTableClientCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.live_test_only
     @cosmos_decorator
     @recorded_by_proxy
-    def test_table_name_errors_bad_chars(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_table_name_errors_bad_chars(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         endpoint = self.account_url(tables_cosmos_account_name, "cosmos")
         
         # cosmos table names must be a non-empty string without chars '\', '/', '#', '?', and less than 255 chars.
@@ -150,7 +158,9 @@ class TestTableClientCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.live_test_only
     @cosmos_decorator
     @recorded_by_proxy
-    def test_table_name_errors_bad_length(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_table_name_errors_bad_length(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         endpoint = self.account_url(tables_cosmos_account_name, "cosmos")
         
         # cosmos table names must be a non-empty string without chars '\', '/', '#', '?', and less than 255 chars.

--- a/sdk/tables/azure-data-tables/tests/test_table_client_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_cosmos_async.py
@@ -34,7 +34,9 @@ class TestTableClientCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_user_agent_default_async(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_user_agent_default_async(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         service = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
 
         def callback(response):
@@ -54,7 +56,9 @@ class TestTableClientCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_user_agent_custom_async(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_user_agent_custom_async(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         custom_app = "TestApp/v1.0"
         service = TableServiceClient(
             self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key, user_agent=custom_app)
@@ -88,7 +92,9 @@ class TestTableClientCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_user_agent_append(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_user_agent_append(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         service = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
 
         def callback(response):
@@ -106,7 +112,9 @@ class TestTableClientCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.live_test_only
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_table_name_errors_bad_chars(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_table_name_errors_bad_chars(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         endpoint = self.account_url(tables_cosmos_account_name, "cosmos")
         
         # cosmos table names must be a non-empty string without chars '\', '/', '#', '?', and less than 255 chars.
@@ -144,7 +152,9 @@ class TestTableClientCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @pytest.mark.live_test_only
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_table_name_errors_bad_length(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_table_name_errors_bad_length(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         endpoint = self.account_url(tables_cosmos_account_name, "cosmos")
         
         # cosmos table names must be a non-empty string without chars '\', '/', '#', '?', and less than 255 chars.

--- a/sdk/tables/azure-data-tables/tests/test_table_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_cosmos.py
@@ -22,7 +22,9 @@ TEST_TABLE_PREFIX = 'pytablesync'
 class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
-    def test_create_table(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_create_table(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
 
@@ -38,7 +40,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_create_table_fail_on_exist(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_create_table_fail_on_exist(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = self._get_table_reference()
@@ -54,7 +58,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_tables_per_page(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_tables_per_page(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
 
@@ -82,7 +88,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_tables(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_tables(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table = self._create_table(ts)
@@ -98,7 +106,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_tables_with_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_tables_with_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table = self._create_table(ts)
@@ -116,7 +126,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_tables_with_num_results(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_tables_with_num_results(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         prefix = 'listtable'
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
@@ -142,7 +154,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_tables_with_marker(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_tables_with_marker(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         prefix = 'listtable'
@@ -171,7 +185,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_table_with_existing_table(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_table_with_existing_table(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table = self._create_table(ts)
@@ -185,8 +201,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_table_with_non_existing_table_fail_not_exist(self, tables_cosmos_account_name,
-                                                                 tables_primary_cosmos_account_key):
+    def test_delete_table_with_non_existing_table_fail_not_exist(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = self._get_table_reference()
@@ -194,7 +211,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
         
     @cosmos_decorator
     @recorded_by_proxy
-    def test_create_table_underscore_name(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_create_table_underscore_name(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = "my_table"
@@ -206,7 +225,9 @@ class TestTableCosmos(AzureRecordedTestCase, TableTestCase):
         
     @cosmos_decorator
     @recorded_by_proxy
-    def test_create_table_unicode_name(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_create_table_unicode_name(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = u'啊齄丂狛狜'

--- a/sdk/tables/azure-data-tables/tests/test_table_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_cosmos_async.py
@@ -23,7 +23,9 @@ TEST_TABLE_PREFIX = 'pytableasync'
 class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_create_table(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_create_table(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = self._get_table_reference()
@@ -39,7 +41,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_create_table_fail_on_exist(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_create_table_fail_on_exist(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = self._get_table_reference()
@@ -55,7 +59,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_tables_per_page(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_tables_per_page(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
 
@@ -83,7 +89,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_list_tables(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_list_tables(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table = await self._create_table(ts)
@@ -100,7 +108,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_tables_with_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_tables_with_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table = await self._create_table(ts)
@@ -118,7 +128,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_list_tables_with_num_results(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_list_tables_with_num_results(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._delete_all_tables(tables_cosmos_account_name, tables_primary_cosmos_account_key)
         prefix = 'listtable'
@@ -145,7 +157,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_list_tables_with_marker(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_list_tables_with_marker(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         prefix = 'listtable'
@@ -178,8 +192,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_table_with_existing_table(self, tables_cosmos_account_name,
-                                                    tables_primary_cosmos_account_key):
+    async def test_delete_table_with_existing_table(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table = await self._create_table(ts)
@@ -192,8 +207,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_table_with_non_existing_table_fail_not_exist(self, tables_cosmos_account_name,
-                                                                       tables_primary_cosmos_account_key):
+    async def test_delete_table_with_non_existing_table_fail_not_exist(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = self._get_table_reference()
@@ -201,7 +217,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
         
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_create_table_underscore_name(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_create_table_underscore_name(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = "my_table"
@@ -213,7 +231,9 @@ class TestTableCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
         
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_create_table_unicode_name(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_create_table_unicode_name(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         ts = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         table_name = u'啊齄丂狛狜'

--- a/sdk/tables/azure-data-tables/tests/test_table_entity.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity.py
@@ -46,7 +46,9 @@ TEST_GUID = UUID("1c241c8d-f7b6-4b0a-abba-d9b169010038")
 class TestTableEntity(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
-    def test_url_encoding_at_symbol(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_url_encoding_at_symbol(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
             entity = {
@@ -81,7 +83,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_etag(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_etag(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
 
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -101,7 +105,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -125,7 +131,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter_multiple_params(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter_multiple_params(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -150,7 +158,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter_integers(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter_integers(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -174,7 +184,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter_floats(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter_floats(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -198,7 +210,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter_datetimes(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter_datetimes(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -222,7 +236,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter_guids(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter_guids(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -246,7 +262,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter_binary(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter_binary(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -270,7 +288,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_user_filter_int64(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_user_filter_int64(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -301,7 +321,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_invalid_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_invalid_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -326,7 +348,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_dictionary(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_dictionary(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -342,7 +366,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_hook(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_with_hook(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -363,7 +389,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_no_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_with_no_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -389,7 +417,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_full_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_with_full_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -415,7 +445,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_conflict(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_conflict(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -431,8 +463,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_large_int32_value_throws(self, tables_storage_account_name,
-                                                         tables_primary_storage_account_key):
+    def test_insert_entity_with_large_int32_value_throws(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -452,8 +485,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_large_int64_value_throws(self, tables_storage_account_name,
-                                                         tables_primary_storage_account_key):
+    def test_insert_entity_with_large_int64_value_throws(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -473,8 +507,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_large_int_success(self, tables_storage_account_name,
-                                                         tables_primary_storage_account_key):
+    def test_insert_entity_with_large_int_success(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -500,7 +535,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_missing_pk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_missing_pk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -515,7 +552,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_empty_string_pk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_empty_string_pk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -530,7 +569,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_missing_rk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_missing_rk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -546,7 +587,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_empty_string_rk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_empty_string_rk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -561,7 +604,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_too_many_properties(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_too_many_properties(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -579,7 +624,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_property_name_too_long(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_insert_entity_property_name_too_long(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -596,8 +643,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_enums(self, tables_storage_account_name,
-                                                         tables_primary_storage_account_key):
+    def test_insert_entity_with_enums(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -627,7 +675,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -646,7 +696,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_with_select(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_with_select(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -668,7 +720,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_with_hook(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_with_hook(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -691,7 +745,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_if_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_if_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -718,7 +774,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_if_match_entity_bad_etag(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_if_match_entity_bad_etag(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -743,7 +801,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_entity_if_match_table_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_entity_if_match_table_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -767,7 +827,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_full_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_full_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -788,7 +850,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_no_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_no_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -809,7 +873,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -826,7 +892,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_get_entity_with_special_doubles(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_get_entity_with_special_doubles(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -851,7 +919,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_update_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_update_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -876,7 +946,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_update_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_update_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -893,7 +965,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_update_entity_with_if_matches(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_update_entity_with_if_matches(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -915,7 +989,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_update_entity_with_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_update_entity_with_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -934,8 +1010,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_or_merge_entity_with_existing_entity(self, tables_storage_account_name,
-                                                         tables_primary_storage_account_key):
+    def test_insert_or_merge_entity_with_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -954,8 +1031,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_or_merge_entity_with_non_existing_entity(self, tables_storage_account_name,
-                                                             tables_primary_storage_account_key):
+    def test_insert_or_merge_entity_with_non_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -975,8 +1053,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_or_replace_entity_with_existing_entity(self, tables_storage_account_name,
-                                                           tables_primary_storage_account_key):
+    def test_insert_or_replace_entity_with_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -995,8 +1074,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_insert_or_replace_entity_with_non_existing_entity(self, tables_storage_account_name,
-                                                               tables_primary_storage_account_key):
+    def test_insert_or_replace_entity_with_non_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1016,7 +1096,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_merge_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_merge_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1035,7 +1117,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_merge_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_merge_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1052,7 +1136,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_merge_entity_with_if_matches(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_merge_entity_with_if_matches(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1075,7 +1161,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_merge_entity_with_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_merge_entity_with_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1095,7 +1183,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1113,7 +1203,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1124,7 +1216,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_entity_with_if_matches(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_entity_with_if_matches(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1143,7 +1237,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_entity_with_if_doesnt_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_entity_with_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1163,7 +1259,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_entity_overloads(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_entity_overloads(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1192,7 +1290,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_delete_entity_overloads_kwargs(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_delete_entity_overloads_kwargs(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1221,7 +1321,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_unicode_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_unicode_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1246,7 +1348,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_unicode_property_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_unicode_property_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1271,7 +1375,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_operations_on_entity_with_partition_key_having_single_quote(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_operations_on_entity_with_partition_key_having_single_quote(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         partition_key_with_single_quote = u"a''''b"
         row_key_with_single_quote = u"a''''b"
@@ -1309,7 +1415,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_empty_and_spaces_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_empty_and_spaces_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1348,7 +1456,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_none_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_none_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1367,7 +1477,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_binary_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_binary_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1387,7 +1499,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_timezone(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_timezone(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1410,7 +1524,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1428,7 +1544,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities_each_page(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities_each_page(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1469,7 +1587,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_zero_entities(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_zero_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1485,7 +1605,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities_full_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities_full_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1503,7 +1625,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities_no_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities_no_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1521,7 +1645,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities_with_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities_with_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1543,7 +1669,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_injection(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_injection(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1571,7 +1699,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_special_chars(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_special_chars(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1613,7 +1743,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities_with_select(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities_with_select(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1634,7 +1766,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities_with_top(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities_with_top(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1650,7 +1784,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_query_entities_with_top_and_next(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_query_entities_with_top_and_next(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1684,7 +1820,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_query(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_query(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
 
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -1717,7 +1855,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_add(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_add(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1750,7 +1890,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_add_inside_range(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_add_inside_range(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1782,7 +1924,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_add_outside_range(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_add_outside_range(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1813,7 +1957,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_update(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_update(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1844,7 +1990,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_delete(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_delete(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1874,7 +2022,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_upper_case_table_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_upper_case_table_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1915,7 +2065,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_sas_signed_identifier(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_sas_signed_identifier(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1954,7 +2106,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_datetime_milliseconds(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_datetime_milliseconds(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
             entity = self._create_random_entity_dict()
@@ -1976,7 +2130,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_datetime_str_passthrough(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_datetime_str_passthrough(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2005,7 +2161,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
     
     @tables_decorator
     @recorded_by_proxy
-    def test_datetime_duplicate_field(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_datetime_duplicate_field(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2037,7 +2195,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_etag_duplicate_field(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_etag_duplicate_field(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2079,7 +2239,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_entity_create_response_echo(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_entity_create_response_echo(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2114,7 +2276,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_keys_with_specialchar(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_keys_with_specialchar(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -2169,7 +2333,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_entity_with_edmtypes(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_entity_with_edmtypes(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
@@ -2210,7 +2376,9 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_upsert_entity_with_invalid_key_type(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_upsert_entity_with_invalid_key_type(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
@@ -44,7 +44,9 @@ TEST_GUID = UUID("1ca72025-f78c-437d-87df-9bcf0dd0d297")
 class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_url_encoding_at_symbol(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_url_encoding_at_symbol(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
 
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -80,7 +82,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_dictionary(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_dictionary(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -96,7 +100,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_hook(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_with_hook(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -116,7 +122,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_no_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_with_no_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -142,8 +150,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_full_metadata(self, tables_storage_account_name,
-                                                    tables_primary_storage_account_key):
+    async def test_insert_entity_with_full_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -170,7 +179,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_conflict(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_conflict(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -187,8 +198,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_large_int32_value_throws(self, tables_storage_account_name,
-                                                               tables_primary_storage_account_key):
+    async def test_insert_entity_with_large_int32_value_throws(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -208,8 +220,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_large_int64_value_throws(self, tables_storage_account_name,
-                                                               tables_primary_storage_account_key):
+    async def test_insert_entity_with_large_int64_value_throws(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -229,8 +242,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_large_int_success(self, tables_storage_account_name,
-                                                         tables_primary_storage_account_key):
+    async def test_insert_entity_with_large_int_success(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -256,7 +270,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_missing_pk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_missing_pk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -271,7 +287,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_empty_string_pk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_empty_string_pk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -285,7 +303,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_missing_rk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_missing_rk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -300,7 +320,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_empty_string_rk(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_insert_entity_empty_string_rk(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -315,8 +337,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_too_many_properties(self, tables_storage_account_name,
-                                                     tables_primary_storage_account_key):
+    async def test_insert_entity_too_many_properties(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -333,8 +356,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_property_name_too_long(self, tables_storage_account_name,
-                                                        tables_primary_storage_account_key):
+    async def test_insert_entity_property_name_too_long(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -351,7 +375,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -370,7 +396,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_with_select(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity_with_select(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -392,7 +420,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_with_hook(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity_with_hook(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -415,7 +445,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_if_match(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity_if_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -442,7 +474,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_if_match_entity_bad_etag(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity_if_match_entity_bad_etag(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -466,7 +500,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
             await self._tear_down()
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_if_match_table_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_entity_if_match_table_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -491,7 +527,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_full_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity_full_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -512,7 +550,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_no_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity_no_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -533,7 +573,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_get_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -550,8 +592,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_with_special_doubles(self, tables_storage_account_name,
-                                                   tables_primary_storage_account_key):
+    async def test_get_entity_with_special_doubles(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -576,7 +619,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_update_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -599,7 +644,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_update_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -616,7 +663,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity_with_if_matches(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_update_entity_with_if_matches(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -639,8 +688,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity_with_if_doesnt_match(self, tables_storage_account_name,
-                                                      tables_primary_storage_account_key):
+    async def test_update_entity_with_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -661,8 +711,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_merge_entity_with_existing_entity(self, tables_storage_account_name,
-                                                               tables_primary_storage_account_key):
+    async def test_insert_or_merge_entity_with_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -682,8 +733,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_merge_entity_with_non_existing_entity(self, tables_storage_account_name,
-                                                                   tables_primary_storage_account_key):
+    async def test_insert_or_merge_entity_with_non_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -703,8 +755,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_replace_entity_with_existing_entity(self, tables_storage_account_name,
-                                                                 tables_primary_storage_account_key):
+    async def test_insert_or_replace_entity_with_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -724,8 +777,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_replace_entity_with_non_existing_entity(self, tables_storage_account_name,
-                                                                     tables_primary_storage_account_key):
+    async def test_insert_or_replace_entity_with_non_existing_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -745,7 +799,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_merge_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -765,7 +821,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_merge_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -782,7 +840,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity_with_if_matches(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_merge_entity_with_if_matches(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -804,8 +864,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity_with_if_doesnt_match(self, tables_storage_account_name,
-                                                     tables_primary_storage_account_key):
+    async def test_merge_entity_with_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -825,7 +886,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_entity(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -843,7 +906,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_not_existing(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_entity_not_existing(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -854,7 +919,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_with_if_matches(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_entity_with_if_matches(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -877,8 +944,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_with_if_doesnt_match(self, tables_storage_account_name,
-                                                      tables_primary_storage_account_key):
+    async def test_delete_entity_with_if_doesnt_match(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -899,7 +967,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_overloads(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_entity_overloads(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -928,7 +998,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_overloads_kwargs(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_delete_entity_overloads_kwargs(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -957,7 +1029,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_unicode_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_unicode_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         ''' regression test for github issue #57'''
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -985,7 +1059,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_unicode_property_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_unicode_property_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1012,7 +1088,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_operations_on_entity_with_partition_key_having_single_quote(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_operations_on_entity_with_partition_key_having_single_quote(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         partition_key_with_single_quote = u"a''''b"
         row_key_with_single_quote = u"a''''b"
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -1039,8 +1117,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_empty_and_spaces_property_value(self, tables_storage_account_name,
-                                                   tables_primary_storage_account_key):
+    async def test_empty_and_spaces_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1079,7 +1158,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_none_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_none_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1098,7 +1179,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_binary_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_binary_property_value(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1118,7 +1201,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_timezone(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_timezone(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1141,7 +1226,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1161,7 +1248,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_each_page(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_entities_each_page(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1202,7 +1291,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_injection_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_injection_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1239,7 +1330,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_special_chars(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_special_chars(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1299,7 +1392,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1320,7 +1415,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_multiple_params(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter_multiple_params(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1345,7 +1442,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_integers(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter_integers(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1369,7 +1468,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_floats(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter_floats(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1393,7 +1494,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_datetimes(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter_datetimes(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1417,7 +1520,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_guids(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter_guids(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1441,7 +1546,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_binary(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter_binary(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1465,7 +1572,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_int64(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_user_filter_int64(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1496,7 +1605,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_zero_entities(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_zero_entities(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1514,7 +1625,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_full_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_entities_full_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1534,7 +1647,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_no_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_entities_no_metadata(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1554,7 +1669,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_entities_with_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1577,7 +1694,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_invalid_filter(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_invalid_filter(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1600,7 +1719,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_select(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_entities_with_select(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1623,7 +1744,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_top(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_query_entities_with_top(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1641,8 +1764,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_top_and_next(self, tables_storage_account_name,
-                                                    tables_primary_storage_account_key):
+    async def test_query_entities_with_top_and_next(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1678,7 +1802,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_query(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_query(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
 
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
@@ -1713,7 +1839,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_add(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_add(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1746,7 +1874,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_add_inside_range(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_add_inside_range(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1778,7 +1908,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_add_outside_range(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_add_outside_range(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1809,7 +1941,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_update(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_update(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1843,7 +1977,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_delete(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_delete(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1873,7 +2009,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_upper_case_table_name(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_upper_case_table_name(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1909,7 +2047,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_signed_identifier(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_sas_signed_identifier(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         url = self.account_url(tables_storage_account_name, "table")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -1950,7 +2090,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_datetime_milliseconds(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_datetime_milliseconds(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
             entity = self._create_random_entity_dict()
@@ -1971,7 +2113,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_datetime_str_passthrough(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_datetime_str_passthrough(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2000,7 +2144,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_datetime_duplicate_field(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_datetime_duplicate_field(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2032,7 +2178,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_etag_duplicate_field(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_etag_duplicate_field(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2074,7 +2222,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_entity_create_response_echo(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_entity_create_response_echo(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
 
@@ -2109,7 +2259,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_keys_with_specialchar(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_keys_with_specialchar(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:
@@ -2163,7 +2315,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_entity_with_edmtypes(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_entity_with_edmtypes(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         partition, row = self._create_pk_rk(None, None)
@@ -2204,7 +2358,9 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_upsert_entity_with_invalid_key_type(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_upsert_entity_with_invalid_key_type(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
         try:

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos.py
@@ -43,7 +43,9 @@ TEST_GUID = UUID("3bd67b28-2155-4caf-b492-207172d4f183")
 class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
-    def test_url_encoding_at_symbol(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_url_encoding_at_symbol(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
             entity = {
@@ -78,7 +80,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_etag(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_etag(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
 
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -96,7 +100,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -117,7 +123,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter_multiple_params(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter_multiple_params(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -142,7 +150,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter_integers(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter_integers(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -166,7 +176,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter_floats(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter_floats(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -190,7 +202,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter_datetimes(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter_datetimes(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -214,7 +228,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter_guids(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter_guids(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -238,7 +254,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter_binary(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter_binary(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -262,7 +280,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_user_filter_int64(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_user_filter_int64(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -292,7 +312,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_invalid_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_invalid_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -317,7 +339,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_dictionary(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_dictionary(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -333,7 +357,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_hook(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_with_hook(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -354,7 +380,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_no_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_with_no_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -380,7 +408,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_full_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_with_full_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -406,7 +436,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_conflict(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_conflict(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -424,8 +456,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_large_int32_value_throws(self, tables_cosmos_account_name,
-                                                         tables_primary_cosmos_account_key):
+    def test_insert_entity_with_large_int32_value_throws(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -445,8 +478,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_large_int64_value_throws(self, tables_cosmos_account_name,
-                                                         tables_primary_cosmos_account_key):
+    def test_insert_entity_with_large_int64_value_throws(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -466,8 +500,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_with_large_int_success(self, tables_cosmos_account_name,
-                                                         tables_primary_cosmos_account_key):
+    def test_insert_entity_with_large_int_success(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -493,7 +528,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_missing_pk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_missing_pk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -508,7 +545,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_empty_string_pk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_empty_string_pk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -525,7 +564,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_missing_rk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_missing_rk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -542,7 +583,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_entity_empty_string_rk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_insert_entity_empty_string_rk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -557,7 +600,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -576,7 +621,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_with_select(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_with_select(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -595,7 +642,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_with_hook(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_with_hook(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -618,7 +667,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_if_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_if_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -645,7 +696,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_if_match_entity_bad_etag(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_if_match_entity_bad_etag(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -670,7 +723,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_entity_if_match_table_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_entity_if_match_table_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -694,7 +749,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_full_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_full_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -715,7 +772,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_no_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_no_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -736,7 +795,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -753,7 +814,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_get_entity_with_special_doubles(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_get_entity_with_special_doubles(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -778,7 +841,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_update_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_update_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -800,7 +865,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_update_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_update_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -817,7 +884,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_update_entity_with_if_matches(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_update_entity_with_if_matches(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -839,7 +908,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_update_entity_with_if_doesnt_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_update_entity_with_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -860,8 +931,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_or_merge_entity_with_existing_entity(self, tables_cosmos_account_name,
-                                                         tables_primary_cosmos_account_key):
+    def test_insert_or_merge_entity_with_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -880,8 +952,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_or_merge_entity_with_non_existing_entity(self, tables_cosmos_account_name,
-                                                             tables_primary_cosmos_account_key):
+    def test_insert_or_merge_entity_with_non_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -901,8 +974,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_or_replace_entity_with_existing_entity(self, tables_cosmos_account_name,
-                                                           tables_primary_cosmos_account_key):
+    def test_insert_or_replace_entity_with_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -921,8 +995,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_insert_or_replace_entity_with_non_existing_entity(self, tables_cosmos_account_name,
-                                                               tables_primary_cosmos_account_key):
+    def test_insert_or_replace_entity_with_non_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -942,7 +1017,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_merge_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_merge_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -961,7 +1038,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_merge_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_merge_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -978,7 +1057,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_merge_entity_with_if_matches(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_merge_entity_with_if_matches(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1001,7 +1082,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_merge_entity_with_if_doesnt_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_merge_entity_with_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1021,7 +1104,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1038,7 +1123,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1049,7 +1136,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_entity_with_if_matches(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_entity_with_if_matches(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1071,7 +1160,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_entity_with_if_doesnt_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_entity_with_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1092,7 +1183,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_entity_overloads(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_entity_overloads(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1121,7 +1214,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_delete_entity_overloads_kwargs(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_delete_entity_overloads_kwargs(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1150,7 +1245,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_unicode_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_unicode_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1174,7 +1271,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_unicode_property_name(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_unicode_property_name(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1199,7 +1298,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_operations_on_entity_with_partition_key_having_single_quote(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_operations_on_entity_with_partition_key_having_single_quote(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
 
         # Arrange
         partition_key_with_single_quote = u"a''''b"
@@ -1236,7 +1337,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_empty_and_spaces_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_empty_and_spaces_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1274,7 +1377,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_none_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_none_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1293,7 +1398,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_binary_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_binary_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1313,7 +1420,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_timezone(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_timezone(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1336,7 +1445,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1354,7 +1465,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities_each_page(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities_each_page(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1395,7 +1508,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_zero_entities(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_zero_entities(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1411,7 +1526,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities_full_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities_full_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1429,7 +1546,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities_no_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities_no_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1447,7 +1566,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities_with_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities_with_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1468,7 +1589,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_injection(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_injection(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1538,7 +1661,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities_with_select(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities_with_select(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1561,7 +1686,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities_with_top(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities_with_top(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1577,7 +1704,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_query_entities_with_top_and_next(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_query_entities_with_top_and_next(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1611,7 +1740,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_datetime_milliseconds(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_datetime_milliseconds(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
             entity = self._create_random_entity_dict()
@@ -1632,7 +1763,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_datetime_str_passthrough(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_datetime_str_passthrough(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1661,7 +1794,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_sas_query(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_sas_query(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
 
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -1694,7 +1829,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_sas_add(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_sas_add(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1726,7 +1863,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_sas_add_outside_range(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_sas_add_outside_range(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1757,7 +1896,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_sas_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_sas_update(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1788,7 +1929,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_sas_delete(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_sas_delete(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1818,7 +1961,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_datetime_duplicate_field(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_datetime_duplicate_field(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1850,7 +1995,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_etag_duplicate_field(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_etag_duplicate_field(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1892,7 +2039,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_entity_create_response_echo(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_entity_create_response_echo(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1927,7 +2076,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_keys_with_specialchar(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_keys_with_specialchar(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
             table2_name = self._get_table_reference('table2')
@@ -1980,7 +2131,9 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_entity_with_edmtypes(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_entity_with_edmtypes(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos_async.py
@@ -44,7 +44,9 @@ TEST_GUID = UUID("c8924069-90ee-4726-83b5-45ff92496126")
 class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_url_encoding_at_symbol(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_url_encoding_at_symbol(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
 
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -80,7 +82,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_dictionary(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_dictionary(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -96,7 +100,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_hook(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_with_hook(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -116,7 +122,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_no_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_with_no_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -142,8 +150,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_full_metadata(self, tables_cosmos_account_name,
-                                                    tables_primary_cosmos_account_key):
+    async def test_insert_entity_with_full_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -169,7 +178,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_conflict(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_conflict(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -185,8 +196,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_large_int32_value_throws(self, tables_cosmos_account_name,
-                                                               tables_primary_cosmos_account_key):
+    async def test_insert_entity_with_large_int32_value_throws(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -206,8 +218,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_large_int64_value_throws(self, tables_cosmos_account_name,
-                                                               tables_primary_cosmos_account_key):
+    async def test_insert_entity_with_large_int64_value_throws(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -227,8 +240,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_with_large_int_success(self, tables_cosmos_account_name,
-                                                         tables_primary_cosmos_account_key):
+    async def test_insert_entity_with_large_int_success(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -254,7 +268,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_missing_pk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_missing_pk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -269,7 +285,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_empty_string_pk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_empty_string_pk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -283,7 +301,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_missing_rk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_missing_rk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -298,7 +318,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_entity_empty_string_rk(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_insert_entity_empty_string_rk(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -313,7 +335,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -332,7 +356,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_with_select(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity_with_select(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -354,7 +380,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_with_hook(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity_with_hook(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -375,7 +403,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_if_match(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity_if_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -402,7 +432,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_if_match_entity_bad_etag(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity_if_match_entity_bad_etag(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -427,7 +459,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_if_match_table_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_delete_entity_if_match_table_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -452,7 +486,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_full_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity_full_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -473,7 +509,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_no_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity_no_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -494,7 +532,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_get_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -511,8 +551,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_get_entity_with_special_doubles(self, tables_cosmos_account_name,
-                                                   tables_primary_cosmos_account_key):
+    async def test_get_entity_with_special_doubles(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -537,7 +578,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_update_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -560,7 +603,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_update_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -577,7 +622,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity_with_if_matches(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_update_entity_with_if_matches(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -600,8 +647,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_update_entity_with_if_doesnt_match(self, tables_cosmos_account_name,
-                                                      tables_primary_cosmos_account_key):
+    async def test_update_entity_with_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -622,8 +670,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_merge_entity_with_existing_entity(self, tables_cosmos_account_name,
-                                                               tables_primary_cosmos_account_key):
+    async def test_insert_or_merge_entity_with_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -642,8 +691,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_merge_entity_with_non_existing_entity(self, tables_cosmos_account_name,
-                                                                   tables_primary_cosmos_account_key):
+    async def test_insert_or_merge_entity_with_non_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -661,8 +711,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_replace_entity_with_existing_entity(self, tables_cosmos_account_name,
-                                                                 tables_primary_cosmos_account_key):
+    async def test_insert_or_replace_entity_with_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -681,8 +732,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_insert_or_replace_entity_with_non_existing_entity(self, tables_cosmos_account_name,
-                                                                     tables_primary_cosmos_account_key):
+    async def test_insert_or_replace_entity_with_non_existing_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -699,7 +751,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_merge_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -717,7 +771,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_merge_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -734,7 +790,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity_with_if_matches(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_merge_entity_with_if_matches(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -754,8 +812,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_merge_entity_with_if_doesnt_match(self, tables_cosmos_account_name,
-                                                     tables_primary_cosmos_account_key):
+    async def test_merge_entity_with_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -775,7 +834,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_delete_entity(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -790,7 +851,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_not_existing(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_delete_entity_not_existing(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -801,7 +864,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_with_if_matches(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_delete_entity_with_if_matches(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -821,8 +886,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_with_if_doesnt_match(self, tables_cosmos_account_name,
-                                                      tables_primary_cosmos_account_key):
+    async def test_delete_entity_with_if_doesnt_match(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -841,7 +907,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_overloads(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_delete_entity_overloads(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -871,7 +939,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_entity_overloads_kwargs(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_delete_entity_overloads_kwargs(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -901,7 +971,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_unicode_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_unicode_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         ''' regression test for github issue #57'''
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -929,7 +1001,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_unicode_property_name(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_unicode_property_name(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -956,7 +1030,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_operations_on_entity_with_partition_key_having_single_quote(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_operations_on_entity_with_partition_key_having_single_quote(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         partition_key_with_single_quote = "a''''b"
         row_key_with_single_quote = "a''''b"
@@ -984,8 +1060,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_empty_and_spaces_property_value(self, tables_cosmos_account_name,
-                                                   tables_primary_cosmos_account_key):
+    async def test_empty_and_spaces_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1024,7 +1101,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_none_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_none_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1043,7 +1122,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_binary_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_binary_property_value(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1063,7 +1144,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_timezone(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_timezone(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1086,7 +1169,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_entities(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1106,7 +1191,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_each_page(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_entities_each_page(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1147,7 +1234,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1169,7 +1258,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_multiple_params(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter_multiple_params(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1194,7 +1285,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_integers(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter_integers(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1218,7 +1311,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_floats(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter_floats(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1242,7 +1337,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_datetimes(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter_datetimes(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1266,7 +1363,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_guids(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter_guids(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1290,7 +1389,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_binary(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter_binary(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1314,7 +1415,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_user_filter_int64(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_user_filter_int64(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1345,7 +1448,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_zero_entities(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_zero_entities(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1363,7 +1468,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_full_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_entities_full_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1383,7 +1490,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_no_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_entities_no_metadata(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1403,7 +1512,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_entities_with_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1426,7 +1537,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_injection_async(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_injection_async(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1521,7 +1634,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_invalid_filter(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_invalid_filter(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1544,7 +1659,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_select(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_entities_with_select(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
             table = await self._create_query_table(2)
@@ -1566,7 +1683,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_top(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_query_entities_with_top(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1582,8 +1701,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_query_entities_with_top_and_next(self, tables_cosmos_account_name,
-                                                    tables_primary_cosmos_account_key):
+    async def test_query_entities_with_top_and_next(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1619,7 +1739,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_datetime_milliseconds(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_datetime_milliseconds(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
             entity = self._create_random_entity_dict()
@@ -1640,7 +1762,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_datetime_str_passthrough(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_datetime_str_passthrough(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1669,7 +1793,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_query(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_sas_query(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
 
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
@@ -1704,7 +1830,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_add(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_sas_add(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1737,7 +1865,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_add_outside_range(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_sas_add_outside_range(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1768,7 +1898,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_update(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_sas_update(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1802,7 +1934,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_sas_delete(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_sas_delete(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         url = self.account_url(tables_cosmos_account_name, "cosmos")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
@@ -1832,7 +1966,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_datetime_duplicate_field(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_datetime_duplicate_field(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1864,7 +2000,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_etag_duplicate_field(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_etag_duplicate_field(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1906,7 +2044,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_entity_create_response_echo(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_entity_create_response_echo(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 
@@ -1941,7 +2081,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_keys_with_specialchar(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_keys_with_specialchar(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         try:
             table2_name = self._get_table_reference('table2')
@@ -1994,7 +2136,9 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_entity_with_edmtypes(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_entity_with_edmtypes(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
         partition, row = self._create_pk_rk(None, None)
 

--- a/sdk/tables/azure-data-tables/tests/test_table_service_properties.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_properties.py
@@ -28,7 +28,9 @@ from preparers import tables_decorator
 class TestTableServiceProperties(AzureRecordedTestCase, TableTestCase):
     @tables_decorator
     @recorded_by_proxy
-    def test_table_service_properties(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_table_service_properties(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -48,7 +50,9 @@ class TestTableServiceProperties(AzureRecordedTestCase, TableTestCase):
     # --Test cases per feature ---------------------------------------
     @tables_decorator
     @recorded_by_proxy
-    def test_set_logging(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_logging(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -65,7 +69,9 @@ class TestTableServiceProperties(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_set_hour_metrics(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_hour_metrics(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -82,7 +88,9 @@ class TestTableServiceProperties(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_set_minute_metrics(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_minute_metrics(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -100,7 +108,9 @@ class TestTableServiceProperties(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_set_cors(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_set_cors(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -130,7 +140,9 @@ class TestTableServiceProperties(AzureRecordedTestCase, TableTestCase):
     # --Test cases for errors ---------------------------------------
     @tables_decorator
     @recorded_by_proxy
-    def test_too_many_cors_rules(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_too_many_cors_rules(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
         cors = []
@@ -143,7 +155,9 @@ class TestTableServiceProperties(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_retention_too_long(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_retention_too_long(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
         minute_metrics = TableMetrics(enabled=True, include_apis=True,

--- a/sdk/tables/azure-data-tables/tests/test_table_service_properties_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_properties_async.py
@@ -25,7 +25,9 @@ from async_preparers import tables_decorator_async
 class TestTableServicePropertiesAsync(AzureRecordedTestCase, TableTestCase):
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_table_service_properties_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_table_service_properties_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key, logging_enable=True)
@@ -45,7 +47,9 @@ class TestTableServicePropertiesAsync(AzureRecordedTestCase, TableTestCase):
     # --Test cases per feature ---------------------------------------
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_logging_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_logging_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -62,7 +66,9 @@ class TestTableServicePropertiesAsync(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_hour_metrics_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_hour_metrics_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -79,7 +85,9 @@ class TestTableServicePropertiesAsync(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_minute_metrics_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_minute_metrics_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -97,7 +105,9 @@ class TestTableServicePropertiesAsync(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_set_cors_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_set_cors_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         url = self.account_url(tables_storage_account_name, "table")
         tsc = TableServiceClient(url, credential=tables_primary_storage_account_key)
@@ -127,7 +137,9 @@ class TestTableServicePropertiesAsync(AzureRecordedTestCase, TableTestCase):
     # --Test cases for errors ---------------------------------------
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_too_many_cors_rules_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_too_many_cors_rules_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
         cors = []
@@ -140,7 +152,9 @@ class TestTableServicePropertiesAsync(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_retention_too_long_async(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_retention_too_long_async(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
         minute_metrics = TableMetrics(enabled=True, include_apis=True,

--- a/sdk/tables/azure-data-tables/tests/test_table_service_properties_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_properties_cosmos.py
@@ -25,7 +25,9 @@ from preparers import cosmos_decorator
 class TestTableServicePropertiesCosmos(AzureRecordedTestCase, TableTestCase):
     @cosmos_decorator
     @recorded_by_proxy
-    def test_too_many_cors_rules(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_too_many_cors_rules(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         cors = []
         for i in range(0, 6):
@@ -36,7 +38,9 @@ class TestTableServicePropertiesCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
-    def test_retention_too_long(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_retention_too_long(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         minute_metrics = TableMetrics(enabled=True, include_apis=True, retention_policy=TableRetentionPolicy(enabled=True, days=366))
 

--- a/sdk/tables/azure-data-tables/tests/test_table_service_properties_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_properties_cosmos_async.py
@@ -22,7 +22,9 @@ from async_preparers import cosmos_decorator_async
 class TestTableServicePropertiesCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_too_many_cors_rules_async(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_too_many_cors_rules_async(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         cors = []
@@ -35,7 +37,9 @@ class TestTableServicePropertiesCosmosAsync(AzureRecordedTestCase, AsyncTableTes
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_retention_too_long_async(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_retention_too_long_async(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         minute_metrics = TableMetrics(enabled=True, include_apis=True,

--- a/sdk/tables/azure-data-tables/tests/test_table_service_stats.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_stats.py
@@ -14,7 +14,9 @@ class TestTableServiceStats(AzureRecordedTestCase, TableTestCase):
     # --Test cases per service ---------------------------------------
     @tables_decorator
     @recorded_by_proxy
-    def test_table_service_stats_f(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_table_service_stats_f(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 
@@ -25,7 +27,9 @@ class TestTableServiceStats(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
-    def test_table_service_stats_when_unavailable(self, tables_storage_account_name, tables_primary_storage_account_key):
+    def test_table_service_stats_when_unavailable(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 

--- a/sdk/tables/azure-data-tables/tests/test_table_service_stats_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_stats_async.py
@@ -33,7 +33,9 @@ class TestTableServiceStatsAsync(AzureRecordedTestCase, AsyncTableTestCase):
     # --Test cases per service ---------------------------------------
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_table_service_stats_f(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_table_service_stats_f(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 
@@ -44,7 +46,9 @@ class TestTableServiceStatsAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
-    async def test_table_service_stats_when_unavailable(self, tables_storage_account_name, tables_primary_storage_account_key):
+    async def test_table_service_stats_when_unavailable(self, **kwargs):
+        tables_storage_account_name = kwargs.pop("tables_storage_account_name")
+        tables_primary_storage_account_key = kwargs.pop("tables_primary_storage_account_key")
         # Arrange
         tsc = TableServiceClient(self.account_url(tables_storage_account_name, "table"), credential=tables_primary_storage_account_key)
 

--- a/sdk/tables/azure-data-tables/tests/test_table_service_stats_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_stats_cosmos.py
@@ -35,7 +35,9 @@ class TestTableServiceStatsCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skip("JSON is invalid for cosmos")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_table_service_stats_f(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_table_service_stats_f(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         stats = tsc.get_service_stats(raw_response_hook=self.override_response_body_with_live_status)
         self._assert_stats_default(stats)
@@ -43,7 +45,9 @@ class TestTableServiceStatsCosmos(AzureRecordedTestCase, TableTestCase):
     @pytest.mark.skip("JSON is invalid for cosmos")
     @cosmos_decorator
     @recorded_by_proxy
-    def test_table_service_stats_when_unavailable(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    def test_table_service_stats_when_unavailable(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         stats = tsc.get_service_stats(raw_response_hook=self.override_response_body_with_unavailable_status)
         self._assert_stats_unavailable(stats)

--- a/sdk/tables/azure-data-tables/tests/test_table_service_stats_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_service_stats_cosmos_async.py
@@ -36,7 +36,9 @@ class TestTableServiceStatsCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase
     @pytest.mark.skip("JSON is invalid for cosmos")
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_table_service_stats_f(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_table_service_stats_f(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         stats = await tsc.get_service_stats(raw_response_hook=self.override_response_body_with_live_status)
         self._assert_stats_default(stats)
@@ -44,7 +46,9 @@ class TestTableServiceStatsCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase
     @pytest.mark.skip("JSON is invalid for cosmos")
     @cosmos_decorator_async
     @recorded_by_proxy_async
-    async def test_table_service_stats_when_unavailable(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+    async def test_table_service_stats_when_unavailable(self, **kwargs):
+        tables_cosmos_account_name = kwargs.pop("tables_cosmos_account_name")
+        tables_primary_cosmos_account_key = kwargs.pop("tables_primary_cosmos_account_key")
         tsc = TableServiceClient(self.account_url(tables_cosmos_account_name, "cosmos"), credential=tables_primary_cosmos_account_key)
         stats = await tsc.get_service_stats(raw_response_hook=self.override_response_body_with_unavailable_status)
         self._assert_stats_unavailable(stats)

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -70,14 +70,16 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.begin_analyze_actions("hello world", actions=[], polling_interval=self._interval())
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict_key_phrase_task(self, client):
+    def test_all_successful_passing_dict_key_phrase_task(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -103,7 +105,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict_sentiment_task(self, client):
+    def test_all_successful_passing_dict_sentiment_task(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
@@ -144,7 +147,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_sentiment_analysis_task_with_opinion_mining(self, client):
+    def test_sentiment_analysis_task_with_opinion_mining(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "It has a sleek premium aluminum design that makes it beautiful to look at.",
             "The food and service is not good"
@@ -220,7 +224,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_text_document_input_entities_task(self, client):
+    def test_all_successful_passing_text_document_input_entities_task(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975", language="en"),
             TextDocumentInput(id="2", text="Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975.", language="es"),
@@ -255,7 +260,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_string_pii_entities_task(self, client):
+    def test_all_successful_passing_string_pii_entities_task(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = ["My SSN is 859-98-0987.",
                 "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
@@ -290,7 +296,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_request_on_empty_document(self, client):
+    def test_bad_request_on_empty_document(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [""]
 
         with pytest.raises(HttpResponseError):
@@ -305,7 +312,8 @@ class TestAnalyze(TextAnalyticsTest):
         "textanalytics_test_api_key": "",
     })
     @recorded_by_proxy
-    def test_empty_credential_class(self, client):
+    def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.begin_analyze_actions(
                 ["This is written in English."],
@@ -325,7 +333,8 @@ class TestAnalyze(TextAnalyticsTest):
         "textanalytics_test_api_key": "xxxxxxxxxxxx",
     })
     @recorded_by_proxy
-    def test_bad_credentials(self, client):
+    def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.begin_analyze_actions(
                 ["This is written in English."],
@@ -343,7 +352,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids_multiple_tasks(self, client):
+    def test_out_of_order_ids_multiple_tasks(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "19", "text": ":P"},
@@ -383,7 +393,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy
-    def test_show_stats_and_model_version_multiple_tasks_v3_1(self, client):
+    def test_show_stats_and_model_version_multiple_tasks_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             assert resp.raw_response
@@ -444,7 +455,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version_multiple_tasks(self, client):
+    def test_show_stats_and_model_version_multiple_tasks(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             assert resp.raw_response
@@ -505,7 +517,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_poller_metadata(self, client):
+    def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"}]
 
         poller = client.begin_analyze_actions(
@@ -532,7 +545,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_method(self, client):
+    def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = list(client.begin_analyze_actions(
             ["This should fail because we're passing in an invalid language hint"],
             language="notalanguage",
@@ -554,7 +568,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error_multiple_tasks(self, client):
+    def test_bad_model_version_error_multiple_tasks(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "I did not like the hotel we stayed at."}]
 
         with pytest.raises(HttpResponseError):
@@ -574,7 +589,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error_all_tasks(self, client):  # TODO: verify behavior of service
+    def test_bad_model_version_error_all_tasks(self, **kwargs):
+        client = kwargs.pop("client")  # TODO: verify behavior of service
         docs = [{"id": "1", "language": "en", "text": "I did not like the hotel we stayed at."}]
 
         with pytest.raises(HttpResponseError):
@@ -594,7 +610,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_missing_input_records_error(self, client):
+    def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             client.begin_analyze_actions(
@@ -614,7 +631,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_none_docs(self, client):
+    def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.begin_analyze_actions(None, None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -622,7 +640,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.begin_analyze_actions(
@@ -638,7 +657,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_multiple_pages_of_results_returned_successfully(self, client):
+    def test_multiple_pages_of_results_returned_successfully(self, **kwargs):
+        client = kwargs.pop("client")
         single_doc = "hello world"
         docs = [{"id": str(idx), "text": val} for (idx, val) in enumerate(list(itertools.repeat(single_doc, 25)))] # max number of documents is 25
 
@@ -682,7 +702,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_too_many_documents(self, client):
+    def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = list(itertools.repeat("input document", 26))  # Maximum number of documents per request is 25
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -760,7 +781,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pii_action_categories_filter(self, client):
+    def test_pii_action_categories_filter(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": "My SSN is 859-98-0987."},
                 {"id": "2",
@@ -789,7 +811,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_partial_success_for_actions(self, client):
+    def test_partial_success_for_actions(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "tr", "text": "I did not like the hotel we stayed at."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed at."}]
 
@@ -827,7 +850,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_multiple_of_same_action(self, client):
+    def test_multiple_of_same_action(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "28", "text": "My SSN is 859-98-0987. Here is another sentence."},
             {"id": "3", "text": "Is 998.214.865-68 your Brazilian CPF number? Here is another sentence."},
@@ -918,7 +942,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_multiple_of_same_action_with_partial_results(self, client):
+    def test_multiple_of_same_action_with_partial_results(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "5", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
                 {"id": "2", "text": ""}]
 
@@ -955,7 +980,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict_extract_summary_action(self, client):
+    def test_all_successful_passing_dict_extract_summary_action(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text":
             "The government of British Prime Minster Theresa May has been plunged into turmoil with the resignation"
             " of two senior Cabinet ministers in a deep split over her Brexit strategy. The Foreign Secretary Boris "
@@ -1001,7 +1027,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_extract_summary_action_with_options(self, client):
+    def test_extract_summary_action_with_options(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["The government of British Prime Minster Theresa May has been plunged into turmoil with the resignation"
             " of two senior Cabinet ministers in a deep split over her Brexit strategy. The Foreign Secretary Boris "
             "Johnson, quit on Monday, hours after the resignation late on Sunday night of the minister in charge of "
@@ -1047,7 +1074,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_extract_summary_partial_results(self, client):
+    def test_extract_summary_partial_results(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""}, {"id": "2", "language": "en", "text": "hello world"}]
 
         response = client.begin_analyze_actions(
@@ -1242,7 +1270,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_analyze_continuation_token(self, client):
+    def test_analyze_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
             {"id": "2", "language": "en", "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component."},
@@ -1693,7 +1722,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy
-    def test_analyze_works_with_v3_1(self, client):
+    def test_analyze_works_with_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "19", "text": ":P"},
@@ -1802,7 +1832,8 @@ class TestAnalyze(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_healthcare_action(self, client):
+    def test_healthcare_action(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily.",

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -106,14 +106,16 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = await client.begin_analyze_actions("hello world", actions=[], polling_interval=self._interval())
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict_key_phrase_task(self, client):
+    async def test_all_successful_passing_dict_key_phrase_task(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -142,7 +144,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict_sentiment_task(self, client):
+    async def test_all_successful_passing_dict_sentiment_task(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
@@ -187,7 +190,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_sentiment_analysis_task_with_opinion_mining(self, client):
+    async def test_sentiment_analysis_task_with_opinion_mining(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "It has a sleek premium aluminum design that makes it beautiful to look at.",
             "The food and service is not good"
@@ -267,7 +271,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_text_document_input_entities_task(self, client):
+    async def test_all_successful_passing_text_document_input_entities_task(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975", language="en"),
             TextDocumentInput(id="2", text="Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975.", language="es"),
@@ -306,7 +311,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_string_pii_entities_task(self, client):
+    async def test_all_successful_passing_string_pii_entities_task(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = ["My SSN is 859-98-0987.",
                 "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
@@ -344,7 +350,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_request_on_empty_document(self, client):
+    async def test_bad_request_on_empty_document(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [""]
 
         with pytest.raises(HttpResponseError):
@@ -360,7 +367,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
         "textanalytics_test_api_key": "",
     })
     @recorded_by_proxy_async
-    async def test_empty_credential_class(self, client):
+    async def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             async with client:
                 await (await client.begin_analyze_actions(
@@ -381,7 +389,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
         "textanalytics_test_api_key": "xxxxxxxxxxxx"
     })
     @recorded_by_proxy_async
-    async def test_bad_credentials(self, client):
+    async def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             async with client:
                 await (await client.begin_analyze_actions(
@@ -400,7 +409,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids_multiple_tasks(self, client):
+    async def test_out_of_order_ids_multiple_tasks(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "19", "text": ":P"},
@@ -443,7 +453,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version_multiple_tasks_v3_1(self, client):
+    async def test_show_stats_and_model_version_multiple_tasks_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
@@ -506,7 +517,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version_multiple_tasks(self, client):
+    async def test_show_stats_and_model_version_multiple_tasks(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             assert resp.raw_response
@@ -570,7 +582,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_poller_metadata(self, client):
+    async def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"}]
 
         async with client:
@@ -598,7 +611,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error_multiple_tasks(self, client):
+    async def test_bad_model_version_error_multiple_tasks(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "I did not like the hotel we stayed at."}]
 
         async with client:
@@ -620,7 +634,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error_all_tasks(self, client):  # TODO: verify behavior of service
+    async def test_bad_model_version_error_all_tasks(self, **kwargs):
+        client = kwargs.pop("client")  # TODO: verify behavior of service
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         with pytest.raises(HttpResponseError):
@@ -641,7 +656,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_missing_input_records_error(self, client):
+    async def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             async with client:
@@ -662,7 +678,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_none_docs(self, client):
+    async def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             async with client:
                 await client.begin_analyze_actions(None, None, polling_interval=self._interval())
@@ -671,7 +688,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, client):
+    async def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
 
@@ -689,7 +707,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_multiple_pages_of_results_returned_successfully(self, client):
+    async def test_multiple_pages_of_results_returned_successfully(self, **kwargs):
+        client = kwargs.pop("client")
         single_doc = "hello world"
         docs = [{"id": str(idx), "text": val} for (idx, val) in
                 enumerate(list(itertools.repeat(single_doc, 25)))]  # max number of documents is 25
@@ -738,7 +757,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_too_many_documents(self, client):
+    async def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = list(itertools.repeat("input document", 26))  # Maximum number of documents per request is 25
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -810,7 +830,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pii_action_categories_filter(self, client):
+    async def test_pii_action_categories_filter(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": "My SSN is 859-98-0987."},
                 {"id": "2",
@@ -842,7 +863,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_partial_success_for_actions(self, client):
+    async def test_partial_success_for_actions(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "tr", "text": "I did not like the hotel we stayed at."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed at."}]
 
@@ -883,7 +905,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_multiple_of_same_action(self, client):
+    async def test_multiple_of_same_action(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "28", "text": "My SSN is 859-98-0987. Here is another sentence."},
             {"id": "3", "text": "Is 998.214.865-68 your Brazilian CPF number? Here is another sentence."},
@@ -976,7 +999,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_multiple_of_same_action_with_partial_results(self, client):
+    async def test_multiple_of_same_action_with_partial_results(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "5", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
                 {"id": "2", "text": ""}]
 
@@ -1017,7 +1041,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict_extract_summary_action(self, client):
+    async def test_all_successful_passing_dict_extract_summary_action(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text":
             "The government of British Prime Minster Theresa May has been plunged into turmoil with the resignation"
             " of two senior Cabinet ministers in a deep split over her Brexit strategy. The Foreign Secretary Boris "
@@ -1066,7 +1091,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_extract_summary_action_with_options(self, client):
+    async def test_extract_summary_action_with_options(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["The government of British Prime Minster Theresa May has been plunged into turmoil with the resignation"
             " of two senior Cabinet ministers in a deep split over her Brexit strategy. The Foreign Secretary Boris "
             "Johnson, quit on Monday, hours after the resignation late on Sunday night of the minister in charge of "
@@ -1115,7 +1141,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_extract_summary_partial_results(self, client):
+    async def test_extract_summary_partial_results(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""}, {"id": "2", "language": "en", "text": "hello world"}]
 
         async with client:
@@ -1327,7 +1354,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_analyze_continuation_token(self, client):
+    async def test_analyze_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
             {"id": "2", "language": "en", "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component."},
@@ -1803,7 +1831,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy_async
-    async def test_analyze_works_with_v3_1(self, client):
+    async def test_analyze_works_with_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "19", "text": ":P"},
@@ -1916,7 +1945,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_healthcare_action(self, client):
+    async def test_healthcare_action(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily.",

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -35,14 +35,16 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.begin_analyze_healthcare_entities("hello world").result()
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_only_string(self, client):
+    def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily.",
@@ -61,7 +63,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_passing_only_string_v3_1(self, client):
+    def test_passing_only_string_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily.",
@@ -80,7 +83,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_some_errors(self, client):
+    def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "Patient does not suffer from high blood pressure."},
                 {"id": "3", "language": "en", "text": "Prescribed 100mg ibuprofen, taken twice daily."}]
@@ -93,7 +97,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_too_many_documents(self, client):
+    def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = list(itertools.repeat("input document", 26))  # Maximum number of documents per request is 25
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -104,7 +109,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_payload_too_large(self, client):
+    def test_payload_too_large(self, **kwargs):
+        client = kwargs.pop("client")
         large_doc = "RECORD #333582770390100 | MH | 85986313 | | 054351 | 2/14/2001 12:00:00 AM | \
             CORONARY ARTERY DISEASE | Signed | DIS | Admission Date: 5/22/2001 \
             Report Status: Signed Discharge Date: 4/24/2001 ADMISSION DIAGNOSIS: \
@@ -128,7 +134,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids(self, client):
+    def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
 
 
         docs = [{"id": "56", "text": ":)"},
@@ -153,7 +160,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy
-    def test_show_stats_and_model_version_v3_1(self, client):
+    def test_show_stats_and_model_version_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -188,7 +196,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version(self, client):
+    def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -233,7 +242,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_dict_input(self, client):
+    def test_whole_batch_language_hint_and_dict_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": "I will go to the park."},
                 {"id": "2", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
@@ -246,7 +256,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_method(self, client):
+    def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = list(client.begin_analyze_healthcare_entities(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage", polling_interval=self._interval()
         ).result())
@@ -255,7 +266,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_docs(self, client):
+    def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = list(client.begin_analyze_healthcare_entities(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}],
             polling_interval=self._interval()
@@ -265,7 +277,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_user_agent(self, client):  # TODO: verify
+    def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")  # TODO: verify
         docs = [{"id": "1", "text": "I will go to the park."}]
 
         poller = client.begin_analyze_healthcare_entities(docs, polling_interval=self._interval())
@@ -278,7 +291,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_no_result_attribute(self, client):
+    def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}, {"id": "2", "text": "okay"}]
         result = client.begin_analyze_healthcare_entities(docs, polling_interval=self._interval()).result()
         response = list(result)
@@ -300,7 +314,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error(self, client):
+    def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "I did not like the hotel we stayed at."}]
 
         with pytest.raises(HttpResponseError) as err:
@@ -311,7 +326,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_errors(self, client):
+    def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -332,7 +348,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_duplicate_ids_error(self, client):
+    def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -346,7 +363,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.begin_analyze_healthcare_entities(
@@ -359,7 +377,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_cancellation(self, client):
+    def test_cancellation(self, **kwargs):
+        client = kwargs.pop("client")
         large_doc = "RECORD #333582770390100 | MH | 85986313 | | 054351 | 2/14/2001 12:00:00 AM | \
             CORONARY ARTERY DISEASE | Signed | DIS | Admission Date: 5/22/2001 \
             Report Status: Signed Discharge Date: 4/24/2001 ADMISSION DIAGNOSIS: \
@@ -386,7 +405,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         poller = client.begin_analyze_healthcare_entities(documents=["Hello world"], polling_interval=self._interval())
         actual_string_index_type = poller._polling_method._initial_response.http_request.query["stringIndexType"]
         assert actual_string_index_type == "UnicodeCodePoint"
@@ -395,7 +415,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
         poller = client.begin_analyze_healthcare_entities(documents=["Hello world"], polling_interval=self._interval(), raw_response_hook=callback)
@@ -403,7 +424,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type(self, client):
+    def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         poller = client.begin_analyze_healthcare_entities(
             documents=["Hello world"],
             string_index_type="TextElement_v8",
@@ -417,7 +439,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_explicit_set_string_index_type_body_param(self, client):
+    def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -430,7 +453,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_relations(self, client):
+    def test_relations(self, **kwargs):
+        client = kwargs.pop("client")
         result = list(client.begin_analyze_healthcare_entities(
             documents=["The patient was diagnosed with Parkinsons Disease (PD)"],
             polling_interval=self._interval(),
@@ -459,7 +483,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_normalized_text(self, client):
+    def test_normalized_text(self, **kwargs):
+        client = kwargs.pop("client")
         result = list(client.begin_analyze_healthcare_entities(
             documents=["patients must have histologically confirmed NHL"],
             polling_interval=self._interval(),
@@ -475,7 +500,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_healthcare_assertion(self, client):
+    def test_healthcare_assertion(self, **kwargs):
+        client = kwargs.pop("client")
         result = list(client.begin_analyze_healthcare_entities(
             documents=["Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."],
             polling_interval=self._interval(),
@@ -489,7 +515,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_disable_service_logs(self, client):
+    def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             # this is called for both the initial post
             # and the gets. Only care about the initial post
@@ -505,7 +532,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_healthcare_continuation_token(self, client):
+    def test_healthcare_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         initial_poller = client.begin_analyze_healthcare_entities(
             documents=[
                 {"id": "1", "text": "Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."},
@@ -541,7 +569,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_poller_metadata(self, client):
+    def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"}]
 
         poller = client.begin_analyze_healthcare_entities(
@@ -632,7 +661,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_healthcare_fhir_bundle(self, client):
+    def test_healthcare_fhir_bundle(self, **kwargs):
+        client = kwargs.pop("client")
         poller = client.begin_analyze_healthcare_entities(
             documents=[
                 "Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -36,7 +36,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             async with client:
                 response = await (await client.begin_analyze_healthcare_entities("hello world", polling_interval=self._interval())).result()
@@ -44,7 +45,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_only_string(self, client):
+    async def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily.",
@@ -67,7 +69,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_passing_only_string_v3_1(self, client):
+    async def test_passing_only_string_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily.",
@@ -90,7 +93,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_some_errors(self, client):
+    async def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "Patient does not suffer from high blood pressure."},
                 {"id": "3", "language": "en", "text": "Prescribed 100mg ibuprofen, taken twice daily."}]
@@ -108,7 +112,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_too_many_documents(self, client):
+    async def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = list(itertools.repeat("input document", 26))  # Maximum number of documents per request is 25
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -120,7 +125,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_payload_too_large(self, client):
+    async def test_payload_too_large(self, **kwargs):
+        client = kwargs.pop("client")
         large_doc = "RECORD #333582770390100 | MH | 85986313 | | 054351 | 2/14/2001 12:00:00 AM | \
             CORONARY ARTERY DISEASE | Signed | DIS | Admission Date: 5/22/2001 \
             Report Status: Signed Discharge Date: 4/24/2001 ADMISSION DIAGNOSIS: \
@@ -145,7 +151,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids(self, client):
+    async def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -171,7 +178,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version_v3_1(self, client):
+    async def test_show_stats_and_model_version_v3_1(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -210,7 +218,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version(self, client):
+    async def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -259,7 +268,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_dict_input(self, client):
+    async def test_whole_batch_language_hint_and_dict_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": "I will go to the park."},
                 {"id": "2", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
@@ -277,7 +287,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_method(self, client):
+    async def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["This should fail because we're passing in an invalid language hint"]
 
         async with client:
@@ -291,7 +302,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_docs(self, client):
+    async def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
 
         async with client:
@@ -305,7 +317,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_user_agent(self, client):  # TODO: verify
+    async def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")  # TODO: verify
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -324,7 +337,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error(self, client):
+    async def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         with pytest.raises(HttpResponseError) as err:
@@ -339,7 +353,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_errors(self, client):
+    async def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -363,7 +378,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_duplicate_ids_error(self, client):
+    async def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -377,7 +393,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, client):
+    async def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
 
@@ -392,7 +409,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_cancellation(self, client):
+    async def test_cancellation(self, **kwargs):
+        client = kwargs.pop("client")
         large_doc = "RECORD #333582770390100 | MH | 85986313 | | 054351 | 2/14/2001 12:00:00 AM | \
             CORONARY ARTERY DISEASE | Signed | DIS | Admission Date: 5/22/2001 \
             Report Status: Signed Discharge Date: 4/24/2001 ADMISSION DIAGNOSIS: \
@@ -421,7 +439,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    async def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         poller = await client.begin_analyze_healthcare_entities(documents=["Hello world"], polling_interval=self._interval())
         actual_string_index_type = poller._polling_method._initial_response.http_request.query["stringIndexType"]
         assert actual_string_index_type == "UnicodeCodePoint"
@@ -430,7 +449,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type(self, client):
+    async def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         poller = await client.begin_analyze_healthcare_entities(
             documents=["Hello world"],
             string_index_type="TextElement_v8",
@@ -443,7 +463,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_relations(self, client):
+    async def test_relations(self, **kwargs):
+        client = kwargs.pop("client")
         response = await (await client.begin_analyze_healthcare_entities(
             documents=["The patient was diagnosed with Parkinsons Disease (PD)"],
             polling_interval=self._interval(),
@@ -476,7 +497,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_normalized_text(self, client):
+    async def test_normalized_text(self, **kwargs):
+        client = kwargs.pop("client")
         response = await (await client.begin_analyze_healthcare_entities(
             documents=["patients must have histologically confirmed NHL"],
             polling_interval=self._interval(),
@@ -496,7 +518,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_healthcare_assertion(self, client):
+    async def test_healthcare_assertion(self, **kwargs):
+        client = kwargs.pop("client")
         response = await (await client.begin_analyze_healthcare_entities(
             documents=["Baby not likely to have Meningitis. In case of fever in the mother, consider Penicillin for the baby too."],
             polling_interval=self._interval(),
@@ -514,7 +537,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_disable_service_logs(self, client):
+    async def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             # this is called for both the initial post
             # and the gets. Only care about the initial post
@@ -530,7 +554,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_healthcare_continuation_token(self, client):
+    async def test_healthcare_continuation_token(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             initial_poller = await client.begin_analyze_healthcare_entities(
                 documents=[
@@ -570,7 +595,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_poller_metadata(self, client):
+    async def test_poller_metadata(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"}]
 
         async with client:
@@ -662,7 +688,8 @@ class TestHealth(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_healthcare_fhir_bundle(self, client):
+    async def test_healthcare_fhir_bundle(self, **kwargs):
+        client = kwargs.pop("client")
         async with client:
             poller = await client.begin_analyze_healthcare_entities(
                 documents=[

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment.py
@@ -27,14 +27,16 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.analyze_sentiment("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict(self, client):
+    def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
@@ -62,7 +64,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_text_document_input(self, client):
+    def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen."),
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -90,7 +93,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_only_string(self, client):
+    def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen.",
             "I did not like the hotel we stayed at. It was too expensive.",
@@ -107,7 +111,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_some_errors(self, client):
+    def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
@@ -120,7 +125,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_all_errors(self, client):
+    def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": ""}]
@@ -133,7 +139,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_too_many_documents(self, client):
+    def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -145,7 +152,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_warnings(self, client):
+    def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for analyze_sentiment. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -159,7 +167,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_output_same_order_as_input(self, client):
+    def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -176,7 +185,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy
-    def test_empty_credential_class(self, client):
+    def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.analyze_sentiment(
                 ["This is written in English."]
@@ -185,7 +195,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy
-    def test_bad_credentials(self, client):
+    def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.analyze_sentiment(
                 ["This is written in English."]
@@ -194,7 +205,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_document_input(self, client):
+    def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -203,7 +215,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_mixing_inputs(self, client):
+    def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -215,7 +228,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids(self, client):
+    def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -230,7 +244,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version(self, client):
+    def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -256,7 +271,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit(self, client):
+    def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = client.analyze_sentiment(docs)
@@ -264,7 +280,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint(self, client):
+    def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -281,7 +298,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_dont_use_language_hint(self, client):
+    def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -298,7 +316,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_per_item_dont_use_language_hint(self, client):
+    def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -317,7 +336,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_input(self, client):
+    def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -334,7 +354,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_dict_input(self, client):
+    def test_whole_batch_language_hint_and_dict_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -349,7 +370,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -369,7 +391,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -388,7 +411,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy
-    def test_client_passed_default_language_hint(self, client):
+    def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -410,7 +434,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_method(self, client):
+    def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.analyze_sentiment(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -419,7 +444,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_docs(self, client):
+    def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.analyze_sentiment(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -427,7 +453,9 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy
-    def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -449,7 +477,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_user_agent(self, client):
+    def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -464,7 +493,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_no_result_attribute(self, client):
+    def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.analyze_sentiment(docs)
 
@@ -485,7 +515,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_nonexistent_attribute(self, client):
+    def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.analyze_sentiment(docs)
 
@@ -498,7 +529,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error(self, client):
+    def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -510,7 +542,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_errors(self, client):
+    def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -530,7 +563,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_not_passing_list_for_docs(self, client):
+    def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             client.analyze_sentiment(docs)
@@ -539,7 +573,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_missing_input_records_error(self, client):
+    def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             client.analyze_sentiment(docs)
@@ -548,7 +583,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_none_docs(self, client):
+    def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.analyze_sentiment(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -556,7 +592,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_duplicate_ids_error(self, client):
+    def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -569,7 +606,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit_error(self, client):
+    def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -581,7 +619,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_language_kwarg_spanish(self, client):
+    def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"es\""
             assert response.http_request.body.count(language_str) == 1
@@ -599,7 +638,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.analyze_sentiment(
@@ -611,7 +651,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_opinion_mining(self, client):
+    def test_opinion_mining(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "It has a sleek premium aluminum design that makes it beautiful to look at."
         ]
@@ -655,7 +696,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_opinion_mining_with_negated_opinion(self, client):
+    def test_opinion_mining_with_negated_opinion(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "The food and service is not good"
         ]
@@ -693,7 +735,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_opinion_mining_more_than_5_documents(self, client):
+    def test_opinion_mining_more_than_5_documents(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "The food was unacceptable",
             "The rooms were beautiful. The AC was good and quiet.",
@@ -728,7 +771,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_opinion_mining_no_mined_opinions(self, client):
+    def test_opinion_mining_no_mined_opinions(self, **kwargs):
+        client = kwargs.pop("client")
         document = client.analyze_sentiment(documents=["today is a hot day"], show_opinion_mining=True)[0]
 
         assert not document.sentences[0].mined_opinions
@@ -745,7 +789,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_offset(self, client):
+    def test_offset(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.analyze_sentiment(["I like nature. I do not like being inside"])
         sentences = result[0].sentences
         assert sentences[0].offset == 0
@@ -754,7 +799,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy
-    def test_no_offset_v3_sentence_sentiment(self, client):
+    def test_no_offset_v3_sentence_sentiment(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.analyze_sentiment(["I like nature. I do not like being inside"])
         sentences = result[0].sentences
         assert sentences[0].offset is None
@@ -763,7 +809,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -775,7 +822,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -787,7 +835,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type(self, client):
+    def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -800,7 +849,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type_body_param(self, client):
+    def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -813,7 +863,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_disable_service_logs(self, client):
+    def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         client.analyze_sentiment(
@@ -825,7 +876,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_disable_service_logs_body_param(self, client):
+    def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         client.analyze_sentiment(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
@@ -31,14 +31,16 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = await client.analyze_sentiment("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict(self, client):
+    async def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
@@ -66,7 +68,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_text_document_input(self, client):
+    async def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen."),
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -94,7 +97,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_only_string(self, client):
+    async def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen.",
             "I did not like the hotel we stayed at. It was too expensive.",
@@ -111,7 +115,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_some_errors(self, client):
+    async def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
@@ -124,7 +129,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_all_errors(self, client):
+    async def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": ""}]
@@ -137,7 +143,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_too_many_documents(self, client):
+    async def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -149,7 +156,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_output_same_order_as_input(self, client):
+    async def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -166,7 +174,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy_async
-    async def test_empty_credential_class(self, client):
+    async def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.analyze_sentiment(
                 ["This is written in English."]
@@ -175,7 +184,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy_async
-    async def test_bad_credentials(self, client):
+    async def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.analyze_sentiment(
                 ["This is written in English."]
@@ -184,7 +194,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_document_input(self, client):
+    async def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -193,7 +204,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_mixing_inputs(self, client):
+    async def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -205,7 +217,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids(self, client):
+    async def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -220,7 +233,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version(self, client):
+    async def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -246,7 +260,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit(self, client):
+    async def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = await client.analyze_sentiment(docs)
@@ -254,7 +269,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint(self, client):
+    async def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -271,7 +287,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_dont_use_language_hint(self, client):
+    async def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -288,7 +305,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_per_item_dont_use_language_hint(self, client):
+    async def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -307,7 +325,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_input(self, client):
+    async def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -324,7 +343,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_dict_input(self, client):
+    async def test_whole_batch_language_hint_and_dict_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -339,7 +359,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -359,7 +380,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -378,7 +400,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy_async
-    async def test_client_passed_default_language_hint(self, client):
+    async def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -400,7 +423,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_method(self, client):
+    async def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.analyze_sentiment(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -409,7 +433,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_docs(self, client):
+    async def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.analyze_sentiment(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -417,7 +442,9 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -439,7 +466,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_user_agent(self, client):
+    async def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -454,7 +482,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_no_result_attribute(self, client):
+    async def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.analyze_sentiment(docs)
 
@@ -475,7 +504,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_nonexistent_attribute(self, client):
+    async def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.analyze_sentiment(docs)
 
@@ -488,7 +518,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error(self, client):
+    async def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -500,7 +531,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_errors(self, client):
+    async def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -520,7 +552,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_warnings(self, client):
+    async def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for analyze_sentiment. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -534,7 +567,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_not_passing_list_for_docs(self, client):
+    async def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             await client.analyze_sentiment(docs)
@@ -543,7 +577,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_missing_input_records_error(self, client):
+    async def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             await client.analyze_sentiment(docs)
@@ -552,7 +587,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_none_docs(self, client):
+    async def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             await client.analyze_sentiment(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -560,7 +596,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_duplicate_ids_error(self, client):
+    async def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -573,7 +610,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit_error(self, client):
+    async def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -585,7 +623,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_language_kwarg_spanish(self, client):
+    async def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"es\""
             assert response.http_request.body.count(language_str) == 1
@@ -603,7 +642,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, client):
+    async def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = await client.analyze_sentiment(
@@ -615,7 +655,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_opinion_mining(self, client):
+    async def test_opinion_mining(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "It has a sleek premium aluminum design that makes it beautiful to look at."
         ]
@@ -659,7 +700,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_opinion_mining_with_negated_opinion(self, client):
+    async def test_opinion_mining_with_negated_opinion(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "The food and service is not good"
         ]
@@ -696,7 +738,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_opinion_mining_more_than_5_documents(self, client):
+    async def test_opinion_mining_more_than_5_documents(self, **kwargs):
+        client = kwargs.pop("client")
         documents = [
             "The food was unacceptable",
             "The rooms were beautiful. The AC was good and quiet.",
@@ -731,7 +774,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_opinion_mining_no_mined_opinions(self, client):
+    async def test_opinion_mining_no_mined_opinions(self, **kwargs):
+        client = kwargs.pop("client")
         document = (await client.analyze_sentiment(documents=["today is a hot day"], show_opinion_mining=True))[0]
 
         assert not document.sentences[0].mined_opinions
@@ -748,7 +792,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_offset(self, client):
+    async def test_offset(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.analyze_sentiment(["I like nature. I do not like being inside"])
         sentences = result[0].sentences
         assert sentences[0].offset == 0
@@ -757,7 +802,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy_async
-    async def test_no_offset_v3_sentence_sentiment(self, client):
+    async def test_no_offset_v3_sentence_sentiment(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.analyze_sentiment(["I like nature. I do not like being inside"])
         sentences = result[0].sentences
         assert sentences[0].offset is None
@@ -766,7 +812,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy_async
-    async def test_string_index_type_not_fail_v3(self, client):
+    async def test_string_index_type_not_fail_v3(self, **kwargs):
+        client = kwargs.pop("client")
         # make sure that the addition of the string_index_type kwarg for v3.1-preview.1 doesn't
         # cause v3.0 calls to fail
         await client.analyze_sentiment(["please don't fail"])
@@ -774,7 +821,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    async def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -786,7 +834,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -798,7 +847,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type(self, client):
+    async def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -811,7 +861,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type_body_param(self, client):
+    async def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -824,7 +875,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_disable_service_logs(self, client):
+    async def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         await client.analyze_sentiment(
@@ -836,7 +888,8 @@ class TestAnalyzeSentiment(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_disable_service_logs_body_param(self, client):
+    async def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         await client.analyze_sentiment(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language.py
@@ -28,14 +28,16 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.detect_language("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict(self, client):
+    def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
@@ -61,7 +63,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_text_document_input(self, client):
+    def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             DetectLanguageInput(id="1", text="I should take my cat to the veterinarian"),
             DetectLanguageInput(id="2", text="Este es un document escrito en Español."),
@@ -86,7 +89,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_only_string(self, client):
+    def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "I should take my cat to the veterinarian.",
             "Este es un document escrito en Español.",
@@ -105,7 +109,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_some_errors(self, client):
+    def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "country_hint": "United States", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
                 {"id": "3", "text": ""},
@@ -121,7 +126,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_all_errors(self, client):
+    def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -139,7 +145,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_output_same_order_as_input(self, client):
+    def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             DetectLanguageInput(id="1", text="one"),
             DetectLanguageInput(id="2", text="two"),
@@ -156,7 +163,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy
-    def test_empty_credential_class(self, client):
+    def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.detect_language(
                 ["This is written in English."]
@@ -165,7 +173,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy
-    def test_bad_credentials(self, client):
+    def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.detect_language(
                 ["This is written in English."]
@@ -174,7 +183,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_document_input(self, client):
+    def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -183,7 +193,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_mixing_inputs(self, client):
+    def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             DetectLanguageInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -195,7 +206,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids(self, client):
+    def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -210,7 +222,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version(self, client):
+    def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -236,7 +249,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit(self, client):
+    def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = client.detect_language(docs)
@@ -244,7 +258,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_country_hint(self, client):
+    def test_whole_batch_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -261,7 +276,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_dont_use_country_hint(self, client):
+    def test_whole_batch_dont_use_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"\""
             country = resp.http_request.body.count(country_str)
@@ -278,7 +294,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_per_item_dont_use_country_hint(self, client):
+    def test_per_item_dont_use_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"\""
             country = resp.http_request.body.count(country_str)
@@ -297,7 +314,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_country_hint_and_obj_input(self, client):
+    def test_whole_batch_country_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -314,7 +332,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_country_hint_and_dict_input(self, client):
+    def test_whole_batch_country_hint_and_dict_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -329,7 +348,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_country_hint_and_obj_per_item_hints(self, client):
+    def test_whole_batch_country_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -349,7 +369,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_country_hint_and_dict_per_item_hints(self, client):
+    def test_whole_batch_country_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -367,7 +388,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_country_hint": "CA"})
     @recorded_by_proxy
-    def test_client_passed_default_country_hint(self, client):
+    def test_client_passed_default_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -388,7 +410,9 @@ class TestDetectLanguage(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy
-    def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -410,7 +434,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_user_agent(self, client):
+    def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -425,7 +450,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_no_result_attribute(self, client):
+    def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.detect_language(docs)
 
@@ -446,7 +472,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_nonexistent_attribute(self, client):
+    def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.detect_language(docs)
 
@@ -459,7 +486,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error(self, client):
+    def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -471,7 +499,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_errors(self, client):
+    def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -488,7 +517,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_warnings(self, client):
+    def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for detect_language. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -502,7 +532,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_not_passing_list_for_docs(self, client):
+    def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             client.detect_language(docs)
@@ -511,7 +542,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_missing_input_records_error(self, client):
+    def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             client.detect_language(docs)
@@ -520,7 +552,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_none_docs(self, client):
+    def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.detect_language(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -528,7 +561,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_duplicate_ids_error(self, client):
+    def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -541,7 +575,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit_error(self, client):
+    def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -553,7 +588,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_country_hint_method(self, client):
+    def test_invalid_country_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": "hello world"}]
 
         response = client.detect_language(docs, country_hint="United States")
@@ -563,7 +599,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_country_hint_docs(self, client):
+    def test_invalid_country_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "country_hint": "United States", "text": "hello world"}]
 
         response = client.detect_language(docs)
@@ -572,7 +609,9 @@ class TestDetectLanguage(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy
-    def test_country_hint_none(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_country_hint_none(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         client = TextAnalyticsClient(textanalytics_test_endpoint, AzureKeyCredential(textanalytics_test_api_key))
 
         # service will eventually support this and we will not need to send "" for input == "none"
@@ -597,7 +636,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_country_hint_kwarg(self, client):
+    def test_country_hint_kwarg(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(response):
             country_str = "\"countryHint\": \"ES\""
@@ -616,7 +656,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.detect_language(
@@ -628,7 +669,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy
-    def test_string_index_type_not_fail_v3(self, client):
+    def test_string_index_type_not_fail_v3(self, **kwargs):
+        client = kwargs.pop("client")
         # make sure that the addition of the string_index_type kwarg for v3.1-preview.1 doesn't
         # cause v3.0 calls to fail
         client.detect_language(["please don't fail"])
@@ -636,7 +678,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_disable_service_logs(self, client):
+    def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         client.detect_language(
@@ -648,7 +691,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_disable_service_logs_body_param(self, client):
+    def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             import json
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_detect_language_async.py
@@ -31,14 +31,16 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = await client.detect_language("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict(self, client):
+    async def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
                 {"id": "3", "text": "猫は幸せ"},
@@ -63,7 +65,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_text_document_input(self, client):
+    async def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             DetectLanguageInput(id="1", text="I should take my cat to the veterinarian"),
             DetectLanguageInput(id="2", text="Este es un document escrito en Español."),
@@ -88,7 +91,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_only_string(self, client):
+    async def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "I should take my cat to the veterinarian.",
             "Este es un document escrito en Español.",
@@ -107,7 +111,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_some_errors(self, client):
+    async def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "country_hint": "United States", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
                 {"id": "3", "text": ""},
@@ -123,7 +128,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_all_errors(self, client):
+    async def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -141,7 +147,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_output_same_order_as_input(self, client):
+    async def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             DetectLanguageInput(id="1", text="one"),
             DetectLanguageInput(id="2", text="two"),
@@ -158,7 +165,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy_async
-    async def test_empty_credential_class(self, client):
+    async def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.detect_language(
                 ["This is written in English."]
@@ -167,7 +175,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy_async
-    async def test_bad_credentials(self, client):
+    async def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.detect_language(
                 ["This is written in English."]
@@ -176,7 +185,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_document_input(self, client):
+    async def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -185,7 +195,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_mixing_inputs(self, client):
+    async def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             DetectLanguageInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -197,7 +208,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids(self, client):
+    async def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -212,7 +224,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version(self, client):
+    async def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -238,7 +251,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit(self, client):
+    async def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = await client.detect_language(docs)
@@ -246,7 +260,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_country_hint(self, client):
+    async def test_whole_batch_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -263,7 +278,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_dont_use_country_hint(self, client):
+    async def test_whole_batch_dont_use_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"\""
             country = resp.http_request.body.count(country_str)
@@ -280,7 +296,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_per_item_dont_use_country_hint(self, client):
+    async def test_per_item_dont_use_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"\""
             country = resp.http_request.body.count(country_str)
@@ -299,7 +316,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_country_hint_and_obj_input(self, client):
+    async def test_whole_batch_country_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -316,7 +334,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_country_hint_and_dict_input(self, client):
+    async def test_whole_batch_country_hint_and_dict_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -331,7 +350,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_country_hint_and_obj_per_item_hints(self, client):
+    async def test_whole_batch_country_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -351,7 +371,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_country_hint_and_dict_per_item_hints(self, client):
+    async def test_whole_batch_country_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -369,7 +390,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_country_hint": "CA"})
     @recorded_by_proxy_async
-    async def test_client_passed_default_country_hint(self, client):
+    async def test_client_passed_default_country_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
             country = resp.http_request.body.count(country_str)
@@ -390,7 +412,9 @@ class TestDetectLanguage(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -412,7 +436,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_user_agent(self, client):
+    async def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in resp.http_request.headers["User-Agent"]
@@ -426,7 +451,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_no_result_attribute(self, client):
+    async def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.detect_language(docs)
 
@@ -447,7 +473,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_nonexistent_attribute(self, client):
+    async def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.detect_language(docs)
 
@@ -460,7 +487,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error(self, client):
+    async def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -472,7 +500,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_errors(self, client):
+    async def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -489,7 +518,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_warnings(self, client):
+    async def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for detect_language. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -503,7 +533,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_not_passing_list_for_docs(self, client):
+    async def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             await client.detect_language(docs)
@@ -512,7 +543,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_missing_input_records_error(self, client):
+    async def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             await client.detect_language(docs)
@@ -521,7 +553,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_none_docs(self, client):
+    async def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             await client.detect_language(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -529,7 +562,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_duplicate_ids_error(self, client):
+    async def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -542,7 +576,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit_error(self, client):
+    async def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
 
         # Batch size over limit
         docs = ["hello world"] * 1001
@@ -555,7 +590,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_country_hint_method(self, client):
+    async def test_invalid_country_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": "hello world"}]
 
         response = await client.detect_language(docs, country_hint="United States")
@@ -565,7 +601,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_country_hint_docs(self, client):
+    async def test_invalid_country_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "country_hint": "United States", "text": "hello world"}]
 
@@ -575,7 +612,9 @@ class TestDetectLanguage(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_country_hint_none(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_country_hint_none(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         client = TextAnalyticsClient(textanalytics_test_endpoint, AzureKeyCredential(textanalytics_test_api_key))
         # service will eventually support this and we will not need to send "" for input == "none"
         documents = [{"id": "0", "country_hint": "none", "text": "This is written in English."}]
@@ -599,7 +638,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_country_hint_kwarg(self, client):
+    async def test_country_hint_kwarg(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             country_str = "\"countryHint\": \"ES\""
             assert response.http_request.body.count(country_str) == 1
@@ -616,7 +656,9 @@ class TestDetectLanguage(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_pass_cls(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         text_analytics = TextAnalyticsClient(textanalytics_test_endpoint, AzureKeyCredential(textanalytics_test_api_key))
@@ -629,7 +671,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy_async
-    async def test_string_index_type_not_fail_v3(self, client):
+    async def test_string_index_type_not_fail_v3(self, **kwargs):
+        client = kwargs.pop("client")
         # make sure that the addition of the string_index_type kwarg for v3.1-preview.1 doesn't
         # cause v3.0 calls to fail
         await client.detect_language(["please don't fail"])
@@ -637,7 +680,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_disable_service_logs(self, client):
+    async def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         await client.detect_language(
@@ -649,7 +693,8 @@ class TestDetectLanguage(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_disable_service_logs_body_param(self, client):
+    async def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             import json
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_encoding.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_encoding.py
@@ -22,62 +22,71 @@ class TestEncoding(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_emoji(self, client):
+    def test_emoji(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["👩 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 7
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_emoji_with_skin_tone_modifier(self, client):
+    def test_emoji_with_skin_tone_modifier(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["👩🏻 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 8
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_emoji_family(self, client):
+    def test_emoji_family(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["👩‍👩‍👧‍👧 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 13
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_emoji_family_with_skin_tone_modifier(self, client):
+    def test_emoji_family_with_skin_tone_modifier(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 17
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_diacritics_nfc(self, client):
+    def test_diacritics_nfc(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["año SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 9
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_diacritics_nfd(self, client):
+    def test_diacritics_nfd(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["año SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 10
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_korean_nfc(self, client):
+    def test_korean_nfc(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["아가 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 8
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_korean_nfd(self, client):
+    def test_korean_nfd(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["아가 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 8
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_zalgo_text(self, client):
+    def test_zalgo_text(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["ơ̵̧̧̢̳̘̘͕͔͕̭̟̙͎͈̞͔̈̇̒̃͋̇̅͛̋͛̎́͑̄̐̂̎͗͝m̵͍͉̗̄̏͌̂̑̽̕͝͠g̵̢̡̢̡̨̡̧̛͉̞̯̠̤̣͕̟̫̫̼̰͓̦͖̣̣͎̋͒̈́̓̒̈̍̌̓̅͑̒̓̅̅͒̿̏́͗̀̇͛̏̀̈́̀̊̾̀̔͜͠͝ͅ SSN: 859-98-0987"])
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_encoding_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_encoding_async.py
@@ -23,63 +23,72 @@ class TestEncoding(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_emoji(self, client):
+    async def test_emoji(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["👩 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 7
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_emoji_with_skin_tone_modifier(self, client):
+    async def test_emoji_with_skin_tone_modifier(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["👩🏻 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 8
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_emoji_family(self, client):
+    async def test_emoji_family(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["👩‍👩‍👧‍👧 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 13
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_emoji_family_with_skin_tone_modifier(self, client):
+    async def test_emoji_family_with_skin_tone_modifier(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 17
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_diacritics_nfc(self, client):
+    async def test_diacritics_nfc(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["año SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 9
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_diacritics_nfd(self, client):
+    async def test_diacritics_nfd(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["año SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 10
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_korean_nfc(self, client):
+    async def test_korean_nfc(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["아가 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 8
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_korean_nfd(self, client):
+    async def test_korean_nfd(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["아가 SSN: 859-98-0987"])
         assert result[0].entities[0].offset == 8
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_zalgo_text(self, client):
+    async def test_zalgo_text(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["ơ̵̧̧̢̳̘̘͕͔͕̭̟̙͎͈̞͔̈̇̒̃͋̇̅͛̋͛̎́͑̄̐̂̎͗͝m̵͍͉̗̄̏͌̂̑̽̕͝͠g̵̢̡̢̡̨̡̧̛͉̞̯̠̤̣͕̟̫̫̼̰͓̦͖̣̣͎̋͒̈́̓̒̈̍̌̓̅͑̒̓̅̅͒̿̏́͗̀̇͛̏̀̈́̀̊̾̀̔͜͠͝ͅ SSN: 859-98-0987"])
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases.py
@@ -28,14 +28,16 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.extract_key_phrases("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict(self, client):
+    def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -50,7 +52,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_text_document_input(self, client):
+    def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen", language="en"),
             TextDocumentInput(id="2", text="Microsoft fue fundado por Bill Gates y Paul Allen", language="es")
@@ -66,7 +69,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_only_string(self, client):
+    def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen",
             "Microsoft fue fundado por Bill Gates y Paul Allen",
@@ -79,7 +83,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_some_errors(self, client):
+    def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -90,7 +95,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_all_errors(self, client):
+    def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": ""}]
 
@@ -101,7 +107,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_too_many_documents(self, client):
+    def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -113,7 +120,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_output_same_order_as_input(self, client):
+    def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -130,7 +138,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy
-    def test_empty_credential_class(self, client):
+    def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.extract_key_phrases(
                 ["This is written in English."]
@@ -139,7 +148,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy
-    def test_bad_credentials(self, client):
+    def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.extract_key_phrases(
                 ["This is written in English."]
@@ -148,7 +158,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_document_input(self, client):
+    def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -157,7 +168,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_mixing_inputs(self, client):
+    def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -169,7 +181,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids(self, client):
+    def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -184,7 +197,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version(self, client):
+    def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -210,7 +224,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit(self, client):
+    def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = client.extract_key_phrases(docs)
@@ -218,7 +233,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint(self, client):
+    def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -235,7 +251,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_dont_use_language_hint(self, client):
+    def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -252,7 +269,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_per_item_dont_use_language_hint(self, client):
+    def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -271,7 +289,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_input(self, client):
+    def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -288,7 +307,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -308,7 +328,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -327,7 +348,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy
-    def test_client_passed_default_language_hint(self, client):
+    def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -349,7 +371,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_method(self, client):
+    def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.extract_key_phrases(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -358,7 +381,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_docs(self, client):
+    def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.extract_key_phrases(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -366,7 +390,9 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy
-    def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -388,7 +414,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_user_agent(self, client):
+    def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -403,7 +430,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_no_result_attribute(self, client):
+    def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.extract_key_phrases(docs)
 
@@ -425,7 +453,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_nonexistent_attribute(self, client):
+    def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.extract_key_phrases(docs)
 
@@ -438,7 +467,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error(self, client):
+    def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -450,7 +480,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_errors(self, client):
+    def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -470,7 +501,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_not_passing_list_for_docs(self, client):
+    def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             client.extract_key_phrases(docs)
@@ -479,7 +511,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_missing_input_records_error(self, client):
+    def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             client.extract_key_phrases(docs)
@@ -488,7 +521,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_none_docs(self, client):
+    def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.extract_key_phrases(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -496,7 +530,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_duplicate_ids_error(self, client):
+    def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -509,7 +544,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit_error(self, client):
+    def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -521,7 +557,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_language_kwarg_spanish(self, client):
+    def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"es\""
             assert response.http_request.body.count(language_str) == 1
@@ -539,7 +576,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.extract_key_phrases(
@@ -551,7 +589,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_disable_service_logs(self, client):
+    def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         client.extract_key_phrases(
@@ -563,7 +602,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_disable_service_logs_body_param(self, client):
+    def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         client.extract_key_phrases(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_extract_key_phrases_async.py
@@ -31,14 +31,16 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = await client.extract_key_phrases("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict(self, client):
+    async def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -53,7 +55,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_text_document_input(self, client):
+    async def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen", language="en"),
             TextDocumentInput(id="2", text="Microsoft fue fundado por Bill Gates y Paul Allen", language="es")
@@ -69,7 +72,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_only_string(self, client):
+    async def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen",
             "Microsoft fue fundado por Bill Gates y Paul Allen",
@@ -82,7 +86,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_some_errors(self, client):
+    async def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -93,7 +98,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_all_errors(self, client):
+    async def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": ""}]
 
@@ -104,7 +110,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_too_many_documents(self, client):
+    async def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -116,7 +123,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_output_same_order_as_input(self, client):
+    async def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -133,7 +141,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy_async
-    async def test_empty_credential_class(self, client):
+    async def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.extract_key_phrases(
                 ["This is written in English."]
@@ -142,7 +151,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy_async
-    async def test_bad_credentials(self, client):
+    async def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.extract_key_phrases(
                 ["This is written in English."]
@@ -151,7 +161,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_document_input(self, client):
+    async def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -160,7 +171,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_mixing_inputs(self, client):
+    async def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -172,7 +184,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids(self, client):
+    async def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -187,7 +200,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version(self, client):
+    async def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -213,7 +227,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit(self, client):
+    async def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = await client.extract_key_phrases(docs)
@@ -221,7 +236,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint(self, client):
+    async def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -238,7 +254,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_dont_use_language_hint(self, client):
+    async def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -255,7 +272,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_per_item_dont_use_language_hint(self, client):
+    async def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -274,7 +292,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_input(self, client):
+    async def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -291,7 +310,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -311,7 +331,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -330,7 +351,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy_async
-    async def test_client_passed_default_language_hint(self, client):
+    async def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -352,7 +374,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_method(self, client):
+    async def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.extract_key_phrases(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -361,7 +384,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_docs(self, client):
+    async def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.extract_key_phrases(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -369,7 +393,9 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -391,7 +417,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_user_agent(self, client):
+    async def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -406,7 +433,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_no_result_attribute(self, client):
+    async def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.extract_key_phrases(docs)
 
@@ -428,7 +456,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_nonexistent_attribute(self, client):
+    async def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.extract_key_phrases(docs)
 
@@ -440,7 +469,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error(self, client):
+    async def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -452,7 +482,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_errors(self, client):
+    async def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -472,7 +503,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_not_passing_list_for_docs(self, client):
+    async def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             await client.extract_key_phrases(docs)
@@ -481,7 +513,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_missing_input_records_error(self, client):
+    async def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             await client.extract_key_phrases(docs)
@@ -490,7 +523,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_none_docs(self, client):
+    async def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             await client.extract_key_phrases(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -498,7 +532,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_duplicate_ids_error(self, client):
+    async def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -511,7 +546,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit_error(self, client):
+    async def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -523,7 +559,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_language_kwarg_spanish(self, client):
+    async def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"es\""
             assert response.http_request.body.count(language_str) == 1
@@ -541,7 +578,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, client):
+    async def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = await client.extract_key_phrases(
@@ -553,7 +591,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_disable_service_logs(self, client):
+    async def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         await client.extract_key_phrases(
@@ -565,7 +604,8 @@ class TestExtractKeyPhrases(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_disable_service_logs_body_param(self, client):
+    async def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         await client.extract_key_phrases(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
@@ -27,14 +27,16 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.recognize_entities("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict(self, client):
+    def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975."},
                 {"id": "3", "language": "de", "text": "Microsoft wurde am 4. April 1975 von Bill Gates und Paul Allen gegründet."}]
@@ -53,7 +55,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_text_document_input(self, client):
+    def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975.", language="en"),
             TextDocumentInput(id="2", text="Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975.", language="es"),
@@ -72,7 +75,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_only_string(self, client):
+    def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975.",
             "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975.",
@@ -87,7 +91,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_some_errors(self, client):
+    def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
                 {"id": "3", "language": "de", "text": ""}]
@@ -100,7 +105,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_all_errors(self, client):
+    def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
                 {"id": "3", "language": "de", "text": ""}]
@@ -113,7 +119,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_too_many_documents(self, client):
+    def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -125,7 +132,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_output_same_order_as_input(self, client):
+    def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -142,7 +150,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy
-    def test_empty_credential_class(self, client):
+    def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.recognize_entities(
                 ["This is written in English."]
@@ -151,7 +160,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy
-    def test_bad_credentials(self, client):
+    def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.recognize_entities(
                 ["This is written in English."]
@@ -160,7 +170,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_document_input(self, client):
+    def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -169,7 +180,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_mixing_inputs(self, client):
+    def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -181,7 +193,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids(self, client):
+    def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -196,7 +209,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version(self, client):
+    def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -222,7 +236,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit(self, client):
+    def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = client.recognize_entities(docs)
@@ -230,7 +245,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint(self, client):
+    def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -247,7 +263,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_dont_use_language_hint(self, client):
+    def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -264,7 +281,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_per_item_dont_use_language_hint(self, client):
+    def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -283,7 +301,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_input(self, client):
+    def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -300,7 +319,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -320,7 +340,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -339,7 +360,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy
-    def test_client_passed_default_language_hint(self, client):
+    def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -361,7 +383,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_method(self, client):
+    def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.recognize_entities(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -370,7 +393,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_docs(self, client):
+    def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.recognize_entities(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -378,7 +402,9 @@ class TestRecognizeEntities(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy
-    def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -400,7 +426,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_user_agent(self, client):
+    def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -415,7 +442,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_no_result_attribute(self, client):
+    def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.recognize_entities(docs)
 
@@ -437,7 +465,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_nonexistent_attribute(self, client):
+    def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.recognize_entities(docs)
 
@@ -450,7 +479,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error(self, client):
+    def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -462,7 +492,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_errors(self, client):
+    def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -482,7 +513,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_warnings(self, client):
+    def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for recognize_entities. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -496,7 +528,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_not_passing_list_for_docs(self, client):
+    def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             client.recognize_entities(docs)
@@ -505,7 +538,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_missing_input_records_error(self, client):
+    def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             client.recognize_entities(docs)
@@ -514,7 +548,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_none_docs(self, client):
+    def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.recognize_entities(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -522,7 +557,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_duplicate_ids_error(self, client):
+    def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -535,7 +571,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit_error(self, client):
+    def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -547,7 +584,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_language_kwarg_spanish(self, client):
+    def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"es\""
             assert response.http_request.body.count(language_str) == 1
@@ -565,7 +603,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.recognize_entities(
@@ -577,7 +616,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_offset(self, client):
+    def test_offset(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -590,7 +630,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy
-    def test_no_offset_v3_categorized_entities(self, client):
+    def test_no_offset_v3_categorized_entities(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -601,7 +642,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -613,7 +655,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -625,7 +668,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type(self, client):
+    def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -638,7 +682,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type_body_param(self, client):
+    def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -651,7 +696,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_disable_service_logs(self, client):
+    def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         client.recognize_entities(
@@ -663,7 +709,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_disable_service_logs_body_param(self, client):
+    def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         client.recognize_entities(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
@@ -31,14 +31,16 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = await client.recognize_entities("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict(self, client):
+    async def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975."},
                 {"id": "3", "language": "de", "text": "Microsoft wurde am 4. April 1975 von Bill Gates und Paul Allen gegründet."}]
@@ -57,7 +59,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_text_document_input(self, client):
+    async def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975.", language="en"),
             TextDocumentInput(id="2", text="Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975.", language="es"),
@@ -76,7 +79,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_only_string(self, client):
+    async def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975.",
             "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975.",
@@ -91,7 +95,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_some_errors(self, client):
+    async def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
                 {"id": "3", "language": "de", "text": ""}]
@@ -104,7 +109,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_all_errors(self, client):
+    async def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
                 {"id": "3", "language": "de", "text": ""}]
@@ -117,7 +123,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_too_many_documents(self, client):
+    async def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -129,7 +136,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_output_same_order_as_input(self, client):
+    async def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -146,7 +154,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy_async
-    async def test_empty_credential_class(self, client):
+    async def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.recognize_entities(
                 ["This is written in English."]
@@ -155,7 +164,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy_async
-    async def test_bad_credentials(self, client):
+    async def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.recognize_entities(
                 ["This is written in English."]
@@ -164,7 +174,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_document_input(self, client):
+    async def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -173,7 +184,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_mixing_inputs(self, client):
+    async def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -185,7 +197,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids(self, client):
+    async def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -200,7 +213,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version(self, client):
+    async def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -226,7 +240,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit(self, client):
+    async def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = await client.recognize_entities(docs)
@@ -234,7 +249,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint(self, client):
+    async def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -251,7 +267,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_dont_use_language_hint(self, client):
+    async def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -268,7 +285,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_per_item_dont_use_language_hint(self, client):
+    async def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -287,7 +305,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_input(self, client):
+    async def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -304,7 +323,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -324,7 +344,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -343,7 +364,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy_async
-    async def test_client_passed_default_language_hint(self, client):
+    async def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -365,7 +387,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_method(self, client):
+    async def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.recognize_entities(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -374,7 +397,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_docs(self, client):
+    async def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.recognize_entities(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -382,7 +406,9 @@ class TestRecognizeEntities(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -404,7 +430,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_user_agent(self, client):
+    async def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
@@ -420,7 +447,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_no_result_attribute(self, client):
+    async def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": ""}]
         response = await client.recognize_entities(docs)
@@ -443,7 +471,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_nonexistent_attribute(self, client):
+    async def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": ""}]
         response = await client.recognize_entities(docs)
@@ -457,7 +486,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error(self, client):
+    async def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -469,7 +499,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_errors(self, client):
+    async def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -489,7 +520,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_warnings(self, client):
+    async def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for recognize_entities. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -503,7 +535,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_not_passing_list_for_docs(self, client):
+    async def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             await client.recognize_entities(docs)
@@ -512,7 +545,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_missing_input_records_error(self, client):
+    async def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             await client.recognize_entities(docs)
@@ -521,7 +555,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_none_docs(self, client):
+    async def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             await client.recognize_entities(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -529,7 +564,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_duplicate_ids_error(self, client):
+    async def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -542,7 +578,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit_error(self, client):
+    async def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -554,7 +591,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_language_kwarg_spanish(self, client):
+    async def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"es\""
             assert response.http_request.body.count(language_str) == 1
@@ -572,7 +610,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, client):
+    async def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = await client.recognize_entities(
@@ -584,7 +623,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_offset(self, client):
+    async def test_offset(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -597,7 +637,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy_async
-    async def test_no_offset_v3_categorized_entities(self, client):
+    async def test_no_offset_v3_categorized_entities(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -608,7 +649,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    async def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -620,7 +662,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -632,7 +675,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type(self, client):
+    async def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -645,7 +689,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type_body_param(self, client):
+    async def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -658,7 +703,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_disable_service_logs(self, client):
+    async def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         await client.recognize_entities(
@@ -670,7 +716,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_disable_service_logs_body_param(self, client):
+    async def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         await client.recognize_entities(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities.py
@@ -27,14 +27,16 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.recognize_linked_entities("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict(self, client):
+    def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -56,7 +58,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_text_document_input(self, client):
+    def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen"),
             TextDocumentInput(id="2", text="Microsoft fue fundado por Bill Gates y Paul Allen")
@@ -78,7 +81,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_only_string(self, client):
+    def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen",
             "Microsoft fue fundado por Bill Gates y Paul Allen",
@@ -93,7 +97,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_some_errors(self, client):
+    def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -104,7 +109,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_all_errors(self, client):
+    def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
 
@@ -115,7 +121,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_too_many_documents(self, client):
+    def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -127,7 +134,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_output_same_order_as_input(self, client):
+    def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -144,7 +152,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy
-    def test_empty_credential_class(self, client):
+    def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.recognize_linked_entities(
                 ["This is written in English."]
@@ -153,7 +162,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy
-    def test_bad_credentials(self, client):
+    def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.recognize_linked_entities(
                 ["This is written in English."]
@@ -162,7 +172,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_document_input(self, client):
+    def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -171,7 +182,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_mixing_inputs(self, client):
+    def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -183,7 +195,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids(self, client):
+    def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -198,7 +211,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version(self, client):
+    def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -224,7 +238,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit(self, client):
+    def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = client.recognize_linked_entities(docs)
@@ -232,7 +247,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint(self, client):
+    def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -249,7 +265,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_dont_use_language_hint(self, client):
+    def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -266,7 +283,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_per_item_dont_use_language_hint(self, client):
+    def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -285,7 +303,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_input(self, client):
+    def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -302,7 +321,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -322,7 +342,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -341,7 +362,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy
-    def test_client_passed_default_language_hint(self, client):
+    def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -363,7 +385,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_method(self, client):
+    def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.recognize_linked_entities(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -372,7 +395,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_docs(self, client):
+    def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.recognize_linked_entities(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -380,7 +404,9 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy
-    def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -402,7 +428,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_user_agent(self, client):
+    def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -417,7 +444,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_no_result_attribute(self, client):
+    def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.recognize_linked_entities(docs)
 
@@ -439,7 +467,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_nonexistent_attribute(self, client):
+    def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.recognize_linked_entities(docs)
 
@@ -452,7 +481,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error(self, client):
+    def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -464,7 +494,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_errors(self, client):
+    def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -484,7 +515,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_warnings(self, client):
+    def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for recognize_linked_entities. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -498,7 +530,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_not_passing_list_for_docs(self, client):
+    def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             client.recognize_linked_entities(docs)
@@ -507,7 +540,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_missing_input_records_error(self, client):
+    def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             client.recognize_linked_entities(docs)
@@ -516,7 +550,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_none_docs(self, client):
+    def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.recognize_linked_entities(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -524,7 +559,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_duplicate_ids_error(self, client):
+    def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -537,7 +573,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit_error(self, client):
+    def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -549,7 +586,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_language_kwarg_spanish(self, client):
+    def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"es\""
             assert response.http_request.body.count(language_str) == 1
@@ -567,7 +605,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.recognize_linked_entities(
@@ -579,7 +618,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_offset(self, client):
+    def test_offset(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_linked_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -597,7 +637,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy
-    def test_no_offset_v3_linked_entity_match(self, client):
+    def test_no_offset_v3_linked_entity_match(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_linked_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -608,7 +649,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy
-    def test_string_index_type_not_fail_v3(self, client):
+    def test_string_index_type_not_fail_v3(self, **kwargs):
+        client = kwargs.pop("client")
         # make sure that the addition of the string_index_type kwarg for v3.1-preview doesn't
         # cause v3.0 calls to fail
         client.recognize_linked_entities(["please don't fail"])
@@ -616,7 +658,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bing_id(self, client):
+    def test_bing_id(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_linked_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         for doc in result:
             for entity in doc.entities:
@@ -625,7 +668,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -637,7 +681,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -649,7 +694,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type(self, client):
+    def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -662,7 +708,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type_body_param(self, client):
+    def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -675,7 +722,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_disable_service_logs(self, client):
+    def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         client.recognize_linked_entities(
@@ -687,7 +735,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_disable_service_logs_body_param(self, client):
+    def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         client.recognize_linked_entities(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_linked_entities_async.py
@@ -31,14 +31,16 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = await client.recognize_linked_entities("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict(self, client):
+    async def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -61,7 +63,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_text_document_input(self, client):
+    async def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen"),
@@ -84,7 +87,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_only_string(self, client):
+    async def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [
             "Microsoft was founded by Bill Gates and Paul Allen",
@@ -100,7 +104,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_some_errors(self, client):
+    async def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -112,7 +117,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_all_errors(self, client):
+    async def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -124,7 +130,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_too_many_documents(self, client):
+    async def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -136,7 +143,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_output_same_order_as_input(self, client):
+    async def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -153,7 +161,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy_async
-    async def test_empty_credential_class(self, client):
+    async def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.recognize_linked_entities(
                 ["This is written in English."]
@@ -162,7 +171,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy_async
-    async def test_bad_credentials(self, client):
+    async def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.recognize_linked_entities(
                 ["This is written in English."]
@@ -171,7 +181,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_document_input(self, client):
+    async def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = "This is the wrong type"
 
@@ -181,7 +192,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_mixing_inputs(self, client):
+    async def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -193,7 +205,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids(self, client):
+    async def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
@@ -209,7 +222,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version(self, client):
+    async def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(response):
             assert response is not None
@@ -236,7 +250,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit(self, client):
+    async def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
@@ -245,7 +260,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint(self, client):
+    async def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             language_str = "\"language\": \"fr\""
@@ -263,7 +279,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_dont_use_language_hint(self, client):
+    async def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             language_str = "\"language\": \"\""
@@ -281,7 +298,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_per_item_dont_use_language_hint(self, client):
+    async def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             language_str = "\"language\": \"\""
@@ -301,7 +319,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_input(self, client):
+    async def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             language_str = "\"language\": \"de\""
@@ -319,7 +338,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -340,7 +360,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -360,7 +381,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy_async
-    async def test_client_passed_default_language_hint(self, client):
+    async def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -383,7 +405,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_method(self, client):
+    async def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.recognize_linked_entities(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -392,7 +415,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_docs(self, client):
+    async def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.recognize_linked_entities(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -400,7 +424,9 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -422,7 +448,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_user_agent(self, client):
+    async def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
@@ -438,7 +465,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_no_result_attribute(self, client):
+    async def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": ""}]
         response = await client.recognize_linked_entities(docs)
@@ -461,7 +489,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_nonexistent_attribute(self, client):
+    async def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": ""}]
         response = await client.recognize_linked_entities(docs)
@@ -475,7 +504,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error(self, client):
+    async def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -487,7 +517,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_errors(self, client):
+    async def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -507,7 +538,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_warnings(self, client):
+    async def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for recognize_linked_entities. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -521,7 +553,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_not_passing_list_for_docs(self, client):
+    async def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             await client.recognize_linked_entities(docs)
@@ -530,7 +563,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_missing_input_records_error(self, client):
+    async def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             await client.recognize_linked_entities(docs)
@@ -539,7 +573,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_none_docs(self, client):
+    async def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             await client.recognize_linked_entities(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -547,7 +582,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_duplicate_ids_error(self, client):
+    async def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -560,7 +596,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit_error(self, client):
+    async def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -572,7 +609,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_language_kwarg_spanish(self, client):
+    async def test_language_kwarg_spanish(self, **kwargs):
+        client = kwargs.pop("client")
 
         def callback(response):
             language_str = "\"language\": \"es\""
@@ -591,7 +629,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, client):
+    async def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = await client.recognize_linked_entities(
@@ -603,7 +642,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_offset(self, client):
+    async def test_offset(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_linked_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -621,7 +661,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy_async
-    async def test_no_offset_v3_linked_entity_match(self, client):
+    async def test_no_offset_v3_linked_entity_match(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_linked_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         entities = result[0].entities
 
@@ -632,7 +673,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_0})
     @recorded_by_proxy_async
-    async def test_string_index_type_not_fail_v3(self, client):
+    async def test_string_index_type_not_fail_v3(self, **kwargs):
+        client = kwargs.pop("client")
         # make sure that the addition of the string_index_type kwarg for v3.1-preview doesn't
         # cause v3.0 calls to fail
         await client.recognize_linked_entities(["please don't fail"])
@@ -640,7 +682,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bing_id(self, client):
+    async def test_bing_id(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_linked_entities(["Microsoft was founded by Bill Gates and Paul Allen"])
         for doc in result:
             for entity in doc.entities:
@@ -649,7 +692,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    async def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -661,7 +705,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -673,7 +718,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type(self, client):
+    async def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -686,7 +732,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type_body_param(self, client):
+    async def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -700,7 +747,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_disable_service_logs(self, client):
+    async def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         await client.recognize_linked_entities(
@@ -712,7 +760,8 @@ class TestRecognizeLinkedEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_disable_service_logs_body_param(self, client):
+    async def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities.py
@@ -30,14 +30,16 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_no_single_input(self, client):
+    def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = client.recognize_pii_entities("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_dict(self, client):
+    def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": "My SSN is 859-98-0987."},
                 {"id": "2", "text": "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."},
@@ -63,7 +65,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_all_successful_passing_text_document_input(self, client):
+    def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="My SSN is 859-98-0987."),
             TextDocumentInput(id="2", text="Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."),
@@ -90,7 +93,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_only_string(self, client):
+    def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "My SSN is 859-98-0987.",
             "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
@@ -112,7 +116,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_some_errors(self, client):
+    def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "notalanguage", "text": "hola"},
                 {"id": "2", "text": ""},
                 {"id": "3", "text": "Is 998.214.865-68 your Brazilian CPF number?"}]
@@ -125,7 +130,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_input_with_all_errors(self, client):
+    def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
                 {"id": "3", "language": "de", "text": ""}]
@@ -138,7 +144,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_too_many_documents(self, client):
+    def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -150,7 +157,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_output_same_order_as_input(self, client):
+    def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -167,7 +175,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy
-    def test_empty_credential_class(self, client):
+    def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.recognize_pii_entities(
                 ["This is written in English."]
@@ -176,7 +185,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy
-    def test_bad_credentials(self, client):
+    def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = client.recognize_pii_entities(
                 ["This is written in English."]
@@ -185,7 +195,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_document_input(self, client):
+    def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -194,7 +205,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_mixing_inputs(self, client):
+    def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -206,7 +218,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_out_of_order_ids(self, client):
+    def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -221,7 +234,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_show_stats_and_model_version(self, client):
+    def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -247,7 +261,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit(self, client):
+    def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = client.recognize_pii_entities(docs)
@@ -255,7 +270,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint(self, client):
+    def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -272,7 +288,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_dont_use_language_hint(self, client):
+    def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -289,7 +306,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_per_item_dont_use_language_hint(self, client):
+    def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -308,7 +326,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_input(self, client):
+    def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -325,7 +344,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -345,7 +365,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -364,7 +385,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy
-    def test_client_passed_default_language_hint(self, client):
+    def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -386,7 +408,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_method(self, client):
+    def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.recognize_pii_entities(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -395,7 +418,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_invalid_language_hint_docs(self, client):
+    def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = client.recognize_pii_entities(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -403,7 +427,9 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy
-    def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -425,7 +451,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_user_agent(self, client):
+    def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -440,7 +467,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_no_result_attribute(self, client):
+    def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.recognize_pii_entities(docs)
 
@@ -462,7 +490,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_attribute_error_nonexistent_attribute(self, client):
+    def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = client.recognize_pii_entities(docs)
 
@@ -475,7 +504,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_bad_model_version_error(self, client):
+    def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -487,7 +517,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_errors(self, client):
+    def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -507,7 +538,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_document_warnings(self, client):
+    def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for recognize_pii_entities. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -521,7 +553,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_not_passing_list_for_docs(self, client):
+    def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             client.recognize_pii_entities(docs)
@@ -530,7 +563,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_missing_input_records_error(self, client):
+    def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             client.recognize_pii_entities(docs)
@@ -539,7 +573,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_passing_none_docs(self, client):
+    def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             client.recognize_pii_entities(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -547,7 +582,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_duplicate_ids_error(self, client):
+    def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -560,7 +596,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_batch_size_over_limit_error(self, client):
+    def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -573,7 +610,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_pass_cls(self, client):
+    def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = client.recognize_pii_entities(
@@ -585,7 +623,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_language_kwarg_english(self, client):
+    def test_language_kwarg_english(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"en\""
             assert response.http_request.body.count(language_str) == 1
@@ -603,7 +642,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_redacted_text(self, client):
+    def test_redacted_text(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(["My SSN is 859-98-0987."])
         assert "My SSN is ***********." == result[0].redacted_text
 
@@ -611,7 +651,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_phi_domain_filter(self, client):
+    def test_phi_domain_filter(self, **kwargs):
+        client = kwargs.pop("client")
         # without the domain filter, this should return two entities: Microsoft as an org,
         # and the phone number. With the domain filter, it should only return one.
         result = client.recognize_pii_entities(
@@ -627,7 +668,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_categories_filter(self, client):
+    def test_categories_filter(self, **kwargs):
+        client = kwargs.pop("client")
         result = client.recognize_pii_entities(
             ["My name is Inigo Montoya, my SSN in 243-56-0987 and my phone number is 333-3333."],
         )
@@ -646,7 +688,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
-    def test_categories_filter_with_domain_filter(self, client):
+    def test_categories_filter_with_domain_filter(self, **kwargs):
+        client = kwargs.pop("client")
         # Currently there seems to be no effective difference with or without the PHI domain filter.
         result = client.recognize_pii_entities(
             ["My name is Inigo Montoya, my SSN in 243-56-0987 and my phone number is 333-3333."],
@@ -661,7 +704,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -673,7 +717,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -685,7 +730,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type(self, client):
+    def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -698,7 +744,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_explicit_set_string_index_type_body_param(self, client):
+    def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -711,7 +758,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy
-    def test_disable_service_logs(self, client):
+    def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         client.recognize_pii_entities(
@@ -723,7 +771,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy
-    def test_disable_service_logs_body_param(self, client):
+    def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         client.recognize_pii_entities(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities_async.py
@@ -31,14 +31,16 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_no_single_input(self, client):
+    async def test_no_single_input(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(TypeError):
             response = await client.recognize_pii_entities("hello world")
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_dict(self, client):
+    async def test_all_successful_passing_dict(self, **kwargs):
+        client = kwargs.pop("client")
 
         docs = [{"id": "1", "text": "My SSN is 859-98-0987."},
                 {"id": "2", "text": "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."},
@@ -65,7 +67,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_all_successful_passing_text_document_input(self, client):
+    async def test_all_successful_passing_text_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="My SSN is 859-98-0987."),
             TextDocumentInput(id="2", text="Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."),
@@ -92,7 +95,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_only_string(self, client):
+    async def test_passing_only_string(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             "My SSN is 859-98-0987.",
             "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
@@ -114,7 +118,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_some_errors(self, client):
+    async def test_input_with_some_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "notalanguage", "text": "hola"},
                 {"id": "2", "text": ""},
                 {"id": "3", "text": "Is 998.214.865-68 your Brazilian CPF number?"}]
@@ -127,7 +132,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_input_with_all_errors(self, client):
+    async def test_input_with_all_errors(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
                 {"id": "3", "language": "de", "text": ""}]
@@ -140,7 +146,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_too_many_documents(self, client):
+    async def test_too_many_documents(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["One", "Two", "Three", "Four", "Five", "Six"]
 
         with pytest.raises(HttpResponseError) as excinfo:
@@ -152,7 +159,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_output_same_order_as_input(self, client):
+    async def test_output_same_order_as_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             TextDocumentInput(id="1", text="one"),
             TextDocumentInput(id="2", text="two"),
@@ -169,7 +177,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": ""})
     @recorded_by_proxy_async
-    async def test_empty_credential_class(self, client):
+    async def test_empty_credential_class(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.recognize_pii_entities(
                 ["This is written in English."]
@@ -178,7 +187,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"textanalytics_test_api_key": "xxxxxxxxxxxx"})
     @recorded_by_proxy_async
-    async def test_bad_credentials(self, client):
+    async def test_bad_credentials(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ClientAuthenticationError):
             response = await client.recognize_pii_entities(
                 ["This is written in English."]
@@ -187,7 +197,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_document_input(self, client):
+    async def test_bad_document_input(self, **kwargs):
+        client = kwargs.pop("client")
         docs = "This is the wrong type"
 
         with pytest.raises(TypeError):
@@ -196,7 +207,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_mixing_inputs(self, client):
+    async def test_mixing_inputs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
@@ -208,7 +220,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_out_of_order_ids(self, client):
+    async def test_out_of_order_ids(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
                 {"id": "22", "text": ""},
@@ -223,7 +236,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_show_stats_and_model_version(self, client):
+    async def test_show_stats_and_model_version(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response is not None
             assert response.model_version
@@ -249,7 +263,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit(self, client):
+    async def test_batch_size_over_limit(self, **kwargs):
+        client = kwargs.pop("client")
         docs = ["hello world"] * 1050
         with pytest.raises(HttpResponseError):
             response = await client.recognize_pii_entities(docs)
@@ -257,7 +272,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint(self, client):
+    async def test_whole_batch_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"fr\""
             language = resp.http_request.body.count(language_str)
@@ -274,7 +290,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_dont_use_language_hint(self, client):
+    async def test_whole_batch_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -291,7 +308,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_per_item_dont_use_language_hint(self, client):
+    async def test_per_item_dont_use_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"\""
             language = resp.http_request.body.count(language_str)
@@ -310,7 +328,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_input(self, client):
+    async def test_whole_batch_language_hint_and_obj_input(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"de\""
             language = resp.http_request.body.count(language_str)
@@ -327,7 +346,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_obj_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -347,7 +367,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, client):
+    async def test_whole_batch_language_hint_and_dict_per_item_hints(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -366,7 +387,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
     @recorded_by_proxy_async
-    async def test_client_passed_default_language_hint(self, client):
+    async def test_client_passed_default_language_hint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             language_str = "\"language\": \"es\""
             language = resp.http_request.body.count(language_str)
@@ -388,7 +410,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_method(self, client):
+    async def test_invalid_language_hint_method(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.recognize_pii_entities(
             ["This should fail because we're passing in an invalid language hint"], language="notalanguage"
         )
@@ -397,7 +420,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_invalid_language_hint_docs(self, client):
+    async def test_invalid_language_hint_docs(self, **kwargs):
+        client = kwargs.pop("client")
         response = await client.recognize_pii_entities(
             [{"id": "1", "language": "notalanguage", "text": "This should fail because we're passing in an invalid language hint"}]
         )
@@ -405,7 +429,9 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
 
     @TextAnalyticsPreparer()
     @recorded_by_proxy_async
-    async def test_rotate_subscription_key(self, textanalytics_test_endpoint, textanalytics_test_api_key):
+    async def test_rotate_subscription_key(self, **kwargs):
+        textanalytics_test_endpoint = kwargs.pop("textanalytics_test_endpoint")
+        textanalytics_test_api_key = kwargs.pop("textanalytics_test_api_key")
         credential = AzureKeyCredential(textanalytics_test_api_key)
         client = TextAnalyticsClient(textanalytics_test_endpoint, credential)
 
@@ -427,7 +453,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_user_agent(self, client):
+    async def test_user_agent(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert "azsdk-python-ai-textanalytics/{} Python/{} ({})".format(
                 VERSION, platform.python_version(), platform.platform()) in \
@@ -442,7 +469,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_no_result_attribute(self, client):
+    async def test_document_attribute_error_no_result_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.recognize_pii_entities(docs)
 
@@ -464,7 +492,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_attribute_error_nonexistent_attribute(self, client):
+    async def test_document_attribute_error_nonexistent_attribute(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "text": ""}]
         response = await client.recognize_pii_entities(docs)
 
@@ -477,7 +506,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_bad_model_version_error(self, client):
+    async def test_bad_model_version_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
@@ -489,7 +519,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_errors(self, client):
+    async def test_document_errors(self, **kwargs):
+        client = kwargs.pop("client")
         text = ""
         for _ in range(5121):
             text += "x"
@@ -509,7 +540,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_document_warnings(self, client):
+    async def test_document_warnings(self, **kwargs):
+        client = kwargs.pop("client")
         # No warnings actually returned for recognize_pii_entities. Will update when they add
         docs = [
             {"id": "1", "text": "This won't actually create a warning :'("},
@@ -523,7 +555,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_not_passing_list_for_docs(self, client):
+    async def test_not_passing_list_for_docs(self, **kwargs):
+        client = kwargs.pop("client")
         docs = {"id": "1", "text": "hello world"}
         with pytest.raises(TypeError) as excinfo:
             await client.recognize_pii_entities(docs)
@@ -532,7 +565,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_missing_input_records_error(self, client):
+    async def test_missing_input_records_error(self, **kwargs):
+        client = kwargs.pop("client")
         docs = []
         with pytest.raises(ValueError) as excinfo:
             await client.recognize_pii_entities(docs)
@@ -541,7 +575,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_passing_none_docs(self, client):
+    async def test_passing_none_docs(self, **kwargs):
+        client = kwargs.pop("client")
         with pytest.raises(ValueError) as excinfo:
             await client.recognize_pii_entities(None)
         assert "Input documents can not be empty or None" in str(excinfo.value)
@@ -549,7 +584,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_duplicate_ids_error(self, client):
+    async def test_duplicate_ids_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Duplicate Ids
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
@@ -562,7 +598,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_batch_size_over_limit_error(self, client):
+    async def test_batch_size_over_limit_error(self, **kwargs):
+        client = kwargs.pop("client")
         # Batch size over limit
         docs = ["hello world"] * 1001
         try:
@@ -575,7 +612,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_pass_cls(self, client):
+    async def test_pass_cls(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(pipeline_response, deserialized, _):
             return "cls result"
         res = await client.recognize_pii_entities(
@@ -587,7 +625,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_language_kwarg_english(self, client):
+    async def test_language_kwarg_english(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             language_str = "\"language\": \"en\""
             assert response.http_request.body.count(language_str) == 1
@@ -605,14 +644,16 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_redacted_text(self, client):
+    async def test_redacted_text(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(["My SSN is 859-98-0987."])
         assert "My SSN is ***********." == result[0].redacted_text
 
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_phi_domain_filter(self, client):
+    async def test_phi_domain_filter(self, **kwargs):
+        client = kwargs.pop("client")
         # without the domain filter, this should return two entities: Microsoft as an org,
         # and the phone number. With the domain filter, it should only return one.
         result = await client.recognize_pii_entities(
@@ -628,7 +669,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_categories_filter(self, client):
+    async def test_categories_filter(self, **kwargs):
+        client = kwargs.pop("client")
         result = await client.recognize_pii_entities(
             ["My name is Inigo Montoya, my SSN in 243-56-0987 and my phone number is 333-3333."],
         )
@@ -647,7 +689,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
-    async def test_categories_filter_with_domain_filter(self, client):
+    async def test_categories_filter_with_domain_filter(self, **kwargs):
+        client = kwargs.pop("client")
         # Currently there seems to be no effective difference with or without the PHI domain filter.
         result = await client.recognize_pii_entities(
             ["My name is Inigo Montoya, my SSN in 243-56-0987 and my phone number is 333-3333."],
@@ -662,7 +705,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_is_UnicodeCodePoint(self, client):
+    async def test_default_string_index_type_is_UnicodeCodePoint(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "UnicodeCodePoint"
 
@@ -674,7 +718,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, client):
+    async def test_default_string_index_type_UnicodeCodePoint_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "UnicodeCodePoint"
 
@@ -686,7 +731,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type(self, client):
+    async def test_explicit_set_string_index_type(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert response.http_request.query["stringIndexType"] == "TextElement_v8"
 
@@ -699,7 +745,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_explicit_set_string_index_type_body_param(self, client):
+    async def test_explicit_set_string_index_type_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(response):
             assert json.loads(response.http_request.body)['parameters']["stringIndexType"] == "TextElements_v8"
 
@@ -712,7 +759,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V3_1})
     @recorded_by_proxy_async
-    async def test_disable_service_logs(self, client):
+    async def test_disable_service_logs(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert resp.http_request.query['loggingOptOut']
         await client.recognize_pii_entities(
@@ -724,7 +772,8 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": TextAnalyticsApiVersion.V2022_05_01})
     @recorded_by_proxy_async
-    async def test_disable_service_logs_body_param(self, client):
+    async def test_disable_service_logs_body_param(self, **kwargs):
+        client = kwargs.pop("client")
         def callback(resp):
             assert json.loads(resp.http_request.body)['parameters']['loggingOptOut']
         await client.recognize_pii_entities(

--- a/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation.py
@@ -19,7 +19,7 @@ class TestCancelTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_cancel_translation(self, **kwargs):
-        '''
+                '''
             some notes (test sporadically failing):
             1. use a large number of translations
                 - because when running tests the translations sometimes finishes with status 'Succeeded'

--- a/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation_async.py
@@ -20,7 +20,7 @@ class TestCancelTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_cancel_translation(self, **kwargs):
-        '''
+                '''
             some notes (test sporadically failing):
             1. use a large number of translations
                 - because when running tests the translation sometimes finishes with status 'Succeeded'

--- a/sdk/translation/azure-ai-translation-document/tests/test_document_status.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_document_status.py
@@ -17,7 +17,7 @@ class TestDocumentStatus(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_statuses(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = [Document(data=b'This is some text')]

--- a/sdk/translation/azure-ai-translation-document/tests/test_document_status_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_document_status_async.py
@@ -19,7 +19,7 @@ class TestDocumentStatus(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_statuses(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = [Document(data=b'This is some text')]

--- a/sdk/translation/azure-ai-translation-document/tests/test_list_document_statuses.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_list_document_statuses.py
@@ -20,7 +20,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_document_statuses(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         target_language = "es"
@@ -40,7 +40,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_document_statuses_with_skip(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 10
         skip = 2
@@ -62,7 +62,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_document_statuses_filter_by_status(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 10
         target_language = "es"
@@ -88,7 +88,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_document_statuses_filter_by_ids(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         target_language = "es"
@@ -113,7 +113,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_document_statuses_order_by_creation_time_asc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         target_language = "es"
@@ -135,7 +135,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_document_statuses_order_by_creation_time_desc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         target_language = "es"
@@ -157,7 +157,7 @@ class TestAllDocumentStatuses(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_document_statuses_mixed_filters(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 10
         target_language = "es"

--- a/sdk/translation/azure-ai-translation-document/tests/test_list_document_statuses_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_list_document_statuses_async.py
@@ -20,7 +20,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_document_statuses(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         target_language = "es"
@@ -43,7 +43,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_document_statuses_with_skip(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         skip = 2
@@ -68,7 +68,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_document_statuses_filter_by_status(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 10
         target_language = "es"
@@ -103,7 +103,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_document_statuses_filter_by_ids(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 15
         target_language = "es"
@@ -131,7 +131,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_document_statuses_order_by_creation_time_asc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         target_language = "es"
@@ -156,7 +156,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_document_statuses_order_by_creation_time_desc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 5
         target_language = "es"
@@ -181,7 +181,7 @@ class TestAllDocumentStatuses(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_document_statuses_mixed_filters(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         docs_count = 25
         target_language = "es"

--- a/sdk/translation/azure-ai-translation-document/tests/test_list_translations.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_list_translations.py
@@ -21,7 +21,7 @@ class TestListTranslations(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_translations(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # create some translations
         operations_count = 5
@@ -41,7 +41,7 @@ class TestListTranslations(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_translations_with_skip(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare data
         operations_count = 10
@@ -61,7 +61,7 @@ class TestListTranslations(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_translations_filter_by_status(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 5
         docs_per_operation = 1
@@ -89,7 +89,7 @@ class TestListTranslations(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_translations_filter_by_ids(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 3
         docs_per_operation = 2
@@ -158,7 +158,7 @@ class TestListTranslations(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_translations_order_by_creation_time_asc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 3
         docs_per_operation = 2
@@ -181,7 +181,7 @@ class TestListTranslations(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_list_translations_order_by_creation_time_desc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 3
         docs_per_operation = 2

--- a/sdk/translation/azure-ai-translation-document/tests/test_list_translations_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_list_translations_async.py
@@ -22,7 +22,7 @@ class TestSubmittedTranslations(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_translations(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # create some translations
         operations_count = 5
@@ -42,7 +42,7 @@ class TestSubmittedTranslations(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_translations_with_skip(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare data
         operations_count = 10
@@ -70,7 +70,7 @@ class TestSubmittedTranslations(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_translations_filter_by_status(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 5
         docs_per_operation = 1
@@ -98,7 +98,7 @@ class TestSubmittedTranslations(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_translations_filter_by_ids(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 3
         docs_per_operation = 2
@@ -167,7 +167,7 @@ class TestSubmittedTranslations(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_translations_order_by_creation_time_asc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 3
         docs_per_operation = 2
@@ -190,7 +190,7 @@ class TestSubmittedTranslations(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_list_translations_order_by_creation_time_desc(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         operations_count = 3
         docs_per_operation = 2

--- a/sdk/translation/azure-ai-translation-document/tests/test_supported_formats.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_supported_formats.py
@@ -17,7 +17,7 @@ class TestSupportedFormats(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_supported_document_formats(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         # get supported formats
         supported_doc_formats = client.get_supported_document_formats()
         assert supported_doc_formats is not None
@@ -29,7 +29,7 @@ class TestSupportedFormats(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_supported_glossary_formats(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         # get supported formats
         supported_glossary_formats = client.get_supported_glossary_formats()
         assert supported_glossary_formats is not None

--- a/sdk/translation/azure-ai-translation-document/tests/test_supported_formats_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_supported_formats_async.py
@@ -17,7 +17,7 @@ class TestSupportedFormats(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_supported_document_formats(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         # get supported formats
         supported_doc_formats = await client.get_supported_document_formats()
         assert supported_doc_formats is not None
@@ -29,7 +29,7 @@ class TestSupportedFormats(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_supported_glossary_formats(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         # get supported formats
         supported_glossary_formats = await client.get_supported_glossary_formats()
         assert supported_glossary_formats is not None

--- a/sdk/translation/azure-ai-translation-document/tests/test_translation.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_translation.py
@@ -61,7 +61,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_single_source_single_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -89,7 +89,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_single_source_two_targets(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -122,7 +122,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_multiple_sources_single_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -161,7 +161,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_single_source_single_target_with_prefix(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -191,7 +191,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_single_source_single_target_with_suffix(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -221,7 +221,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_bad_input_source(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         target_container_sas_url = self.create_target_container(variables=variables)
@@ -249,7 +249,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_bad_input_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -278,7 +278,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_use_supported_and_unsupported_files(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=[
@@ -313,7 +313,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_existing_documents_in_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(name="document"), variables=variables)
@@ -345,7 +345,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_existing_documents_in_target_one_valid(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=[Document(name="document"), Document()], variables=variables)
@@ -377,7 +377,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_empty_document(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(Document(data=b''), variables=variables)
@@ -409,7 +409,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_overloaded_inputs(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(data=b'hello world'), variables=variables)
@@ -446,7 +446,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_overloaded_single_input(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(data=b'hello world'), variables=variables)
@@ -514,7 +514,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_single_input_with_kwargs(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(data=b'hello world'), variables=variables)
@@ -559,7 +559,7 @@ class TestTranslation(DocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy
     def test_single_input_with_kwarg_successful(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=[Document(data=b'hello world', prefix="kwargs"),

--- a/sdk/translation/azure-ai-translation-document/tests/test_translation_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_translation_async.py
@@ -58,7 +58,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_single_source_single_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -86,7 +86,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_single_source_two_targets(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -119,7 +119,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_multiple_sources_single_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -158,7 +158,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_single_source_single_target_with_prefix(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -188,7 +188,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_single_source_single_target_with_suffix(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -218,7 +218,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_bad_input_source(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         target_container_sas_url = self.create_target_container(variables=variables)
@@ -246,7 +246,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_bad_input_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         blob_data = b'This is some text'
@@ -276,7 +276,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_use_supported_and_unsupported_files(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=[
@@ -311,7 +311,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_existing_documents_in_target(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(name="document"), variables=variables)
@@ -344,7 +344,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_existing_documents_in_target_one_valid(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=[Document(name="document"), Document()], variables=variables)
@@ -376,7 +376,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_empty_document(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(Document(data=b''), variables=variables)
@@ -408,7 +408,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_overloaded_inputs(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(data=b'hello world'), variables=variables)
@@ -446,7 +446,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_overloaded_single_input(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(data=b'hello world'), variables=variables)
@@ -517,7 +517,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_single_input_with_kwargs(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=Document(data=b'hello world'), variables=variables)
@@ -563,7 +563,7 @@ class TestTranslation(AsyncDocumentTranslationTest):
     @DocumentTranslationClientPreparer()
     @recorded_by_proxy_async
     async def test_single_input_with_kwarg_successful(self, **kwargs):
-        client = kwargs.pop("client")
+                client = kwargs.pop("client")
         variables = kwargs.pop("variables", {})
         # prepare containers and test data
         source_container_sas_url = self.create_source_container(data=[Document(data=b'hello world', prefix="kwargs"),

--- a/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
+++ b/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import functools
 import logging
 import urllib.parse as url_parse
 
@@ -27,6 +28,7 @@ def recorded_by_proxy_async(test_func):
     https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/test_proxy_migration_guide.md
     """
 
+    @functools.wraps(test_func)
     async def record_wrap(*args, **kwargs):
 
         def transform_args(*args, **kwargs):

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import functools
 import logging
 import requests
 import six
@@ -133,6 +134,7 @@ def recorded_by_proxy(test_func):
     https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/test_proxy_migration_guide.md
     """
 
+    @functools.wraps(test_func)
     def record_wrap(*args, **kwargs):
         if sys.version_info.major == 2 and not is_live():
             pytest.skip("Playback testing is incompatible with the azure-sdk-tools test proxy on Python 2")


### PR DESCRIPTION
# Description

This adds `functools.wraps` decorators to the `record_wrap` wrappers of the `recorded_by_proxy` and `recorded_by_proxy_async` decorators. This change will allow these decorators to preserve the method signature of decorated test cases, which will enable the use of `pytest` fixtures in test methods (which was necessitated by the ML team, but should be supported in other test suites).

Because of this change, `pytest` now assumes that any positional parameter in a test method signature is a request for a fixture. That in itself is fine, but since positional parameters didn't have this behavior before in recorded tests, it's a breaking change. This PR updates all existing uses of positional parameters in tests to instead accept `**kwargs` and pull necessary arguments out at the start of test execution.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
