### PR TITLE
[Core] Add authorization challenge parsing helper

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
@@ -25,7 +25,12 @@
 # --------------------------------------------------------------------------
 
 from ._base import HTTPPolicy, SansIOHTTPPolicy, RequestHistory
-from ._authentication import BearerTokenCredentialPolicy, AzureKeyCredentialPolicy, AzureSasCredentialPolicy
+from ._authentication import (
+    AuthorizationChallengeParser,
+    BearerTokenCredentialPolicy,
+    AzureKeyCredentialPolicy,
+    AzureSasCredentialPolicy,
+)
 from ._custom_hook import CustomHookPolicy
 from ._redirect import RedirectPolicy
 from ._retry import RetryPolicy, RetryMode
@@ -43,6 +48,7 @@ from ._universal import (
 __all__ = [
     'HTTPPolicy',
     'SansIOHTTPPolicy',
+    'AuthorizationChallengeParser',
     'BearerTokenCredentialPolicy',
     'AzureKeyCredentialPolicy',
     'AzureSasCredentialPolicy',


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/23613. This is a follow-up to https://github.com/Azure/azure-sdk-for-python/pull/24019, adjusting to feedback in https://github.com/Azure/azure-sdk/issues/4302. Instead of adding a new policy to handle authorization challenges, this PR follows other languages' lead in providing a helper class for parsing challenges (see [.NET's](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/Shared/AuthorizationChallengeParser.cs)), and leaves the implementation of `on_challenge` and/or custom `on_request` methods to `BearerTokenCredentialPolicy` subclasses.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
