### PR TITLE
Added entry_points for exporters' auto-instrumentation

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -13,6 +13,8 @@
 ## 1.0.0b6 (2022-06-10)
 
 ### Features Added
+- Added OpenTelemetry entry points for auto-instrumentation of Azure Monitor exporters
+    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
 - Implement log exporter using experimental OT logging sdk
     ([#23486](https://github.com/Azure/azure-sdk-for-python/pull/23486))
 - Implement sending of exception telemetry via log exporter

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features Added
 - Added OpenTelemetry entry points for auto-instrumentation of Azure Monitor exporters
-    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+    ([#25368](https://github.com/Azure/azure-sdk-for-python/pull/25368))
 - Implement log exporter using experimental OT logging sdk
     ([#23486](https://github.com/Azure/azure-sdk-for-python/pull/23486))
 - Implement sending of exception telemetry via log exporter

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.cfg
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.cfg
@@ -8,4 +8,3 @@ opentelemetry_logs_exporter =
     azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorLogExporter
 opentelemetry_metrics_exporter =
     azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorMetricExporter
-    

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.cfg
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.cfg
@@ -1,2 +1,11 @@
 [bdist_wheel]
 universal=1
+
+[options.entry_points]
+opentelemetry_traces_exporter =
+    azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorTraceExporter
+opentelemetry_logs_exporter =
+    azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorLogExporter
+opentelemetry_metrics_exporter =
+    azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorMetricExporter
+    


### PR DESCRIPTION
# Description

In order for OpenTelemetry to automatically instrument exporters, they need to have entry points in their configs that are published upon installation.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [] Pull request includes test coverage for the included changes.
Since entry points are create upon package installation, this was manually tested by auto-instrumenting all 3 exporters.