### PR TITLE
[formrecognizer] Fix parameter order on new test

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
@@ -87,6 +87,7 @@ class TestDMACTraining(FormRecognizerTest):
                 assert field["type"]
                 assert doc_type.field_confidence[key] is not None
 
+    @pytest.mark.skip()
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
@@ -94,8 +94,8 @@ class TestDMACTraining(FormRecognizerTest):
         set_bodiless_matcher()
         model_id = str(uuid.uuid4())
         poller = client.begin_build_model(
+            "neural",
             formrecognizer_storage_container_sas_url,
-            build_mode="neural",
             model_id=model_id,
             description="a v3 model",
             tags={"testkey": "testvalue"}


### PR DESCRIPTION
Apparently `neural` build mode is no longer supported in West US 2: https://docs.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/concept-custom-neural#supported-regions. Skipping the test and fixing the param order.