### PR TITLE
[Storage] Fix some live tests

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob.pyTestStorageAppendBlobtest_create_append_blob_with_immutability_policy.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob.pyTestStorageAppendBlobtest_create_append_blob_with_immutability_policy.json
@@ -6,27 +6,23 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "6ee1f4a2-02e7-11ed-adce-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:33 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:05 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:07:33 GMT",
-        "ETag": "\u00220x8DA650B530D4A34\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:07:33 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:05 GMT",
+        "ETag": "\u00220x8DA65109160C860\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:45:05 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6ee1f4a2-02e7-11ed-adce-f4939fee4ab2",
-        "x-ms-request-id": "22ff60b5-801e-0033-25f4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -37,27 +33,23 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "6f1d9fa6-02e7-11ed-a8ee-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:34 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:06 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:07:33 GMT",
-        "ETag": "\u00220x8DA650B531BA002\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:07:33 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:05 GMT",
+        "ETag": "\u00220x8DA65109168414B\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:45:05 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6f1d9fa6-02e7-11ed-a8ee-f4939fee4ab2",
-        "x-ms-request-id": "22ff60e8-801e-0033-4df4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -79,18 +71,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 13 Jul 2022 20:07:35 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:05 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=Au6VMOec9QdJrkWT3XIDS58; expires=Fri, 12-Aug-2022 20:07:35 GMT; path=/; secure; HttpOnly; SameSite=None",
-          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrqJqDZI_IjCyZSX9jccIdYwDwdzxtUYAagOfTbY8TzQPnY0eznfL0LuHaatjtbTaES4ozv4mQTeQoLHr0fi9iIJoh_tBjtQwF3-XaNm7le-pVDUW7tvIqeTWlkP0Wb-hvngzslMgmSfddQOCvuM8_Imxk6dD2amKL8vwXdDh_De4gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AnPtpJ9wYIxDmGvTcmpzSqg; expires=Fri, 12-Aug-2022 20:45:06 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr38W_2E0Oc_Cb7LXZm-xqzBAPwBwwF6viLeoU0MdNx0vrc-wgYGsLi5Nk02t5K5E0dBs42oM6Uf08vp0tTZikqEZU8rwWhr6jAphAzWfunpiJTwCT3bWUWRrMYCKsUIYySLSkjBLJWEwCQjI8L7LmuNyMJPGGoUW5LVk__pzV37ggAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.13201.7 - SCUS ProdSlices",
-        "x-ms-request-id": "b56ca525-ce5d-4f85-9c66-84e61b7a3e00",
+        "x-ms-ests-server": "2.1.13201.7 - EUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -168,7 +159,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=Au6VMOec9QdJrkWT3XIDS58; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "Cookie": "fpc=AnPtpJ9wYIxDmGvTcmpzSqg; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
         "User-Agent": "azsdk-python-identity/1.11.0b3 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
@@ -179,17 +170,16 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 13 Jul 2022 20:07:35 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:05 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=Au6VMOec9QdJrkWT3XIDS58; expires=Fri, 12-Aug-2022 20:07:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AnPtpJ9wYIxDmGvTcmpzSqg; expires=Fri, 12-Aug-2022 20:45:06 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-ests-server": "2.1.13156.10 - EUS ProdSlices",
-        "x-ms-request-id": "6bcf77dd-c7b3-4a25-a8a7-9b8400a84c01",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -245,12 +235,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "6fea91e4-02e7-11ed-82a1-f4939fee4ab2"
+        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "properties": {
@@ -264,17 +252,16 @@
         "Cache-Control": "no-cache",
         "Content-Length": "455",
         "Content-Type": "application/json",
-        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
-        "ETag": "\u00220x8DA650B55129517\u0022",
+        "Date": "Wed, 13 Jul 2022 20:45:07 GMT",
+        "ETag": "\u00220x8DA651092B17E51\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "194dc866-e031-49af-a578-bb435c52704a",
+        "x-ms-correlation-request-id": "3e520058-660d-48fc-8612-afc2b56cae51",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "a1479c50-2142-4e1a-b30b-7142b49b4220",
-        "x-ms-routing-request-id": "WESTUS2:20220713T200737Z:194dc866-e031-49af-a578-bb435c52704a"
+        "x-ms-routing-request-id": "WESTUS2:20220713T204508Z:3e520058-660d-48fc-8612-afc2b56cae51"
       },
       "ResponseBody": {
         "id": "/subscriptions/ba45b233-e2ef-4169-8808-49eb0d8eba0d/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storagenamestorname/blobServices/default/containers/vlwcontainer32763514",
@@ -297,15 +284,13 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-client-request-id": "71289835-02e7-11ed-ac76-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "x-ms-immutability-policy-mode": "Unlocked",
-        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:07:43 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:45:15 GMT",
         "x-ms-legal-hold": "true",
         "x-ms-version": "2021-08-06"
       },
@@ -313,18 +298,16 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
-        "ETag": "\u00220x8DA650B55275A25\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:07 GMT",
+        "ETag": "\u00220x8DA651092CACA98\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:45:08 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "71289835-02e7-11ed-ac76-f4939fee4ab2",
-        "x-ms-request-id": "22ff68ab-801e-0033-02f4-962e76000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-13T20:07:37.4034469Z"
+        "x-ms-version-id": "2022-07-13T20:45:08.2992280Z"
       },
       "ResponseBody": null
     },
@@ -334,11 +317,9 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "7130c974-02e7-11ed-ace8-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -347,27 +328,25 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
-        "ETag": "\u00220x8DA650B55275A25\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:07 GMT",
+        "ETag": "\u00220x8DA651092CACA98\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:45:08 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-committed-block-count": "0",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-client-request-id": "7130c974-02e7-11ed-ace8-f4939fee4ab2",
-        "x-ms-creation-time": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "x-ms-creation-time": "Wed, 13 Jul 2022 20:45:08 GMT",
         "x-ms-immutability-policy-mode": "unlocked",
-        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:07:43 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:45:15 GMT",
         "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-legal-hold": "true",
-        "x-ms-request-id": "22ff68cd-801e-0033-1cf4-962e76000000",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-13T20:07:37.4034469Z"
+        "x-ms-version-id": "2022-07-13T20:45:08.2992280Z"
       },
       "ResponseBody": null
     },
@@ -377,12 +356,10 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "71364b9d-02e7-11ed-a8a7-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -390,20 +367,18 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "71364b9d-02e7-11ed-a8a7-f4939fee4ab2",
         "x-ms-error-code": "BlobImmutableDueToLegalHold",
-        "x-ms-request-id": "22ff68f5-801e-0033-3ff4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobImmutableDueToLegalHold\u003C/Code\u003E\u003CMessage\u003EThis operation is not permitted as the blob is immutable due to one or more legal holds.\n",
-        "RequestId:22ff68f5-801e-0033-3ff4-962e76000000\n",
-        "Time:2022-07-13T20:07:37.4801564Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:c5707668-701e-00a1-37f9-96aaa0000000\n",
+        "Time:2022-07-13T20:45:08.3872745Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
@@ -412,25 +387,21 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "713c2085-02e7-11ed-bf59-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "713c2085-02e7-11ed-bf59-f4939fee4ab2",
-        "x-ms-request-id": "22ff6917-801e-0033-5ef4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -441,12 +412,10 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "7140f83c-02e7-11ed-92e2-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "x-ms-legal-hold": "false",
         "x-ms-version": "2021-08-06"
       },
@@ -454,14 +423,12 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "7140f83c-02e7-11ed-92e2-f4939fee4ab2",
         "x-ms-legal-hold": "false",
-        "x-ms-request-id": "22ff6927-801e-0033-6ef4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -472,26 +439,22 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "7146a3bf-02e7-11ed-abba-f4939fee4ab2",
-        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "7146a3bf-02e7-11ed-abba-f4939fee4ab2",
         "x-ms-delete-type-permanent": "false",
-        "x-ms-request-id": "22ff6937-801e-0033-7ef4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -502,11 +465,9 @@
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
-        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-client-request-id": "714c6a07-02e7-11ed-8e17-f4939fee4ab2"
+        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -514,21 +475,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "0",
         "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Wed, 13 Jul 2022 20:07:37 GMT",
+        "Date": "Wed, 13 Jul 2022 20:45:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "f802c3a2-5985-4e88-b2dd-c01eb73a4fe4",
+        "x-ms-correlation-request-id": "31b6f5d7-f8ea-4d7b-8788-42399d34320e",
         "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-request-id": "d56f14c3-7d52-4d08-bb39-c42f2cb06491",
-        "x-ms-routing-request-id": "WESTUS2:20220713T200737Z:f802c3a2-5985-4e88-b2dd-c01eb73a4fe4"
+        "x-ms-routing-request-id": "WESTUS2:20220713T204508Z:31b6f5d7-f8ea-4d7b-8788-42399d34320e"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "expiry_time": "2022-07-13T20:07:43.915570"
+    "expiry_time": "2022-07-13T20:45:15.935672"
   }
 }

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob.pyTestStorageAppendBlobtest_create_append_blob_with_immutability_policy.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob.pyTestStorageAppendBlobtest_create_append_blob_with_immutability_policy.json
@@ -6,23 +6,27 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:15 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "6ee1f4a2-02e7-11ed-adce-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:33 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:42:14 GMT",
-        "ETag": "\u00220x8DA61331B059BC3\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:42:15 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:33 GMT",
+        "ETag": "\u00220x8DA650B530D4A34\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:07:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-client-request-id": "6ee1f4a2-02e7-11ed-adce-f4939fee4ab2",
+        "x-ms-request-id": "22ff60b5-801e-0033-25f4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -33,23 +37,27 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:15 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "6f1d9fa6-02e7-11ed-a8ee-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:34 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:42:14 GMT",
-        "ETag": "\u00220x8DA61331B121D1E\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:42:15 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:33 GMT",
+        "ETag": "\u00220x8DA650B531BA002\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:07:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-client-request-id": "6f1d9fa6-02e7-11ed-a8ee-f4939fee4ab2",
+        "x-ms-request-id": "22ff60e8-801e-0033-4df4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -61,7 +69,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.11.0b3 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -71,17 +79,18 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 08 Jul 2022 22:42:16 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:35 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=Auu3eYdtIg9Asha4fm5W32U; expires=Sun, 07-Aug-2022 22:42:17 GMT; path=/; secure; HttpOnly; SameSite=None",
-          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrv50D2qimbc4ShWWZPLWSMSORHSPN9Mq0y2jRmKd1AlmM-Bg52hRXHkeLWBTLNZg21xg8BJ5ASVwBt9pL5vy4feUiRh67Zrqcii5AoVzFyIvPT06r6DaZ5spUfHAXcOFrA1st_Rq_BX3jfFYdvRlJMuMqTCdRdX9lrrKVaoLESJIgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=Au6VMOec9QdJrkWT3XIDS58; expires=Fri, 12-Aug-2022 20:07:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrqJqDZI_IjCyZSX9jccIdYwDwdzxtUYAagOfTbY8TzQPnY0eznfL0LuHaatjtbTaES4ozv4mQTeQoLHr0fi9iIJoh_tBjtQwF3-XaNm7le-pVDUW7tvIqeTWlkP0Wb-hvngzslMgmSfddQOCvuM8_Imxk6dD2amKL8vwXdDh_De4gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.13156.10 - EUS ProdSlices",
+        "x-ms-ests-server": "2.1.13201.7 - SCUS ProdSlices",
+        "x-ms-request-id": "b56ca525-ce5d-4f85-9c66-84e61b7a3e00",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -159,8 +168,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=Auu3eYdtIg9Asha4fm5W32U; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.11.0b2 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=Au6VMOec9QdJrkWT3XIDS58; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.11.0b3 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -170,16 +179,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 08 Jul 2022 22:42:16 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:35 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=Auu3eYdtIg9Asha4fm5W32U; expires=Sun, 07-Aug-2022 22:42:17 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=Au6VMOec9QdJrkWT3XIDS58; expires=Fri, 12-Aug-2022 20:07:35 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.13156.10 - SCUS ProdSlices",
+        "x-ms-ests-server": "2.1.13156.10 - EUS ProdSlices",
+        "x-ms-request-id": "6bcf77dd-c7b3-4a25-a8a7-9b8400a84c01",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -235,10 +245,12 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "6fea91e4-02e7-11ed-82a1-f4939fee4ab2"
       },
       "RequestBody": {
         "properties": {
@@ -252,16 +264,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "455",
         "Content-Type": "application/json",
-        "Date": "Fri, 08 Jul 2022 22:42:18 GMT",
-        "ETag": "\u00220x8DA61331D5D449D\u0022",
+        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
+        "ETag": "\u00220x8DA650B55129517\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "eccfe685-27d1-4cd0-9846-0a4687218ec0",
+        "x-ms-correlation-request-id": "194dc866-e031-49af-a578-bb435c52704a",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-routing-request-id": "WESTUS2:20220708T224219Z:eccfe685-27d1-4cd0-9846-0a4687218ec0"
+        "x-ms-request-id": "a1479c50-2142-4e1a-b30b-7142b49b4220",
+        "x-ms-routing-request-id": "WESTUS2:20220713T200737Z:194dc866-e031-49af-a578-bb435c52704a"
       },
       "ResponseBody": {
         "id": "/subscriptions/ba45b233-e2ef-4169-8808-49eb0d8eba0d/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storagenamestorname/blobServices/default/containers/vlwcontainer32763514",
@@ -284,13 +297,15 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "x-ms-client-request-id": "71289835-02e7-11ed-ac76-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
         "x-ms-immutability-policy-mode": "Unlocked",
-        "x-ms-immutability-policy-until-date": "Fri, 08 Jul 2022 22:42:25 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:07:43 GMT",
         "x-ms-legal-hold": "true",
         "x-ms-version": "2021-08-06"
       },
@@ -298,16 +313,18 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:42:18 GMT",
-        "ETag": "\u00220x8DA61331D6EB421\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
+        "ETag": "\u00220x8DA650B55275A25\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:07:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-client-request-id": "71289835-02e7-11ed-ac76-f4939fee4ab2",
+        "x-ms-request-id": "22ff68ab-801e-0033-02f4-962e76000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-08T22:42:19.1367201Z"
+        "x-ms-version-id": "2022-07-13T20:07:37.4034469Z"
       },
       "ResponseBody": null
     },
@@ -317,9 +334,11 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7130c974-02e7-11ed-ace8-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -328,25 +347,27 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Fri, 08 Jul 2022 22:42:19 GMT",
-        "ETag": "\u00220x8DA61331D6EB421\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
+        "ETag": "\u00220x8DA650B55275A25\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:07:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-committed-block-count": "0",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-creation-time": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "x-ms-client-request-id": "7130c974-02e7-11ed-ace8-f4939fee4ab2",
+        "x-ms-creation-time": "Wed, 13 Jul 2022 20:07:37 GMT",
         "x-ms-immutability-policy-mode": "unlocked",
-        "x-ms-immutability-policy-until-date": "Fri, 08 Jul 2022 22:42:25 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:07:43 GMT",
         "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-legal-hold": "true",
+        "x-ms-request-id": "22ff68cd-801e-0033-1cf4-962e76000000",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-08T22:42:19.1367201Z"
+        "x-ms-version-id": "2022-07-13T20:07:37.4034469Z"
       },
       "ResponseBody": null
     },
@@ -356,10 +377,12 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "71364b9d-02e7-11ed-a8a7-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -367,18 +390,20 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-client-request-id": "71364b9d-02e7-11ed-a8a7-f4939fee4ab2",
         "x-ms-error-code": "BlobImmutableDueToLegalHold",
+        "x-ms-request-id": "22ff68f5-801e-0033-3ff4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobImmutableDueToLegalHold\u003C/Code\u003E\u003CMessage\u003EThis operation is not permitted as the blob is immutable due to one or more legal holds.\n",
-        "RequestId:d8c0817a-401e-0061-121b-93529e000000\n",
-        "Time:2022-07-08T22:42:19.2431848Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:22ff68f5-801e-0033-3ff4-962e76000000\n",
+        "Time:2022-07-13T20:07:37.4801564Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
@@ -387,21 +412,25 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "713c2085-02e7-11ed-bf59-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-client-request-id": "713c2085-02e7-11ed-bf59-f4939fee4ab2",
+        "x-ms-request-id": "22ff6917-801e-0033-5ef4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -412,10 +441,12 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7140f83c-02e7-11ed-92e2-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
         "x-ms-legal-hold": "false",
         "x-ms-version": "2021-08-06"
       },
@@ -423,12 +454,14 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-client-request-id": "7140f83c-02e7-11ed-92e2-f4939fee4ab2",
         "x-ms-legal-hold": "false",
+        "x-ms-request-id": "22ff6927-801e-0033-6ef4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -439,22 +472,26 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "7146a3bf-02e7-11ed-abba-f4939fee4ab2",
+        "x-ms-date": "Wed, 13 Jul 2022 20:07:37 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:36 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-client-request-id": "7146a3bf-02e7-11ed-abba-f4939fee4ab2",
         "x-ms-delete-type-permanent": "false",
+        "x-ms-request-id": "22ff6937-801e-0033-7ef4-962e76000000",
         "x-ms-version": "2021-08-06"
       },
       "ResponseBody": null
@@ -465,9 +502,11 @@
       "RequestHeaders": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azure-mgmt-storage/20.0.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-client-request-id": "714c6a07-02e7-11ed-8e17-f4939fee4ab2"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -475,20 +514,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "0",
         "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 08 Jul 2022 22:42:19 GMT",
+        "Date": "Wed, 13 Jul 2022 20:07:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "8d49f4b0-2968-4421-a818-4bb847d50e50",
+        "x-ms-correlation-request-id": "f802c3a2-5985-4e88-b2dd-c01eb73a4fe4",
         "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-routing-request-id": "WESTUS2:20220708T224220Z:8d49f4b0-2968-4421-a818-4bb847d50e50"
+        "x-ms-request-id": "d56f14c3-7d52-4d08-bb39-c42f2cb06491",
+        "x-ms-routing-request-id": "WESTUS2:20220713T200737Z:f802c3a2-5985-4e88-b2dd-c01eb73a4fe4"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "expiry_time": "2022-07-08T22:42:25.248569"
+    "expiry_time": "2022-07-13T20:07:43.915570"
   }
 }

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob_async.pyTestStorageAppendBlobAsynctest_create_append_blob_with_immutability_policy.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob_async.pyTestStorageAppendBlobAsynctest_create_append_blob_with_immutability_policy.json
@@ -7,17 +7,17 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:00 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:50 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:44:59 GMT",
-        "ETag": "\u00220x8DA61337D949D6A\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:45:00 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:50 GMT",
+        "ETag": "\u00220x8DA650BA44AE31F\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:09:50 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -33,17 +33,17 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:01 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:50 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:44:59 GMT",
-        "ETag": "\u00220x8DA61337DA208F9\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:45:00 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:50 GMT",
+        "ETag": "\u00220x8DA650BA45911C7\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:09:50 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -74,16 +74,16 @@
         "Cache-Control": "no-cache",
         "Content-Length": "465",
         "Content-Type": "application/json",
-        "Date": "Fri, 08 Jul 2022 22:45:02 GMT",
-        "ETag": "\u00220x8DA61337EE96355\u0022",
+        "Date": "Wed, 13 Jul 2022 20:09:52 GMT",
+        "ETag": "\u00220x8DA650BA5EB7F55\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "63a0e9da-32ec-429c-bcae-8eef591d8884",
+        "x-ms-correlation-request-id": "f98af503-53b3-4335-819a-8e903ebb50d4",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-routing-request-id": "WESTUS2:20220708T224502Z:63a0e9da-32ec-429c-bcae-8eef591d8884"
+        "x-ms-routing-request-id": "WESTUS2:20220713T200952Z:f98af503-53b3-4335-819a-8e903ebb50d4"
       },
       "ResponseBody": {
         "id": "/subscriptions/ba45b233-e2ef-4169-8808-49eb0d8eba0d/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storagenamestorname/blobServices/default/containers/vlwcontainerasynca398398f",
@@ -107,11 +107,11 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:03 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "x-ms-immutability-policy-mode": "Unlocked",
-        "x-ms-immutability-policy-until-date": "Fri, 08 Jul 2022 22:45:10 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:10:00 GMT",
         "x-ms-legal-hold": "true",
         "x-ms-version": "2021-08-06"
       },
@@ -119,16 +119,16 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:45:02 GMT",
-        "ETag": "\u00220x8DA61337EFC0391\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:45:02 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:52 GMT",
+        "ETag": "\u00220x8DA650BA605F9A4\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:09:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-08T22:45:02.8018065Z"
+        "x-ms-version-id": "2022-07-13T20:09:53.0801572Z"
       },
       "ResponseBody": null
     },
@@ -138,8 +138,8 @@
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:03 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -148,25 +148,25 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Fri, 08 Jul 2022 22:45:02 GMT",
-        "ETag": "\u00220x8DA61337EFC0391\u0022",
-        "Last-Modified": "Fri, 08 Jul 2022 22:45:02 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "ETag": "\u00220x8DA650BA605F9A4\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:09:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-committed-block-count": "0",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-creation-time": "Fri, 08 Jul 2022 22:45:02 GMT",
+        "x-ms-creation-time": "Wed, 13 Jul 2022 20:09:53 GMT",
         "x-ms-immutability-policy-mode": "unlocked",
-        "x-ms-immutability-policy-until-date": "Fri, 08 Jul 2022 22:45:10 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:10:00 GMT",
         "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-legal-hold": "true",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-08T22:45:02.8018065Z"
+        "x-ms-version-id": "2022-07-13T20:09:53.0801572Z"
       },
       "ResponseBody": null
     },
@@ -177,8 +177,8 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:03 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -186,7 +186,7 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Fri, 08 Jul 2022 22:45:02 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -196,8 +196,8 @@
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobImmutableDueToLegalHold\u003C/Code\u003E\u003CMessage\u003EThis operation is not permitted as the blob is immutable due to one or more legal holds.\n",
-        "RequestId:6e28df0c-001e-0012-441c-930a0d000000\n",
-        "Time:2022-07-08T22:45:02.8760730Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:d4f796f1-301e-00a0-71f4-96f57c000000\n",
+        "Time:2022-07-13T20:09:53.1745407Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
@@ -207,15 +207,15 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:03 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:45:02 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -231,8 +231,8 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:03 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "x-ms-legal-hold": "false",
         "x-ms-version": "2021-08-06"
       },
@@ -240,7 +240,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:45:02 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -257,15 +257,15 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.13.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 08 Jul 2022 22:45:03 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 08 Jul 2022 22:45:02 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -290,20 +290,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "0",
         "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 08 Jul 2022 22:45:03 GMT",
+        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "1fd3c993-ccbc-497d-9ac5-e4ccee07b8d3",
+        "x-ms-correlation-request-id": "d8d17417-48d8-4f1f-9171-18b282ff2425",
         "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-routing-request-id": "WESTUS2:20220708T224503Z:1fd3c993-ccbc-497d-9ac5-e4ccee07b8d3"
+        "x-ms-routing-request-id": "WESTUS2:20220713T200953Z:d8d17417-48d8-4f1f-9171-18b282ff2425"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "expiry_time": "2022-07-08T22:45:10.658505"
+    "expiry_time": "2022-07-13T20:10:00.162112"
   }
 }

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob_async.pyTestStorageAppendBlobAsynctest_create_append_blob_with_immutability_policy.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_append_blob_async.pyTestStorageAppendBlobAsynctest_create_append_blob_with_immutability_policy.json
@@ -8,16 +8,16 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:50 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:20 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:09:50 GMT",
-        "ETag": "\u00220x8DA650BA44AE31F\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:09:50 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:20 GMT",
+        "ETag": "\u00220x8DA6510E1AEC4F7\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:47:20 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -34,16 +34,16 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:50 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:21 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:09:50 GMT",
-        "ETag": "\u00220x8DA650BA45911C7\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:09:50 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:20 GMT",
+        "ETag": "\u00220x8DA6510E1C09C88\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:47:20 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -74,16 +74,16 @@
         "Cache-Control": "no-cache",
         "Content-Length": "465",
         "Content-Type": "application/json",
-        "Date": "Wed, 13 Jul 2022 20:09:52 GMT",
-        "ETag": "\u00220x8DA650BA5EB7F55\u0022",
+        "Date": "Wed, 13 Jul 2022 20:47:22 GMT",
+        "ETag": "\u00220x8DA6510E35579A0\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "f98af503-53b3-4335-819a-8e903ebb50d4",
+        "x-ms-correlation-request-id": "59e43bb6-42ec-41d5-98e5-22d108525ad8",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-routing-request-id": "WESTUS2:20220713T200952Z:f98af503-53b3-4335-819a-8e903ebb50d4"
+        "x-ms-routing-request-id": "WESTUS2:20220713T204723Z:59e43bb6-42ec-41d5-98e5-22d108525ad8"
       },
       "ResponseBody": {
         "id": "/subscriptions/ba45b233-e2ef-4169-8808-49eb0d8eba0d/resourceGroups/rgname/providers/Microsoft.Storage/storageAccounts/storagenamestorname/blobServices/default/containers/vlwcontainerasynca398398f",
@@ -109,9 +109,9 @@
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:23 GMT",
         "x-ms-immutability-policy-mode": "Unlocked",
-        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:10:00 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:47:30 GMT",
         "x-ms-legal-hold": "true",
         "x-ms-version": "2021-08-06"
       },
@@ -119,16 +119,16 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:09:52 GMT",
-        "ETag": "\u00220x8DA650BA605F9A4\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:23 GMT",
+        "ETag": "\u00220x8DA6510E3693669\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:47:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-13T20:09:53.0801572Z"
+        "x-ms-version-id": "2022-07-13T20:47:23.5551849Z"
       },
       "ResponseBody": null
     },
@@ -139,7 +139,7 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:23 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -148,25 +148,25 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
-        "ETag": "\u00220x8DA650BA605F9A4\u0022",
-        "Last-Modified": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:23 GMT",
+        "ETag": "\u00220x8DA6510E3693669\u0022",
+        "Last-Modified": "Wed, 13 Jul 2022 20:47:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-committed-block-count": "0",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-creation-time": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "x-ms-creation-time": "Wed, 13 Jul 2022 20:47:23 GMT",
         "x-ms-immutability-policy-mode": "unlocked",
-        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:10:00 GMT",
+        "x-ms-immutability-policy-until-date": "Wed, 13 Jul 2022 20:47:30 GMT",
         "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-legal-hold": "true",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2021-08-06",
-        "x-ms-version-id": "2022-07-13T20:09:53.0801572Z"
+        "x-ms-version-id": "2022-07-13T20:47:23.5551849Z"
       },
       "ResponseBody": null
     },
@@ -178,7 +178,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:24 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -186,7 +186,7 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -196,8 +196,8 @@
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobImmutableDueToLegalHold\u003C/Code\u003E\u003CMessage\u003EThis operation is not permitted as the blob is immutable due to one or more legal holds.\n",
-        "RequestId:d4f796f1-301e-00a0-71f4-96f57c000000\n",
-        "Time:2022-07-13T20:09:53.1745407Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:bdeaae33-601e-0059-7ef9-96f65e000000\n",
+        "Time:2022-07-13T20:47:23.6778238Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
@@ -208,14 +208,14 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:24 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -232,7 +232,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:24 GMT",
         "x-ms-legal-hold": "false",
         "x-ms-version": "2021-08-06"
       },
@@ -240,7 +240,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -258,14 +258,14 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "x-ms-date": "Wed, 13 Jul 2022 20:47:24 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -290,20 +290,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "0",
         "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Wed, 13 Jul 2022 20:09:53 GMT",
+        "Date": "Wed, 13 Jul 2022 20:47:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "d8d17417-48d8-4f1f-9171-18b282ff2425",
+        "x-ms-correlation-request-id": "1033532b-9d26-4ad1-b002-c4c81bf4bb41",
         "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-routing-request-id": "WESTUS2:20220713T200953Z:d8d17417-48d8-4f1f-9171-18b282ff2425"
+        "x-ms-routing-request-id": "WESTUS2:20220713T204724Z:1033532b-9d26-4ad1-b002-c4c81bf4bb41"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "expiry_time": "2022-07-13T20:10:00.162112"
+    "expiry_time": "2022-07-13T20:47:30.627101"
   }
 }

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob.py
@@ -1527,10 +1527,9 @@ class TestStorageAppendBlob(StorageRecordedTestCase):
         versioned_storage_account_key = kwargs.pop("versioned_storage_account_key")
         storage_resource_group_name = kwargs.pop("storage_resource_group_name")
 
-        variables = kwargs.pop("variables")
-        if self.is_live:
-            expiry_time = datetime.utcnow() + timedelta(seconds=10)
-            variables = {"expiry_time": expiry_time.isoformat()}
+        variables = kwargs.pop("variables", {})
+        expiry_time = datetime.utcnow() + timedelta(seconds=10)
+        expiry_time_string = variables.setdefault("expiry_time", expiry_time.isoformat())
 
         bsc = BlobServiceClient(self.account_url(versioned_storage_account_name, "blob"), versioned_storage_account_key, max_block_size=4 * 1024)
         self._setup(bsc)
@@ -1548,7 +1547,7 @@ class TestStorageAppendBlob(StorageRecordedTestCase):
         blob_name = self.get_resource_name('vlwblob')
         blob = bsc.get_blob_client(container_name, blob_name)
 
-        expires = datetime.strptime(variables["expiry_time"], "%Y-%m-%dT%H:%M:%S.%f")
+        expires = datetime.strptime(expiry_time_string, "%Y-%m-%dT%H:%M:%S.%f")
         immutability_policy = ImmutabilityPolicy(expiry_time=expires, policy_mode=BlobImmutabilityPolicyMode.Unlocked)
         blob.create_append_blob(immutability_policy=immutability_policy,
                                 legal_hold=True)

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -1521,10 +1521,9 @@ class TestStorageAppendBlobAsync(AsyncStorageRecordedTestCase):
         versioned_storage_account_key = kwargs.pop("versioned_storage_account_key")
         storage_resource_group_name = kwargs.pop("storage_resource_group_name")
 
-        variables = kwargs.pop("variables")
-        if self.is_live:
-            expiry_time = datetime.utcnow() + timedelta(seconds=10)
-            variables = {"expiry_time": expiry_time.isoformat()}
+        variables = kwargs.pop("variables", {})
+        expiry_time = datetime.utcnow() + timedelta(seconds=10)
+        expiry_time_string = variables.setdefault("expiry_time", expiry_time.isoformat())
 
         bsc = BlobServiceClient(self.account_url(versioned_storage_account_name, "blob"), versioned_storage_account_key, max_block_size=4 * 1024)
         await self._setup(bsc)
@@ -1542,7 +1541,7 @@ class TestStorageAppendBlobAsync(AsyncStorageRecordedTestCase):
         blob_name = self.get_resource_name('vlwblob')
         blob = bsc.get_blob_client(container_name, blob_name)
 
-        expires = datetime.strptime(variables["expiry_time"], "%Y-%m-%dT%H:%M:%S.%f")
+        expires = datetime.strptime(expiry_time_string, "%Y-%m-%dT%H:%M:%S.%f")
         immutability_policy = ImmutabilityPolicy(expiry_time=expires, policy_mode=BlobImmutabilityPolicyMode.Unlocked)
         await blob.create_append_blob(immutability_policy=immutability_policy,
                                       legal_hold=True)

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -148,7 +148,7 @@ class StorageCommonBlobTest(StorageTestCase):
         # wait until the policy has gone into effect
         if self.is_live:
             self.bsc.set_service_properties(delete_retention_policy=delete_retention_policy)
-            time.sleep(35)
+            time.sleep(40)
 
     def _disable_soft_delete(self):
         delete_retention_policy = RetentionPolicy(enabled=False)

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -166,7 +166,7 @@ class StorageCommonBlobAsyncTest(AsyncStorageTestCase):
 
         # wait until the policy has gone into effect
         if self.is_live:
-            time.sleep(35)
+            time.sleep(40)
 
     async def _disable_soft_delete(self):
         delete_retention_policy = RetentionPolicy(enabled=False)


### PR DESCRIPTION
Fixing the recent test proxy test that was introduced which improperly used `variables` and was failing in the Live test pipeline.

Also sneaking a change in to further increase the wait to for soft delete to enable since we're still seeing soft delete tests fail occasionally in the nightly pipeline runs.