### PR TITLE
[PyAMQP] Fix for Update Status and Authentication State

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/cbs.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/cbs.py
@@ -151,16 +151,16 @@ class CBSAuthenticator(object):
             self.auth_state = CbsAuthState.ERROR
 
     def _update_status(self):
-        if self.state == CbsAuthState.OK or self.state == CbsAuthState.REFRESH_REQUIRED:
+        if self.auth_state == CbsAuthState.OK or self.auth_state == CbsAuthState.REFRESH_REQUIRED:
             is_expired, is_refresh_required = check_expiration_and_refresh_status(self._expires_on, self._refresh_window)
             if is_expired:
-                self.state = CbsAuthState.EXPIRED
+                self.auth_state = CbsAuthState.EXPIRED
             elif is_refresh_required:
-                self.state = CbsAuthState.REFRESH_REQUIRED
-        elif self.state == CbsAuthState.IN_PROGRESS:
+                self.auth_state = CbsAuthState.REFRESH_REQUIRED
+        elif self.auth_state == CbsAuthState.IN_PROGRESS:
             put_timeout = check_put_timeout_status(self._auth_timeout, self._token_put_time)
             if put_timeout:
-                self.state = CbsAuthState.TIMEOUT
+                self.auth_state = CbsAuthState.TIMEOUT
 
     def _cbs_link_ready(self):
         if self.state == CbsState.OPEN:


### PR DESCRIPTION
Previously `update_status` was setting the CBS Auth status to `self.state` instead of `self.auth_state`. This would prevent refreshes to the token after the initial refresh when `self.auth_state` was initialized to `CbsAuthState.IDLE`.

This would cause `self.auth_state` to be either `CbsAuthState.IDLE` or `CbsAuthState.IN_PROGRESS` when `handle_token` was called.