### PR TITLE
[Storage] Make lease duration tests less flakey

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1530,7 +1530,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         lease = blob.acquire_lease(lease_duration=15)
         resp = blob.upload_blob(b'hello 2', length=7, lease=lease)
-        self.sleep(15)
+        self.sleep(17)
 
         # Assert
         with self.assertRaises(HttpResponseError):

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -1710,7 +1710,7 @@ class StorageCommonBlobAsyncTest(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         lease = await blob.acquire_lease(lease_duration=15)
         resp = await blob.upload_blob(b'hello 2', length=7, lease=lease)
-        self.sleep(15)
+        self.sleep(17)
 
         # Assert
         with self.assertRaises(HttpResponseError):

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -751,7 +751,7 @@ class StorageContainerTest(StorageTestCase):
         # Assert
         with self.assertRaises(HttpResponseError):
             container.acquire_lease()
-        self.sleep(15)
+        self.sleep(17)
         container.acquire_lease()
 
     @BlobPreparer()

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -844,7 +844,7 @@ class StorageContainerAsyncTest(AsyncStorageTestCase):
         # Assert
         with self.assertRaises(HttpResponseError):
             await container.acquire_lease()
-        self.sleep(15)
+        self.sleep(17)
         await container.acquire_lease()
 
     @BlobPreparer()

--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -259,7 +259,7 @@ class StorageShareTest(StorageTestCase):
         # Assert
         with self.assertRaises(HttpResponseError):
             share_client.acquire_lease()
-        self.sleep(15)
+        self.sleep(17)
         share_client.acquire_lease()
 
     @FileSharePreparer()

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -274,7 +274,7 @@ class StorageShareTest(AsyncStorageTestCase):
         # Assert
         with self.assertRaises(HttpResponseError):
             await share_client.acquire_lease()
-        self.sleep(15)
+        self.sleep(17)
         await share_client.acquire_lease()
 
     @FileSharePreparer()


### PR DESCRIPTION
This change aims to make some tests that rely on a lease expiring less flaky by slightly increasing the sleep time that is used to wait for the lease to expire. Previously the sleep time was exactly equal to the lease duration which meant sometimes the lease would not expire in time during pipeline execution (likely due to clock skew and other timing issues). This change just adds a 2 second buffer to ensure there is enough time for the lease to expire.