### PR TITLE
[formrecognizer] Remove sleep time between tests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model.py
@@ -18,9 +18,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestDACAnalyzeCustomModel(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     def test_analyze_document_none_model_id(self, **kwargs):
         formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_async.py
@@ -22,9 +22,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestDACAnalyzeCustomModelAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     async def test_analyze_document_none_model_id(self, **kwargs):
         formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url.py
@@ -18,9 +18,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestDACAnalyzeCustomModelFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     def test_document_analysis_none_model(self, **kwargs):
         formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_custom_model_from_url_async.py
@@ -20,9 +20,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestDACAnalyzeCustomModelFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     async def test_document_analysis_none_model(self, **kwargs):
         formrecognizer_test_endpoint = kwargs.pop("formrecognizer_test_endpoint")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document.py
@@ -20,9 +20,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzeDocument(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_general_document_async.py
@@ -20,9 +20,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzeDocumentAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout.py
@@ -20,9 +20,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzeLayout(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_layout_async.py
@@ -20,9 +20,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzeLayoutAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
@@ -20,9 +20,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzeRead(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
@@ -20,9 +20,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzeReadAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts.py
@@ -25,9 +25,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzePrebuilts(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_async.py
@@ -25,9 +25,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzePrebuiltsAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
@@ -22,9 +22,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
@@ -24,9 +24,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model.py
@@ -19,9 +19,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestTraining(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_compose_model_async.py
@@ -20,9 +20,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestTrainingAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt.py
@@ -26,9 +26,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestManagement(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_mgmt_async.py
@@ -27,9 +27,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestManagementAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
@@ -21,9 +21,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestDMACTraining(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
@@ -24,9 +24,6 @@ DocumentModelAdministrationClientPreparer = functools.partial(_GlobalClientPrepa
 
 class TestDMACTrainingAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
@@ -19,9 +19,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestBusinessCard(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
@@ -19,9 +19,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestBusinessCardAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
@@ -18,9 +18,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestBusinessCardFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
@@ -19,9 +19,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestBusinessCardFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
@@ -22,9 +22,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestContentFromStream(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
@@ -24,9 +24,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestContentFromStreamAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
@@ -22,9 +22,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestContentFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_content_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
@@ -24,9 +24,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestContentFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_content_url_auth_bad_key(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
@@ -19,9 +19,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestCustomForms(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
@@ -22,9 +22,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestCustomFormsAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
@@ -19,9 +19,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestCustomFormsFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
@@ -21,9 +21,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
@@ -22,9 +22,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestIdDocument(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
@@ -23,9 +23,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
@@ -21,9 +21,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestIdDocumentsFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
@@ -22,9 +22,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
@@ -23,9 +23,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestInvoice(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
@@ -25,9 +25,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestInvoiceAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.skip()
     @FormRecognizerPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
@@ -21,9 +21,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestInvoiceFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
@@ -24,9 +24,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
@@ -18,9 +18,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestReceiptFromStream(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
@@ -21,9 +21,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @pytest.mark.live_test_only
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
@@ -19,9 +19,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestReceiptFromUrl(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
@@ -21,9 +21,6 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
@@ -19,9 +19,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestTraining(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
@@ -21,9 +21,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestTrainingAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
@@ -19,9 +19,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestCopyModel(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
@@ -21,9 +21,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestCopyModelAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
@@ -23,9 +23,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestManagement(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
@@ -23,9 +23,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestManagementAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
@@ -18,9 +18,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestTraining(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
@@ -21,9 +21,6 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestTrainingAsync(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
@@ -18,9 +18,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestGetChildren(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi.py
@@ -26,9 +26,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestMultiapi(FormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_default_api_version_form_recognizer_client(self, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_multiapi_async.py
@@ -25,9 +25,6 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestMultiapi(AsyncFormRecognizerTest):
 
-    def teardown(self):
-        self.sleep(4)
-
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_default_api_version_form_recognizer_client(self, **kwargs):


### PR DESCRIPTION
Fixes #23381

This PR reverts the sleep time between tests. I am looking to get pipeline results since the service has been working on latency issues. 