### PR TITLE
[Core] Update Transpot __Init__

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -24,98 +24,91 @@
 #
 # --------------------------------------------------------------------------
 
-import sys
 from ._base import HttpTransport, HttpRequest, HttpResponse
 
 __all__ = [
     'HttpTransport',
     'HttpRequest',
     'HttpResponse',
+    'RequestsTransport',
+    'RequestsTransportResponse',
+    'AsyncHttpTransport',
+    'AsyncHttpResponse',
+    'AsyncioRequestsTransport',
+    'AsyncioRequestsTransportResponse'
+    'TrioRequestsTransport',
+    'TrioRequestsTransportResponse',
+    'AioHttpTransport',
+    'AioHttpTransportResponse',
 ]
 
 # pylint: disable=unused-import, redefined-outer-name
-try:
-    from ._requests_basic import RequestsTransport, RequestsTransportResponse
-    __all__.extend([
-        'RequestsTransport',
-        'RequestsTransportResponse',
-    ])
-    try:
-        from ._base_async import AsyncHttpTransport, AsyncHttpResponse
-        from ._requests_asyncio import AsyncioRequestsTransport, AsyncioRequestsTransportResponse
-
-        __all__.extend([
-            'AsyncHttpTransport',
-            'AsyncHttpResponse',
-            'AsyncioRequestsTransport',
-            'AsyncioRequestsTransportResponse'
-            'TrioRequestsTransport',
-            'TrioRequestsTransportResponse',
-            'AioHttpTransport',
-            'AioHttpTransportResponse',
-        ])
 
         
-        def __dir__():
-            return __all__
+def __dir__():
+    return __all__
 
-        def __getattr__(name):
-            if name == 'AioHttpTransport':
-                try:
-                    from ._aiohttp import AioHttpTransport
-                    return AioHttpTransport
-                except ImportError:
-                    raise ImportError("aiohttp package is not installed")
-            if name == 'AioHttpTransportResponse':
-                try:
-                    from ._aiohttp import AioHttpTransportResponse
-                    return AioHttpTransportResponse
-                except ImportError:
-                    raise ImportError("aiohttp package is not installed")
-            if name == 'TrioRequestsTransport':
-                try:
-                    from ._requests_trio import TrioRequestsTransport
-                    return TrioRequestsTransport
-                except ImportError:
-                    raise ImportError("trio package is not installed")
-            if name == 'TrioRequestsTransportResponse':
-                try:
-                    from ._requests_trio import TrioRequestsTransportResponse
-                    return TrioRequestsTransportResponse
-                except ImportError:
-                    raise ImportError("trio package is not installed")
-            if name == '__bases__':
-                raise AttributeError("module 'azure.core.pipeline.transport' has no attribute '__bases__'")
-            return name
-
-    except (ImportError, SyntaxError):
-        # requests library is installed but asynchronous pipelines not supported.
-        pass
-except (ImportError, SyntaxError):
-    # requests library is not installed
-    try:
-        from ._base_async import AsyncHttpTransport, AsyncHttpResponse
-        __all__.extend([
-            'AsyncHttpTransport',
-            'AsyncHttpResponse',
-            'AioHttpTransport',
-            'AioHttpTransportResponse',
-        ])
-        def __dir__():
-            return __all__
-        def __getattr__(name):
-            if name == 'AioHttpTransport':
-                try:
-                    from ._aiohttp import AioHttpTransport
-                    return AioHttpTransport
-                except ImportError:
-                    raise ImportError("aiohttp package is not installed")
-            if name == 'AioHttpTransportResponse':
-                try:
-                    from ._aiohttp import AioHttpTransportResponse
-                    return AioHttpTransportResponse
-                except ImportError:
-                    raise ImportError("aiohttp package is not installed")
-            return name
-    except (ImportError, SyntaxError):
-        pass  # Asynchronous pipelines not supported.
+def __getattr__(name):
+    if name == 'AsyncioRequestsTransport':
+        try:
+            from ._requests_asyncio import AsyncHttpResponse
+            return AsyncHttpTransport
+        except ImportError:
+            pass
+    if name == 'AsyncioRequestsTransportResponse':
+        try:
+            from ._requests_asyncio import AsyncioRequestsTransportResponse
+            return AsyncioRequestsTransportResponse
+        except ImportError:
+            pass
+    if name == 'AsyncHttpTransport':
+        try:
+            from ._base_async import AsyncHttpTransport
+            return AsyncHttpTransport
+        except ImportError:
+            pass
+    if name == 'AsyncHttpResponse':
+        try:
+            from ._base_async import AsyncHttpResponse
+            return AsyncHttpResponse
+        except ImportError:
+            pass
+    if name == 'RequestsTransport':
+        try:
+            from ._requests_basic import RequestsTransport
+            return RequestsTransport
+        except ImportError:
+            raise ImportError("requests package is not installed")
+    if name == 'RequestsTransportResponse':
+        try:
+            from ._requests_basic import RequestsTransportResponse
+            return RequestsTransportResponse
+        except ImportError:
+            raise ImportError("requests package is not installed")
+    if name == 'AioHttpTransport':
+        try:
+            from ._aiohttp import AioHttpTransport
+            return AioHttpTransport
+        except ImportError:
+            raise ImportError("aiohttp package is not installed")
+    if name == 'AioHttpTransportResponse':
+        try:
+            from ._aiohttp import AioHttpTransportResponse
+            return AioHttpTransportResponse
+        except ImportError:
+            raise ImportError("aiohttp package is not installed")
+    if name == 'TrioRequestsTransport':
+        try:
+            from ._requests_trio import TrioRequestsTransport
+            return TrioRequestsTransport
+        except ImportError:
+            raise ImportError("trio package is not installed")
+    if name == 'TrioRequestsTransportResponse':
+        try:
+            from ._requests_trio import TrioRequestsTransportResponse
+            return TrioRequestsTransportResponse
+        except ImportError:
+            raise ImportError("trio package is not installed")
+    if name == '__bases__':
+        raise AttributeError("module 'azure.core.pipeline.transport' has no attribute '__bases__'")
+    return name

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -91,8 +91,12 @@ def __getattr__(name):
         try:
             from ._requests_trio import TrioRequestsTransport
             return TrioRequestsTransport
-        except ImportError:
-            raise ImportError("trio package is not installed")
+        except ImportError as ex:
+            if ex.msg.endswith("'requests'"):
+                raise ImportError("requests package is not installed")
+            else:
+                raise ImportError("trio package is not installed")
+                
     if name == 'TrioRequestsTransportResponse':
         try:
             from ._requests_trio import TrioRequestsTransportResponse

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -26,6 +26,7 @@
 
 from ._base import HttpTransport, HttpRequest, HttpResponse
 
+
 __all__ = [
     'HttpTransport',
     'HttpRequest',
@@ -51,8 +52,8 @@ def __dir__():
 def __getattr__(name):
     if name == 'AsyncioRequestsTransport':
         try:
-            from ._requests_asyncio import AsyncHttpResponse
-            return AsyncHttpResponse
+            from ._requests_asyncio import AsyncioRequestsTransport
+            return AsyncioRequestsTransport
         except ImportError:
             pass
     if name == 'AsyncioRequestsTransportResponse':

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -52,7 +52,7 @@ def __getattr__(name):
     if name == 'AsyncioRequestsTransport':
         try:
             from ._requests_asyncio import AsyncHttpResponse
-            return AsyncHttpTransport
+            return AsyncHttpResponse
         except ImportError:
             pass
     if name == 'AsyncioRequestsTransportResponse':

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -51,46 +51,47 @@ def __dir__():
     return __all__
 
 def __getattr__(name):
+    transport = None
     if name == 'AsyncioRequestsTransport':
         try:
             from ._requests_asyncio import AsyncioRequestsTransport
-            return AsyncioRequestsTransport
+            transport = AsyncioRequestsTransport
         except ImportError:
             raise ImportError("requests package is not installed")
     if name == 'AsyncioRequestsTransportResponse':
         try:
             from ._requests_asyncio import AsyncioRequestsTransportResponse
-            return AsyncioRequestsTransportResponse
+            transport = AsyncioRequestsTransportResponse
         except ImportError:
             raise ImportError("requests package is not installed")
     if name == 'RequestsTransport':
         try:
             from ._requests_basic import RequestsTransport
-            return RequestsTransport
+            transport = RequestsTransport
         except ImportError:
             raise ImportError("requests package is not installed")
     if name == 'RequestsTransportResponse':
         try:
             from ._requests_basic import RequestsTransportResponse
-            return RequestsTransportResponse
+            transport = RequestsTransportResponse
         except ImportError:
             raise ImportError("requests package is not installed")
     if name == 'AioHttpTransport':
         try:
             from ._aiohttp import AioHttpTransport
-            return AioHttpTransport
+            transport = AioHttpTransport
         except ImportError:
             raise ImportError("aiohttp package is not installed")
     if name == 'AioHttpTransportResponse':
         try:
             from ._aiohttp import AioHttpTransportResponse
-            return AioHttpTransportResponse
+            transport = AioHttpTransportResponse
         except ImportError:
             raise ImportError("aiohttp package is not installed")
     if name == 'TrioRequestsTransport':
         try:
             from ._requests_trio import TrioRequestsTransport
-            return TrioRequestsTransport
+            transport = TrioRequestsTransport
         except ImportError as ex:
             if ex.msg.endswith("'requests'"):
                 raise ImportError("requests package is not installed")
@@ -98,7 +99,9 @@ def __getattr__(name):
     if name == 'TrioRequestsTransportResponse':
         try:
             from ._requests_trio import TrioRequestsTransportResponse
-            return TrioRequestsTransportResponse
+            transport = TrioRequestsTransportResponse
         except ImportError:
             raise ImportError("trio package is not installed")
+    if transport:
+        return transport
     raise AttributeError(f"module 'azure.core.pipeline.transport' has no attribute {name}")

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -49,68 +49,45 @@ try:
             'AsyncHttpResponse',
             'AsyncioRequestsTransport',
             'AsyncioRequestsTransportResponse'
+            'TrioRequestsTransport',
+            'TrioRequestsTransportResponse',
+            'AioHttpTransport',
+            'AioHttpTransportResponse',
         ])
 
-        if sys.version_info >= (3, 7):
-            __all__.extend([
-                'TrioRequestsTransport',
-                'TrioRequestsTransportResponse',
-                'AioHttpTransport',
-                'AioHttpTransportResponse',
-            ])
+        
+        def __dir__():
+            return __all__
 
-            def __dir__():
-                return __all__
+        def __getattr__(name):
+            if name == 'AioHttpTransport':
+                try:
+                    from ._aiohttp import AioHttpTransport
+                    return AioHttpTransport
+                except ImportError:
+                    raise ImportError("aiohttp package is not installed")
+            if name == 'AioHttpTransportResponse':
+                try:
+                    from ._aiohttp import AioHttpTransportResponse
+                    return AioHttpTransportResponse
+                except ImportError:
+                    raise ImportError("aiohttp package is not installed")
+            if name == 'TrioRequestsTransport':
+                try:
+                    from ._requests_trio import TrioRequestsTransport
+                    return TrioRequestsTransport
+                except ImportError:
+                    raise ImportError("trio package is not installed")
+            if name == 'TrioRequestsTransportResponse':
+                try:
+                    from ._requests_trio import TrioRequestsTransportResponse
+                    return TrioRequestsTransportResponse
+                except ImportError:
+                    raise ImportError("trio package is not installed")
+            if name == '__bases__':
+                raise AttributeError("module 'azure.core.pipeline.transport' has no attribute '__bases__'")
+            return name
 
-            def __getattr__(name):
-                if name == 'AioHttpTransport':
-                    try:
-                        from ._aiohttp import AioHttpTransport
-                        return AioHttpTransport
-                    except ImportError:
-                        raise ImportError("aiohttp package is not installed")
-                if name == 'AioHttpTransportResponse':
-                    try:
-                        from ._aiohttp import AioHttpTransportResponse
-                        return AioHttpTransportResponse
-                    except ImportError:
-                        raise ImportError("aiohttp package is not installed")
-                if name == 'TrioRequestsTransport':
-                    try:
-                        from ._requests_trio import TrioRequestsTransport
-                        return TrioRequestsTransport
-                    except ImportError:
-                        raise ImportError("trio package is not installed")
-                if name == 'TrioRequestsTransportResponse':
-                    try:
-                        from ._requests_trio import TrioRequestsTransportResponse
-                        return TrioRequestsTransportResponse
-                    except ImportError:
-                        raise ImportError("trio package is not installed")
-                if name == '__bases__':
-                    raise AttributeError("module 'azure.core.pipeline.transport' has no attribute '__bases__'")
-                return name
-
-        else:
-            try:
-                from ._requests_trio import TrioRequestsTransport, TrioRequestsTransportResponse
-
-                __all__.extend([
-                    'TrioRequestsTransport',
-                    'TrioRequestsTransportResponse'
-                ])
-            except ImportError:
-                pass  # Trio not installed
-
-            try:
-                from ._aiohttp import AioHttpTransport, AioHttpTransportResponse
-
-                __all__.extend([
-                    'AioHttpTransport',
-                    'AioHttpTransportResponse',
-                ])
-            except ImportError:
-                pass  # Aiohttp not installed
     except (ImportError, SyntaxError):
         # requests library is installed but asynchronous pipelines not supported.
         pass
@@ -121,40 +98,24 @@ except (ImportError, SyntaxError):
         __all__.extend([
             'AsyncHttpTransport',
             'AsyncHttpResponse',
+            'AioHttpTransport',
+            'AioHttpTransportResponse',
         ])
-
-        if sys.version_info >= (3, 7):
-            __all__.extend([
-                'AioHttpTransport',
-                'AioHttpTransportResponse',
-            ])
-
-            def __dir__():
-                return __all__
-
-            def __getattr__(name):
-                if name == 'AioHttpTransport':
-                    try:
-                        from ._aiohttp import AioHttpTransport
-                        return AioHttpTransport
-                    except ImportError:
-                        raise ImportError("aiohttp package is not installed")
-                if name == 'AioHttpTransportResponse':
-                    try:
-                        from ._aiohttp import AioHttpTransportResponse
-                        return AioHttpTransportResponse
-                    except ImportError:
-                        raise ImportError("aiohttp package is not installed")
-                return name
-
-        else:
-            try:
-                from ._aiohttp import AioHttpTransport, AioHttpTransportResponse
-                __all__.extend([
-                    'AioHttpTransport',
-                    'AioHttpTransportResponse',
-                ])
-            except ImportError:
-                pass  # Aiohttp not installed
+        def __dir__():
+            return __all__
+        def __getattr__(name):
+            if name == 'AioHttpTransport':
+                try:
+                    from ._aiohttp import AioHttpTransport
+                    return AioHttpTransport
+                except ImportError:
+                    raise ImportError("aiohttp package is not installed")
+            if name == 'AioHttpTransportResponse':
+                try:
+                    from ._aiohttp import AioHttpTransportResponse
+                    return AioHttpTransportResponse
+                except ImportError:
+                    raise ImportError("aiohttp package is not installed")
+            return name
     except (ImportError, SyntaxError):
         pass  # Asynchronous pipelines not supported.

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -25,6 +25,7 @@
 # --------------------------------------------------------------------------
 
 from ._base import HttpTransport, HttpRequest, HttpResponse
+from ._base_async import AsyncHttpTransport, AsyncHttpResponse
 
 
 __all__ = [
@@ -55,25 +56,13 @@ def __getattr__(name):
             from ._requests_asyncio import AsyncioRequestsTransport
             return AsyncioRequestsTransport
         except ImportError:
-            pass
+            raise ImportError("requests package is not installed")
     if name == 'AsyncioRequestsTransportResponse':
         try:
             from ._requests_asyncio import AsyncioRequestsTransportResponse
             return AsyncioRequestsTransportResponse
         except ImportError:
-            pass
-    if name == 'AsyncHttpTransport':
-        try:
-            from ._base_async import AsyncHttpTransport
-            return AsyncHttpTransport
-        except ImportError:
-            pass
-    if name == 'AsyncHttpResponse':
-        try:
-            from ._base_async import AsyncHttpResponse
-            return AsyncHttpResponse
-        except ImportError:
-            pass
+            raise ImportError("requests package is not installed")
     if name == 'RequestsTransport':
         try:
             from ._requests_basic import RequestsTransport
@@ -110,6 +99,6 @@ def __getattr__(name):
             return TrioRequestsTransportResponse
         except ImportError:
             raise ImportError("trio package is not installed")
-    if name == '__bases__':
-        raise AttributeError("module 'azure.core.pipeline.transport' has no attribute '__bases__'")
-    return name
+    
+    raise AttributeError(f"module 'azure.core.pipeline.transport' has no attribute {name}")
+    

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
     'AioHttpTransportResponse',
 ]
 
-# pylint: disable=unused-import, redefined-outer-name, no-member
+# pylint: disable=unused-import, redefined-outer-name, no-member, too-many-statements, too-many-branches
 
 def __dir__():
     return __all__

--- a/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/__init__.py
@@ -27,6 +27,7 @@
 from ._base import HttpTransport, HttpRequest, HttpResponse
 from ._base_async import AsyncHttpTransport, AsyncHttpResponse
 
+# pylint: disable=undefined-all-variable
 
 __all__ = [
     'HttpTransport',
@@ -44,9 +45,8 @@ __all__ = [
     'AioHttpTransportResponse',
 ]
 
-# pylint: disable=unused-import, redefined-outer-name
+# pylint: disable=unused-import, redefined-outer-name, no-member
 
-        
 def __dir__():
     return __all__
 
@@ -94,15 +94,11 @@ def __getattr__(name):
         except ImportError as ex:
             if ex.msg.endswith("'requests'"):
                 raise ImportError("requests package is not installed")
-            else:
-                raise ImportError("trio package is not installed")
-                
+            raise ImportError("trio package is not installed")
     if name == 'TrioRequestsTransportResponse':
         try:
             from ._requests_trio import TrioRequestsTransportResponse
             return TrioRequestsTransportResponse
         except ImportError:
             raise ImportError("trio package is not installed")
-    
     raise AttributeError(f"module 'azure.core.pipeline.transport' has no attribute {name}")
-    


### PR DESCRIPTION
This PR is to use [PEP 562](https://peps.python.org/pep-0562/) to lazy load imports and have only the base Http classes loaded by default.

- There is a known [issue](https://github.com/PyCQA/pylint/issues/4300) with Pylint to raise an error when using getattr from pep 562
- Some tests for storage are failing due to a `ModuleNotFoundException` and will look into it. 