### PR TITLE
[Core] empty content fix

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -14,6 +14,7 @@ Azure-core is supported on Python 3.7 or later. For more details, please read ou
 
 - Fixed the bug that azure-core could not be imported under Python 3.11.0b3  #24928
 - `ContentDecodePolicy` can now correctly deserialize more JSON bodies with different mime types #22410
+- Fixed the bug where `HttpRequest.content` would return None when initialized with `content=b""` #25489
 
 ## 1.24.1 (2022-06-01)
 

--- a/sdk/core/azure-core/azure/core/rest/_rest_py3.py
+++ b/sdk/core/azure-core/azure/core/rest/_rest_py3.py
@@ -155,7 +155,9 @@ class HttpRequest(HttpRequestBackcompatMixin):
         :return: The request's content
         :rtype: any
         """
-        return self._data or self._files
+        if self._data is not None:
+            return self._data
+        return self._files
 
     def __repr__(self) -> str:
         return "<HttpRequest [{}], url: '{}'>".format(

--- a/sdk/core/azure-core/tests/test_rest_http_request.py
+++ b/sdk/core/azure-core/tests/test_rest_http_request.py
@@ -494,6 +494,12 @@ def test_stream_input():
     data_stream = Stream(length=4)
     HttpRequest(method="PUT", url="http://www.example.com", content=data_stream) # ensure we can make this HttpRequest
 
+def test_empty_bytestring():
+    """The content property of a request should resolve to an empty bytestring when the data
+    is an empty bytestring.
+    """
+    request = HttpRequest(method="PUT", url="https://www.example.com", content=b"")
+    assert request.content == b""
 
 # NOTE: For files, we don't allow list of tuples yet, just dict. Will uncomment when we add this capability
 # def test_multipart_multiple_files_single_input_content():


### PR DESCRIPTION
# Description

Before, `HttpRequest.content` would return `None` if we passed in `content=b""` when initializing the request object. 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
