### PR TITLE
[textanalytics] remove forward refs for credential typing

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
@@ -3,17 +3,15 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-from typing import Union, Any, TYPE_CHECKING
+from typing import Union, Any
 from enum import Enum
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline.policies import AzureKeyCredentialPolicy, HttpLoggingPolicy
-from azure.core.credentials import AzureKeyCredential
+from azure.core.credentials import AzureKeyCredential, TokenCredential
 from ._generated import TextAnalyticsClient as _TextAnalyticsClient
 from ._policies import TextAnalyticsResponseHookPolicy
 from ._user_agent import USER_AGENT
 from ._version import DEFAULT_API_VERSION
-if TYPE_CHECKING:
-    from azure.core.credentials import TokenCredential
 
 
 class TextAnalyticsApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -45,7 +43,7 @@ class TextAnalyticsClientBase:
     def __init__(
         self,
         endpoint: str,
-        credential: Union[AzureKeyCredential, "TokenCredential"],
+        credential: Union[AzureKeyCredential, TokenCredential],
         **kwargs: Any
     ) -> None:
         http_logging_policy = HttpLoggingPolicy(**kwargs)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -10,12 +10,12 @@ from typing import (
     List,
     Dict,
     cast,
-    TYPE_CHECKING
 )
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.exceptions import HttpResponseError
 from azure.core.credentials import AzureKeyCredential
+from azure.core.credentials import TokenCredential
 from ._base_client import TextAnalyticsClientBase
 from ._lro import AnalyzeActionsLROPoller, AnalyzeHealthcareEntitiesLROPoller, TextAnalyticsLROPoller
 from ._request_handlers import (
@@ -67,9 +67,6 @@ from ._models import (
     _AnalyzeActionsType,
 )
 from ._check import is_language_api, string_index_type_compatibility
-
-if TYPE_CHECKING:
-    from azure.core.credentials import TokenCredential
 
 AnalyzeActionsResponse = AnalyzeActionsLROPoller[
     ItemPaged[
@@ -133,7 +130,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def __init__(
         self,
         endpoint: str,
-        credential: Union[AzureKeyCredential, "TokenCredential"],
+        credential: Union[AzureKeyCredential, TokenCredential],
         **kwargs: Any
     ) -> None:
         super().__init__(

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
@@ -2,15 +2,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any, Union, TYPE_CHECKING
+from typing import Any, Union
 from azure.core.credentials import AzureKeyCredential
+from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline.policies import AzureKeyCredentialPolicy, HttpLoggingPolicy
 from .._generated.aio import TextAnalyticsClient as _TextAnalyticsClient
 from .._policies import TextAnalyticsResponseHookPolicy
 from .._user_agent import USER_AGENT
 from .._version import DEFAULT_API_VERSION
-if TYPE_CHECKING:
-    from azure.core.credentials_async import AsyncTokenCredential
 
 
 def _authentication_policy(credential):
@@ -33,7 +32,7 @@ class AsyncTextAnalyticsClientBase:
     def __init__(
         self,
         endpoint: str,
-        credential: Union[AzureKeyCredential, "AsyncTokenCredential"],
+        credential: Union[AzureKeyCredential, AsyncTokenCredential],
         **kwargs: Any
     ) -> None:
         http_logging_policy = HttpLoggingPolicy(**kwargs)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -4,11 +4,12 @@
 # ------------------------------------
 # pylint: disable=too-many-lines
 
-from typing import Union, Any, List, Dict, TYPE_CHECKING, cast
+from typing import Union, Any, List, Dict, cast
 from azure.core.async_paging import AsyncItemPaged
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.exceptions import HttpResponseError
 from azure.core.credentials import AzureKeyCredential
+from azure.core.credentials_async import AsyncTokenCredential
 from ._base_client_async import AsyncTextAnalyticsClientBase
 from .._request_handlers import (
     _validate_input,
@@ -61,9 +62,6 @@ from ._lro_async import (
     AsyncTextAnalyticsLROPoller,
 )
 
-
-if TYPE_CHECKING:
-    from azure.core.credentials_async import AsyncTokenCredential
 
 AsyncAnalyzeActionsResponse = AsyncAnalyzeActionsLROPoller[
     AsyncItemPaged[
@@ -127,7 +125,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
     def __init__(
         self,
         endpoint: str,
-        credential: Union[AzureKeyCredential, "AsyncTokenCredential"],
+        credential: Union[AzureKeyCredential, AsyncTokenCredential],
         **kwargs: Any
     ) -> None:
         super().__init__(


### PR DESCRIPTION
The TokenCredential / AsyncTokenCredential types were fixed in azure-core==1.23.0 (they were previously defined under a TYPE_CHECKING [block](https://github.com/Azure/azure-sdk-for-python/blob/azure-core_1.22.1/sdk/core/azure-core/azure/core/credentials.py#L16)) so we don't need to use type checking blocks / forward refs anymore in client library code.