### PR TITLE
Issue #24273 add async test for offline test compress compressed no header offline

### DIFF
--- a/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
@@ -173,6 +173,7 @@ async def test_decompress_compressed_header(http_request):
         decoded = content.decode('utf-8')
         assert decoded == "test"
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_compress_compressed_header(http_request):


### PR DESCRIPTION
This PR will:
- mark async test_compress_compressed_no_header as live test only
