### PR TITLE
[Key Vault] Remove AAD in CBC decryption tests

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.2_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.2_mhsm].json
@@ -9,7 +9,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -33,7 +33,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -43,16 +43,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:06 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:56 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:06 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAgAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:57 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - EUS ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - NCUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -130,8 +130,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAgAAADIJP9oOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -141,16 +141,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:06 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:56 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:07 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAgAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:57 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - NCUS ProdSlices",
+        "x-ms-ests-server": "2.1.12890.7 - SCUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -209,7 +209,7 @@
         "Connection": "keep-alive",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -232,18 +232,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "190"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "208"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650642487,
+          "created": 1655509557,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650642487
+          "updated": 1655509557
         },
         "key": {
           "key_ops": [
@@ -252,7 +252,7 @@
             "unwrapKey",
             "wrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336",
           "kty": "oct-HSM"
         }
       }
@@ -264,7 +264,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -274,16 +274,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:07 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:57 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:07 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAwAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:57 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - SCUS ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -361,8 +361,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAwAAADIJP9oOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -372,16 +372,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:07 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:57 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:07 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAwAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:58 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - SCUS ProdSlices",
+        "x-ms-ests-server": "2.1.12851.7 - NCUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -432,7 +432,7 @@
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa/encrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336/encrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -440,7 +440,7 @@
         "Connection": "keep-alive",
         "Content-Length": "315",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
@@ -456,21 +456,21 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "49"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "74"
       },
       "ResponseBody": {
         "aad": "dGVzdA",
         "alg": "A256GCM",
-        "iv": "_DyfojvkE8CV9rbh",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa",
-        "tag": "VHDIg84UX46FfSRSv6_4mQ",
-        "value": "fXd8pCuoA40Unu-51Z-xCchY_PNKxBLkGP4vdBHe3PIEvO5igI0R-E3kXybAybcarPYbxAsL08DM3f_sjzCoR2WRA9xLozL5Zwsqmm2Alt1X-pX44nDBjxxjPVAntX8k3_j7n0jgcM-d5xyPOCmWSG3uemylUrXLT2pNUw4c1Ys6SHogGxuCDUXT0Vif69BpeYvmOG0K4UZX7MtEkb42jMbTWYgT-5LQOxsjucLtF43mSibSFEMrVto8gzABhFHCvkFsN6WFIsQ"
+        "iv": "0nCj4Bj6PAtFzIui",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336",
+        "tag": "Mv_kKJAB9KlzDmja2t8F_w",
+        "value": "vdRRg9Pts0jeJojT536YFjuWyAZPEGIKKktQqWdLGCu9f8OM8cxHETz91BW_FXGXbTgZUKw39Z0PA_BDRRYsAh0d1eS8Fbt--v53ry-gjaJAIGnmbo5ggjRF4DhUsXTGJ9c2qWu1upx2GJHhpYKNysM08aEHxTQWaYOi8GxQmdmlvs8_5KzE8Z8rOEu-sUuy5HryCYY332nj8TBlgbvC-Jn_24ep_-nvIhUIYNLGzWClL84_kTNnxXRar_Ey4v6nMQN23SAoscM"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -478,14 +478,14 @@
         "Connection": "keep-alive",
         "Content-Length": "374",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
-        "value": "fXd8pCuoA40Unu-51Z-xCchY_PNKxBLkGP4vdBHe3PIEvO5igI0R-E3kXybAybcarPYbxAsL08DM3f_sjzCoR2WRA9xLozL5Zwsqmm2Alt1X-pX44nDBjxxjPVAntX8k3_j7n0jgcM-d5xyPOCmWSG3uemylUrXLT2pNUw4c1Ys6SHogGxuCDUXT0Vif69BpeYvmOG0K4UZX7MtEkb42jMbTWYgT-5LQOxsjucLtF43mSibSFEMrVto8gzABhFHCvkFsN6WFIsQ",
-        "iv": "_DyfojvkE8CV9rbh",
+        "value": "vdRRg9Pts0jeJojT536YFjuWyAZPEGIKKktQqWdLGCu9f8OM8cxHETz91BW_FXGXbTgZUKw39Z0PA_BDRRYsAh0d1eS8Fbt--v53ry-gjaJAIGnmbo5ggjRF4DhUsXTGJ9c2qWu1upx2GJHhpYKNysM08aEHxTQWaYOi8GxQmdmlvs8_5KzE8Z8rOEu-sUuy5HryCYY332nj8TBlgbvC-Jn_24ep_-nvIhUIYNLGzWClL84_kTNnxXRar_Ey4v6nMQN23SAoscM",
+        "iv": "0nCj4Bj6PAtFzIui",
         "aad": "dGVzdA",
-        "tag": "VHDIg84UX46FfSRSv6_4mQ"
+        "tag": "Mv_kKJAB9KlzDmja2t8F_w"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -496,18 +496,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "1"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256GCM",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa/encrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336/encrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -515,7 +515,7 @@
         "Connection": "keep-alive",
         "Content-Length": "347",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
@@ -532,33 +532,32 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBC",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "358",
+        "Content-Length": "341",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -569,18 +568,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBC",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQAAAAAAAAAAA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa/encrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336/encrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -588,7 +587,7 @@
         "Connection": "keep-alive",
         "Content-Length": "350",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
@@ -605,33 +604,32 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "0"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -642,13 +640,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/c084a913f4e00badb58bcbc7c7b9fefa",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6aea3332/074e61108c414fe3884b6bfa79d62336",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.3_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.3_mhsm].json
@@ -9,7 +9,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -22,7 +22,7 @@
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-server-latency": "0"
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": null
     },
@@ -33,7 +33,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -42,17 +42,19 @@
         "Access-Control-Allow-Origin": "*",
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
+        "Content-Security-Policy-Report-Only": "script-src \u0027self\u0027 \u0027nonce-Wo3dDDFdjFhuvnU0qrQqVg\u0027 \u0027unsafe-eval\u0027 \u0027unsafe-inline\u0027; object-src \u0027none\u0027; base-uri \u0027none\u0027; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:04 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:54 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:04 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NM; expires=Sun, 17-Jul-2022 23:45:54 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrMQF-L_NOin3fYfOCAB_cGZjtfQcxlWCZrW0RX7JBze4JkKn-M-1podERLvhzmnHqQ1h8eAm4EoYcB8oSpnjDPrRyx_bHok20OVeNq8bJPJwCk45VJ4c8LkUmx5Av5RKmFISl6nn-X8-U4x_DpgnjGBOio749drfhjmp-98Qj9SIgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - NCUS ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - WUS2 ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -130,8 +132,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NM; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -141,16 +143,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:04 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:54 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:05 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NM; expires=Sun, 17-Jul-2022 23:45:55 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - WUS2 ProdSlices",
+        "x-ms-ests-server": "2.1.12890.7 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -209,7 +211,7 @@
         "Connection": "keep-alive",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -232,27 +234,27 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "203"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "264"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650642485,
+          "created": 1655509555,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650642485
+          "updated": 1655509555
         },
         "key": {
           "key_ops": [
             "encrypt",
             "decrypt",
-            "unwrapKey",
-            "wrapKey"
+            "wrapKey",
+            "unwrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db",
           "kty": "oct-HSM"
         }
       }
@@ -264,7 +266,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -274,16 +276,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:05 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:54 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:05 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAQAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:55 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - NCUS ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -361,8 +363,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAQAAADIJP9oOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -372,16 +374,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:05 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:55 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:05 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroAQAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:55 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - SCUS ProdSlices",
+        "x-ms-ests-server": "2.1.12851.7 - WUS2 ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -432,7 +434,7 @@
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3/encrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db/encrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -440,7 +442,7 @@
         "Connection": "keep-alive",
         "Content-Length": "315",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
@@ -456,21 +458,21 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "55"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "72"
       },
       "ResponseBody": {
         "aad": "dGVzdA",
         "alg": "A256GCM",
-        "iv": "HoItFt7mAhynMZpG",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3",
-        "tag": "7xgHMYkmbkdScy9YZY1XwA",
-        "value": "5b2mDchjedGcLWadAcnqWF6SZDzN9hREETad66Q7haSbA6BvyZSCMZkIwoofSXJOGbQpg5rw_mmpsyGDUwfyrUFVo-1iUdTwanDuzfeGpWxexG4tJ7z4y7MwdQs-kgZOemvpxO1bYbGVnvHTA1rabGXYWmTaeBZV5uBtdJ4INSkjbns9R5vUpacb4CxydwW8d65d94ekDqq2TCfA64YbjbL_kSv1v5vOKy05_4BJ3anJHfcwwy_xHdZvKfAlN-Tm0zcr0VDWWQQ"
+        "iv": "E-nyaCvXm5Y_Ex3L",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db",
+        "tag": "7JRYbOIbmOeRnUF2omyOew",
+        "value": "LdcracKtfQDnDaJ6IKe50AOLURFVUPTEnEUno6Joxlto6b_HxnexpWNJcgSlB1g9aXtbFQEbfVwMEMprO-5VHl5bXpfaeKLmI1BlnfRpjM_kp2r1b2VOBY7ZDL4mhq6UfUC_sG434zEx6e-TlgU9YQiybQCSbo65IzSy7Hxtr08OwCCosPbwYqFVFdP1Bxh64jDiNclBxOq4TS1jVuOjIn7XGW2R3-8Lcj4ACzOnOUZWG8isTAbaI1R-C6UjjVNtlLDFwUmAYFk"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -478,14 +480,14 @@
         "Connection": "keep-alive",
         "Content-Length": "374",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
-        "value": "5b2mDchjedGcLWadAcnqWF6SZDzN9hREETad66Q7haSbA6BvyZSCMZkIwoofSXJOGbQpg5rw_mmpsyGDUwfyrUFVo-1iUdTwanDuzfeGpWxexG4tJ7z4y7MwdQs-kgZOemvpxO1bYbGVnvHTA1rabGXYWmTaeBZV5uBtdJ4INSkjbns9R5vUpacb4CxydwW8d65d94ekDqq2TCfA64YbjbL_kSv1v5vOKy05_4BJ3anJHfcwwy_xHdZvKfAlN-Tm0zcr0VDWWQQ",
-        "iv": "HoItFt7mAhynMZpG",
+        "value": "LdcracKtfQDnDaJ6IKe50AOLURFVUPTEnEUno6Joxlto6b_HxnexpWNJcgSlB1g9aXtbFQEbfVwMEMprO-5VHl5bXpfaeKLmI1BlnfRpjM_kp2r1b2VOBY7ZDL4mhq6UfUC_sG434zEx6e-TlgU9YQiybQCSbo65IzSy7Hxtr08OwCCosPbwYqFVFdP1Bxh64jDiNclBxOq4TS1jVuOjIn7XGW2R3-8Lcj4ACzOnOUZWG8isTAbaI1R-C6UjjVNtlLDFwUmAYFk",
+        "iv": "E-nyaCvXm5Y_Ex3L",
         "aad": "dGVzdA",
-        "tag": "7xgHMYkmbkdScy9YZY1XwA"
+        "tag": "7JRYbOIbmOeRnUF2omyOew"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -496,18 +498,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256GCM",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3/encrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db/encrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -515,7 +517,7 @@
         "Connection": "keep-alive",
         "Content-Length": "347",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
@@ -532,33 +534,32 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBC",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "358",
+        "Content-Length": "341",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -569,18 +570,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256CBC",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQAAAAAAAAAAA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3/encrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db/encrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -588,7 +589,7 @@
         "Connection": "keep-alive",
         "Content-Length": "350",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
@@ -605,33 +606,32 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "0"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -642,13 +642,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/7e4a3daae7e24ef691e34f9db1a98cc3",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt6af83333/ad07dd3dc2120fb300e985b71dc271db",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_local[7.2_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_local[7.2_mhsm].json
@@ -9,7 +9,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -33,7 +33,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -43,16 +43,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:28 GMT",
+        "Date": "Fri, 17 Jun 2022 23:46:00 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:28 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBgAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:46:01 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - NCUS ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -130,8 +130,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBgAAADIJP9oOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -141,16 +141,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:28 GMT",
+        "Date": "Fri, 17 Jun 2022 23:46:00 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:28 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBgAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:46:01 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - NCUS ProdSlices",
+        "x-ms-ests-server": "2.1.12851.7 - WUS2 ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -209,7 +209,7 @@
         "Connection": "keep-alive",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -232,18 +232,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "187"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "216"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650642509,
+          "created": 1655509561,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650642509
+          "updated": 1655509561
         },
         "key": {
           "key_ops": [
@@ -252,7 +252,7 @@
             "unwrapKey",
             "wrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34a730b0/68333332075f4fcd8902a47c8d7f01e2",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34a730b0/fd080ac4c2c406002019757894b7c945",
           "kty": "oct-HSM"
         }
       }
@@ -264,7 +264,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -274,16 +274,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:29 GMT",
+        "Date": "Fri, 17 Jun 2022 23:46:01 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:29 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBwAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:46:01 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - WUS2 ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - NCUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -361,8 +361,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBwAAADIJP9oOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -372,16 +372,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:29 GMT",
+        "Date": "Fri, 17 Jun 2022 23:46:01 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:29 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBwAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:46:01 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - SCUS ProdSlices",
+        "x-ms-ests-server": "2.1.12890.7 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -432,21 +432,20 @@
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34a730b0/68333332075f4fcd8902a47c8d7f01e2/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34a730b0/fd080ac4c2c406002019757894b7c945/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -457,13 +456,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "56"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "60"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34a730b0/68333332075f4fcd8902a47c8d7f01e2",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34a730b0/fd080ac4c2c406002019757894b7c945",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_local[7.3_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.pyTestCryptoClienttest_symmetric_encrypt_local[7.3_mhsm].json
@@ -9,7 +9,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -22,7 +22,7 @@
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-server-latency": "0"
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": null
     },
@@ -33,7 +33,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -43,16 +43,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:26 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:58 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:27 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBAAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:59 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - NCUS ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - NCUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -130,8 +130,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBAAAADIJP9oOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -141,16 +141,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:27 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:58 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:27 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBAAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:45:59 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - WUS2 ProdSlices",
+        "x-ms-ests-server": "2.1.12851.7 - SCUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -209,7 +209,7 @@
         "Connection": "keep-alive",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -232,27 +232,27 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "522"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "302"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650642507,
+          "created": 1655509559,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650642507
+          "updated": 1655509559
         },
         "key": {
           "key_ops": [
             "encrypt",
             "decrypt",
-            "unwrapKey",
-            "wrapKey"
+            "wrapKey",
+            "unwrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34b530b1/e17931c034c409a6bcee0541531e5698",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34b530b1/df405aae244a0a8e9a3248cee9db937d",
           "kty": "oct-HSM"
         }
       }
@@ -264,7 +264,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -274,16 +274,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:27 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:59 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:28 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBQAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:46:00 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - EUS ProdSlices",
+        "x-ms-ests-server": "2.1.13006.6 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -361,8 +361,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.10.0b2 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBQAAADIJP9oOAAAA; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -372,16 +372,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 22 Apr 2022 15:48:27 GMT",
+        "Date": "Fri, 17 Jun 2022 23:45:59 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=AoYECHYVsYZBnicRrY_2H34hRuoAFAAAABTF9NkOAAAA; expires=Sun, 22-May-2022 15:48:28 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AsGfAVlNHCxLgpkjl-uL_NOiNiroBQAAADIJP9oOAAAA; expires=Sun, 17-Jul-2022 23:46:00 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.12651.7 - SCUS ProdSlices",
+        "x-ms-ests-server": "2.1.12890.7 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -432,21 +432,20 @@
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34b530b1/e17931c034c409a6bcee0541531e5698/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34b530b1/df405aae244a0a8e9a3248cee9db937d/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -457,13 +456,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "88"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "65"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34b530b1/e17931c034c409a6bcee0541531e5698",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt34b530b1/df405aae244a0a8e9a3248cee9db937d",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.2_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.2_mhsm].json
@@ -8,7 +8,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -33,7 +33,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -56,40 +56,40 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "278"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "210"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650656823,
+          "created": 1655509564,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650656823
+          "updated": 1655509564
         },
         "key": {
           "key_ops": [
             "encrypt",
             "decrypt",
-            "wrapKey",
-            "unwrapKey"
+            "unwrapKey",
+            "wrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7",
           "kty": "oct-HSM"
         }
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10/encrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7/encrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "315",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
@@ -105,35 +105,35 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "100"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "64"
       },
       "ResponseBody": {
         "aad": "dGVzdA",
         "alg": "A256GCM",
-        "iv": "DficyOBBle6JjUoB",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10",
-        "tag": "6OXsgB2POQhH1k07hgmNKQ",
-        "value": "alfvc2Ps_6i8iX89gqFGGLB2sghkphUtZjVfrIxOUFMF7u1UzzudpRFSlbFIT3F4APJSFqaoonX6UzpR1uB9ZmZ8PSVmxcxQKiQ_qjZIE5JAi7t79fgMZhFyXYwDFJ5ypR3UKds8Gz1JwvgwcbMaROKe8bDoZXl-9-M0FwWrxb-7guP_XX2lE62ApFrpl9qiA5eli6h7DYEAnCtyy-2c1gp3ifYy5Qr5hIBGlhahLB_z-k2jW76a1oPShmpFrtMfoiHiBUYyKhg"
+        "iv": "A2j5xrg3LkT6wBEi",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7",
+        "tag": "lhD5_Fvzw2z-Hx0eoL2bsg",
+        "value": "Ecu75REp3e2u6bJzK656MpU9-TWJ5882mqea5KpdIIYyI2YdYCAR_CJgghBX04-jCUswvaBhzVVR6WL0sshFOPZ4VwNhCn-G0TGNGgWiv1APF7vbSEvpTBkUfdjcOYgbc9xbs0g30_UWih4C6OkpaLpYNILYXbj4De9HbXlsw-4j65nN0mu5R8h16LJuzidvqB4kBegA-HKeqDsti1Ak7uKLA2PZOH9-TA-UtrEDal4lhbAZc1BlXl4YTcth16alKK_q9DDmuYE"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "374",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
-        "value": "alfvc2Ps_6i8iX89gqFGGLB2sghkphUtZjVfrIxOUFMF7u1UzzudpRFSlbFIT3F4APJSFqaoonX6UzpR1uB9ZmZ8PSVmxcxQKiQ_qjZIE5JAi7t79fgMZhFyXYwDFJ5ypR3UKds8Gz1JwvgwcbMaROKe8bDoZXl-9-M0FwWrxb-7guP_XX2lE62ApFrpl9qiA5eli6h7DYEAnCtyy-2c1gp3ifYy5Qr5hIBGlhahLB_z-k2jW76a1oPShmpFrtMfoiHiBUYyKhg",
-        "iv": "DficyOBBle6JjUoB",
+        "value": "Ecu75REp3e2u6bJzK656MpU9-TWJ5882mqea5KpdIIYyI2YdYCAR_CJgghBX04-jCUswvaBhzVVR6WL0sshFOPZ4VwNhCn-G0TGNGgWiv1APF7vbSEvpTBkUfdjcOYgbc9xbs0g30_UWih4C6OkpaLpYNILYXbj4De9HbXlsw-4j65nN0mu5R8h16LJuzidvqB4kBegA-HKeqDsti1Ak7uKLA2PZOH9-TA-UtrEDal4lhbAZc1BlXl4YTcth16alKK_q9DDmuYE",
+        "iv": "A2j5xrg3LkT6wBEi",
         "aad": "dGVzdA",
-        "tag": "6OXsgB2POQhH1k07hgmNKQ"
+        "tag": "lhD5_Fvzw2z-Hx0eoL2bsg"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -144,25 +144,25 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "1"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256GCM",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10/encrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7/encrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "347",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
@@ -179,32 +179,31 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "1"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBC",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "358",
+        "Content-Length": "341",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -215,25 +214,25 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "1"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBC",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQAAAAAAAAAAA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10/encrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7/encrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "350",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
@@ -250,32 +249,31 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "0"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -286,13 +284,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "1"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/992571f058cb46ce99cb9950cefedd10",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb57a35af/9984a5af291c49470ee34f61afb70ed7",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.3_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_and_decrypt[7.3_mhsm].json
@@ -8,7 +8,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -33,7 +33,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -56,18 +56,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "290"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "285"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650656821,
+          "created": 1655509562,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650656821
+          "updated": 1655509562
         },
         "key": {
           "key_ops": [
@@ -76,20 +76,20 @@
             "wrapKey",
             "unwrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb",
           "kty": "oct-HSM"
         }
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120/encrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb/encrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "315",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
@@ -105,35 +105,35 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "111"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "58"
       },
       "ResponseBody": {
         "aad": "dGVzdA",
         "alg": "A256GCM",
-        "iv": "xSDJ_Pd7UPmh0E3D",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120",
-        "tag": "JtjLQbH5ktFq5QdRCfz90Q",
-        "value": "9Xokmv_gzFTuJGw_fLGPeDkbrEVJhS8ZjxFC_ME_xjRwxVXx6d-cBxL9lJEP5rqyyIiY_e-LYU-XLzhP1OR8WSP4qX-K7xcuSuq0qD2_w1AaOvGTXYsWEr1IEFNlxAvslJ0mpo0KT9ypMDmBcRaQid4304U4UD9b-vELgsH9gdEUyb-7ZcAEmxo20jK56RsT7iekjTDp94_M_ZaHjpcY6TcyUc7cmJdgVBEdpXAvY2Bc-_YlNfc7utPAB6UyZ4p8ELWJtyF7XMs"
+        "iv": "Y0ryQDBjcDPSsTNE",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb",
+        "tag": "xTr5iU9Li8jtCfInxOqMUA",
+        "value": "LChLFaz3IEKprJOwb352M9JrHKIPdorKNR-_L_qTfuxRuyKv1MGOE51Agk-e2F1idIA2y07lmcSQAGI8Fc7F0XezixRja43lQhudObmAdXOkom-OCcGhPV7corrfUh1aTaXg63d1Uz9BMp8xqyShmy7zF01HRko737NfJzmpwegFWO_IAkvWA2h8EN5Jzqr_gtGD3MPb-I6teL9VC9jphNtmfKKIFyc7vbafUwQlJdmOiQG8CkI43lK6DTN_N8E-LFzIlhmWNl4"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "374",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256GCM",
-        "value": "9Xokmv_gzFTuJGw_fLGPeDkbrEVJhS8ZjxFC_ME_xjRwxVXx6d-cBxL9lJEP5rqyyIiY_e-LYU-XLzhP1OR8WSP4qX-K7xcuSuq0qD2_w1AaOvGTXYsWEr1IEFNlxAvslJ0mpo0KT9ypMDmBcRaQid4304U4UD9b-vELgsH9gdEUyb-7ZcAEmxo20jK56RsT7iekjTDp94_M_ZaHjpcY6TcyUc7cmJdgVBEdpXAvY2Bc-_YlNfc7utPAB6UyZ4p8ELWJtyF7XMs",
-        "iv": "xSDJ_Pd7UPmh0E3D",
+        "value": "LChLFaz3IEKprJOwb352M9JrHKIPdorKNR-_L_qTfuxRuyKv1MGOE51Agk-e2F1idIA2y07lmcSQAGI8Fc7F0XezixRja43lQhudObmAdXOkom-OCcGhPV7corrfUh1aTaXg63d1Uz9BMp8xqyShmy7zF01HRko737NfJzmpwegFWO_IAkvWA2h8EN5Jzqr_gtGD3MPb-I6teL9VC9jphNtmfKKIFyc7vbafUwQlJdmOiQG8CkI43lK6DTN_N8E-LFzIlhmWNl4",
+        "iv": "Y0ryQDBjcDPSsTNE",
         "aad": "dGVzdA",
-        "tag": "JtjLQbH5ktFq5QdRCfz90Q"
+        "tag": "xTr5iU9Li8jtCfInxOqMUA"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -144,25 +144,25 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "0"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256GCM",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120/encrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb/encrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "347",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
@@ -179,32 +179,31 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256CBC",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "358",
+        "Content-Length": "341",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBC",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCJfUmfl8S8IDlUyQKOpqmtA",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -215,25 +214,25 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "1"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBC",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQAAAAAAAAAAA"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120/encrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb/encrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "350",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
@@ -250,32 +249,31 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "1"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
         "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg"
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -286,13 +284,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/4f4db0e0f01201e38b2c92c4832dd120",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encryptb58835b0/3794d7a2ee7c46a1813225f66d593dfb",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_local[7.2_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_local[7.2_mhsm].json
@@ -8,7 +8,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -33,7 +33,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -56,18 +56,18 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "194"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "203"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650657236,
+          "created": 1655509567,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650657236
+          "updated": 1655509567
         },
         "key": {
           "key_ops": [
@@ -76,26 +76,25 @@
             "unwrapKey",
             "wrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7049332d/225ab81b265a0518012417dd3cb77320",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7049332d/3cb3698fa9f10f9b0843fa99ff8d38cb",
           "kty": "oct-HSM"
         }
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7049332d/225ab81b265a0518012417dd3cb77320/decrypt?api-version=7.2",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7049332d/3cb3698fa9f10f9b0843fa99ff8d38cb/decrypt?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -106,13 +105,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "89"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "59"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7049332d/225ab81b265a0518012417dd3cb77320",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7049332d/3cb3698fa9f10f9b0843fa99ff8d38cb",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_local[7.3_mhsm].json
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.pyTestCryptoClienttest_symmetric_encrypt_local[7.3_mhsm].json
@@ -8,7 +8,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -21,7 +21,7 @@
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-server-latency": "0"
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": null
     },
@@ -33,7 +33,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "138",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "key": {
@@ -56,46 +56,45 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "193"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "266"
       },
       "ResponseBody": {
         "attributes": {
-          "created": 1650657235,
+          "created": 1655509566,
           "enabled": true,
           "exportable": false,
           "recoverableDays": 7,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
-          "updated": 1650657235
+          "updated": 1655509566
         },
         "key": {
           "key_ops": [
             "encrypt",
             "decrypt",
-            "unwrapKey",
-            "wrapKey"
+            "wrapKey",
+            "unwrapKey"
           ],
-          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7057332e/294e7db2511240cc10eb501e2e7f4951",
+          "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7057332e/c537ac51004905bc82b9cc70a62f2a0c",
           "kty": "oct-HSM"
         }
       }
     },
     {
-      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7057332e/294e7db2511240cc10eb501e2e7f4951/decrypt?api-version=7.3",
+      "RequestUri": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7057332e/c537ac51004905bc82b9cc70a62f2a0c/decrypt?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "361",
+        "Content-Length": "344",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-keyvault-keys/4.5.1 Python/3.9.9 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-keyvault-keys/4.6.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "alg": "A256CBCPAD",
         "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
-        "iv": "ibitv7BzReNZiTKgnFF0QQ",
-        "aad": "dGVzdA"
+        "iv": "ibitv7BzReNZiTKgnFF0QQ"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -106,13 +105,13 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.232.137.144;act_addr_fam=Ipv4;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-server-latency": "101"
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "canadacentral",
+        "x-ms-server-latency": "58"
       },
       "ResponseBody": {
         "alg": "A256CBCPAD",
-        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7057332e/294e7db2511240cc10eb501e2e7f4951",
+        "kid": "https://managedhsmvaultname.vault.azure.net/keys/livekvtestsymmetric-encrypt7057332e/c537ac51004905bc82b9cc70a62f2a0c",
         "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"
       }
     }

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -266,7 +266,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
                         encrypt_result.algorithm,
                         encrypt_result.ciphertext,
                         iv=encrypt_result.iv,
-                        additional_authenticated_data=None if algorithm.endswith("CBC") else self.aad
+                        additional_authenticated_data=None if "CBC" in algorithm else self.aad
                     )
 
                 assert decrypt_result.key_id == imported_key.id

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -266,7 +266,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
                         encrypt_result.algorithm,
                         encrypt_result.ciphertext,
                         iv=encrypt_result.iv,
-                        additional_authenticated_data=self.aad
+                        additional_authenticated_data=None if algorithm.endswith("CBC") else self.aad
                     )
 
                 assert decrypt_result.key_id == imported_key.id

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -352,7 +352,6 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
             encrypt_result.algorithm,
             encrypt_result.ciphertext,
             iv=encrypt_result.iv,
-            additional_authenticated_data=self.aad
         )
 
         assert decrypt_result.key_id == imported_key.id

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -268,7 +268,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
                         result.algorithm,
                         result.ciphertext,
                         iv=self.iv,
-                        additional_authenticated_data=None if algorithm.endswith("CBC") else self.aad
+                        additional_authenticated_data=None if "CBC" in algorithm else self.aad
                     )
 
                 assert result.key_id == imported_key.id

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -265,7 +265,10 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
                     )
                     assert result.key_id == imported_key.id
                     result = await crypto_client.decrypt(
-                        result.algorithm, result.ciphertext, iv=self.iv, additional_authenticated_data=self.aad
+                        result.algorithm,
+                        result.ciphertext,
+                        iv=self.iv,
+                        additional_authenticated_data=None if algorithm.endswith("CBC") else self.aad
                     )
 
                 assert result.key_id == imported_key.id

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -358,7 +358,6 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
             encrypt_result.algorithm,
             encrypt_result.ciphertext,
             iv=encrypt_result.iv,
-            additional_authenticated_data=self.aad
         )
 
         assert decrypt_result.key_id == imported_key.id


### PR DESCRIPTION
# Description

We recently started seeing live test pipeline failures like [this example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1641145&view=ms.vss-test-web.build-test-results-tab&runId=32532536&resultId=100079&paneView=debug) when testing symmetric encryption. It seems that a service behavior change is causing AES-CBC and AES-CBCPAD decryption to raise an error when additional authenticated data is provided.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
