### PR TITLE
Revert "Override live test location default to westus"

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -55,14 +55,8 @@ parameters:
     default:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-        # TODO: Migrate location override into azure-sdk-tools eng/common
-        # See https://github.com/Azure/azure-sdk-tools/issues/3398
-        Location: 'westus'
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        # TODO: Migrate location override into azure-sdk-tools eng/common
-        # See https://github.com/Azure/azure-sdk-tools/issues/3398
-        Location: 'westus'
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#24684