### PR TITLE
[formrecognizer] Add a type for target authorization for copy requests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.2.0b6 (Unreleased)
 
 ### Features Added
+- Added `TargetAuthorization` of type `dict[str, str]`.
 
 ### Breaking Changes
 - Renamed `begin_create_composed_model()` on `DocumentModelAdministrationClient` to `begin_compose_model()`.
@@ -10,6 +11,8 @@
 - Renamed `AccountInfo` model to `ResourceInfo`.
 - Renamed `DocumentModelInfo` model to `DocumentModelSummary`.
 - Renamed `DocumentModel` to `DocumentModelInfo`.
+- Changed return type of `get_copy_authorization()` from `dict[str, str]` to `TargetAuthorization`.
+- Changed expected `target` parameter in `begin_copy_to()` from `dict[str, str]` to `TargetAuthorization`.
 
 ### Bugs Fixed
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/__init__.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/__init__.py
@@ -63,6 +63,7 @@ from ._models import (
     ResourceInfo,
     DocumentAnalysisError,
     DocumentAnalysisInnerError,
+    TargetAuthorization,
 )
 from ._api_versions import FormRecognizerApiVersion, DocumentAnalysisApiVersion
 
@@ -128,6 +129,7 @@ __all__ = [
     "ResourceInfo",
     "DocumentAnalysisError",
     "DocumentAnalysisInnerError",
+    "TargetAuthorization",
 ]
 
 __VERSION__ = VERSION

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_document_model_administration_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_document_model_administration_client.py
@@ -32,6 +32,7 @@ from ._models import (
     ModelOperation,
     ModelOperationInfo,
     ResourceInfo,
+    TargetAuthorization,
 )
 
 
@@ -259,7 +260,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBase):
         )
 
     @distributed_trace
-    def get_copy_authorization(self, **kwargs: Any) -> Dict[str, str]:
+    def get_copy_authorization(self, **kwargs: Any) -> TargetAuthorization:
         """Generate authorization for copying a custom model into the target Form Recognizer resource.
 
         This should be called by the target resource (where the model will be copied to)
@@ -271,7 +272,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBase):
         :keyword tags: List of user defined key-value tag attributes associated with the model.
         :paramtype tags: dict[str, str]
         :return: A dictionary with values necessary for the copy authorization.
-        :rtype: Dict[str, str]
+        :rtype: TargetAuthorization
         :raises ~azure.core.exceptions.HttpResponseError:
 
         .. versionadded:: v2022-01-30-preview
@@ -298,7 +299,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBase):
     def begin_copy_model_to(
         self,
         model_id: str,
-        target: Dict[str, str],
+        target: TargetAuthorization,
         **kwargs: Any
     ) -> DocumentModelAdministrationLROPoller[DocumentModelInfo]:
         """Copy a model stored in this resource (the source) to the user specified

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_document_model_administration_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_document_model_administration_client.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Union,
     List,
-    Dict,
 )
 from azure.core.credentials import AzureKeyCredential, TokenCredential
 from azure.core.tracing.decorator import distributed_trace
@@ -310,7 +309,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBase):
         target resource's output from calling the :func:`~get_copy_authorization()` method.
 
         :param str model_id: Model identifier of the model to copy to target resource.
-        :param Dict[str, str] target:
+        :param TargetAuthorization target:
             The copy authorization generated from the target resource's call to
             :func:`~get_copy_authorization()`.
         :keyword str continuation_token: A continuation token to restart a poller from a saved state.

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -5,7 +5,7 @@
 
 # pylint: disable=protected-access, too-many-lines
 
-from typing import Any, Iterable, List
+from typing import Any, Dict, Iterable, List, NewType
 from enum import Enum
 from collections import namedtuple
 from azure.core import CaseInsensitiveEnumMeta
@@ -18,6 +18,8 @@ from ._helpers import (
     _get_deserialize,
 )
 
+
+TargetAuthorization = NewType('TargetAuthorization', Dict[str, str])
 
 def prepare_document_spans(spans):
     return [DocumentSpan._from_generated(span) for span in spans] if spans else []

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_document_model_administration_client_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_document_model_administration_client_async.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Union,
     List,
-    Dict,
 )
 from azure.core.credentials import AzureKeyCredential
 from azure.core.credentials_async import AsyncTokenCredential
@@ -32,6 +31,7 @@ from .._models import (
     ModelOperation,
     ModelOperationInfo,
     ResourceInfo,
+    TargetAuthorization,
 )
 
 
@@ -264,7 +264,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBaseAsync):
         )
 
     @distributed_trace_async
-    async def get_copy_authorization(self, **kwargs: Any) -> Dict[str, str]:
+    async def get_copy_authorization(self, **kwargs: Any) -> TargetAuthorization:
         """Generate authorization for copying a custom model into the target Form Recognizer resource.
 
         This should be called by the target resource (where the model will be copied to)
@@ -276,7 +276,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBaseAsync):
         :keyword tags: List of user defined key-value tag attributes associated with the model.
         :paramtype tags: dict[str, str]
         :return: A dictionary with values necessary for the copy authorization.
-        :rtype: Dict[str, str]
+        :rtype: TargetAuthorization
         :raises ~azure.core.exceptions.HttpResponseError:
 
         .. versionadded:: v2022-01-30-preview
@@ -301,7 +301,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBaseAsync):
 
     @distributed_trace_async
     async def begin_copy_model_to(
-        self, model_id: str, target: Dict[str, str], **kwargs: Any
+        self, model_id: str, target: TargetAuthorization, **kwargs: Any
     ) -> AsyncDocumentModelAdministrationLROPoller[DocumentModelInfo]:
         """Copy a model stored in this resource (the source) to the user specified
         target Form Recognizer resource.
@@ -311,7 +311,7 @@ class DocumentModelAdministrationClient(FormRecognizerClientBaseAsync):
         target resource's output from calling the :func:`~get_copy_authorization()` method.
 
         :param str model_id: Model identifier of the model to copy to target resource.
-        :param Dict[str, str] target:
+        :param TargetAuthorization target:
             The copy authorization generated from the target resource's call to
             :func:`~get_copy_authorization()`.
         :keyword str continuation_token: A continuation token to restart a poller from a saved state.


### PR DESCRIPTION
Address architect feedback to add a type for target authorization for copy request. This will give us some type checking when passing the target in to the copy request method.