### PR TITLE
Fixes in parameter usage of Async CosmosDB container class

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -296,7 +296,13 @@ class ContainerProxy(object):
     def query_items(
         self,
         query: Union[str, Dict[str, Any]],
-        **kwargs: Any
+        parameters: Optional[List[Dict[str, object]]] = None,
+        partition_key: Optional[Any] = None,
+        enable_cross_partition_query: Optional[bool] = None,  
+        max_item_count: Optional[int] = None, 
+        enable_scan_in_query: Optional[bool] = None, 
+        populate_query_metrics: Optional[bool] = None,
+        **kwargs  # type: Any
     ) -> AsyncItemPaged[Dict[str, Any]]:
         """Return all results matching the given `query`.
 
@@ -348,20 +354,16 @@ class ContainerProxy(object):
         """
         feed_options = _build_options(kwargs)
         response_hook = kwargs.pop('response_hook', None)
-        max_item_count = kwargs.pop('max_item_count', None)
+        if enable_cross_partition_query is not None:
+            feed_options["enableCrossPartitionQuery"] = enable_cross_partition_query
         if max_item_count is not None:
             feed_options["maxItemCount"] = max_item_count
-        populate_query_metrics = kwargs.pop('populate_query_metrics', None)
         if populate_query_metrics is not None:
             feed_options["populateQueryMetrics"] = populate_query_metrics
-        enable_scan_in_query = kwargs.pop('enable_scan_in_query', None)
         if enable_scan_in_query is not None:
             feed_options["enableScanInQuery"] = enable_scan_in_query
-        partition_key = kwargs.pop('partition_key', None)
         if partition_key is not None:
             feed_options["partitionKey"] = self._set_partition_key(partition_key)
-        else:
-            feed_options["enableCrossPartitionQuery"] = True
         max_integrated_cache_staleness_in_ms = kwargs.pop('max_integrated_cache_staleness_in_ms', None)
         if max_integrated_cache_staleness_in_ms:
             validate_cache_staleness_value(max_integrated_cache_staleness_in_ms)


### PR DESCRIPTION
# Description
Fix for #25104 
Found out that because there was a difference in parameter definition in sync container that were all relying on kwargs in async some faulty behaviour with partition_key and cross partition queries came out, fixed that for all methods in _container of aio cosmos.

Please add an informative description that covers that changes made by the pull request and link all relevant issues.


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
