### PR TITLE
[AzureML] correct param desc in online_endpoint.py

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
@@ -50,7 +50,7 @@ class OnlineEndpoint(Endpoint):
     :type location: str, optional
     :param traffic:  Traffic rules on how the traffic will be routed across deployments, defaults to {}
     :type traffic: Dict[str, int], optional
-    :param mirror_traffic: Duplicated life traffic used to train a single deployment, defaults to {}
+    :param mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to {}
     :type mirror_traffic: Dict[str, int], optional
     :param provisioning_state: str, provisioning state, readonly
     :type provisioning_state: str, optional


### PR DESCRIPTION
I corrected description of param in online_endpoint.py 
Mirror traffic is for inferencing, so I corrected from "train" to "inference".

This is a change to correct a description in the following document.
https://docs.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.onlineendpoint?view=azure-python-preview