### PR TITLE
Ability to specify tenant_id

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -36,7 +36,7 @@ class AzureCliCredential(object):
 
     This requires previously logging in to Azure via "az login", and will use the CLI's currently logged in identity.
     """
-    def __init__(self, tenant_id: str = None):
+    def __init__(self, tenant_id: str = ""):
         object.__init__(self)
 
         self.tenant_id = tenant_id
@@ -71,7 +71,7 @@ class AzureCliCredential(object):
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
-        tenant = resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
+        tenant = resolve_tenant(default_tenant= self.tenant_id, **kwargs)
         
         if tenant:
             command += " --tenant " + tenant

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -72,7 +72,7 @@ class AzureCliCredential(object):
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
         tenant = resolve_tenant(default_tenant= self.tenant_id, **kwargs)
-        
+
         if tenant:
             command += " --tenant " + tenant
         output = _run_command(command)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -36,6 +36,10 @@ class AzureCliCredential(object):
 
     This requires previously logging in to Azure via "az login", and will use the CLI's currently logged in identity.
     """
+    def __init__(self, tenant_id: str = None):
+        object.__init__(self)
+
+        self.tenant_id = tenant_id
 
     def __enter__(self):
         return self
@@ -67,7 +71,8 @@ class AzureCliCredential(object):
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
-        tenant = resolve_tenant("", **kwargs)
+        tenant = resolve_tenant(default_tenant= "", **kwargs) if self.tenant_id is None else resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
+        
         if tenant:
             command += " --tenant " + tenant
         output = _run_command(command)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -71,7 +71,7 @@ class AzureCliCredential(object):
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
-        tenant = resolve_tenant(default_tenant= "", **kwargs) if self.tenant_id is None else resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
+        tenant = resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
         
         if tenant:
             command += " --tenant " + tenant

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -59,7 +59,7 @@ class AzureCliCredential(AsyncContextManager):
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
-        tenant = resolve_tenant(default_tenant= "", **kwargs) if self.tenant_id is None else resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
+        tenant = resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
         
         if tenant:
             command += " --tenant " + tenant

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -60,7 +60,7 @@ class AzureCliCredential(AsyncContextManager):
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
         tenant = resolve_tenant(default_tenant= self.tenant_id, **kwargs)
-        
+
         if tenant:
             command += " --tenant " + tenant
         output = await _run_command(command)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -32,6 +32,10 @@ class AzureCliCredential(AsyncContextManager):
 
     This requires previously logging in to Azure via "az login", and will use the CLI's currently logged in identity.
     """
+    def __init__(self, tenant_id = None):
+        AsyncContextManager.__init__(self)
+
+        self.tenant_id = tenant_id
 
     @log_get_token_async
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
@@ -55,7 +59,7 @@ class AzureCliCredential(AsyncContextManager):
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
-        tenant = resolve_tenant("", **kwargs)
+        tenant = resolve_tenant("", **kwargs) if self.tenant_id is None else resolve_tenant("", self.tenant_id, **kwargs)
         if tenant:
             command += " --tenant " + tenant
         output = await _run_command(command)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -59,7 +59,8 @@ class AzureCliCredential(AsyncContextManager):
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
-        tenant = resolve_tenant("", **kwargs) if self.tenant_id is None else resolve_tenant("", self.tenant_id, **kwargs)
+        tenant = resolve_tenant(default_tenant= "", **kwargs) if self.tenant_id is None else resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
+        
         if tenant:
             command += " --tenant " + tenant
         output = await _run_command(command)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -32,7 +32,7 @@ class AzureCliCredential(AsyncContextManager):
 
     This requires previously logging in to Azure via "az login", and will use the CLI's currently logged in identity.
     """
-    def __init__(self, tenant_id = None):
+    def __init__(self, tenant_id: str = None):
         AsyncContextManager.__init__(self)
 
         self.tenant_id = tenant_id

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -32,7 +32,7 @@ class AzureCliCredential(AsyncContextManager):
 
     This requires previously logging in to Azure via "az login", and will use the CLI's currently logged in identity.
     """
-    def __init__(self, tenant_id: str = None):
+    def __init__(self, tenant_id: str = ""):
         AsyncContextManager.__init__(self)
 
         self.tenant_id = tenant_id
@@ -59,7 +59,7 @@ class AzureCliCredential(AsyncContextManager):
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
-        tenant = resolve_tenant(default_tenant= "", tenant_id= self.tenant_id, **kwargs)
+        tenant = resolve_tenant(default_tenant= self.tenant_id, **kwargs)
         
         if tenant:
             command += " --tenant " + tenant


### PR DESCRIPTION
Updates the Azure CLI SDK To allow to create credential objects that are connected to tenants. This is EXTREMELY useful when you work with multiple tenants.

# Description
 This allows developers to specify what tenant the credentials should use. This way if you have access to multiple you do not need to worry about switching other ways.






### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
I created the following wrapper class locally and it has fixed my issue. No reason I should have to be that hacky.

```
from azure.identity import AzureCliCredential as main_AzureCliCredential

class AzureCliCredential(main_AzureCliCredential):
    def __init__(self, tenant_id = None):
        main_AzureCliCredential.__init__(self)

        self.tenant_id = tenant_id

    def get_token(self, *scopes: str, **kwargs):
        if self.tenant_id is not None:
            if kwargs is None:
                kwargs = {}
            kwargs["tenant_id"] = self.tenant_id
            return main_AzureCliCredential.get_token(self, *scopes, **kwargs)
        
        return main_AzureCliCredential.get_token(self, *scopes, **kwargs)
```
