### PR TITLE
[textanalytics] add custom named entities bespoke method

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `begin_recognize_custom_entities` client method to recognize custom named entities in documents.
+
 ### Breaking Changes
 
 - Removed the Extractive Text Summarization feature and related models: `ExtractSummaryAction`, `ExtractSummaryResult`, and `SummarySentence`. To access this beta feature, install the `5.2.0b4` version of the client library.

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
@@ -58,7 +58,7 @@ from ._models import (
     AnalyzeHealthcareEntitiesAction,
 )
 
-from ._lro import AnalyzeHealthcareEntitiesLROPoller, AnalyzeActionsLROPoller
+from ._lro import AnalyzeHealthcareEntitiesLROPoller, AnalyzeActionsLROPoller, TextAnalyticsLROPoller
 
 __all__ = [
     "TextAnalyticsApiVersion",
@@ -114,6 +114,7 @@ __all__ = [
     "ClassifyDocumentResult",
     "ClassificationCategory",
     "AnalyzeHealthcareEntitiesAction",
+    "TextAnalyticsLROPoller",
 ]
 
 __version__ = VERSION

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_lro.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_lro.py
@@ -7,7 +7,7 @@ import base64
 import functools
 import json
 import datetime
-from typing import Any, Optional
+from typing import Any, Optional, MutableMapping
 from urllib.parse import urlencode
 from azure.core.polling._poller import PollingReturnType
 from azure.core.exceptions import HttpResponseError
@@ -228,6 +228,9 @@ class AnalyzeHealthcareEntitiesLROPoller(LROPoller[PollingReturnType]):
         continuation_token: str,
         **kwargs: Any
     ) -> "AnalyzeHealthcareEntitiesLROPoller":  # type: ignore
+        """
+        :meta private:
+        """
         client, initial_response, deserialization_callback = polling_method.from_continuation_token(
             continuation_token, **kwargs
         )
@@ -457,6 +460,50 @@ class AnalyzeActionsLROPoller(LROPoller[PollingReturnType]):
         continuation_token: str,
         **kwargs: Any
     ) -> "AnalyzeActionsLROPoller":  # type: ignore
+        """
+        :meta private:
+        """
+        client, initial_response, deserialization_callback = polling_method.from_continuation_token(
+            continuation_token, **kwargs
+        )
+        polling_method._lro_algorithms = [  # pylint: disable=protected-access
+            TextAnalyticsOperationResourcePolling(
+                show_stats=initial_response.context.options["show_stats"]
+            )
+        ]
+        return cls(
+            client,
+            initial_response,
+            functools.partial(deserialization_callback, initial_response),
+            polling_method
+        )
+
+
+class TextAnalyticsLROPoller(LROPoller[PollingReturnType]):
+    def polling_method(self) -> AnalyzeActionsLROPollingMethod:
+        """Return the polling method associated to this poller."""
+        return self._polling_method  # type: ignore
+
+    @property
+    def details(self) -> MutableMapping[str, Any]:
+        return {
+            "id": self.polling_method().id,
+            "created_on": self.polling_method().created_on,
+            "expires_on": self.polling_method().expires_on,
+            "display_name": self.polling_method().display_name,
+            "last_modified_on": self.polling_method().last_modified_on,
+        }
+
+    @classmethod
+    def from_continuation_token(  # type: ignore
+        cls,
+        polling_method: AnalyzeActionsLROPollingMethod,
+        continuation_token: str,
+        **kwargs: Any
+    ) -> "TextAnalyticsLROPoller":  # type: ignore
+        """
+        :meta private:
+        """
         client, initial_response, deserialization_callback = polling_method.from_continuation_token(
             continuation_token, **kwargs
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
@@ -96,8 +96,8 @@ def order_lro_results(doc_id_order, combined):
 def prepare_result(func):
     def choose_wrapper(*args, **kwargs):
         def wrapper(
-            response, obj, response_headers, ordering_function
-        ):  # pylint: disable=unused-argument
+            response, obj, _, ordering_function
+        ):
             if hasattr(obj, "results"):
                 obj = obj.results  # language API compat
 
@@ -280,7 +280,7 @@ def classify_document_result(
 
 
 def healthcare_extract_page_data(
-    doc_id_order, obj, response_headers, health_job_state
+    doc_id_order, obj, health_job_state
 ):  # pylint: disable=unused-argument
     return (
         health_job_state.next_link,
@@ -289,7 +289,7 @@ def healthcare_extract_page_data(
             health_job_state.results
             if hasattr(health_job_state, "results")
             else health_job_state.tasks.items[0].results,
-            response_headers,
+            {},
             lro=True
         ),
     )
@@ -382,7 +382,7 @@ def get_ordered_errors(tasks_obj, task_name, doc_id_order):
     raise ValueError("Unexpected response from service - no errors for missing action results.")
 
 
-def _get_doc_results(task, doc_id_order, response_headers, returned_tasks_object):
+def _get_doc_results(task, doc_id_order, returned_tasks_object):
     returned_tasks = returned_tasks_object.tasks
     current_task_type, task_name = task
     deserialization_callback = _get_deserialization_callback_from_task_type(
@@ -401,18 +401,25 @@ def _get_doc_results(task, doc_id_order, response_headers, returned_tasks_object
     if response_task_to_deserialize.results is None:
         return get_ordered_errors(returned_tasks_object, task_name, doc_id_order)
     return deserialization_callback(
-        doc_id_order, response_task_to_deserialize.results, response_headers, lro=True
+        doc_id_order, response_task_to_deserialize.results, {}, lro=True
     )
 
 
-def get_iter_items(doc_id_order, task_order, response_headers, analyze_job_state):
+def get_iter_items(doc_id_order, task_order, bespoke, analyze_job_state):
     iter_items = defaultdict(list)  # map doc id to action results
     returned_tasks_object = analyze_job_state
+
+    if bespoke:
+        return _get_doc_results(
+            task_order[0],
+            doc_id_order,
+            returned_tasks_object,
+        )
+
     for task in task_order:
         results = _get_doc_results(
             task,
             doc_id_order,
-            response_headers,
             returned_tasks_object,
         )
         for result in results:
@@ -422,11 +429,11 @@ def get_iter_items(doc_id_order, task_order, response_headers, analyze_job_state
 
 
 def analyze_extract_page_data(
-    doc_id_order, task_order, response_headers, analyze_job_state
+    doc_id_order, task_order, bespoke, analyze_job_state
 ):
     # return next link, list of
     iter_items = get_iter_items(
-        doc_id_order, task_order, response_headers, analyze_job_state
+        doc_id_order, task_order, bespoke, analyze_job_state
     )
     return analyze_job_state.next_link, iter_items
 
@@ -456,14 +463,14 @@ def lro_get_next_page(
 
 
 def healthcare_paged_result(
-    doc_id_order, health_status_callback, _, obj, response_headers, show_stats=False
-):  # pylint: disable=unused-argument
+    doc_id_order, health_status_callback, _, obj, show_stats=False
+):
     return ItemPaged(
         functools.partial(
             lro_get_next_page, health_status_callback, obj, show_stats=show_stats
         ),
         functools.partial(
-            healthcare_extract_page_data, doc_id_order, obj, response_headers
+            healthcare_extract_page_data, doc_id_order, obj
         ),
     )
 
@@ -474,14 +481,38 @@ def analyze_paged_result(
     analyze_status_callback,
     _,
     obj,
-    response_headers,
     show_stats=False,
-):  # pylint: disable=unused-argument
+    bespoke=False
+):
     return ItemPaged(
         functools.partial(
             lro_get_next_page, analyze_status_callback, obj, show_stats=show_stats
         ),
         functools.partial(
-            analyze_extract_page_data, doc_id_order, task_order, response_headers
+            analyze_extract_page_data, doc_id_order, task_order, bespoke
         ),
     )
+
+
+def _get_result_from_continuation_token(
+    client, continuation_token, poller_type, polling_method, callback, bespoke=False
+):
+    def result_callback(initial_response, pipeline_response):
+        doc_id_order = initial_response.context.options["doc_id_order"]
+        show_stats = initial_response.context.options["show_stats"]
+        task_id_order = initial_response.context.options.get("task_id_order")
+        return callback(
+            pipeline_response,
+            None,
+            doc_id_order,
+            task_id_order=task_id_order,
+            show_stats=show_stats,
+            bespoke=bespoke
+        )
+
+    return poller_type.from_continuation_token(
+            polling_method=polling_method,
+            client=client,
+            deserialization_callback=result_callback,
+            continuation_token=continuation_token
+        )

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -596,6 +596,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         except HttpResponseError as error:
             return process_http_response_error(error)
 
+    # pylint: disable=unused-argument
     def _healthcare_result_callback(
         self, raw_response, deserialized, doc_id_order, task_id_order=None, show_stats=False, bespoke=False
     ):
@@ -1297,6 +1298,66 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         deployment_name,
         **kwargs: Any,
     ) -> TextAnalyticsLROPoller[ItemPaged[Union[RecognizeCustomEntitiesResult, DocumentError]]]:
+        """Start a long-running custom named entity recognition operation.
+
+        For information on regional support of custom features and how to train a model to
+        recognize custom entities, see https://aka.ms/azsdk/textanalytics/customentityrecognition
+
+        :param documents: The set of documents to process as part of this batch.
+            If you wish to specify the ID and language on a per-item basis you must
+            use as input a list[:class:`~azure.ai.textanalytics.TextDocumentInput`] or a list of
+            dict representations of :class:`~azure.ai.textanalytics.TextDocumentInput`, like
+            `{"id": "1", "language": "en", "text": "hello world"}`.
+        :type documents:
+            list[str] or list[~azure.ai.textanalytics.TextDocumentInput] or list[dict[str, str]]
+        :param str project_name: Required. This field indicates the project name for the model.
+        :param str deployment_name: This field indicates the deployment name for the model.
+        :keyword str language: The 2 letter ISO 639-1 representation of language for the
+            entire batch. For example, use "en" for English; "es" for Spanish etc.
+            If not set, uses "en" for English as default. Per-document language will
+            take precedence over whole batch language. See https://aka.ms/talangs for
+            supported languages in Language API.
+        :keyword bool show_stats: If set to true, response will contain document level statistics.
+        :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
+            logged on the service side for troubleshooting. By default, the Language service logs your
+            input text for 48 hours, solely to allow for troubleshooting issues in providing you with
+            the service's natural language processing functions. Setting this parameter to true,
+            disables input logging and may limit our ability to remediate issues that occur. Please see
+            Cognitive Services Compliance and Privacy notes at https://aka.ms/cs-compliance for
+            additional details, and Microsoft Responsible AI principles at
+            https://www.microsoft.com/ai/responsible-ai.
+        :keyword str string_index_type: Specifies the method used to interpret string offsets.
+            `UnicodeCodePoint`, the Python encoding, is the default. To override the Python default,
+            you can also pass in `Utf16CodeUnit` or `TextElement_v8`. For additional information
+            see https://aka.ms/text-analytics-offsets
+        :keyword int polling_interval: Waiting time between two polls for LRO operations
+            if no Retry-After header is present. Defaults to 5 seconds.
+        :keyword str continuation_token:
+            Call `continuation_token()` on the poller object to save the long-running operation (LRO)
+            state into an opaque token. Pass the value as the `continuation_token` keyword argument
+            to restart the LRO from a saved state.
+        :keyword str display_name: An optional display name to set for the requested analysis.
+        :return: An instance of an TextAnalyticsLROPoller. Call `result()` on the this
+            object to return a heterogeneous pageable of
+            :class:`~azure.ai.textanalytics.RecognizeCustomEntitiesResult` and
+            :class:`~azure.ai.textanalytics.DocumentError`.
+        :rtype:
+            ~azure.ai.textanalytics.TextAnalyticsLROPoller[~azure.core.paging.ItemPaged[
+            ~azure.ai.textanalytics.RecognizeCustomEntitiesResult or ~azure.ai.textanalytics.DocumentError]]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        .. versionadded:: 2022-05-01
+            The *begin_recognize_custom_entities* client method.
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_recognize_custom_entities.py
+                :start-after: [START recognize_custom_entities]
+                :end-before: [END recognize_custom_entities]
+                :language: python
+                :dedent: 4
+                :caption: Recognize custom entities in a batch of documents.
+        """
 
         continuation_token = kwargs.pop("continuation_token", None)
         string_index_type = kwargs.pop("string_index_type", self._string_index_type_default)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/__init__.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/__init__.py
@@ -7,10 +7,12 @@ from ._text_analytics_client_async import TextAnalyticsClient
 from ._lro_async import (
     AsyncAnalyzeHealthcareEntitiesLROPoller,
     AsyncAnalyzeActionsLROPoller,
+    AsyncTextAnalyticsLROPoller,
 )
 
 __all__ = [
     "TextAnalyticsClient",
     "AsyncAnalyzeHealthcareEntitiesLROPoller",
     "AsyncAnalyzeActionsLROPoller",
+    "AsyncTextAnalyticsLROPoller",
 ]

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_lro_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_lro_async.py
@@ -449,7 +449,7 @@ class AsyncAnalyzeActionsLROPoller(AsyncLROPoller[PollingReturnType]):
 
 
 class AsyncTextAnalyticsLROPoller(AsyncLROPoller[PollingReturnType]):
-    def polling_method(self) -> AsyncAnalyzeActionsLROPollingMethod:
+    def polling_method(self) -> AsyncAnalyzeActionsLROPollingMethod:  # type: ignore
         """Return the polling method associated to this poller."""
         return self._polling_method  # type: ignore
 
@@ -485,5 +485,5 @@ class AsyncTextAnalyticsLROPoller(AsyncLROPoller[PollingReturnType]):
             client,
             initial_response,
             functools.partial(deserialization_callback, initial_response),
-            polling_method
+            polling_method  # type: ignore
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_lro_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_lro_async.py
@@ -6,7 +6,7 @@ import datetime
 import base64
 import functools
 import json
-from typing import Optional, Any
+from typing import Optional, Any, MutableMapping
 from azure.core.exceptions import HttpResponseError
 from azure.core.polling import AsyncLROPoller
 from azure.core.polling.base_polling import OperationFailed, BadStatus
@@ -202,6 +202,9 @@ class AsyncAnalyzeHealthcareEntitiesLROPoller(AsyncLROPoller[PollingReturnType])
         continuation_token: str,
         **kwargs: Any
     ) -> "AsyncAnalyzeHealthcareEntitiesLROPoller":
+        """
+        :meta private:
+        """
         client, initial_response, deserialization_callback = polling_method.from_continuation_token(
             continuation_token, **kwargs
         )
@@ -426,6 +429,9 @@ class AsyncAnalyzeActionsLROPoller(AsyncLROPoller[PollingReturnType]):
         continuation_token: str,
         **kwargs: Any
     ) -> "AsyncAnalyzeActionsLROPoller":  # type: ignore
+        """
+        :meta private:
+        """
         client, initial_response, deserialization_callback = polling_method.from_continuation_token(
             continuation_token, **kwargs
         )
@@ -439,4 +445,45 @@ class AsyncAnalyzeActionsLROPoller(AsyncLROPoller[PollingReturnType]):
             initial_response,
             functools.partial(deserialization_callback, initial_response),
             polling_method  # type: ignore
+        )
+
+
+class AsyncTextAnalyticsLROPoller(AsyncLROPoller[PollingReturnType]):
+    def polling_method(self) -> AsyncAnalyzeActionsLROPollingMethod:
+        """Return the polling method associated to this poller."""
+        return self._polling_method  # type: ignore
+
+    @property
+    def details(self) -> MutableMapping[str, Any]:
+        return {
+            "id": self.polling_method().id,
+            "created_on": self.polling_method().created_on,
+            "expires_on": self.polling_method().expires_on,
+            "display_name": self.polling_method().display_name,
+            "last_modified_on": self.polling_method().last_modified_on,
+        }
+
+    @classmethod
+    def from_continuation_token(  # type: ignore
+        cls,
+        polling_method: AsyncAnalyzeActionsLROPollingMethod,
+        continuation_token: str,
+        **kwargs: Any
+    ) -> "AsyncTextAnalyticsLROPoller":  # type: ignore
+        """
+        :meta private:
+        """
+        client, initial_response, deserialization_callback = polling_method.from_continuation_token(
+            continuation_token, **kwargs
+        )
+        polling_method._lro_algorithms = [  # pylint: disable=protected-access
+            TextAnalyticsOperationResourcePolling(
+                show_stats=initial_response.context.options["show_stats"]
+            )
+        ]
+        return cls(
+            client,
+            initial_response,
+            functools.partial(deserialization_callback, initial_response),
+            polling_method
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_response_handlers_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_response_handlers_async.py
@@ -12,7 +12,7 @@ from .._response_handlers import healthcare_result, get_iter_items
 
 
 async def healthcare_extract_page_data_async(
-    doc_id_order, obj, response_headers, health_job_state
+    doc_id_order, obj, health_job_state
 ):  # pylint: disable=unused-argument
     return (
         health_job_state.next_link,
@@ -21,7 +21,7 @@ async def healthcare_extract_page_data_async(
             health_job_state.results
             if hasattr(health_job_state, "results")
             else health_job_state.tasks.items[0].results,
-            response_headers,
+            {},
             lro=True
         ),
     )
@@ -54,26 +54,25 @@ async def lro_get_next_page_async(
 def healthcare_paged_result(
     doc_id_order,
     health_status_callback,
-    response,
+    _,
     obj,
-    response_headers,
     show_stats=False,
-):  # pylint: disable=unused-argument
+):
     return AsyncItemPaged(
         functools.partial(
             lro_get_next_page_async, health_status_callback, obj, show_stats=show_stats
         ),
         functools.partial(
-            healthcare_extract_page_data_async, doc_id_order, obj, response_headers
+            healthcare_extract_page_data_async, doc_id_order, obj
         ),
     )
 
 
 async def analyze_extract_page_data_async(
-    doc_id_order, task_order, response_headers, analyze_job_state
+    doc_id_order, task_order, bespoke, analyze_job_state
 ):
     iter_items = get_iter_items(
-        doc_id_order, task_order, response_headers, analyze_job_state
+        doc_id_order, task_order, bespoke, analyze_job_state
     )
     return analyze_job_state.next_link, AsyncList(iter_items)
 
@@ -82,14 +81,14 @@ def analyze_paged_result(
     doc_id_order,
     task_order,
     analyze_status_callback,
-    response,  # pylint: disable=unused-argument
+    _,
     obj,
-    response_headers,
-    show_stats=False,  # pylint: disable=unused-argument
+    show_stats=False,
+    bespoke=False
 ):
     return AsyncItemPaged(
         functools.partial(lro_get_next_page_async, analyze_status_callback, obj, show_stats=show_stats),
         functools.partial(
-            analyze_extract_page_data_async, doc_id_order, task_order, response_headers
+            analyze_extract_page_data_async, doc_id_order, task_order, bespoke
         ),
     )

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -813,6 +813,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         except HttpResponseError as error:
             return process_http_response_error(error)
 
+    # pylint: disable=unused-argument
     def _healthcare_result_callback(
         self, raw_response, deserialized, doc_id_order, task_id_order=None, show_stats=False, bespoke=False
     ):
@@ -1295,6 +1296,66 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         deployment_name: str,
         **kwargs: Any,
     ) -> AsyncTextAnalyticsLROPoller[AsyncItemPaged[Union[RecognizeCustomEntitiesResult, DocumentError]]]:
+        """Start a long-running custom named entity recognition operation.
+
+        For information on regional support of custom features and how to train a model to
+        recognize custom entities, see https://aka.ms/azsdk/textanalytics/customentityrecognition
+
+        :param documents: The set of documents to process as part of this batch.
+            If you wish to specify the ID and language on a per-item basis you must
+            use as input a list[:class:`~azure.ai.textanalytics.TextDocumentInput`] or a list of
+            dict representations of :class:`~azure.ai.textanalytics.TextDocumentInput`, like
+            `{"id": "1", "language": "en", "text": "hello world"}`.
+        :type documents:
+            list[str] or list[~azure.ai.textanalytics.TextDocumentInput] or list[dict[str, str]]
+        :param str project_name: Required. This field indicates the project name for the model.
+        :param str deployment_name: This field indicates the deployment name for the model.
+        :keyword str language: The 2 letter ISO 639-1 representation of language for the
+            entire batch. For example, use "en" for English; "es" for Spanish etc.
+            If not set, uses "en" for English as default. Per-document language will
+            take precedence over whole batch language. See https://aka.ms/talangs for
+            supported languages in Language API.
+        :keyword bool show_stats: If set to true, response will contain document level statistics.
+        :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
+            logged on the service side for troubleshooting. By default, the Language service logs your
+            input text for 48 hours, solely to allow for troubleshooting issues in providing you with
+            the service's natural language processing functions. Setting this parameter to true,
+            disables input logging and may limit our ability to remediate issues that occur. Please see
+            Cognitive Services Compliance and Privacy notes at https://aka.ms/cs-compliance for
+            additional details, and Microsoft Responsible AI principles at
+            https://www.microsoft.com/ai/responsible-ai.
+        :keyword str string_index_type: Specifies the method used to interpret string offsets.
+            `UnicodeCodePoint`, the Python encoding, is the default. To override the Python default,
+            you can also pass in `Utf16CodeUnit` or `TextElement_v8`. For additional information
+            see https://aka.ms/text-analytics-offsets
+        :keyword int polling_interval: Waiting time between two polls for LRO operations
+            if no Retry-After header is present. Defaults to 5 seconds.
+        :keyword str continuation_token:
+            Call `continuation_token()` on the poller object to save the long-running operation (LRO)
+            state into an opaque token. Pass the value as the `continuation_token` keyword argument
+            to restart the LRO from a saved state.
+        :keyword str display_name: An optional display name to set for the requested analysis.
+        :return: An instance of an AsyncTextAnalyticsLROPoller. Call `result()` on the this
+            object to return a heterogeneous pageable of
+            :class:`~azure.ai.textanalytics.RecognizeCustomEntitiesResult` and
+            :class:`~azure.ai.textanalytics.DocumentError`.
+        :rtype:
+            ~azure.ai.textanalytics.AsyncTextAnalyticsLROPoller[~azure.core.async_paging.AsyncItemPaged[
+            ~azure.ai.textanalytics.RecognizeCustomEntitiesResult or ~azure.ai.textanalytics.DocumentError]]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        .. versionadded:: 2022-05-01
+            The *begin_recognize_custom_entities* client method.
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_recognize_custom_entities_async.py
+                :start-after: [START recognize_custom_entities_async]
+                :end-before: [END recognize_custom_entities_async]
+                :language: python
+                :dedent: 4
+                :caption: Recognize custom entities in a batch of documents.
+        """
 
         continuation_token = kwargs.pop("continuation_token", None)
         string_index_type = kwargs.pop("string_index_type", self._string_code_unit)
@@ -1305,7 +1366,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             return cast(
                 AsyncTextAnalyticsLROPoller[AsyncItemPaged[Union[RecognizeCustomEntitiesResult, DocumentError]]],
                 _get_result_from_continuation_token(
-                    self._client._client,
+                    self._client._client,  # pylint: disable=protected-access
                     continuation_token,
                     AsyncTextAnalyticsLROPoller,
                     AsyncAnalyzeActionsLROPollingMethod(

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -1340,7 +1340,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             :class:`~azure.ai.textanalytics.RecognizeCustomEntitiesResult` and
             :class:`~azure.ai.textanalytics.DocumentError`.
         :rtype:
-            ~azure.ai.textanalytics.AsyncTextAnalyticsLROPoller[~azure.core.async_paging.AsyncItemPaged[
+            ~azure.ai.textanalytics.aio.AsyncTextAnalyticsLROPoller[~azure.core.async_paging.AsyncItemPaged[
             ~azure.ai.textanalytics.RecognizeCustomEntitiesResult or ~azure.ai.textanalytics.DocumentError]]
         :raises ~azure.core.exceptions.HttpResponseError:
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_custom_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_custom_entities_async.py
@@ -9,7 +9,7 @@ FILE: sample_recognize_custom_entities_async.py
 
 DESCRIPTION:
     This sample demonstrates how to recognize custom entities in documents.
-    Recognizing custom entities is available as an action type through the begin_analyze_actions API.
+    Recognizing custom entities is also available as an action type through the begin_analyze_actions API.
 
     For information on regional support of custom features and how to train a model to
     recognize custom entities, see https://aka.ms/azsdk/textanalytics/customentityrecognition
@@ -30,9 +30,9 @@ import asyncio
 
 
 async def sample_recognize_custom_entities_async():
+    # [START recognize_custom_entities_async]
     from azure.core.credentials import AzureKeyCredential
     from azure.ai.textanalytics.aio import TextAnalyticsClient
-    from azure.ai.textanalytics import RecognizeCustomEntitiesAction
 
     endpoint = os.environ["AZURE_LANGUAGE_ENDPOINT"]
     key = os.environ["AZURE_LANGUAGE_KEY"]
@@ -56,20 +56,15 @@ async def sample_recognize_custom_entities_async():
         document = [fd.read()]
 
     async with text_analytics_client:
-        poller = await text_analytics_client.begin_analyze_actions(
+        poller = await text_analytics_client.begin_recognize_custom_entities(
             document,
-            actions=[
-                RecognizeCustomEntitiesAction(
-                    project_name=project_name,
-                    deployment_name=deployment_name
-                ),
-            ],
+            project_name=project_name,
+            deployment_name=deployment_name
         )
 
         document_results = await poller.result()
 
-        async for result in document_results:
-            custom_entities_result = result[0]  # first document, first result
+        async for custom_entities_result in document_results:
             if not custom_entities_result.is_error:
                 for entity in custom_entities_result.entities:
                     print(
@@ -82,6 +77,7 @@ async def sample_recognize_custom_entities_async():
                     custom_entities_result.code, custom_entities_result.message
                     )
                 )
+    # [END recognize_custom_entities_async]
 
 
 async def main():

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_custom_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_custom_entities.py
@@ -9,7 +9,7 @@ FILE: sample_recognize_custom_entities.py
 
 DESCRIPTION:
     This sample demonstrates how to recognize custom entities in documents.
-    Recognizing custom entities is available as an action type through the begin_analyze_actions API.
+    Recognizing custom entities is also available as an action type through the begin_analyze_actions API.
 
     For information on regional support of custom features and how to train a model to
     recognize custom entities, see https://aka.ms/azsdk/textanalytics/customentityrecognition
@@ -29,11 +29,9 @@ import os
 
 
 def sample_recognize_custom_entities():
+    # [START recognize_custom_entities]
     from azure.core.credentials import AzureKeyCredential
-    from azure.ai.textanalytics import (
-        TextAnalyticsClient,
-        RecognizeCustomEntitiesAction,
-    )
+    from azure.ai.textanalytics import TextAnalyticsClient
 
     endpoint = os.environ["AZURE_LANGUAGE_ENDPOINT"]
     key = os.environ["AZURE_LANGUAGE_KEY"]
@@ -55,18 +53,14 @@ def sample_recognize_custom_entities():
     with open(path_to_sample_document) as fd:
         document = [fd.read()]
 
-    poller = text_analytics_client.begin_analyze_actions(
+    poller = text_analytics_client.begin_recognize_custom_entities(
         document,
-        actions=[
-            RecognizeCustomEntitiesAction(
-                project_name=project_name, deployment_name=deployment_name
-            ),
-        ],
+        project_name=project_name,
+        deployment_name=deployment_name
     )
 
     document_results = poller.result()
-    for result in document_results:
-        custom_entities_result = result[0]  # first document, first result
+    for custom_entities_result in document_results:
         if not custom_entities_result.is_error:
             for entity in custom_entities_result.entities:
                 print(
@@ -80,6 +74,7 @@ def sample_recognize_custom_entities():
                     custom_entities_result.code, custom_entities_result.message
                 )
             )
+    # [END recognize_custom_entities]
 
 
 if __name__ == "__main__":

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_custom_partial_error.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_custom_partial_error.json
@@ -56,18 +56,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "374b913f-2ae4-408a-85ec-efde94d2ddd9",
+        "apim-request-id": "eb890078-e5f3-4f53-a25b-3a421d95ab4b",
         "Content-Length": "0",
-        "Date": "Thu, 09 Jun 2022 22:01:48 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/e87b77fc-3fec-47b4-9338-d0f219f88ed9?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:12:25 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/64c0f660-257f-49c1-90d1-8dcd9e685501?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "446"
+        "x-envoy-upstream-service-time": "254"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/e87b77fc-3fec-47b4-9338-d0f219f88ed9?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/64c0f660-257f-49c1-90d1-8dcd9e685501?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -78,19 +78,19 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "28650259-901e-4ef1-848f-4ca4bb71e70b",
+        "apim-request-id": "4f721399-310e-4410-902e-8f0c72166e57",
         "Content-Length": "3705",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 09 Jun 2022 22:01:54 GMT",
+        "Date": "Thu, 23 Jun 2022 02:12:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "149"
+        "x-envoy-upstream-service-time": "92"
       },
       "ResponseBody": {
-        "jobId": "e87b77fc-3fec-47b4-9338-d0f219f88ed9",
-        "lastUpdatedDateTime": "2022-06-09T22:01:50Z",
-        "createdDateTime": "2022-06-09T22:01:49Z",
-        "expirationDateTime": "2022-06-10T22:01:49Z",
+        "jobId": "64c0f660-257f-49c1-90d1-8dcd9e685501",
+        "lastUpdatedDateTime": "2022-06-23T02:12:27Z",
+        "createdDateTime": "2022-06-23T02:12:26Z",
+        "expirationDateTime": "2022-06-24T02:12:26Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -102,7 +102,7 @@
             {
               "kind": "CustomSingleLabelClassificationLROResults",
               "taskName": "0",
-              "lastUpdateDateTime": "2022-06-09T22:01:50.1185336Z",
+              "lastUpdateDateTime": "2022-06-23T02:12:27.2425498Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -147,7 +147,7 @@
             {
               "kind": "CustomMultiLabelClassificationLROResults",
               "taskName": "1",
-              "lastUpdateDateTime": "2022-06-09T22:01:50.1850609Z",
+              "lastUpdateDateTime": "2022-06-23T02:12:26.8100679Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -187,7 +187,7 @@
             {
               "kind": "CustomEntityRecognitionLROResults",
               "taskName": "2",
-              "lastUpdateDateTime": "2022-06-09T22:01:49.8887865Z",
+              "lastUpdateDateTime": "2022-06-23T02:12:27.1032956Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_healthcare_action.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_healthcare_action.json
@@ -44,18 +44,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c5189649-e4cd-451f-94d3-11bdbcbf7aa6",
+        "apim-request-id": "7de36ce7-ee3c-478f-b47b-4059fd51b010",
         "Content-Length": "0",
-        "Date": "Thu, 09 Jun 2022 23:06:46 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/15bf7cf0-82c0-4406-8ecb-b7c67d57feea?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:12:46 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/b89699e5-70da-4fc8-86ec-44aeb7d37ee7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "174"
+        "x-envoy-upstream-service-time": "165"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/15bf7cf0-82c0-4406-8ecb-b7c67d57feea?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/b89699e5-70da-4fc8-86ec-44aeb7d37ee7?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -66,19 +66,19 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12bc3980-78fd-4666-9ffe-36816f408550",
+        "apim-request-id": "db6da350-f3fb-4cb3-8873-5d19aba8d49e",
         "Content-Length": "4712",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 09 Jun 2022 23:06:50 GMT",
+        "Date": "Thu, 23 Jun 2022 02:12:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "45"
+        "x-envoy-upstream-service-time": "69"
       },
       "ResponseBody": {
-        "jobId": "15bf7cf0-82c0-4406-8ecb-b7c67d57feea",
-        "lastUpdatedDateTime": "2022-06-09T23:06:47Z",
-        "createdDateTime": "2022-06-09T23:06:46Z",
-        "expirationDateTime": "2022-06-10T23:06:46Z",
+        "jobId": "b89699e5-70da-4fc8-86ec-44aeb7d37ee7",
+        "lastUpdatedDateTime": "2022-06-23T02:12:47Z",
+        "createdDateTime": "2022-06-23T02:12:46Z",
+        "expirationDateTime": "2022-06-24T02:12:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -90,7 +90,7 @@
             {
               "kind": "HealthcareLROResults",
               "taskName": "0",
-              "lastUpdateDateTime": "2022-06-09T23:06:47.7061603Z",
+              "lastUpdateDateTime": "2022-06-23T02:12:47.1308918Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_poller_metadata.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_poller_metadata.json
@@ -34,18 +34,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f875053d-8fdc-4ab2-b914-390bb531df60",
+        "apim-request-id": "eacdf7a6-a4e5-4f9f-a857-db70195b353a",
         "Content-Length": "0",
-        "Date": "Fri, 10 Jun 2022 16:41:21 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/d48152ac-452e-4c60-b86b-0ff755f44c4b?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:11:39 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/ca072c7d-0d74-44af-9bd6-b4fa9c9c416e?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "386"
+        "x-envoy-upstream-service-time": "130"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/d48152ac-452e-4c60-b86b-0ff755f44c4b?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/ca072c7d-0d74-44af-9bd6-b4fa9c9c416e?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -56,19 +56,19 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5ef6b071-95db-48f3-b38a-c91be3d041c2",
+        "apim-request-id": "e197e167-b37f-43e6-8617-7f7409a494ff",
         "Content-Length": "679",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 10 Jun 2022 16:41:27 GMT",
+        "Date": "Thu, 23 Jun 2022 02:11:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "43"
+        "x-envoy-upstream-service-time": "54"
       },
       "ResponseBody": {
-        "jobId": "d48152ac-452e-4c60-b86b-0ff755f44c4b",
-        "lastUpdatedDateTime": "2022-06-10T16:41:25Z",
-        "createdDateTime": "2022-06-10T16:41:22Z",
-        "expirationDateTime": "2022-06-11T16:41:22Z",
+        "jobId": "ca072c7d-0d74-44af-9bd6-b4fa9c9c416e",
+        "lastUpdatedDateTime": "2022-06-23T02:11:40Z",
+        "createdDateTime": "2022-06-23T02:11:39Z",
+        "expirationDateTime": "2022-06-24T02:11:39Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -80,7 +80,7 @@
             {
               "kind": "EntityRecognitionLROResults",
               "taskName": "0",
-              "lastUpdateDateTime": "2022-06-10T16:41:25.7474073Z",
+              "lastUpdateDateTime": "2022-06-23T02:11:40.8943502Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_single_category_classify.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze.pyTestAnalyzetest_single_category_classify.json
@@ -44,18 +44,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "dbf05e99-e5d9-44c7-901a-7e9580bcc458",
+        "apim-request-id": "daa0dfdb-74f9-41b6-97e5-7898293b9b11",
         "Content-Length": "0",
-        "Date": "Thu, 09 Jun 2022 21:59:02 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/561ed61f-522a-4e08-b0f2-16f36aa1f399?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:12:04 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/e7600431-d603-4978-a490-e951cf24b9dd?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "203"
+        "x-envoy-upstream-service-time": "381"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/561ed61f-522a-4e08-b0f2-16f36aa1f399?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/e7600431-d603-4978-a490-e951cf24b9dd?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -66,19 +66,19 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "da57d75e-d723-4e6e-8f3c-9a5f4c3d9611",
+        "apim-request-id": "a7f1e92f-f383-4a3e-bcb9-32c7c3d91d10",
         "Content-Length": "1107",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 09 Jun 2022 21:59:08 GMT",
+        "Date": "Thu, 23 Jun 2022 02:12:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "61"
+        "x-envoy-upstream-service-time": "43"
       },
       "ResponseBody": {
-        "jobId": "561ed61f-522a-4e08-b0f2-16f36aa1f399",
-        "lastUpdatedDateTime": "2022-06-09T21:59:04Z",
-        "createdDateTime": "2022-06-09T21:59:03Z",
-        "expirationDateTime": "2022-06-10T21:59:03Z",
+        "jobId": "e7600431-d603-4978-a490-e951cf24b9dd",
+        "lastUpdatedDateTime": "2022-06-23T02:12:05Z",
+        "createdDateTime": "2022-06-23T02:12:04Z",
+        "expirationDateTime": "2022-06-24T02:12:04Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -90,7 +90,7 @@
             {
               "kind": "CustomSingleLabelClassificationLROResults",
               "taskName": "0",
-              "lastUpdateDateTime": "2022-06-09T21:59:04.3332055Z",
+              "lastUpdateDateTime": "2022-06-23T02:12:05.6220693Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_async.pyTestAnalyzeAsynctest_healthcare_action.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_async.pyTestAnalyzeAsynctest_healthcare_action.json
@@ -43,18 +43,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "15d7ae2e-ab27-4e9a-be01-5ab0e8ed7df5",
+        "apim-request-id": "e07a54dd-4af3-436d-ae88-df4455a7afaf",
         "Content-Length": "0",
-        "Date": "Thu, 09 Jun 2022 23:07:39 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/0f0c939c-64d8-4277-acc5-0a61ec9a7232?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:14:37 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/0daedaae-603b-44b5-aec9-327e7da80d39?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "315"
+        "x-envoy-upstream-service-time": "174"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/0f0c939c-64d8-4277-acc5-0a61ec9a7232?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/0daedaae-603b-44b5-aec9-327e7da80d39?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -64,19 +64,19 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "91de4974-6ca9-4f9b-98e3-ec4372be36f3",
+        "apim-request-id": "6397d104-1145-4771-833f-0a605cea00ba",
         "Content-Length": "4712",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 09 Jun 2022 23:07:44 GMT",
+        "Date": "Thu, 23 Jun 2022 02:14:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "57"
+        "x-envoy-upstream-service-time": "131"
       },
       "ResponseBody": {
-        "jobId": "0f0c939c-64d8-4277-acc5-0a61ec9a7232",
-        "lastUpdatedDateTime": "2022-06-09T23:07:40Z",
-        "createdDateTime": "2022-06-09T23:07:39Z",
-        "expirationDateTime": "2022-06-10T23:07:39Z",
+        "jobId": "0daedaae-603b-44b5-aec9-327e7da80d39",
+        "lastUpdatedDateTime": "2022-06-23T02:14:38Z",
+        "createdDateTime": "2022-06-23T02:14:37Z",
+        "expirationDateTime": "2022-06-24T02:14:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -88,7 +88,7 @@
             {
               "kind": "HealthcareLROResults",
               "taskName": "0",
-              "lastUpdateDateTime": "2022-06-09T23:07:40.8443555Z",
+              "lastUpdateDateTime": "2022-06-23T02:14:38.4697255Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_async.pyTestAnalyzeAsynctest_poller_metadata.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_async.pyTestAnalyzeAsynctest_poller_metadata.json
@@ -33,18 +33,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d5b72667-2148-4de1-a48e-2f6e67acd308",
+        "apim-request-id": "e38125b3-d41e-4e81-a476-c3a77891f75e",
         "Content-Length": "0",
-        "Date": "Fri, 10 Jun 2022 00:45:42 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/d3252774-a38e-465f-8291-e192e7184fe8?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:13:37 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/54175a2b-e452-408d-ad39-1901f1d4ffd4?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "120"
+        "x-envoy-upstream-service-time": "118"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/d3252774-a38e-465f-8291-e192e7184fe8?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/54175a2b-e452-408d-ad39-1901f1d4ffd4?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -54,19 +54,19 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "796503af-363d-4b3b-888e-5975e17dc5e1",
-        "Content-Length": "678",
+        "apim-request-id": "25dbe765-719a-40f0-b3d1-1d9c8ff41060",
+        "Content-Length": "679",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 10 Jun 2022 00:45:47 GMT",
+        "Date": "Thu, 23 Jun 2022 02:13:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
-        "jobId": "d3252774-a38e-465f-8291-e192e7184fe8",
-        "lastUpdatedDateTime": "2022-06-10T00:45:45Z",
-        "createdDateTime": "2022-06-10T00:45:42Z",
-        "expirationDateTime": "2022-06-11T00:45:42Z",
+        "jobId": "54175a2b-e452-408d-ad39-1901f1d4ffd4",
+        "lastUpdatedDateTime": "2022-06-23T02:13:39Z",
+        "createdDateTime": "2022-06-23T02:13:37Z",
+        "expirationDateTime": "2022-06-24T02:13:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -78,7 +78,7 @@
             {
               "kind": "EntityRecognitionLROResults",
               "taskName": "0",
-              "lastUpdateDateTime": "2022-06-10T00:45:45.677056Z",
+              "lastUpdateDateTime": "2022-06-23T02:13:39.1126992Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_async.pyTestAnalyzeAsynctest_single_category_classify.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_async.pyTestAnalyzeAsynctest_single_category_classify.json
@@ -43,18 +43,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7a7e3223-bc0c-40d6-8b93-6f2d10c05b2e",
+        "apim-request-id": "0697cb62-5481-4680-ac13-8c2326384816",
         "Content-Length": "0",
-        "Date": "Thu, 09 Jun 2022 22:07:34 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/9ea8cc8b-a838-4276-b3e2-a974c4c90934?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:13:58 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/94b6a7a7-4d10-4857-ad01-4592b3aae214?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "236"
+        "x-envoy-upstream-service-time": "175"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/9ea8cc8b-a838-4276-b3e2-a974c4c90934?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/94b6a7a7-4d10-4857-ad01-4592b3aae214?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -64,19 +64,19 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b1e5ac5a-1f43-488a-b4b2-e12bb5113c39",
-        "Content-Length": "1105",
+        "apim-request-id": "67cba6f8-7cdc-412f-ae38-0321bfbf18d8",
+        "Content-Length": "1107",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 09 Jun 2022 22:07:39 GMT",
+        "Date": "Thu, 23 Jun 2022 02:14:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "54"
+        "x-envoy-upstream-service-time": "50"
       },
       "ResponseBody": {
-        "jobId": "9ea8cc8b-a838-4276-b3e2-a974c4c90934",
-        "lastUpdatedDateTime": "2022-06-09T22:07:35Z",
-        "createdDateTime": "2022-06-09T22:07:34Z",
-        "expirationDateTime": "2022-06-10T22:07:34Z",
+        "jobId": "94b6a7a7-4d10-4857-ad01-4592b3aae214",
+        "lastUpdatedDateTime": "2022-06-23T02:13:59Z",
+        "createdDateTime": "2022-06-23T02:13:58Z",
+        "expirationDateTime": "2022-06-24T02:13:58Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -88,7 +88,7 @@
             {
               "kind": "CustomSingleLabelClassificationLROResults",
               "taskName": "0",
-              "lastUpdateDateTime": "2022-06-09T22:07:35.16287Z",
+              "lastUpdateDateTime": "2022-06-23T02:13:59.2796949Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text.pyTestCustomTexttest_poller_metadata.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text.pyTestCustomTexttest_poller_metadata.json
@@ -1,0 +1,167 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "479",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "displayName": "testing",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "56",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "taskName": "0",
+            "kind": "CustomEntityRecognition",
+            "parameters": {
+              "projectName": "custom_entities_project_name",
+              "deploymentName": "custom_entities_project_name",
+              "stringIndexType": "UnicodeCodePoint"
+            }
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "b69593a3-c6ef-4499-a633-f02e4bbd0c9a",
+        "Content-Length": "0",
+        "Date": "Tue, 28 Jun 2022 17:01:48 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/07d0acd6-b3a3-454a-ac1e-18a4f207f14c?api-version=2022-05-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "387"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/07d0acd6-b3a3-454a-ac1e-18a4f207f14c?api-version=2022-05-01\u0026showStats=True",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "73bc3c22-78a5-4092-a91d-4cf1a878aa13",
+        "Content-Length": "1435",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 28 Jun 2022 17:01:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "24"
+      },
+      "ResponseBody": {
+        "jobId": "07d0acd6-b3a3-454a-ac1e-18a4f207f14c",
+        "lastUpdatedDateTime": "2022-06-28T17:01:49Z",
+        "createdDateTime": "2022-06-28T17:01:48Z",
+        "expirationDateTime": "2022-06-29T17:01:48Z",
+        "status": "succeeded",
+        "errors": [],
+        "displayName": "testing",
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomEntityRecognitionLROResults",
+              "taskName": "0",
+              "lastUpdateDateTime": "2022-06-28T17:01:49.0142904Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 1,
+                  "validDocumentsCount": 1,
+                  "erroneousDocumentsCount": 0,
+                  "transactionsCount": 1
+                },
+                "documents": [
+                  {
+                    "id": "56",
+                    "statistics": {
+                      "charactersCount": 158,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "David Schmidt",
+                        "category": "artist",
+                        "offset": 0,
+                        "length": 13,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Food",
+                        "category": "service",
+                        "offset": 38,
+                        "length": 4,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "Safety",
+                        "category": "geographic_poi",
+                        "offset": 43,
+                        "length": 6,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "International Food",
+                        "category": "geographic_poi",
+                        "offset": 51,
+                        "length": 18,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "IFIC",
+                        "category": "geographic_poi",
+                        "offset": 91,
+                        "length": 4,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Information Council",
+                        "category": "restaurant_name",
+                        "offset": 70,
+                        "length": 19,
+                        "confidenceScore": 0.1
+                      },
+                      {
+                        "text": "Washington, D.C.",
+                        "category": "state",
+                        "offset": 98,
+                        "length": 16,
+                        "confidenceScore": 0.49
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "projectName": "custom_entities_project_name",
+                "deploymentName": "custom_entities_project_name"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text.pyTestCustomTexttest_recognize_custom_entities.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text.pyTestCustomTexttest_recognize_custom_entities.json
@@ -6,7 +6,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "1015",
+        "Connection": "keep-alive",
+        "Content-Length": "954",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
@@ -20,7 +21,12 @@
             },
             {
               "id": "2",
-              "text": "",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "en"
+            },
+            {
+              "id": "3",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
               "language": "en"
             }
           ]
@@ -28,22 +34,6 @@
         "tasks": [
           {
             "taskName": "0",
-            "kind": "CustomSingleLabelClassification",
-            "parameters": {
-              "projectName": "single_category_classify_project_name",
-              "deploymentName": "single_category_classify_project_name"
-            }
-          },
-          {
-            "taskName": "1",
-            "kind": "CustomMultiLabelClassification",
-            "parameters": {
-              "projectName": "multi_category_classify_project_name",
-              "deploymentName": "multi_category_classify_project_name"
-            }
-          },
-          {
-            "taskName": "2",
             "kind": "CustomEntityRecognition",
             "parameters": {
               "projectName": "custom_entities_project_name",
@@ -55,144 +45,60 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "761b0e43-83cf-483b-a221-63c30f82ad51",
+        "apim-request-id": "c2bf393b-5f47-403c-b2c6-0be2ce2e9712",
         "Content-Length": "0",
-        "Date": "Thu, 23 Jun 2022 02:14:18 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/6e1fd1a6-f7f2-440d-aba2-d57a93c45173?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 01:22:30 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/b563471a-57b2-499e-99f8-bf7e820ef016?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "193"
+        "x-envoy-upstream-service-time": "199"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/6e1fd1a6-f7f2-440d-aba2-d57a93c45173?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/b563471a-57b2-499e-99f8-bf7e820ef016?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cbc7e582-e063-48d4-ba0f-e2dab6e548c9",
-        "Content-Length": "3705",
+        "apim-request-id": "e874005a-a33e-43a0-a9cf-45acb22bb32e",
+        "Content-Length": "3488",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Jun 2022 02:14:23 GMT",
+        "Date": "Thu, 23 Jun 2022 01:22:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "95"
+        "x-envoy-upstream-service-time": "46"
       },
       "ResponseBody": {
-        "jobId": "6e1fd1a6-f7f2-440d-aba2-d57a93c45173",
-        "lastUpdatedDateTime": "2022-06-23T02:14:20Z",
-        "createdDateTime": "2022-06-23T02:14:18Z",
-        "expirationDateTime": "2022-06-24T02:14:18Z",
+        "jobId": "b563471a-57b2-499e-99f8-bf7e820ef016",
+        "lastUpdatedDateTime": "2022-06-23T01:22:31Z",
+        "createdDateTime": "2022-06-23T01:22:30Z",
+        "expirationDateTime": "2022-06-24T01:22:30Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 1,
           "failed": 0,
           "inProgress": 0,
-          "total": 3,
+          "total": 1,
           "items": [
             {
-              "kind": "CustomSingleLabelClassificationLROResults",
-              "taskName": "0",
-              "lastUpdateDateTime": "2022-06-23T02:14:19.3208436Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
-                },
-                "documents": [
-                  {
-                    "id": "1",
-                    "class": [
-                      {
-                        "category": "RateBook",
-                        "confidenceScore": 0.76
-                      }
-                    ],
-                    "statistics": {
-                      "charactersCount": 295,
-                      "transactionsCount": 1
-                    },
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "projectName": "single_category_classify_project_name",
-                "deploymentName": "single_category_classify_project_name"
-              }
-            },
-            {
-              "kind": "CustomMultiLabelClassificationLROResults",
-              "taskName": "1",
-              "lastUpdateDateTime": "2022-06-23T02:14:19.4132374Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
-                },
-                "documents": [
-                  {
-                    "id": "1",
-                    "class": [],
-                    "statistics": {
-                      "charactersCount": 295,
-                      "transactionsCount": 1
-                    },
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "projectName": "multi_category_classify_project_name",
-                "deploymentName": "multi_category_classify_project_name"
-              }
-            },
-            {
               "kind": "CustomEntityRecognitionLROResults",
-              "taskName": "2",
-              "lastUpdateDateTime": "2022-06-23T02:14:20.0882905Z",
+              "taskName": "0",
+              "lastUpdateDateTime": "2022-06-23T01:22:31.6498194Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
+                  "documentsCount": 3,
+                  "validDocumentsCount": 3,
+                  "erroneousDocumentsCount": 0,
+                  "transactionsCount": 3
                 },
                 "documents": [
                   {
@@ -316,21 +222,113 @@
                       }
                     ],
                     "warnings": []
-                  }
-                ],
-                "errors": [
+                  },
                   {
                     "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
+                    "statistics": {
+                      "charactersCount": 158,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "David Schmidt",
+                        "category": "artist",
+                        "offset": 0,
+                        "length": 13,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Food",
+                        "category": "service",
+                        "offset": 38,
+                        "length": 4,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "Safety",
+                        "category": "geographic_poi",
+                        "offset": 43,
+                        "length": 6,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "International Food",
+                        "category": "geographic_poi",
+                        "offset": 51,
+                        "length": 18,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "IFIC",
+                        "category": "geographic_poi",
+                        "offset": 91,
+                        "length": 4,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Information Council",
+                        "category": "restaurant_name",
+                        "offset": 70,
+                        "length": 19,
+                        "confidenceScore": 0.1
+                      },
+                      {
+                        "text": "Washington, D.C.",
+                        "category": "state",
+                        "offset": 98,
+                        "length": 16,
+                        "confidenceScore": 0.49
                       }
-                    }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 121,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "indoor",
+                        "category": "facility",
+                        "offset": 28,
+                        "length": 6,
+                        "confidenceScore": 0.57
+                      },
+                      {
+                        "text": "restaurant",
+                        "category": "restaurant_type",
+                        "offset": 35,
+                        "length": 10,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "China",
+                        "category": "country",
+                        "offset": 49,
+                        "length": 5,
+                        "confidenceScore": 0.48
+                      },
+                      {
+                        "text": "music",
+                        "category": "music_item",
+                        "offset": 78,
+                        "length": 5,
+                        "confidenceScore": 0.63
+                      },
+                      {
+                        "text": "my",
+                        "category": "playlist_owner",
+                        "offset": 110,
+                        "length": 2,
+                        "confidenceScore": 0.84
+                      }
+                    ],
+                    "warnings": []
                   }
                 ],
+                "errors": [],
                 "projectName": "custom_entities_project_name",
                 "deploymentName": "custom_entities_project_name"
               }

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text.pyTestCustomTexttest_recognize_custom_entities_continuation_token.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text.pyTestCustomTexttest_recognize_custom_entities_continuation_token.json
@@ -1,0 +1,624 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "954",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "1",
+              "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities.",
+              "language": "en"
+            },
+            {
+              "id": "2",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "en"
+            },
+            {
+              "id": "3",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "taskName": "0",
+            "kind": "CustomEntityRecognition",
+            "parameters": {
+              "projectName": "custom_entities_project_name",
+              "deploymentName": "custom_entities_project_name",
+              "stringIndexType": "UnicodeCodePoint"
+            }
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "cd596b7c-5b58-450b-bce7-6b032842d974",
+        "Content-Length": "0",
+        "Date": "Thu, 23 Jun 2022 02:05:35 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/5b0895a4-c7f2-412e-b448-7f5fc69e0f71?api-version=2022-05-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "193"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/5b0895a4-c7f2-412e-b448-7f5fc69e0f71?api-version=2022-05-01\u0026showStats=True",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "86f90753-0446-41de-a5b8-a470fb814b28",
+        "Content-Length": "3488",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 23 Jun 2022 02:05:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "41"
+      },
+      "ResponseBody": {
+        "jobId": "5b0895a4-c7f2-412e-b448-7f5fc69e0f71",
+        "lastUpdatedDateTime": "2022-06-23T02:05:36Z",
+        "createdDateTime": "2022-06-23T02:05:35Z",
+        "expirationDateTime": "2022-06-24T02:05:35Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomEntityRecognitionLROResults",
+              "taskName": "0",
+              "lastUpdateDateTime": "2022-06-23T02:05:36.2457369Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 3,
+                  "validDocumentsCount": 3,
+                  "erroneousDocumentsCount": 0,
+                  "transactionsCount": 3
+                },
+                "documents": [
+                  {
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 295,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "Government",
+                        "category": "restaurant_name",
+                        "offset": 23,
+                        "length": 10,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Office",
+                        "category": "restaurant_name",
+                        "offset": 49,
+                        "length": 6,
+                        "confidenceScore": 0.11
+                      },
+                      {
+                        "text": "GAO",
+                        "category": "restaurant_name",
+                        "offset": 57,
+                        "length": 3,
+                        "confidenceScore": 0.04
+                      },
+                      {
+                        "text": "Accountability",
+                        "category": "geographic_poi",
+                        "offset": 34,
+                        "length": 14,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "natural",
+                        "category": "geographic_poi",
+                        "offset": 106,
+                        "length": 7,
+                        "confidenceScore": 0.04
+                      },
+                      {
+                        "text": "dramatic",
+                        "category": "sort",
+                        "offset": 77,
+                        "length": 8,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "oil",
+                        "category": "restaurant_type",
+                        "offset": 98,
+                        "length": 3,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "gas",
+                        "category": "restaurant_type",
+                        "offset": 114,
+                        "length": 3,
+                        "confidenceScore": 0.09
+                      },
+                      {
+                        "text": "and",
+                        "category": "served_dish",
+                        "offset": 102,
+                        "length": 3,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "development",
+                        "category": "object_type",
+                        "offset": 118,
+                        "length": 11,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "federal",
+                        "category": "state",
+                        "offset": 133,
+                        "length": 7,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "protection",
+                        "category": "state",
+                        "offset": 267,
+                        "length": 10,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "lands",
+                        "category": "poi",
+                        "offset": 141,
+                        "length": 5,
+                        "confidenceScore": 0.04
+                      },
+                      {
+                        "text": "BLM",
+                        "category": "poi",
+                        "offset": 202,
+                        "length": 3,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "the",
+                        "category": "timeRange",
+                        "offset": 152,
+                        "length": 3,
+                        "confidenceScore": 0.24
+                      },
+                      {
+                        "text": "past six years",
+                        "category": "timeRange",
+                        "offset": 156,
+                        "length": 14,
+                        "confidenceScore": 0.54
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "statistics": {
+                      "charactersCount": 158,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "David Schmidt",
+                        "category": "artist",
+                        "offset": 0,
+                        "length": 13,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Food",
+                        "category": "service",
+                        "offset": 38,
+                        "length": 4,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "Safety",
+                        "category": "geographic_poi",
+                        "offset": 43,
+                        "length": 6,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "International Food",
+                        "category": "geographic_poi",
+                        "offset": 51,
+                        "length": 18,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "IFIC",
+                        "category": "geographic_poi",
+                        "offset": 91,
+                        "length": 4,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Information Council",
+                        "category": "restaurant_name",
+                        "offset": 70,
+                        "length": 19,
+                        "confidenceScore": 0.1
+                      },
+                      {
+                        "text": "Washington, D.C.",
+                        "category": "state",
+                        "offset": 98,
+                        "length": 16,
+                        "confidenceScore": 0.49
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 121,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "indoor",
+                        "category": "facility",
+                        "offset": 28,
+                        "length": 6,
+                        "confidenceScore": 0.57
+                      },
+                      {
+                        "text": "restaurant",
+                        "category": "restaurant_type",
+                        "offset": 35,
+                        "length": 10,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "China",
+                        "category": "country",
+                        "offset": 49,
+                        "length": 5,
+                        "confidenceScore": 0.48
+                      },
+                      {
+                        "text": "music",
+                        "category": "music_item",
+                        "offset": 78,
+                        "length": 5,
+                        "confidenceScore": 0.63
+                      },
+                      {
+                        "text": "my",
+                        "category": "playlist_owner",
+                        "offset": 110,
+                        "length": 2,
+                        "confidenceScore": 0.84
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "projectName": "custom_entities_project_name",
+                "deploymentName": "custom_entities_project_name"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/5b0895a4-c7f2-412e-b448-7f5fc69e0f71?api-version=2022-05-01\u0026showStats=True",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f10245b9-9eb3-4f4d-9dc9-31872cab1ca2",
+        "Content-Length": "3488",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 23 Jun 2022 02:05:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1874"
+      },
+      "ResponseBody": {
+        "jobId": "5b0895a4-c7f2-412e-b448-7f5fc69e0f71",
+        "lastUpdatedDateTime": "2022-06-23T02:05:36Z",
+        "createdDateTime": "2022-06-23T02:05:35Z",
+        "expirationDateTime": "2022-06-24T02:05:35Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomEntityRecognitionLROResults",
+              "taskName": "0",
+              "lastUpdateDateTime": "2022-06-23T02:05:36.2457369Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 3,
+                  "validDocumentsCount": 3,
+                  "erroneousDocumentsCount": 0,
+                  "transactionsCount": 3
+                },
+                "documents": [
+                  {
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 295,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "Government",
+                        "category": "restaurant_name",
+                        "offset": 23,
+                        "length": 10,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Office",
+                        "category": "restaurant_name",
+                        "offset": 49,
+                        "length": 6,
+                        "confidenceScore": 0.11
+                      },
+                      {
+                        "text": "GAO",
+                        "category": "restaurant_name",
+                        "offset": 57,
+                        "length": 3,
+                        "confidenceScore": 0.04
+                      },
+                      {
+                        "text": "Accountability",
+                        "category": "geographic_poi",
+                        "offset": 34,
+                        "length": 14,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "natural",
+                        "category": "geographic_poi",
+                        "offset": 106,
+                        "length": 7,
+                        "confidenceScore": 0.04
+                      },
+                      {
+                        "text": "dramatic",
+                        "category": "sort",
+                        "offset": 77,
+                        "length": 8,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "oil",
+                        "category": "restaurant_type",
+                        "offset": 98,
+                        "length": 3,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "gas",
+                        "category": "restaurant_type",
+                        "offset": 114,
+                        "length": 3,
+                        "confidenceScore": 0.09
+                      },
+                      {
+                        "text": "and",
+                        "category": "served_dish",
+                        "offset": 102,
+                        "length": 3,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "development",
+                        "category": "object_type",
+                        "offset": 118,
+                        "length": 11,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "federal",
+                        "category": "state",
+                        "offset": 133,
+                        "length": 7,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "protection",
+                        "category": "state",
+                        "offset": 267,
+                        "length": 10,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "lands",
+                        "category": "poi",
+                        "offset": 141,
+                        "length": 5,
+                        "confidenceScore": 0.04
+                      },
+                      {
+                        "text": "BLM",
+                        "category": "poi",
+                        "offset": 202,
+                        "length": 3,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "the",
+                        "category": "timeRange",
+                        "offset": 152,
+                        "length": 3,
+                        "confidenceScore": 0.24
+                      },
+                      {
+                        "text": "past six years",
+                        "category": "timeRange",
+                        "offset": 156,
+                        "length": 14,
+                        "confidenceScore": 0.54
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "statistics": {
+                      "charactersCount": 158,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "David Schmidt",
+                        "category": "artist",
+                        "offset": 0,
+                        "length": 13,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Food",
+                        "category": "service",
+                        "offset": 38,
+                        "length": 4,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "Safety",
+                        "category": "geographic_poi",
+                        "offset": 43,
+                        "length": 6,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "International Food",
+                        "category": "geographic_poi",
+                        "offset": 51,
+                        "length": 18,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "IFIC",
+                        "category": "geographic_poi",
+                        "offset": 91,
+                        "length": 4,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Information Council",
+                        "category": "restaurant_name",
+                        "offset": 70,
+                        "length": 19,
+                        "confidenceScore": 0.1
+                      },
+                      {
+                        "text": "Washington, D.C.",
+                        "category": "state",
+                        "offset": 98,
+                        "length": 16,
+                        "confidenceScore": 0.49
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 121,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "indoor",
+                        "category": "facility",
+                        "offset": 28,
+                        "length": 6,
+                        "confidenceScore": 0.57
+                      },
+                      {
+                        "text": "restaurant",
+                        "category": "restaurant_type",
+                        "offset": 35,
+                        "length": 10,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "China",
+                        "category": "country",
+                        "offset": 49,
+                        "length": 5,
+                        "confidenceScore": 0.48
+                      },
+                      {
+                        "text": "music",
+                        "category": "music_item",
+                        "offset": 78,
+                        "length": 5,
+                        "confidenceScore": 0.63
+                      },
+                      {
+                        "text": "my",
+                        "category": "playlist_owner",
+                        "offset": 110,
+                        "length": 2,
+                        "confidenceScore": 0.84
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "projectName": "custom_entities_project_name",
+                "deploymentName": "custom_entities_project_name"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text_async.pyTestCustomTextAsynctest_poller_metadata.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text_async.pyTestCustomTextAsynctest_poller_metadata.json
@@ -1,0 +1,165 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "479",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": {
+        "displayName": "testing",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "56",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "taskName": "0",
+            "kind": "CustomEntityRecognition",
+            "parameters": {
+              "projectName": "custom_entities_project_name",
+              "deploymentName": "custom_entities_project_name",
+              "stringIndexType": "UnicodeCodePoint"
+            }
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "24150eee-10dd-42b1-83cc-a36bfc34ac8c",
+        "Content-Length": "0",
+        "Date": "Tue, 28 Jun 2022 17:03:25 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/2e04c59b-e178-4e4d-9c6b-04e6eb710a41?api-version=2022-05-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "234"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/2e04c59b-e178-4e4d-9c6b-04e6eb710a41?api-version=2022-05-01\u0026showStats=True",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "51c2b971-3127-4918-81a8-a4242404007c",
+        "Content-Length": "1435",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 28 Jun 2022 17:03:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "157"
+      },
+      "ResponseBody": {
+        "jobId": "2e04c59b-e178-4e4d-9c6b-04e6eb710a41",
+        "lastUpdatedDateTime": "2022-06-28T17:03:26Z",
+        "createdDateTime": "2022-06-28T17:03:25Z",
+        "expirationDateTime": "2022-06-29T17:03:25Z",
+        "status": "succeeded",
+        "errors": [],
+        "displayName": "testing",
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomEntityRecognitionLROResults",
+              "taskName": "0",
+              "lastUpdateDateTime": "2022-06-28T17:03:26.3632213Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 1,
+                  "validDocumentsCount": 1,
+                  "erroneousDocumentsCount": 0,
+                  "transactionsCount": 1
+                },
+                "documents": [
+                  {
+                    "id": "56",
+                    "statistics": {
+                      "charactersCount": 158,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "David Schmidt",
+                        "category": "artist",
+                        "offset": 0,
+                        "length": 13,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Food",
+                        "category": "service",
+                        "offset": 38,
+                        "length": 4,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "Safety",
+                        "category": "geographic_poi",
+                        "offset": 43,
+                        "length": 6,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "International Food",
+                        "category": "geographic_poi",
+                        "offset": 51,
+                        "length": 18,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "IFIC",
+                        "category": "geographic_poi",
+                        "offset": 91,
+                        "length": 4,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Information Council",
+                        "category": "restaurant_name",
+                        "offset": 70,
+                        "length": 19,
+                        "confidenceScore": 0.1
+                      },
+                      {
+                        "text": "Washington, D.C.",
+                        "category": "state",
+                        "offset": 98,
+                        "length": 16,
+                        "confidenceScore": 0.49
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "projectName": "custom_entities_project_name",
+                "deploymentName": "custom_entities_project_name"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text_async.pyTestCustomTextAsynctest_recognize_custom_entities.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text_async.pyTestCustomTextAsynctest_recognize_custom_entities.json
@@ -6,7 +6,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "1015",
+        "Content-Length": "954",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
@@ -20,7 +20,12 @@
             },
             {
               "id": "2",
-              "text": "",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "en"
+            },
+            {
+              "id": "3",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
               "language": "en"
             }
           ]
@@ -28,22 +33,6 @@
         "tasks": [
           {
             "taskName": "0",
-            "kind": "CustomSingleLabelClassification",
-            "parameters": {
-              "projectName": "single_category_classify_project_name",
-              "deploymentName": "single_category_classify_project_name"
-            }
-          },
-          {
-            "taskName": "1",
-            "kind": "CustomMultiLabelClassification",
-            "parameters": {
-              "projectName": "multi_category_classify_project_name",
-              "deploymentName": "multi_category_classify_project_name"
-            }
-          },
-          {
-            "taskName": "2",
             "kind": "CustomEntityRecognition",
             "parameters": {
               "projectName": "custom_entities_project_name",
@@ -55,18 +44,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "761b0e43-83cf-483b-a221-63c30f82ad51",
+        "apim-request-id": "04d1e713-2dae-4ce5-8fd5-1e6ad44c73e5",
         "Content-Length": "0",
-        "Date": "Thu, 23 Jun 2022 02:14:18 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/6e1fd1a6-f7f2-440d-aba2-d57a93c45173?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 01:22:50 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/ef16dc84-b18a-4fb2-8fc5-b72b5a1c03b0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "193"
+        "x-envoy-upstream-service-time": "209"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/6e1fd1a6-f7f2-440d-aba2-d57a93c45173?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/ef16dc84-b18a-4fb2-8fc5-b72b5a1c03b0?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -76,123 +65,38 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cbc7e582-e063-48d4-ba0f-e2dab6e548c9",
-        "Content-Length": "3705",
+        "apim-request-id": "d4413897-6f1a-4a3d-91f0-2b9479b6cf2c",
+        "Content-Length": "3488",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Jun 2022 02:14:23 GMT",
+        "Date": "Thu, 23 Jun 2022 01:22:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "95"
+        "x-envoy-upstream-service-time": "51"
       },
       "ResponseBody": {
-        "jobId": "6e1fd1a6-f7f2-440d-aba2-d57a93c45173",
-        "lastUpdatedDateTime": "2022-06-23T02:14:20Z",
-        "createdDateTime": "2022-06-23T02:14:18Z",
-        "expirationDateTime": "2022-06-24T02:14:18Z",
+        "jobId": "ef16dc84-b18a-4fb2-8fc5-b72b5a1c03b0",
+        "lastUpdatedDateTime": "2022-06-23T01:22:51Z",
+        "createdDateTime": "2022-06-23T01:22:51Z",
+        "expirationDateTime": "2022-06-24T01:22:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 1,
           "failed": 0,
           "inProgress": 0,
-          "total": 3,
+          "total": 1,
           "items": [
             {
-              "kind": "CustomSingleLabelClassificationLROResults",
-              "taskName": "0",
-              "lastUpdateDateTime": "2022-06-23T02:14:19.3208436Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
-                },
-                "documents": [
-                  {
-                    "id": "1",
-                    "class": [
-                      {
-                        "category": "RateBook",
-                        "confidenceScore": 0.76
-                      }
-                    ],
-                    "statistics": {
-                      "charactersCount": 295,
-                      "transactionsCount": 1
-                    },
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "projectName": "single_category_classify_project_name",
-                "deploymentName": "single_category_classify_project_name"
-              }
-            },
-            {
-              "kind": "CustomMultiLabelClassificationLROResults",
-              "taskName": "1",
-              "lastUpdateDateTime": "2022-06-23T02:14:19.4132374Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
-                },
-                "documents": [
-                  {
-                    "id": "1",
-                    "class": [],
-                    "statistics": {
-                      "charactersCount": 295,
-                      "transactionsCount": 1
-                    },
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "projectName": "multi_category_classify_project_name",
-                "deploymentName": "multi_category_classify_project_name"
-              }
-            },
-            {
               "kind": "CustomEntityRecognitionLROResults",
-              "taskName": "2",
-              "lastUpdateDateTime": "2022-06-23T02:14:20.0882905Z",
+              "taskName": "0",
+              "lastUpdateDateTime": "2022-06-23T01:22:51.9516981Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
+                  "documentsCount": 3,
+                  "validDocumentsCount": 3,
+                  "erroneousDocumentsCount": 0,
+                  "transactionsCount": 3
                 },
                 "documents": [
                   {
@@ -316,21 +220,113 @@
                       }
                     ],
                     "warnings": []
-                  }
-                ],
-                "errors": [
+                  },
                   {
                     "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
+                    "statistics": {
+                      "charactersCount": 158,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "David Schmidt",
+                        "category": "artist",
+                        "offset": 0,
+                        "length": 13,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Food",
+                        "category": "service",
+                        "offset": 38,
+                        "length": 4,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "Safety",
+                        "category": "geographic_poi",
+                        "offset": 43,
+                        "length": 6,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "International Food",
+                        "category": "geographic_poi",
+                        "offset": 51,
+                        "length": 18,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "IFIC",
+                        "category": "geographic_poi",
+                        "offset": 91,
+                        "length": 4,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Information Council",
+                        "category": "restaurant_name",
+                        "offset": 70,
+                        "length": 19,
+                        "confidenceScore": 0.1
+                      },
+                      {
+                        "text": "Washington, D.C.",
+                        "category": "state",
+                        "offset": 98,
+                        "length": 16,
+                        "confidenceScore": 0.49
                       }
-                    }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 121,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "indoor",
+                        "category": "facility",
+                        "offset": 28,
+                        "length": 6,
+                        "confidenceScore": 0.57
+                      },
+                      {
+                        "text": "restaurant",
+                        "category": "restaurant_type",
+                        "offset": 35,
+                        "length": 10,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "China",
+                        "category": "country",
+                        "offset": 49,
+                        "length": 5,
+                        "confidenceScore": 0.48
+                      },
+                      {
+                        "text": "music",
+                        "category": "music_item",
+                        "offset": 78,
+                        "length": 5,
+                        "confidenceScore": 0.63
+                      },
+                      {
+                        "text": "my",
+                        "category": "playlist_owner",
+                        "offset": 110,
+                        "length": 2,
+                        "confidenceScore": 0.84
+                      }
+                    ],
+                    "warnings": []
                   }
                 ],
+                "errors": [],
                 "projectName": "custom_entities_project_name",
                 "deploymentName": "custom_entities_project_name"
               }

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text_async.pyTestCustomTextAsynctest_recognize_custom_entities_continuation_token.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_custom_text_async.pyTestCustomTextAsynctest_recognize_custom_entities_continuation_token.json
@@ -6,7 +6,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "1015",
+        "Content-Length": "954",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-python-ai-textanalytics/5.2.0b5 Python/3.10.0 (Windows-10-10.0.22000-SP0)"
       },
@@ -20,7 +20,12 @@
             },
             {
               "id": "2",
-              "text": "",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "en"
+            },
+            {
+              "id": "3",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
               "language": "en"
             }
           ]
@@ -28,22 +33,6 @@
         "tasks": [
           {
             "taskName": "0",
-            "kind": "CustomSingleLabelClassification",
-            "parameters": {
-              "projectName": "single_category_classify_project_name",
-              "deploymentName": "single_category_classify_project_name"
-            }
-          },
-          {
-            "taskName": "1",
-            "kind": "CustomMultiLabelClassification",
-            "parameters": {
-              "projectName": "multi_category_classify_project_name",
-              "deploymentName": "multi_category_classify_project_name"
-            }
-          },
-          {
-            "taskName": "2",
             "kind": "CustomEntityRecognition",
             "parameters": {
               "projectName": "custom_entities_project_name",
@@ -55,18 +44,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "761b0e43-83cf-483b-a221-63c30f82ad51",
+        "apim-request-id": "24ff7244-b200-44dd-aee7-e648bc387f08",
         "Content-Length": "0",
-        "Date": "Thu, 23 Jun 2022 02:14:18 GMT",
-        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/6e1fd1a6-f7f2-440d-aba2-d57a93c45173?api-version=2022-05-01",
+        "Date": "Thu, 23 Jun 2022 02:09:10 GMT",
+        "operation-location": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/685362d8-a64f-463c-a2a1-74cf939cbee6?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "193"
+        "x-envoy-upstream-service-time": "181"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/6e1fd1a6-f7f2-440d-aba2-d57a93c45173?api-version=2022-05-01\u0026showStats=True",
+      "RequestUri": "https://fakeendpoint.cognitiveservices.azure.com/language/analyze-text/jobs/685362d8-a64f-463c-a2a1-74cf939cbee6?api-version=2022-05-01\u0026showStats=True",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "*/*",
@@ -76,123 +65,38 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cbc7e582-e063-48d4-ba0f-e2dab6e548c9",
-        "Content-Length": "3705",
+        "apim-request-id": "18ed2991-4ee6-495d-b6ee-0c307d645d08",
+        "Content-Length": "3488",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Jun 2022 02:14:23 GMT",
+        "Date": "Thu, 23 Jun 2022 02:09:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "95"
+        "x-envoy-upstream-service-time": "38"
       },
       "ResponseBody": {
-        "jobId": "6e1fd1a6-f7f2-440d-aba2-d57a93c45173",
-        "lastUpdatedDateTime": "2022-06-23T02:14:20Z",
-        "createdDateTime": "2022-06-23T02:14:18Z",
-        "expirationDateTime": "2022-06-24T02:14:18Z",
+        "jobId": "685362d8-a64f-463c-a2a1-74cf939cbee6",
+        "lastUpdatedDateTime": "2022-06-23T02:09:11Z",
+        "createdDateTime": "2022-06-23T02:09:10Z",
+        "expirationDateTime": "2022-06-24T02:09:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 1,
           "failed": 0,
           "inProgress": 0,
-          "total": 3,
+          "total": 1,
           "items": [
             {
-              "kind": "CustomSingleLabelClassificationLROResults",
-              "taskName": "0",
-              "lastUpdateDateTime": "2022-06-23T02:14:19.3208436Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
-                },
-                "documents": [
-                  {
-                    "id": "1",
-                    "class": [
-                      {
-                        "category": "RateBook",
-                        "confidenceScore": 0.76
-                      }
-                    ],
-                    "statistics": {
-                      "charactersCount": 295,
-                      "transactionsCount": 1
-                    },
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "projectName": "single_category_classify_project_name",
-                "deploymentName": "single_category_classify_project_name"
-              }
-            },
-            {
-              "kind": "CustomMultiLabelClassificationLROResults",
-              "taskName": "1",
-              "lastUpdateDateTime": "2022-06-23T02:14:19.4132374Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
-                },
-                "documents": [
-                  {
-                    "id": "1",
-                    "class": [],
-                    "statistics": {
-                      "charactersCount": 295,
-                      "transactionsCount": 1
-                    },
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "projectName": "multi_category_classify_project_name",
-                "deploymentName": "multi_category_classify_project_name"
-              }
-            },
-            {
               "kind": "CustomEntityRecognitionLROResults",
-              "taskName": "2",
-              "lastUpdateDateTime": "2022-06-23T02:14:20.0882905Z",
+              "taskName": "0",
+              "lastUpdateDateTime": "2022-06-23T02:09:11.1587289Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
-                  "documentsCount": 2,
-                  "validDocumentsCount": 1,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 1
+                  "documentsCount": 3,
+                  "validDocumentsCount": 3,
+                  "erroneousDocumentsCount": 0,
+                  "transactionsCount": 3
                 },
                 "documents": [
                   {
@@ -316,21 +220,113 @@
                       }
                     ],
                     "warnings": []
-                  }
-                ],
-                "errors": [
+                  },
                   {
                     "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
+                    "statistics": {
+                      "charactersCount": 158,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "David Schmidt",
+                        "category": "artist",
+                        "offset": 0,
+                        "length": 13,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Food",
+                        "category": "service",
+                        "offset": 38,
+                        "length": 4,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "Safety",
+                        "category": "geographic_poi",
+                        "offset": 43,
+                        "length": 6,
+                        "confidenceScore": 0.06
+                      },
+                      {
+                        "text": "International Food",
+                        "category": "geographic_poi",
+                        "offset": 51,
+                        "length": 18,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "IFIC",
+                        "category": "geographic_poi",
+                        "offset": 91,
+                        "length": 4,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Information Council",
+                        "category": "restaurant_name",
+                        "offset": 70,
+                        "length": 19,
+                        "confidenceScore": 0.1
+                      },
+                      {
+                        "text": "Washington, D.C.",
+                        "category": "state",
+                        "offset": 98,
+                        "length": 16,
+                        "confidenceScore": 0.49
                       }
-                    }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 121,
+                      "transactionsCount": 1
+                    },
+                    "entities": [
+                      {
+                        "text": "indoor",
+                        "category": "facility",
+                        "offset": 28,
+                        "length": 6,
+                        "confidenceScore": 0.57
+                      },
+                      {
+                        "text": "restaurant",
+                        "category": "restaurant_type",
+                        "offset": 35,
+                        "length": 10,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "China",
+                        "category": "country",
+                        "offset": 49,
+                        "length": 5,
+                        "confidenceScore": 0.48
+                      },
+                      {
+                        "text": "music",
+                        "category": "music_item",
+                        "offset": 78,
+                        "length": 5,
+                        "confidenceScore": 0.63
+                      },
+                      {
+                        "text": "my",
+                        "category": "playlist_owner",
+                        "offset": 110,
+                        "length": 2,
+                        "confidenceScore": 0.84
+                      }
+                    ],
+                    "warnings": []
                   }
                 ],
+                "errors": [],
                 "projectName": "custom_entities_project_name",
                 "deploymentName": "custom_entities_project_name"
               }

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -16,6 +16,7 @@ from azure.core.credentials import AzureKeyCredential
 from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from azure.ai.textanalytics._lro import AnalyzeActionsLROPoller
 from azure.ai.textanalytics import (
     TextAnalyticsClient,
     RecognizeEntitiesAction,
@@ -491,7 +492,6 @@ class TestAnalyze(TextAnalyticsTest):
                 assert document_result.statistics.character_count
                 assert document_result.statistics.transaction_count
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
@@ -509,6 +509,7 @@ class TestAnalyze(TextAnalyticsTest):
 
         poller.result()
 
+        assert isinstance(poller, AnalyzeActionsLROPoller)
         assert isinstance(poller.created_on, datetime.datetime)
         assert not poller.display_name
         assert isinstance(poller.expires_on, datetime.datetime)
@@ -922,7 +923,6 @@ class TestAnalyze(TextAnalyticsTest):
         assert action_results[1][1].is_error
         assert action_results[1][2].is_error
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsCustomPreparer()
     @recorded_by_proxy
@@ -1049,7 +1049,6 @@ class TestAnalyze(TextAnalyticsTest):
                     assert entity.length is not None
                     assert entity.confidence_score is not None
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsCustomPreparer()
     @recorded_by_proxy
@@ -1135,6 +1134,7 @@ class TestAnalyze(TextAnalyticsTest):
         )
         response = poller.result()
 
+        assert isinstance(poller, AnalyzeActionsLROPoller)
         action_results = list(response)
         assert len(action_results) == len(docs)
         action_order = [
@@ -1253,7 +1253,6 @@ class TestAnalyze(TextAnalyticsTest):
                 client._client.analyze_text_job_status,
                 response,
                 deserialized,
-                headers,
                 show_stats=True,
             )
 
@@ -1395,7 +1394,6 @@ class TestAnalyze(TextAnalyticsTest):
                 client._client.analyze_text_job_status,
                 response,
                 deserialized,
-                headers,
                 show_stats=True,
             )
 
@@ -1531,7 +1529,6 @@ class TestAnalyze(TextAnalyticsTest):
                 client._client.analyze_text_job_status,
                 response,
                 deserialized,
-                headers,
                 show_stats=True,
             )
 
@@ -1656,7 +1653,6 @@ class TestAnalyze(TextAnalyticsTest):
                                f"only available for API version {version_supported} and up.\n'AnalyzeHealthcareEntitiesAction' is " \
                                f"only available for API version {version_supported} and up.\n"
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -20,6 +20,7 @@ from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 from testcase import TextAnalyticsTest
+from azure.ai.textanalytics.aio._lro_async import AsyncAnalyzeActionsLROPoller
 from azure.ai.textanalytics.aio import TextAnalyticsClient
 from azure.ai.textanalytics import (
     TextDocumentInput,
@@ -556,7 +557,6 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                     assert document_result.statistics.character_count
                     assert document_result.statistics.transaction_count
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
@@ -575,6 +575,7 @@ class TestAnalyzeAsync(TextAnalyticsTest):
 
             response = await poller.result()
 
+            assert isinstance(poller, AsyncAnalyzeActionsLROPoller)
             assert isinstance(poller.created_on, datetime.datetime)
             assert not poller.display_name
             assert isinstance(poller.expires_on, datetime.datetime)
@@ -985,7 +986,6 @@ class TestAnalyzeAsync(TextAnalyticsTest):
         assert action_results[1][1].is_error
         assert action_results[1][2].is_error
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
@@ -1123,7 +1123,6 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                     assert entity.length is not None
                     assert entity.confidence_score is not None
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsCustomPreparer()
     @recorded_by_proxy_async
@@ -1211,7 +1210,7 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                 polling_interval=self._interval(),
             )
             response = await poller.result()
-
+            assert isinstance(poller, AsyncAnalyzeActionsLROPoller)
             action_results = []
             async for action_result in response:
                 action_results.append(action_result)
@@ -1335,7 +1334,6 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                 client._client.analyze_text_job_status,
                 response,
                 deserialized,
-                headers,
                 show_stats=True,
             )
 
@@ -1487,7 +1485,6 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                 client._client.analyze_text_job_status,
                 response,
                 deserialized,
-                headers,
                 show_stats=True,
             )
 
@@ -1631,7 +1628,6 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                 client._client.analyze_text_job_status,
                 response,
                 deserialized,
-                headers,
                 show_stats=True,
             )
         async with client:
@@ -1762,7 +1758,6 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                                f"only available for API version {version_supported} and up.\n'AnalyzeHealthcareEntitiesAction' is " \
                                f"only available for API version {version_supported} and up.\n"
 
-    @pytest.mark.skip("code changes needed before we can run test")
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -525,7 +525,7 @@ class TestHealth(TextAnalyticsTest):
             polling_interval=self._interval(),
         )
         response = poller.result()
-
+        assert isinstance(poller, AnalyzeHealthcareEntitiesLROPoller)
         results = list(response)
         document_order = ["1", "2", "3", "4"]
         for doc_idx, result in enumerate(results):

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -550,6 +550,7 @@ class TestHealth(TextAnalyticsTest):
                 continuation_token=cont_token,
                 polling_interval=self._interval(),
             )
+            assert isinstance(poller, AsyncAnalyzeHealthcareEntitiesLROPoller)
             response = await poller.result()
 
             results = []

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_custom_text.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_custom_text.py
@@ -1,0 +1,123 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+import pytest
+import functools
+from azure.core.credentials import AzureKeyCredential
+from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
+from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
+from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
+from azure.ai.textanalytics._lro import TextAnalyticsLROPoller
+from azure.ai.textanalytics import (
+    TextAnalyticsClient
+)
+
+# pre-apply the client_cls positional argument so it needn't be explicitly passed below
+TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, TextAnalyticsClient)
+
+TextAnalyticsCustomPreparer = functools.partial(
+    TextAnalyticsPreparer,
+    textanalytics_custom_text_endpoint="https://fakeendpoint.cognitiveservices.azure.com",
+    textanalytics_custom_text_key="fakeZmFrZV9hY29jdW50X2tleQ==",
+    textanalytics_single_category_classify_project_name="single_category_classify_project_name",
+    textanalytics_single_category_classify_deployment_name="single_category_classify_deployment_name",
+    textanalytics_multi_category_classify_project_name="multi_category_classify_project_name",
+    textanalytics_multi_category_classify_deployment_name="multi_category_classify_deployment_name",
+    textanalytics_custom_entities_project_name="custom_entities_project_name",
+    textanalytics_custom_entities_deployment_name="custom_entities_deployment_name",
+)
+
+
+class TestCustomText(TextAnalyticsTest):
+
+    def _interval(self):
+        return 5 if self.is_live else 0
+
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
+    @recorded_by_proxy
+    def test_recognize_custom_entities(
+            self,
+            textanalytics_custom_text_endpoint,
+            textanalytics_custom_text_key,
+            textanalytics_custom_entities_project_name,
+            textanalytics_custom_entities_deployment_name
+    ):
+        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
+        docs = [
+            {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
+            {"id": "2", "language": "en", "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component."},
+            {"id": "3", "language": "en", "text": "I need a reservation for an indoor restaurant in China. Please don't stop the music. Play music and add it to my playlist"},
+        ]
+
+        poller = client.begin_recognize_custom_entities(
+            docs,
+            project_name=textanalytics_custom_entities_project_name,
+            deployment_name=textanalytics_custom_entities_deployment_name,
+            show_stats=True,
+            polling_interval=self._interval(),
+        )
+
+        assert isinstance(poller, TextAnalyticsLROPoller)
+        document_results = list(poller.result())
+
+        for result in document_results:
+            assert result.id
+            assert not result.is_error
+            assert not result.warnings
+            assert result.statistics
+            for entity in result.entities:
+                assert entity.text
+                assert entity.category
+                assert entity.offset is not None
+                assert entity.length is not None
+                assert entity.confidence_score is not None
+
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
+    @recorded_by_proxy
+    def test_recognize_custom_entities_continuation_token(
+            self,
+            textanalytics_custom_text_endpoint,
+            textanalytics_custom_text_key,
+            textanalytics_custom_entities_project_name,
+            textanalytics_custom_entities_deployment_name
+    ):
+        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
+        docs = [
+            {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
+            {"id": "2", "language": "en", "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component."},
+            {"id": "3", "language": "en", "text": "I need a reservation for an indoor restaurant in China. Please don't stop the music. Play music and add it to my playlist"},
+        ]
+
+        initial_poller = client.begin_recognize_custom_entities(
+            docs,
+            project_name=textanalytics_custom_entities_project_name,
+            deployment_name=textanalytics_custom_entities_deployment_name,
+            show_stats=True,
+            polling_interval=self._interval(),
+        )
+        continuation_token = initial_poller.continuation_token()
+
+        poller = client.begin_recognize_custom_entities(
+            None, None, None, continuation_token=continuation_token
+        )
+
+        assert isinstance(poller, TextAnalyticsLROPoller)
+        document_results = list(poller.result())
+
+        for result in document_results:
+            assert result.id
+            assert not result.is_error
+            assert not result.warnings
+            assert result.statistics
+            for entity in result.entities:
+                assert entity.text
+                assert entity.category
+                assert entity.offset is not None
+                assert entity.length is not None
+                assert entity.confidence_score is not None

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_custom_text.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_custom_text.py
@@ -5,13 +5,14 @@
 
 import pytest
 import functools
+import datetime
 from azure.core.credentials import AzureKeyCredential
 from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
-from azure.ai.textanalytics._lro import TextAnalyticsLROPoller
 from azure.ai.textanalytics import (
-    TextAnalyticsClient
+    TextAnalyticsClient,
+    TextAnalyticsLROPoller
 )
 
 # pre-apply the client_cls positional argument so it needn't be explicitly passed below
@@ -34,6 +35,37 @@ class TestCustomText(TextAnalyticsTest):
 
     def _interval(self):
         return 5 if self.is_live else 0
+
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
+    @recorded_by_proxy
+    def test_poller_metadata(
+            self,
+            textanalytics_custom_text_endpoint,
+            textanalytics_custom_text_key,
+            textanalytics_custom_entities_project_name,
+            textanalytics_custom_entities_deployment_name
+    ):
+        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
+        docs = [{"id": "56", "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component."}]
+
+        poller = client.begin_recognize_custom_entities(
+            docs,
+            project_name=textanalytics_custom_entities_project_name,
+            deployment_name=textanalytics_custom_entities_deployment_name,
+            show_stats=True,
+            display_name="testing",
+            polling_interval=self._interval(),
+        )
+        poller.result()
+
+        assert isinstance(poller, TextAnalyticsLROPoller)
+        assert isinstance(poller.details["created_on"], datetime.datetime)
+        assert isinstance(poller.details["expires_on"], datetime.datetime)
+        assert isinstance(poller.details["last_modified_on"], datetime.datetime)
+        assert poller.details["display_name"] == 'testing'
+        assert poller.details["id"]
 
     @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsCustomPreparer()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_custom_text_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_custom_text_async.py
@@ -1,0 +1,123 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+
+import pytest
+import functools
+from azure.core.credentials import AzureKeyCredential
+from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
+from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
+from devtools_testutils import set_bodiless_matcher
+from devtools_testutils.aio import recorded_by_proxy_async
+from azure.ai.textanalytics.aio._lro_async import AsyncTextAnalyticsLROPoller
+from azure.ai.textanalytics.aio import TextAnalyticsClient
+
+# pre-apply the client_cls positional argument so it needn't be explicitly passed below
+TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, TextAnalyticsClient)
+
+TextAnalyticsCustomPreparer = functools.partial(
+    TextAnalyticsPreparer,
+    textanalytics_custom_text_endpoint="https://fakeendpoint.cognitiveservices.azure.com",
+    textanalytics_custom_text_key="fakeZmFrZV9hY29jdW50X2tleQ==",
+    textanalytics_single_category_classify_project_name="single_category_classify_project_name",
+    textanalytics_single_category_classify_deployment_name="single_category_classify_deployment_name",
+    textanalytics_multi_category_classify_project_name="multi_category_classify_project_name",
+    textanalytics_multi_category_classify_deployment_name="multi_category_classify_deployment_name",
+    textanalytics_custom_entities_project_name="custom_entities_project_name",
+    textanalytics_custom_entities_deployment_name="custom_entities_deployment_name",
+)
+
+
+class TestCustomTextAsync(TextAnalyticsTest):
+
+    def _interval(self):
+        return 5 if self.is_live else 0
+
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
+    @recorded_by_proxy_async
+    async def test_recognize_custom_entities(
+            self,
+            textanalytics_custom_text_endpoint,
+            textanalytics_custom_text_key,
+            textanalytics_custom_entities_project_name,
+            textanalytics_custom_entities_deployment_name
+    ):
+        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
+        docs = [
+            {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
+            {"id": "2", "language": "en", "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component."},
+            {"id": "3", "language": "en", "text": "I need a reservation for an indoor restaurant in China. Please don't stop the music. Play music and add it to my playlist"},
+        ]
+        async with client:
+            poller = await client.begin_recognize_custom_entities(
+                docs,
+                project_name=textanalytics_custom_entities_project_name,
+                deployment_name=textanalytics_custom_entities_deployment_name,
+                show_stats=True,
+                polling_interval=self._interval(),
+            )
+
+            assert isinstance(poller, AsyncTextAnalyticsLROPoller)
+            document_results = await poller.result()
+
+            async for result in document_results:
+                assert result.id
+                assert not result.is_error
+                assert not result.warnings
+                assert result.statistics
+                for entity in result.entities:
+                    assert entity.text
+                    assert entity.category
+                    assert entity.offset is not None
+                    assert entity.length is not None
+                    assert entity.confidence_score is not None
+
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
+    @TextAnalyticsCustomPreparer()
+    @recorded_by_proxy_async
+    async def test_recognize_custom_entities_continuation_token(
+            self,
+            textanalytics_custom_text_endpoint,
+            textanalytics_custom_text_key,
+            textanalytics_custom_entities_project_name,
+            textanalytics_custom_entities_deployment_name
+    ):
+        set_bodiless_matcher()  # don't match on body for this test since we scrub the proj/deployment values
+        client = TextAnalyticsClient(textanalytics_custom_text_endpoint, AzureKeyCredential(textanalytics_custom_text_key))
+        docs = [
+            {"id": "1", "language": "en", "text": "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."},
+            {"id": "2", "language": "en", "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component."},
+            {"id": "3", "language": "en", "text": "I need a reservation for an indoor restaurant in China. Please don't stop the music. Play music and add it to my playlist"},
+        ]
+        async with client:
+            initial_poller = await client.begin_recognize_custom_entities(
+                docs,
+                project_name=textanalytics_custom_entities_project_name,
+                deployment_name=textanalytics_custom_entities_deployment_name,
+                show_stats=True,
+                polling_interval=self._interval(),
+            )
+
+            continuation_token = initial_poller.continuation_token()
+            poller = await client.begin_recognize_custom_entities(
+                None, None, None, continuation_token=continuation_token
+            )
+
+            assert isinstance(poller, AsyncTextAnalyticsLROPoller)
+            document_results = await poller.result()
+
+            async for result in document_results:
+                assert result.id
+                assert not result.is_error
+                assert not result.warnings
+                assert result.statistics
+                for entity in result.entities:
+                    assert entity.text
+                    assert entity.category
+                    assert entity.offset is not None
+                    assert entity.length is not None
+                    assert entity.confidence_score is not None


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-python/issues/23528

Adds the foundation/shared code that the bespoke methods will use + adds the first one - `begin_recognize_custom_entities`. The custom single/multi label classification methods will be added in another PR.

- Adds common TextAnalyticsLROPoller for bespoke methods to use
- Refactors code to allow bespoke methods to internally use begin_analyze_actions and shared code for rehydrating with a continuation token
- Updates samples, adds some tests (only a few since most options are already tested through begin_analyze_actions), and unskips some tests which were still skipped by accident.