### PR TITLE
[Storage] Add base test classes that support the test proxy

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/storage/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/__init__.py
@@ -1,6 +1,13 @@
 from .api_version_policy import ApiVersionAssertPolicy
 from .service_versions import service_version_map, ServiceVersion, is_version_before
-from .testcase import StorageTestCase, LogCaptured
+from .testcase import StorageTestCase, StorageRecordedTestCase, LogCaptured
 
-__all__ = ["ApiVersionAssertPolicy", "service_version_map", "StorageTestCase", "ServiceVersion", "is_version_before",
-           "LogCaptured"]
+__all__ = [
+    "ApiVersionAssertPolicy",
+    "service_version_map",
+    "StorageTestCase",
+    "StorageRecordedTestCase",
+    "ServiceVersion",
+    "is_version_before",
+    "LogCaptured"
+]

--- a/tools/azure-sdk-tools/devtools_testutils/storage/aio/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/aio/__init__.py
@@ -1,3 +1,3 @@
-from .asynctestcase import AsyncStorageTestCase
+from .asynctestcase import AsyncStorageTestCase, AsyncStorageRecordedTestCase
 
-__all__ = ["AsyncStorageTestCase"]
+__all__ = ["AsyncStorageTestCase", "AsyncStorageRecordedTestCase"]

--- a/tools/azure-sdk-tools/devtools_testutils/storage/aio/asynctestcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/aio/asynctestcase.py
@@ -1,7 +1,7 @@
 import asyncio
 import functools
 
-from .. import StorageTestCase
+from .. import StorageTestCase, StorageRecordedTestCase
 from ...fake_credentials_async import AsyncFakeCredential
 
 from azure_devtools.scenario_tests.patches import mock_in_unit_test
@@ -40,6 +40,37 @@ class AsyncStorageTestCase(StorageTestCase):
         super().__init__(*args, **kwargs)
         self.replay_patches.append(patch_play_responses)
 
+    @staticmethod
+    def await_prepared_test(test_fn):
+        """Synchronous wrapper for async test methods. Used to avoid making changes
+        upstream to AbstractPreparer (which doesn't await the functions it wraps)
+        """
+
+        @functools.wraps(test_fn)
+        def run(test_class_instance, *args, **kwargs):
+            trim_kwargs_from_test_function(test_fn, kwargs)
+            loop = asyncio.get_event_loop()
+            return loop.run_until_complete(test_fn(test_class_instance, **kwargs))
+
+        return run
+
+    def generate_oauth_token(self):
+        if self.is_live:
+            from azure.identity.aio import ClientSecretCredential
+
+            return ClientSecretCredential(
+                self.get_settings_value("TENANT_ID"),
+                self.get_settings_value("CLIENT_ID"),
+                self.get_settings_value("CLIENT_SECRET"),
+            )
+        return self.generate_fake_token()
+
+    def generate_fake_token(self):
+        return AsyncFakeCredential()
+
+
+class AsyncStorageRecordedTestCase(StorageRecordedTestCase):
+    
     @staticmethod
     def await_prepared_test(test_fn):
         """Synchronous wrapper for async test methods. Used to avoid making changes


### PR DESCRIPTION
# Description

This adds two new test classes to `devtools_testutils` -- `AsyncStorageRecordedTestCase` and `StorageRecordedTestCase` -- that support the test proxy system. Migrated tests should inherit from these classes instead of `AsyncStorageTestCase` and `StorageTestCase`.

These classes currently use the `setup_class` method to set a `self.sas_token` attribute, to emulate the setup done in `test_blob_client(_async).py` today. However, this should be removed (if possible) once tests migrate to using `AzureRecordedTestCase`'s `generate_sas` method.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - These classes are used in the proof-of-concept Storage migration PR: https://github.com/Azure/azure-sdk-for-python/pull/24570
