### PR TITLE
Don't skip checkout exclusion in release config

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -171,7 +171,6 @@ stages:
                         steps:
                           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
                             parameters:
-                              SkipDefaultCheckout: true
                               Paths:
                                 - sdk/**/*.md
                                 - .github/CODEOWNERS
@@ -281,7 +280,6 @@ stages:
       steps:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
-            SkipDefaultCheckout: true 
             Paths:
               - sdk/**/*.md
               - .github/CODEOWNERS


### PR DESCRIPTION
This is not necessary and is causing us to do a full checkout unnecessarily.