### PR TITLE
[storage] set version tolerant to false in readme

### DIFF
--- a/sdk/storage/azure-storage-blob/swagger/README.md
+++ b/sdk/storage/azure-storage-blob/swagger/README.md
@@ -25,6 +25,7 @@ enable-xml: true
 vanilla: true
 clear-output-folder: true
 python: true
+version-tolerant: false
 ```
 
 ### Remove x-ms-pageable

--- a/sdk/storage/azure-storage-file-datalake/swagger/README.md
+++ b/sdk/storage/azure-storage-file-datalake/swagger/README.md
@@ -25,6 +25,7 @@ enable-xml: true
 vanilla: true
 clear-output-folder: true
 python: true
+version-tolerant: false
 ```
 
 ### Remove x-ms-pageable
@@ -48,7 +49,7 @@ directive:
         if (property.includes('/{filesystem}/{path}'))
         {
             $[property]["parameters"] = $[property]["parameters"].filter(function(param) { return (typeof param['$ref'] === "undefined") || (false == param['$ref'].endsWith("#/parameters/FileSystem") && false == param['$ref'].endsWith("#/parameters/Path"))});
-        } 
+        }
         else if (property.includes('/{filesystem}'))
         {
             $[property]["parameters"] = $[property]["parameters"].filter(function(param) { return (typeof param['$ref'] === "undefined") || (false == param['$ref'].endsWith("#/parameters/FileSystem"))});

--- a/sdk/storage/azure-storage-file-share/swagger/README.md
+++ b/sdk/storage/azure-storage-file-share/swagger/README.md
@@ -25,6 +25,7 @@ enable-xml: true
 vanilla: true
 clear-output-folder: true
 python: true
+version-tolerant: false
 ```
 
 ### Remove x-ms-pageable
@@ -98,7 +99,7 @@ directive:
         if (property.includes('/{shareName}/{directory}/{fileName}'))
         {
             $[property]["parameters"] = $[property]["parameters"].filter(function(param) { return (typeof param['$ref'] === "undefined") || (false == param['$ref'].endsWith("#/parameters/ShareName") && false == param['$ref'].endsWith("#/parameters/DirectoryPath") && false == param['$ref'].endsWith("#/parameters/FilePath"))});
-        } 
+        }
         else if (property.includes('/{shareName}/{directory}'))
         {
             $[property]["parameters"] = $[property]["parameters"].filter(function(param) { return (typeof param['$ref'] === "undefined") || (false == param['$ref'].endsWith("#/parameters/ShareName") && false == param['$ref'].endsWith("#/parameters/DirectoryPath"))});

--- a/sdk/storage/azure-storage-queue/swagger/README.md
+++ b/sdk/storage/azure-storage-queue/swagger/README.md
@@ -28,6 +28,7 @@ enable-xml: true
 vanilla: true
 clear-output-folder: true
 python: true
+version-tolerant: false
 ```
 
 ### Remove x-ms-pageable


### PR DESCRIPTION
Autorest is going to do a stable release of our new DPG generation, where `version-tolerant` will default to `True`. Setting it explicitly to false for storage for now, so pipelines pass bc storage has not updated to version tolerant yet.

Doesn't make a difference for the current stable generation, we're just being more explicit instead of relying on defaults