### PR TITLE
[Test Proxy] Support `target` keyword in sanitizers

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -426,6 +426,8 @@ def _get_request_args(**kwargs: "Any") -> dict:
         request_args["regex"] = kwargs.get("regex")
     if "reset_after_first" in kwargs:
         request_args["resetAfterFirst"] = kwargs.get("reset_after_first")
+    if "target" in kwargs:
+        request_args["target"] = kwargs.get("target")
     if "value" in kwargs:
         request_args["value"] = kwargs.get("value")
     return request_args


### PR DESCRIPTION
# Description

When adding new sanitizers and options, I neglected to correctly add support for the `target` keyword. Thank you @jalauzon-msft for the catch! Tests to verify proxy behavior are definitely needed and are something I'll hopefully address soon.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - Locally verified to work with `add_uri_string_sanitizer(target=".preprod.", value=".")` command that raised the issue.