### PR TITLE
[Test Proxy] Improve variables API documentation

### DIFF
--- a/doc/dev/test_proxy_migration_guide.md
+++ b/doc/dev/test_proxy_migration_guide.md
@@ -316,19 +316,24 @@ class TestExample(AzureRecordedTestCase):
 
     @recorded_by_proxy
     def test_example(self, **kwargs):
-        # in live mode, variables is an empty dictionary
-        # in playback mode, the value of variables is {"table_name": "random-value"}
-        variables = kwargs.pop("variables")
-        if self.is_live:
-            table_name = "random-value"
-            variables = {"table_name": table_name}
+        # In live mode, variables is an empty dictionary
+        # In playback mode, the value of variables is {"table_name": "random-value"}
+        variables = kwargs.pop("variables", {})
+ 
+        # To fetch variable values, use the `setdefault` method to look for a key ("table_name")
+        # and set a real value for that key if it's not present ("random-value")
+        table_name = variables.setdefault("table_name", "random-value")
 
         # use variables["table_name"] when using the table name throughout the test
         ...
 
-        # return the variables at the end of the test
+        # return the variables at the end of the test to record them
         return variables
 ```
+
+> **Note:** `variables` will be passed as a named argument to any test that accepts `kwargs` by the test proxy. In
+> environments that don't use the test proxy, though -- like live test pipelines -- `variables` won't be provided.
+> To avoid a KeyError, providing an empty dictionary as the default value to `kwargs.pop` is recommended.
 
 ## Migrate management-plane tests
 


### PR DESCRIPTION
# Description

Prompted by [an issue](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1706163&view=ms.vss-test-web.build-test-results-tab&runId=33366212&resultId=100099&paneView=debug) the Storage team ran into, when `kwargs.pop("variables")` fails in live test pipelines (because the test proxy isn't running, and `variables` therefore aren't provided).

In addition to recommending a default value for `kwargs.pop`, this simplifies the use of `variables` by using the `setdefault` method to query the dictionary, or update it, in the same line -- without any need to check for emptiness or live-running status of the test!

@scbedd 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - Verified using the Storage test that prompted this change 
