### PR TITLE
Use Python 3.10 to generate API stub file

### DIFF
--- a/eng/pipelines/templates/steps/run_apistub.yml
+++ b/eng/pipelines/templates/steps/run_apistub.yml
@@ -8,6 +8,12 @@ parameters:
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.10'
+    inputs:
+     versionSpec: '3.10'
+    condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
+
   - task: PythonScript@0
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
     displayName: 'Generate API stub files'

--- a/eng/pipelines/templates/steps/run_apistub.yml
+++ b/eng/pipelines/templates/steps/run_apistub.yml
@@ -14,6 +14,10 @@ steps:
      versionSpec: '3.10'
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
 
+  - script: |
+      pip install -r eng/ci_tools.txt
+    displayName: 'Prep Environment'
+
   - task: PythonScript@0
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
     displayName: 'Generate API stub files'


### PR DESCRIPTION
APIView server has been using Python 3.10.2 to generate APIView file from wheel. So all automatic reviews were created using Python version 3.10.2.

CI pipeline generates APIView stub file using Python 3.9.x and this stub file is used to generate automatic review revision instead of uploading wheel now. APIView stub file has a lot of diff when running this using 3.9.x v/s 3.10.

This PR is to update Python version to run apistub step to 3.10 so three won't be any false negative diff in APIview which blocks release.