### PR TITLE
[Storage] Revert removing aiohttp dependency for storage.blob.aio

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Bugs Fixed
 - Stable release of features from 12.13.0b1.
 - Added support for deleting versions in `delete_blobs` by supplying `version_id`.
-- Removed forced `aiohttp` import from storage async download. (#24965)
 
 ## 12.13.0b1 (2022-06-15)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -12,8 +12,8 @@ from itertools import islice
 from typing import AsyncIterator
 
 import asyncio
-
-from azure.core.exceptions import HttpResponseError, ServiceResponseError, IncompleteReadError
+from aiohttp import ClientPayloadError
+from azure.core.exceptions import HttpResponseError, ServiceResponseError
 
 from .._shared.request_handlers import validate_and_format_range_headers
 from .._shared.response_handlers import process_storage_error, parse_length_from_content_range
@@ -114,14 +114,13 @@ class _AsyncChunkDownloader(_ChunkDownloader):
                     )
                     retry_active = False
 
-                except IncompleteReadError as error:
+                except HttpResponseError as error:
+                    process_storage_error(error)
+                except ClientPayloadError as error:
                     retry_total -= 1
                     if retry_total <= 0:
                         raise ServiceResponseError(error, error=error)
                     await asyncio.sleep(1)
-
-                except HttpResponseError as error:
-                    process_storage_error(error)
 
             chunk_data = await process_content(response, offset[0], offset[1], self.encryption_options)
 
@@ -357,12 +356,6 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                     self.size = self._file_size
                 retry_active = False
 
-            except IncompleteReadError as error:
-                retry_total -= 1
-                if retry_total <= 0:
-                    raise ServiceResponseError(error, error=error)
-                await asyncio.sleep(1)
-
             except HttpResponseError as error:
                 if self._start_range is None and error.response.status_code == 416:
                     # Get range will fail on an empty file. If the user did not
@@ -383,6 +376,12 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                     self._file_size = 0
                 else:
                     process_storage_error(error)
+
+            except ClientPayloadError as error:
+                    retry_total -= 1
+                    if retry_total <= 0:
+                        raise ServiceResponseError(error, error=error)
+                    await asyncio.sleep(1)
 
         # get page ranges to optimize downloading sparse page blob
         if response.properties.blob_type == 'PageBlob':

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -378,10 +378,10 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                     process_storage_error(error)
 
             except ClientPayloadError as error:
-                    retry_total -= 1
-                    if retry_total <= 0:
-                        raise ServiceResponseError(error, error=error)
-                    await asyncio.sleep(1)
+                retry_total -= 1
+                if retry_total <= 0:
+                    raise ServiceResponseError(error, error=error)
+                await asyncio.sleep(1)
 
         # get page ranges to optimize downloading sparse page blob
         if response.properties.blob_type == 'PageBlob':


### PR DESCRIPTION
Reverting the changes made in #24965 (sorry @Stevenjin8) as adequate discussion and investigation has not been done on this change before the upcoming GA release. 

In the future, if/when this work gets put back in, simply revert this PR (and probably play with the changelog merge conflicts that will arise)