### PR TITLE
[Storage] STG83 Changelogs

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob-changefeed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 12.0.0b4 (Unreleased)
+### 12.0.0b4 (2022-06-15)
 
 This version and all future versions will require Python 3.6+. Python 2.7 is no longer supported.
 

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.13.0b1 (Unreleased)
+## 12.13.0b1 (2022-06-15)
 
 ### Features Added
 - Added support for service version 2021-08-06.

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.8.0b1 (Unreleased)
+## 12.8.0b1 (2022-06-15)
 
 ### Features Added
 - Added support for service version 2021-08-06

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 12.8.0b1 (2022-06-15)
 
 ### Features Added
-- Added support for service version 2021-08-06
-- Added support for `owner`, `group`, `acl`, `lease_id`, `lease_duration` to both file and directory `create` APIs
-- Added support for `expiry_options`, `expires_on` to file `create` APIs
+- Added support for service version 2021-08-06.
+- Added support for `owner`, `group`, `acl`, `lease_id`, `lease_duration` to both file and directory `create` APIs.
+- Added support for `expiry_options`, `expires_on` to file `create` APIs.
 
 ## 12.7.0 (2022-05-09)
 

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.9.0b1 (Unreleased)
+## 12.9.0b1 (2022-06-15)
 
 ### Features Added
 - Added support for `file_change_time` to `start_copy_from_url` API


### PR DESCRIPTION
Checked the `_version.py` file for each entry and added the release date (tentatively June 15th, AKA `2022-06-15`)