### PR TITLE
Fix span event ai.operation.id to use span id instead of span parent id

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Opentelemetry span events have wrong ParentId in Azure Monitor logs
+    ([#23486](https://github.com/Azure/azure-sdk-for-python/pull/23486))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 - Opentelemetry span events have wrong ParentId in Azure Monitor logs
-    ([#23486](https://github.com/Azure/azure-sdk-for-python/pull/23486))
+    ([#25369](https://github.com/Azure/azure-sdk-for-python/pull/25369))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -444,9 +444,9 @@ def _convert_span_events_to_envelopes(span: Span) -> Sequence[TelemetryItem]:
         envelope = _utils._create_telemetry_item(event.timestamp)
         envelope.tags.update(_utils._populate_part_a_fields(span.resource))
         envelope.tags["ai.operation.id"] = "{:032x}".format(span.context.trace_id)
-        if span.parent and span.parent.span_id:
+        if span.context and span.context.span_id:
             envelope.tags["ai.operation.parentId"] = "{:016x}".format(
-                span.parent.span_id
+                span.context.span_id
             )
         properties = {}
         for key, val in event.attributes.items():

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -1054,7 +1054,7 @@ class TestAzureTraceExporter(unittest.TestCase):
             ),
             parent=SpanContext(
                 trace_id=36873507687745823477771305566750195432,
-                span_id=12030755672171557337,
+                span_id=12030755672171557338,
                 is_remote=False,
             ),
             kind=SpanKind.CLIENT,
@@ -1108,7 +1108,7 @@ class TestAzureTraceExporter(unittest.TestCase):
             ),
             parent=SpanContext(
                 trace_id=36873507687745823477771305566750195432,
-                span_id=12030755672171557337,
+                span_id=12030755672171557338,
                 is_remote=False,
             ),
             kind=SpanKind.CLIENT,


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-python/issues/25341#