### PR TITLE
[typing] Add DefaultAzureCredential to allowed types for credentials in KeyVaultClient

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -17,8 +17,9 @@ from .._sdk_moniker import SDK_MONIKER
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any
+    from typing import Any, Union
     from azure.core.credentials import TokenCredential
+    from azure.identity import DefaultAzureCredential
 
 
 class ApiVersion(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
@@ -37,7 +38,7 @@ DEFAULT_VERSION = ApiVersion.V7_3
 
 class KeyVaultClientBase(object):
     def __init__(self, vault_url, credential, **kwargs):
-        # type: (str, TokenCredential, **Any) -> None
+        # type: (str, Union[TokenCredential,DefaultAzureCredential], **Any) -> None
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "


### PR DESCRIPTION
# Description

The current typing for KeyVaultClient does not match the steps described in current documentation: [here](https://docs.microsoft.com/en-us/azure/key-vault/secrets/quick-create-python?tabs=azure-cli#create-the-sample-code)

I have added the `DefaultAzureCredential` from `azure.identity` based on the current recommended steps from the documentation.

<!---
Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

-->

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
