### PR TITLE
[Key Vault] Skip tests when vault SKU is incompatible

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -639,10 +639,10 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_key_rotation(self, client, **kwargs):
-        set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
+        set_bodiless_matcher()
         key_name = self.get_resource_name("rotation-key")
         key = self._create_rsa_key(client, key_name)
         rotated_key = client.rotate_key(key_name)
@@ -656,10 +656,10 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_key_rotation_policy(self, client, **kwargs):
-        set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
+        set_bodiless_matcher()
         key_name = self.get_resource_name("rotation-key")
         self._create_rsa_key(client, key_name)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -6,25 +6,29 @@ import codecs
 import functools
 import json
 import logging
+import os
 import time
 
 import pytest
-from azure.core.exceptions import (HttpResponseError, ResourceExistsError,
-                                   ResourceNotFoundError)
+from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
-from azure.keyvault.keys import (ApiVersion, JsonWebKey, KeyClient,
-                                 KeyReleasePolicy, KeyRotationLifetimeAction,
-                                 KeyRotationPolicy, KeyRotationPolicyAction,
-                                 KeyType)
-from azure.keyvault.keys._generated.v7_3.models import \
-    KeyRotationPolicy as _KeyRotationPolicy
+from azure.keyvault.keys import (
+    ApiVersion,
+    JsonWebKey,
+    KeyClient,
+    KeyReleasePolicy,
+    KeyRotationLifetimeAction,
+    KeyRotationPolicy,
+    KeyRotationPolicyAction,
+    KeyType
+)
+from azure.keyvault.keys._generated.v7_3.models import KeyRotationPolicy as _KeyRotationPolicy
 from dateutil import parser as date_parse
 from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
 from six import byte2int
 
 from _shared.test_case import KeyVaultTestCase
-from _test_case import (KeysClientPreparer, get_attestation_token,
-                        get_decorator, get_release_policy, is_public_cloud)
+from _test_case import KeysClientPreparer, get_attestation_token, get_decorator, get_release_policy, is_public_cloud
 
 from _keys_test_case import KeysTestCase
 
@@ -510,6 +514,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_key_release(self, client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         attestation = get_attestation_token(attestation_uri)
@@ -550,6 +557,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_update_release_policy(self, client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri)
@@ -592,6 +602,9 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_immutable_release_policy(self, client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri, immutable=True)
@@ -628,7 +641,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     def test_key_rotation(self, client, **kwargs):
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
-            pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
+            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
         key_name = self.get_resource_name("rotation-key")
         key = self._create_rsa_key(client, key_name)
@@ -645,7 +658,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     def test_key_rotation_policy(self, client, **kwargs):
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
-            pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
+            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
         key_name = self.get_resource_name("rotation-key")
         self._create_rsa_key(client, key_name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -8,6 +8,7 @@ from dateutil import parser as date_parse
 import functools
 import json
 import logging
+import os
 
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
@@ -515,6 +516,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_key_release(self, client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         attestation = await get_attestation_token(attestation_uri)
@@ -557,6 +561,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_update_release_policy(self, client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri)
@@ -600,6 +607,9 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_immutable_release_policy(self, client, **kwargs):
+        if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
+
         set_bodiless_matcher()
         attestation_uri = self._get_attestation_uri()
         release_policy = get_release_policy(attestation_uri, immutable=True)
@@ -637,7 +647,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     async def test_key_rotation(self, client, **kwargs):
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
-            pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
+            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
         key_name = self.get_resource_name("rotation-key")
         key = await self._create_rsa_key(client, key_name)
@@ -655,7 +665,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     async def test_key_rotation_policy(self, client, **kwargs):
         set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
-            pytest.skip("This test not supprot in usgov/china region. Follow up with service team.")
+            pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
         key_name = self.get_resource_name("rotation-key")
         await self._create_rsa_key(client, key_name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -645,10 +645,10 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_key_rotation(self, client, **kwargs):
-        set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
+        set_bodiless_matcher()
         key_name = self.get_resource_name("rotation-key")
         key = await self._create_rsa_key(client, key_name)
         rotated_key = await client.rotate_key(key_name)
@@ -663,10 +663,10 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_key_rotation_policy(self, client, **kwargs):
-        set_bodiless_matcher()
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
+        set_bodiless_matcher()
         key_name = self.get_resource_name("rotation-key")
         await self._create_rsa_key(client, key_name)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -42,7 +42,7 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
     @recorded_by_proxy
     def test_example_key_crud_operations(self, key_client, **kwargs):
         if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
-            pytest.skip("This test not supprot in usgov/china region. Follow up with service team")
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
 
         key_name = self.get_resource_name("key-name")
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -46,7 +46,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @recorded_by_proxy_async
     async def test_example_key_crud_operations(self, key_client, **kwargs):
         if (self.is_live and os.environ["KEYVAULT_SKU"] != "premium"):
-            pytest.skip("This test not supprot in usgov/china region. Follow up with service team")
+            pytest.skip("This test is not supported on standard SKU vaults. Follow up with service team")
 
         key_name = self.get_resource_name("key-name")
 


### PR DESCRIPTION
# Description

I recently got our weekly sovereign cloud tests running again, and [test runs show](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1713557&view=ms.vss-test-web.build-test-results-tab&runId=33466850&resultId=100365&paneView=debug) that some tests -- namely, those that deal with key release -- require a premium vault SKU in order to work. Standard SKUs are used in China cloud tests, so we need to skip these when necessary.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
