### PR TITLE
Target 3.10 in mypy.ini

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/mypy.ini
+++ b/sdk/appconfiguration/azure-appconfiguration/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/mypy.ini
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/mypy.ini
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/mypy.ini
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/mypy.ini
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/search/azure-search-documents/mypy.ini
+++ b/sdk/search/azure-search-documents/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/mypy.ini
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/sdk/tables/azure-data-tables/mypy.ini
+++ b/sdk/tables/azure-data-tables/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/sdk/translation/azure-ai-translation-document/mypy.ini
+++ b/sdk/translation/azure-ai-translation-document/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.10
 warn_unused_configs = True
 ignore_missing_imports = True
 


### PR DESCRIPTION
# Description

A few `mypy.ini` files across the repo are targeting Python 3.6, when they should target the most recent available version (3.10) instead. Discovered in https://github.com/Azure/azure-sdk-for-python/pull/25449 (thanks, @wonhyeongseo!)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - Verifying updates with CI
