### PR TITLE
Add azure monitor opentelemetry distro

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-distro/LICENSE
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/MANIFEST.in
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/MANIFEST.in
@@ -1,0 +1,6 @@
+include *.md
+include azure/__init__.py
+include azure/monitor/__init__.py
+include azure/monitor/opentelemetry/__init__.py
+include LICENSE
+recursive-include tests *.py

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/README.md
@@ -1,0 +1,27 @@
+# Azure Monitor Opentelemetry Distro
+
+[![Gitter chat](https://img.shields.io/gitter/room/Microsoft/azure-monitor-python)](https://gitter.im/Azure/azure-sdk-for-python)
+
+Azure Monitor Distro of [Opentelemetry Python][opentelemetry-python] provides multiple installable components available for an Opentelemetry Azure Monitor monitoring solution. It allows you to instrument your Python applications to capture and report telemetry to Azure Monitor via the Azure monitor exporters.
+
+This distro automatically installs the following libraries:
+
+* [Azure Monitor OpenTelemetry exporters][azure_monitor_opentelemetry_exporters]
+
+## Install the package
+
+Install the Azure Monitor Opentelemetry Distro with [pip][pip]:
+
+```Bash
+pip install azure-monitor-opentelemetry-distro --pre
+```
+
+### Additional documentation
+
+[Azure Portal][azure_portal]
+
+<!-- LINKS -->
+[azure_monitor_opentelemetry_exporters]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter#microsoft-opentelemetry-exporter-for-azure-monitor
+[azure_portal]: https://portal.azure.com
+[pip]: https://pypi.org/project/pip/
+[opentelemetry-python]: https://github.com/open-telemetry/opentelemetry-python

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/azure/__init__.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/azure/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/__init__.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__) # type: ignore

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/__init__.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/_version.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/_version.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+VERSION = "1.0.0b7"

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/mypy.ini
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.6
+warn_return_any = True
+warn_unused_configs = True
+ignore_missing_imports = True

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/sdk_packaging.toml
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/sdk_packaging.toml
@@ -1,0 +1,2 @@
+[packaging]
+auto_update = false

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/setup.cfg
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/setup.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+
+import os
+import re
+
+from setuptools import setup, find_packages
+
+
+# Change the PACKAGE_NAME only to change folder and different name
+PACKAGE_NAME = "azure-monitor-opentelemetry-distro"
+PACKAGE_PPRINT_NAME = "Azure Monitor Opentelemetry Distro"
+
+# a-b-c => a/b/c
+package_folder_path = PACKAGE_NAME.replace('-', '/')
+
+
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
+# Version extraction inspired from 'requests'
+with open(os.path.join(package_folder_path, '_version.py'), 'r') as fd:
+    version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
+
+if not version:
+    raise RuntimeError('Cannot find version information')
+
+setup(
+    name=PACKAGE_NAME,
+    version=version,
+    description='Microsoft {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
+    long_description=open('README.md', 'r').read(),
+    long_description_content_type='text/markdown',
+    license='MIT License',
+    author='Microsoft Corporation',
+    author_email='ascl@microsoft.com',
+    url='https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter',
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'License :: OSI Approved :: MIT License',
+    ],
+    zip_safe=False,
+    packages=find_packages(exclude=[
+        'tests',
+        # Exclude packages that will be covered by PEP420 or nspkg
+        'azure',
+        'azure.monitor',
+        'azure.monitor.opentelemetry'
+    ]),
+    include_package_data=True,
+    package_data={
+        'pytyped': ['py.typed'],
+    },
+    python_requires=">=3.6.0",
+    install_requires=[
+        "azure-monitor-opentelemetry-exporter == 1.0.0b7"
+    ],
+)
+

--- a/sdk/monitor/azure-monitor-opentelemetry-distro/tests/test_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-distro/tests/test_exporter.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import unittest
+from azure.monitor.opentelemetry.exporter import (
+    AzureMonitorMetricExporter,
+    AzureMonitorLogExporter,
+    AzureMonitorTraceExporter,
+)
+
+class TestAzureMonitorExporters(unittest.TestCase):
+    def test_constructors(self):
+        for exporter in [
+            AzureMonitorMetricExporter,
+            AzureMonitorLogExporter,
+            AzureMonitorTraceExporter,
+        ]:
+            try:
+                exporter()
+            except Exception:  # pylint: disable=broad-except
+                self.fail(
+                    f"Unexpected exception raised when instantiating {exporter.__name__}"
+                )

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -1,4 +1,4 @@
-# Microsoft Opentelemetry exporter for Azure Monitor
+# Azure Monitor Opentelemetry Exporters
 
 [![Gitter chat](https://img.shields.io/gitter/room/Microsoft/azure-monitor-python)](https://gitter.im/Azure/azure-sdk-for-python)
 
@@ -10,7 +10,7 @@ The exporter for Azure Monitor allows you to export data utilizing the OpenTelem
 
 ### Install the package
 
-Install the Microsoft Opentelemetry exporter for Azure Monitor with [pip][pip]:
+Install the Azure Monitor Opentelemetry Exporters with [pip][pip]:
 
 ```Bash
 pip install azure-monitor-opentelemetry-exporter --pre


### PR DESCRIPTION
Distro is a convenience package that will install azure monitor related components for monitoring solution.