### PR TITLE
[Core] Add `@runtime_checkable` to TokenCredential protocol definitions

### DIFF
--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -5,7 +5,7 @@
 # -------------------------------------------------------------------------
 from collections import namedtuple
 from typing import Any, NamedTuple, Optional
-from typing_extensions import Protocol
+from typing_extensions import Protocol, runtime_checkable
 import six
 
 
@@ -19,6 +19,7 @@ AccessToken.token.__doc__ = """The token string."""
 AccessToken.expires_on.__doc__ = """The token's expiration time in Unix time."""
 
 
+@runtime_checkable
 class TokenCredential(Protocol):
     """Protocol for classes able to provide OAuth tokens."""
 

--- a/sdk/core/azure-core/azure/core/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/credentials_async.py
@@ -3,9 +3,10 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from typing import Any, Optional
-from typing_extensions import Protocol
+from typing_extensions import Protocol, runtime_checkable
 from .credentials import AccessToken as _AccessToken
 
+@runtime_checkable
 class AsyncTokenCredential(Protocol):
     """Protocol for classes able to provide OAuth tokens."""
 


### PR DESCRIPTION
# Description

See https://github.com/Azure/azure-sdk-for-python/issues/25175. With this PR, doing an `isinstance` check with an `azure-identity` credential and a `TokenCredential` protocol returns True -- that check errors today since these protocols aren't runtime checkable.

`isinstance` and `issubclass` checks aren't available without `@runtime_checkable`, but [explicitly declaring the `TokenCredential` implementation](https://peps.python.org/pep-0544/#explicitly-declaring-implementation) (as shown below) could possibly satisfy static type checkers.
```python
# from https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
...
from azure.core.credentials import TokenCredential
...
class GetTokenMixin(ABC, TokenCredential):
```
```python
# from https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
...
from azure.core.credentials_async import AsyncTokenCredential
...
class GetTokenMixin(abc.ABC, AsyncTokenCredential):
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
