### PR TITLE
[eng] use correct subpackage for autorest.python

### DIFF
--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -40,24 +40,25 @@ jobs:
           versionSpec: $(PythonVersion)
 
       - script: |
+          npm install -g pnpm
           git clone $(auto_rest_clone_url)
           cd autorest.python
           git checkout $(repo_branch)
-          npm install
+          pnpm install
         displayName: 'Prepare Environment'
 
       - script: |
-          cd $(Build.SourcesDirectory)/autorest.python/test/vanilla/legacy
+          cd $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/vanilla/legacy
           pip install $(Build.SourcesDirectory)/$(source_path_azure_core)
           pip install -r requirements.txt
           pip freeze
-          pytest $(Build.SourcesDirectory)/autorest.python/test/vanilla/legacy
+          pytest $(Build.SourcesDirectory)/autorest.python/packages/autorest.pythontest/vanilla/legacy
         displayName: 'Install azure-core and Test Vanilla Legacy'
 
       - script: |
-          cd $(Build.SourcesDirectory)/autorest.python/test/azure/legacy
+          cd $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/azure/legacy
           pip install $(Build.SourcesDirectory)/$(source_path_azure_mgmt_core)
           pip install -r requirements.txt
           pip freeze
-          pytest $(Build.SourcesDirectory)/autorest.python/test/azure/legacy
+          pytest $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/azure/legacy
         displayName: 'Install azure-mgmt-core and Test Azure Legacy'

--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -52,7 +52,7 @@ jobs:
           pip install $(Build.SourcesDirectory)/$(source_path_azure_core)
           pip install -r requirements.txt
           pip freeze
-          pytest $(Build.SourcesDirectory)/autorest.python/packages/autorest.pythontest/vanilla/legacy
+          pytest $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/vanilla/legacy
         displayName: 'Install azure-core and Test Vanilla Legacy'
 
       - script: |

--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -14,7 +14,7 @@ pr:
     - sdk/core/
 
 variables:
-  NodeVersion: '12.x'
+  NodeVersion: '14.x'
   PythonVersion: '3.7'
   auto_rest_clone_url: 'https://github.com/Azure/autorest.python.git'
   repo_branch: 'autorestv3'


### PR DESCRIPTION
We've updated autorest.python to be a monorepo with `autorest.python` as a subpackage. Updating this pipeline to correctly test the subpackage