### PR TITLE
[EventHubs] add async unit tests to pyamqp

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/unittest/asynctests/test_client_creation_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/unittest/asynctests/test_client_creation_async.py
@@ -1,0 +1,126 @@
+from azure.eventhub.aio import EventHubProducerClient, EventHubConsumerClient
+from azure.eventhub import TransportType
+
+
+def test_custom_endpoint_async():
+    producer = EventHubProducerClient(
+        "fake.host.com",
+        "fake_eh",
+        None,
+    )
+    assert not producer._config.custom_endpoint_hostname
+    assert producer._config.transport_type == TransportType.Amqp
+    assert producer._config.connection_port == 5671
+
+    producer = EventHubProducerClient(
+        "fake.host.com",
+        "fake_eh",
+        None,
+        custom_endpoint_address="https://12.34.56.78"
+    )
+    assert producer._config.custom_endpoint_hostname == '12.34.56.78'
+    assert producer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert producer._config.connection_port == 443
+
+    producer = EventHubProducerClient(
+        "fake.host.com",
+        "fake_eh",
+        None,
+        custom_endpoint_address="sb://fake.endpoint.com:443"
+    )
+    assert producer._config.custom_endpoint_hostname == 'fake.endpoint.com'
+    assert producer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert producer._config.connection_port == 443
+
+    producer = EventHubProducerClient(
+        "fake.host.com",
+        "fake_eh",
+        None,
+        custom_endpoint_address="https://fake.endpoint.com:200"
+    )
+    assert producer._config.custom_endpoint_hostname == 'fake.endpoint.com'
+    assert producer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert producer._config.connection_port == 200
+
+    producer = EventHubProducerClient(
+        "fake.host.com",
+        "fake_eh",
+        None,
+        custom_endpoint_address="fake.endpoint.com:200"
+    )
+    assert producer._config.custom_endpoint_hostname == 'fake.endpoint.com'
+    assert producer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert producer._config.connection_port == 200
+
+    consumer = EventHubConsumerClient(
+        "fake.host.com",
+        "fake_eh",
+        "fake_group",
+        None,
+    )
+    assert not consumer._config.custom_endpoint_hostname
+    assert consumer._config.transport_type == TransportType.Amqp
+    assert consumer._config.connection_port == 5671
+
+    consumer = EventHubConsumerClient(
+        "fake.host.com",
+        "fake_eh",
+        "fake_group",
+        None,
+        custom_endpoint_address="https://12.34.56.78/"
+    )
+    assert consumer._config.custom_endpoint_hostname == '12.34.56.78'
+    assert consumer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert consumer._config.connection_port == 443
+
+    consumer = EventHubConsumerClient(
+        "fake.host.com",
+        "fake_eh",
+        "fake_group",
+        None,
+        custom_endpoint_address="sb://fake.endpoint.com:443"
+    )
+    assert consumer._config.custom_endpoint_hostname == 'fake.endpoint.com'
+    assert consumer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert consumer._config.connection_port == 443
+
+    consumer = EventHubConsumerClient(
+        "fake.host.com",
+        "fake_eh",
+        "fake_group",
+        None,
+        custom_endpoint_address="https://fake.endpoint.com:200"
+    )
+    assert consumer._config.custom_endpoint_hostname == 'fake.endpoint.com'
+    assert consumer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert consumer._config.connection_port == 200
+
+    consumer = EventHubConsumerClient(
+        "fake.host.com",
+        "fake_eh",
+        "fake_group",
+        None,
+        custom_endpoint_address="fake.endpoint.com:200"
+    )
+    assert consumer._config.custom_endpoint_hostname == 'fake.endpoint.com'
+    assert consumer._config.transport_type == TransportType.AmqpOverWebsocket
+    assert consumer._config.connection_port == 200
+
+
+def test_custom_certificate_async():
+    producer = EventHubProducerClient(
+        "fake.host.com",
+        "fake_eh",
+        None,
+        connection_verify='/usr/bin/local/cert'
+    )
+    assert producer._config.connection_verify == '/usr/bin/local/cert'
+
+    consumer = EventHubConsumerClient(
+        "fake.host.com",
+        "fake_eh",
+        "fake_group",
+        None,
+        connection_verify='D:/local/certfile'
+    )
+    assert consumer._config.connection_verify == 'D:/local/certfile'

--- a/sdk/eventhub/azure-eventhub/tests/unittest/asynctests/test_in_memory_checkpointstore.py
+++ b/sdk/eventhub/azure-eventhub/tests/unittest/asynctests/test_in_memory_checkpointstore.py
@@ -1,0 +1,123 @@
+import time
+import pytest
+from azure.eventhub.aio._eventprocessor.in_memory_checkpoint_store import InMemoryCheckpointStore
+
+
+TEST_NAMESPACE = "test_namespace"
+TEST_EVENTHUB = "test_eventhub"
+TEST_CONSUMER_GROUP = "test_consumer_group"
+TEST_OWNER = "test_owner_id"
+
+
+@pytest.mark.asyncio
+async def test_claim_new_ownership():
+    ownership = {
+        "fully_qualified_namespace": TEST_NAMESPACE,
+        "partition_id": "0",
+        "eventhub_name": TEST_EVENTHUB,
+        "consumer_group": TEST_CONSUMER_GROUP,
+        "owner_id": "owner_0"
+    }
+    checkpoint_store = InMemoryCheckpointStore()
+    claimed_ownership = await checkpoint_store.claim_ownership([ownership])
+    assert len(claimed_ownership) == 1
+    listed_ownership = await checkpoint_store.list_ownership(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP)
+
+    assert listed_ownership[0] == ownership
+    assert ownership["last_modified_time"] is not None
+    assert ownership["etag"] is not None
+
+
+@pytest.mark.asyncio
+async def test_claim_existing_ownership():
+    ownership = {
+        "fully_qualified_namespace": TEST_NAMESPACE,
+        "partition_id": "0",
+        "eventhub_name": TEST_EVENTHUB,
+        "consumer_group": TEST_CONSUMER_GROUP,
+        "owner_id": "owner_0",
+    }
+    checkpoint_store = InMemoryCheckpointStore()
+    await checkpoint_store.claim_ownership([ownership])
+    listed_ownership = await checkpoint_store.list_ownership(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP)
+    existing_ownership = listed_ownership[0]
+    etag_existing = existing_ownership["etag"]
+    last_modified_exising = existing_ownership["last_modified_time"]
+
+    time.sleep(0.01)  # so time is changed
+    copied_existing_ownership = existing_ownership.copy()
+    copied_existing_ownership["owner_id"] = "owner_1"
+    await checkpoint_store.claim_ownership([copied_existing_ownership])
+    listed_ownership2 = await checkpoint_store.list_ownership(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP)
+
+    assert len(listed_ownership2) == 1
+    assert listed_ownership2[0] == copied_existing_ownership
+    assert listed_ownership2[0]["owner_id"] == "owner_1"
+    assert listed_ownership2[0]["etag"] != etag_existing
+    assert listed_ownership2[0]["last_modified_time"] != last_modified_exising
+
+
+@pytest.mark.asyncio
+async def test_claim_two_ownerships():
+    ownership_0 = {
+        "fully_qualified_namespace": TEST_NAMESPACE,
+        "partition_id": "0",
+        "eventhub_name": TEST_EVENTHUB,
+        "consumer_group": TEST_CONSUMER_GROUP,
+        "owner_id": "owner_0"
+    }
+    ownership_1 = {
+        "fully_qualified_namespace": TEST_NAMESPACE,
+        "partition_id": "0",
+        "eventhub_name": TEST_EVENTHUB,
+        "consumer_group": TEST_CONSUMER_GROUP+"1",
+        "owner_id": "owner_1"
+    }
+    checkpoint_store = InMemoryCheckpointStore()
+    claimed_ownership = await checkpoint_store.claim_ownership([ownership_0, ownership_1])
+    assert len(claimed_ownership) == 2
+    listed_ownership0 = await checkpoint_store.list_ownership(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP)
+    listed_ownership1 = await checkpoint_store.list_ownership(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP+"1")
+    assert listed_ownership0[0]["consumer_group"] == TEST_CONSUMER_GROUP
+    assert listed_ownership1[0]["consumer_group"] == TEST_CONSUMER_GROUP+"1"
+
+
+@pytest.mark.asyncio
+async def test_claim_two_partitions():
+    ownership_0 = {
+        "fully_qualified_namespace": TEST_NAMESPACE,
+        "partition_id": "0",
+        "eventhub_name": TEST_EVENTHUB,
+        "consumer_group": TEST_CONSUMER_GROUP,
+        "owner_id": "owner_0"
+    }
+    ownership_1 = {
+        "fully_qualified_namespace": TEST_NAMESPACE,
+        "partition_id": "1",
+        "eventhub_name": TEST_EVENTHUB,
+        "consumer_group": TEST_CONSUMER_GROUP,
+        "owner_id": "owner_0"
+    }
+    checkpoint_store = InMemoryCheckpointStore()
+    await checkpoint_store.claim_ownership([ownership_0, ownership_1])
+    listed_ownership0 = await checkpoint_store.list_ownership(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP)
+    assert set(x["partition_id"] for x in listed_ownership0) == {"0", "1"}
+
+
+@pytest.mark.asyncio
+async def test_update_checkpoint():
+    checkpoint = {
+        "fully_qualified_namespace": TEST_NAMESPACE,
+        "partition_id": "0",
+        "eventhub_name": TEST_EVENTHUB,
+        "consumer_group": TEST_CONSUMER_GROUP,
+        "offset": "0",
+        "sequencenumber": 0
+    }
+    checkpoint_store = InMemoryCheckpointStore()
+    await checkpoint_store.update_checkpoint(checkpoint)
+    listed_checkpoint = await checkpoint_store.list_checkpoints(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP)
+
+    assert listed_checkpoint[0] == checkpoint
+    assert listed_checkpoint[0]["offset"] == "0"
+    assert listed_checkpoint[0]["sequencenumber"] == 0


### PR DESCRIPTION
looks like async unittests were accidentally deleted from `feature/eventhub/pyproto` branch. Adding these back in - copied from main.