### PR TITLE
fix proxy url in tox

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -4,7 +4,7 @@
 # specifically. Notice that in the [testenv] config, we explicitly set PIP_EXTRA_INDEX_URL to pypi.
 
 # In all cases, whenever we install an azure-* package from a requirement (read: not a specific file), the only source will be from the dev feed.
-# once we've downloaded these dependencies, only then do we install other packages from pypi. 
+# once we've downloaded these dependencies, only then do we install other packages from pypi.
 [tox]
 # note that this envlist is the default set of environments that will run if a target environment is not selected.
 envlist = whl,sdist
@@ -57,7 +57,7 @@ requires=
 setenv =
   SPHINX_APIDOC_OPTIONS=members,undoc-members,inherited-members
   PIP_EXTRA_INDEX_URL=https://pypi.python.org/simple
-  PROXY_URL=http://localhost:5001
+  PROXY_URL=http://localhost:5000
   VIRTUALENV_WHEEL=0.37.0
   VIRTUALENV_PIP=20.3.3
   VIRTUALENV_SETUPTOOLS=59.6.0


### PR DESCRIPTION
The current default in tox is for a non-existent url. Trying to see if fixing this helps with running test proxy in the autorest pipelines