### PR TITLE
Update platform matrix to ubuntu 20.04 for storage tests-weekly

### DIFF
--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -6,7 +6,7 @@
     },
     "matrix": {
         "Agent": {
-          "ubuntu-18.04": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" },
+          "ubuntu-18.04": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" },
           "windows-2019": { "OSVmImage": "MMS2019", "Pool": "azsdk-pool-mms-win-2019-general" },
           "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
         },


### PR DESCRIPTION
Resolves #25170

@jalauzon-msft I did some digging and ran down what I'm pretty confident is the problem. This is the only difference between the passing nightly livetests, and the failing weekly livetest.

[manual test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1703886&view=logs&s=1bcc2fd0-6dea-525b-4e01-7c719fea0eb4)