### PR TITLE
fix type of _SansIOHTTPPolicyRunner

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed the bug that azure-core could not be imported under Python 3.11.0b3  #24928
+
 ### Other Changes
 
 ## 1.24.1 (2022-06-01)

--- a/sdk/core/azure-core/azure/core/pipeline/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base.py
@@ -43,7 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 PoliciesType = List[Union[HTTPPolicy, SansIOHTTPPolicy]]
 
 
-class _SansIOHTTPPolicyRunner(HTTPPolicy, Generic[HTTPRequestType, HTTPResponseType]):
+class _SansIOHTTPPolicyRunner(HTTPPolicy):
     """Sync implementation of the SansIO policy.
 
     Modifies the request and sends to the next policy in the chain.


### PR DESCRIPTION
We have 

class HTTPPolicy(ABC, Generic[HTTPRequestType, HTTPResponseType]) and 

class _SansIOHTTPPolicyRunner(HTTPPolicy, Generic[HTTPRequestType, HTTPResponseType]):

Python starts to complain such double inheritance since 3.11.0b3.