### PR TITLE
bump python version in autorest pipeline check

### DIFF
--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -15,7 +15,7 @@ pr:
 
 variables:
   NodeVersion: '12.x'
-  PythonVersion: '3.6'
+  PythonVersion: '3.7'
   auto_rest_clone_url: 'https://github.com/Azure/autorest.python.git'
   repo_branch: 'autorestv3'
   source_path_azure_core: 'sdk/core/azure-core'


### PR DESCRIPTION
Since we're dropping suport for python 3.6, bumping the version of python we use to run autorest so we don't have python version compatibility issues