### PR TITLE
[DPG] upgrade version of autorest.python from `6.0.1` to `6.1.0`

### DIFF
--- a/swagger_to_sdk_config_dpg.json
+++ b/swagger_to_sdk_config_dpg.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.8.1",
-      "use": ["@autorest/python@6.0.0", "@autorest/modelerfour@4.23.5"],
+      "use": ["@autorest/python@6.1.0", "@autorest/modelerfour@4.23.5"],
       "python": "",
       "sdkrel:python-sdks-folder": "./sdk/.",
       "version-tolerant": ""


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-python/issues/25260

generated SDK of `6.1.0` will not support python3.6 anymore