### PR TITLE
[Cosmos] Disable test_distinct test for intermittent behavior

### DIFF
--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -328,6 +328,8 @@ class QueryTest(unittest.TestCase):
         )
         self.assertListEqual(list(map(lambda doc: doc['pk'], list(query_iterable))), results)
 
+    # TODO: Look into distinct query behavior to re-enable this test when possible
+    @unittest.skip("intermittent failures in the pipeline")
     def test_distinct(self):
         created_database = self.config.create_database_if_not_exist(self.client)
         distinct_field = 'distinct_field'


### PR DESCRIPTION
The test_distinct tests seem to have intermittent failures in the pipelines, and as such cause noise in the pipeline. 

Will mark for follow-up/ additional looking into needed and track with this issue: 