### PR TITLE
[keyvault] Drop Python 3.6 support in packages

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+ - Python 3.6 is no longer supported. Please use Python version 3.7 or later.
+
 
 ## 4.1.0 (2022-03-28)
 

--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -19,6 +19,7 @@ create, manage, and deploy public and private SSL/TLS certificates
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Python 3.7 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
 
 ## Getting started
 ### Install packages

--- a/sdk/keyvault/azure-keyvault-administration/mypy.ini
+++ b/sdk/keyvault/azure-keyvault-administration/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/keyvault/azure-keyvault-administration/setup.py
+++ b/sdk/keyvault/azure-keyvault-administration/setup.py
@@ -48,7 +48,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -65,6 +64,6 @@ setup(
             "azure.keyvault",
         ]
     ),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=["azure-common~=1.1", "azure-core<2.0.0,>=1.20.0", "msrest>=0.6.21", "six>=1.11.0"],
 )

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+ - Python 3.6 is no longer supported. Please use Python version 3.7 or later.
 
 ## 4.5.0b1 (2022-06-07)
 

--- a/sdk/keyvault/azure-keyvault-certificates/README.md
+++ b/sdk/keyvault/azure-keyvault-certificates/README.md
@@ -14,6 +14,7 @@ and other secrets
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Python 3.7 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
 
 ## Getting started
 ### Install the package
@@ -27,7 +28,7 @@ authentication as demonstrated below.
 
 ### Prerequisites
 * An [Azure subscription][azure_sub]
-* Python 3.6 or later
+* Python 3.7 or later
 * A Key Vault. If you need to create one, you can use the
 [Azure Cloud Shell][azure_cloud_shell] to create one with these commands
 (replace `"my-resource-group"` and `"my-key-vault"` with your own, unique

--- a/sdk/keyvault/azure-keyvault-certificates/mypy.ini
+++ b/sdk/keyvault/azure-keyvault-certificates/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/keyvault/azure-keyvault-certificates/setup.py
+++ b/sdk/keyvault/azure-keyvault-certificates/setup.py
@@ -48,7 +48,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -65,7 +64,7 @@ setup(
             "azure.keyvault",
         ]
     ),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.20.0",
         "msrest>=0.6.21",

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+ - Python 3.6 is no longer supported. Please use Python version 3.7 or later.
 
 ## 4.6.0b1 (2022-06-07)
 

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -16,6 +16,7 @@ create, manage, and deploy public and private SSL/TLS certificates
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Python 3.7 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
 
 ## Getting started
 ### Install packages
@@ -29,7 +30,7 @@ authentication as demonstrated below.
 
 ### Prerequisites
 * An [Azure subscription][azure_sub]
-* Python 3.6 or later
+* Python 3.7 or later
 * A Key Vault. If you need to create one, you can use the
 [Azure Cloud Shell][azure_cloud_shell] to create one with these commands
 (replace `"my-resource-group"` and `"my-key-vault"` with your own, unique

--- a/sdk/keyvault/azure-keyvault-keys/mypy.ini
+++ b/sdk/keyvault/azure-keyvault-keys/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/keyvault/azure-keyvault-keys/setup.py
+++ b/sdk/keyvault/azure-keyvault-keys/setup.py
@@ -48,7 +48,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -65,7 +64,7 @@ setup(
             "azure.keyvault",
         ]
     ),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.20.0",
         "cryptography>=2.1.4",

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+ - Python 3.6 is no longer supported. Please use Python version 3.7 or later.
 
 ## 4.5.0b1 (2022-06-07)
 

--- a/sdk/keyvault/azure-keyvault-secrets/README.md
+++ b/sdk/keyvault/azure-keyvault-secrets/README.md
@@ -17,6 +17,7 @@ create, manage, and deploy public and private SSL/TLS certificates
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Python 3.7 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
 
 ## Getting started
 ### Install packages

--- a/sdk/keyvault/azure-keyvault-secrets/mypy.ini
+++ b/sdk/keyvault/azure-keyvault-secrets/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/keyvault/azure-keyvault-secrets/setup.py
+++ b/sdk/keyvault/azure-keyvault-secrets/setup.py
@@ -48,7 +48,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -65,7 +64,7 @@ setup(
             "azure.keyvault",
         ]
     ),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.20.0",
         "msrest>=0.6.21",

--- a/sdk/keyvault/azure-keyvault/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 4.2.1b1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+ - Python 3.6 is no longer supported. Please use Python version 3.7 or later.
+
 ## 4.2.0 (2022-03-29)
 **Disclaimer**
 

--- a/sdk/keyvault/azure-keyvault/README.md
+++ b/sdk/keyvault/azure-keyvault/README.md
@@ -13,7 +13,7 @@ of packages that provide APIs for Key Vault operations:
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
-
+_Python 3.7 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
 
 ## Install the package
 Install the Azure Key Vault client libraries for Python with [pip][pip]:

--- a/sdk/keyvault/azure-keyvault/setup.py
+++ b/sdk/keyvault/azure-keyvault/setup.py
@@ -29,7 +29,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/sdk/keyvault/azure-mgmt-keyvault/CHANGELOG.md
+++ b/sdk/keyvault/azure-mgmt-keyvault/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 10.0.1b1 (unreleased)
+
+  - Python 3.6 is no longer supported. Please use Python version 3.7 or later.
+
 ## 10.0.0 (2022-05-24)
 
 **Breaking changes**

--- a/sdk/keyvault/azure-mgmt-keyvault/CHANGELOG.md
+++ b/sdk/keyvault/azure-mgmt-keyvault/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 10.0.1b1 (unreleased)
+## 10.0.1b1 (Unreleased)
 
   - Python 3.6 is no longer supported. Please use Python version 3.7 or later.
 

--- a/sdk/keyvault/azure-mgmt-keyvault/README.md
+++ b/sdk/keyvault/azure-mgmt-keyvault/README.md
@@ -7,6 +7,7 @@ For a more complete view of Azure libraries, see the [azure sdk python release](
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
+_Python 3.7 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
 
 # Usage
 

--- a/sdk/keyvault/azure-mgmt-keyvault/setup.py
+++ b/sdk/keyvault/azure-mgmt-keyvault/setup.py
@@ -51,7 +51,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -74,5 +73,5 @@ setup(
         'azure-common~=1.1',
         'azure-mgmt-core>=1.3.0,<2.0.0',
     ],
-    python_requires=">=3.6"
+    python_requires=">=3.7"
 )


### PR DESCRIPTION
# Description
Fix #25077

**Is your feature request related to a problem? Please describe.**
In accordance with the August Milestone of Azure for dropping Python 3.6 support, I have made changes to the keyvault packages.

**Describe the solution you'd like**
Drop Python 3.6 support and add 3.10 to the supported versions list.

**Describe alternatives you've considered**
None

**Additional context**
https://github.com/Azure/azure-sdk-for-python/issues/25077


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
