### PR TITLE
[Pyamqp] Fix network logging trace in client_base

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -376,7 +376,7 @@ class ClientBase(object):  # pylint:disable=too-many-instance-attributes
             mgmt_client = AMQPClient(
                 hostname,
                 auth=mgmt_auth,
-                debug=self._config.network_tracing,
+                network_trace=self._config.network_tracing,
                 transport_type=self._config.transport_type,
                 http_proxy=self._config.http_proxy,
                 custom_endpoint_address=custom_endpoint_address,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
@@ -122,11 +122,10 @@ class AMQPClient(object):
     :type encoding: str
     """
 
-    def __init__(self, hostname, auth=None, client_name=None, debug=False, **kwargs):
+    def __init__(self, hostname, auth=None, **kwargs):
         self._hostname = hostname
         self._auth = auth
-        self._name = client_name if client_name else str(uuid.uuid4())
-        self.debug_trace = debug
+        self._name = kwargs.pop("client_name", str(uuid.uuid4()))
 
         self._shutdown = False
         self._connection = None

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
@@ -122,10 +122,12 @@ class AMQPClient(object):
     :type encoding: str
     """
 
-    def __init__(self, hostname, auth=None, **kwargs):
+    def __init__(self, hostname, auth=None, client_name=None, debug=False, **kwargs):
         self._hostname = hostname
         self._auth = auth
-        self._name = kwargs.pop("client_name", str(uuid.uuid4()))
+        self._name = client_name if client_name else str(uuid.uuid4())
+        self.debug_trace = debug
+
         self._shutdown = False
         self._connection = None
         self._session = None

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
@@ -255,7 +255,7 @@ class ClientBaseAsync(ClientBase):
             mgmt_client = AMQPClientAsync(
                 hostname,
                 auth=mgmt_auth,
-                debug=self._config.network_tracing,
+                network_trace=self._config.network_tracing,
                 transport_type=self._config.transport_type,
                 http_proxy=self._config.http_proxy,
                 custom_endpoint_address=custom_endpoint_address,


### PR DESCRIPTION
Pass in the right kwarg when setting up a `AMQPClient` so that proper logs are output. 