### PR TITLE
Resolve Failing Storage Builds

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -14,7 +14,9 @@ parameters:
   - name: Artifacts
     type: object
     default: []
-
+  - name: DevFeedName
+    type: string
+    default: 'public/azure-sdk-for-python'
 # The variable TargetingString is set by template `eng/pipelines/templates/steps/targeting-string-resolve.yml`. This template is invoked from yml files:
 #     eng/pipelines/templates/jobs/ci.tests.yml
 #     eng/pipelines/templates/jobs/ci.yml

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -61,6 +61,7 @@ steps:
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with dev version
     condition: and(succeeded(),eq(variables['SetDevVersion'],'true'))
+
   - task: PythonScript@0
     displayName: 'Generate Packages'
     inputs:
@@ -71,7 +72,6 @@ steps:
       twine check $(Build.ArtifactStagingDirectory)/**/*.whl
       twine check $(Build.ArtifactStagingDirectory)/**/*.zip
     displayName: 'Verify Readme'
-
 
   - ${{if eq(variables['System.TeamProject'], 'internal') }}:
     - template: ../steps/auth-dev-feed.yml
@@ -87,6 +87,10 @@ steps:
         "$(TargetingString)" 
         --service="${{ parameters.ServiceDirectory }}" 
         --toxenv=sphinx
+
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=PIP_INDEX_URL]https://pypi.python.org/simple"
+    displayName: Reset PIP Index For APIStubGen
 
   - template: /eng/pipelines/templates/steps/run_apistub.yml
     parameters:

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -70,6 +70,12 @@ steps:
       twine check $(Build.ArtifactStagingDirectory)/**/*.zip
     displayName: 'Verify Readme'
 
+
+  - ${{if eq(variables['System.TeamProject'], 'internal') }}:
+    - template: ../steps/auth-dev-feed.yml
+      parameters:
+        DevFeedName: ${{ parameters.DevFeedName }}
+
   - task: PythonScript@0
     displayName: 'Generate Docs'
     condition: and(succeededOrFailed(), ${{parameters.BuildDocs}})

--- a/eng/pipelines/templates/steps/run_apistub.yml
+++ b/eng/pipelines/templates/steps/run_apistub.yml
@@ -8,6 +8,16 @@ parameters:
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.10'
+    inputs:
+     versionSpec: '3.10'
+    condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
+
+  - script: |
+      pip install -r eng/ci_tools.txt
+    displayName: 'Prep Environment'
+
   - task: PythonScript@0
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
     displayName: 'Generate API stub files'

--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -9,6 +9,7 @@
 
 import argparse
 import sys
+import re
 import os
 import logging
 import glob
@@ -109,7 +110,9 @@ def process_requires(setup_py_path):
             version = get_version(pkg_name)
             base_version = get_base_version(pkg_name)
             logging.info("Updating version {0} in requirement {1} to dev build version".format(version, old_req))
-            new_req = old_req.replace(version, "{}{}".format(base_version, DEV_BUILD_IDENTIFIER))
+            # to properly replace the version, we must replace the entire version, not a partial piece of it
+            rx = r'{}(((a|b|rc)\d+)?(\.post\d+)?)?'.format(base_version)
+            new_req = re.sub(rx, "{}{}".format(base_version, DEV_BUILD_IDENTIFIER), str(req), flags=re.IGNORECASE)
             logging.info("New requirement for package {0}: {1}".format(pkg_name, new_req))
             requirement_to_update[old_req] = new_req
 

--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -112,7 +112,7 @@ def process_requires(setup_py_path):
             logging.info("Updating version {0} in requirement {1} to dev build version".format(version, old_req))
             # to properly replace the version, we must replace the entire version, not a partial piece of it
             rx = r'{}(((a|b|rc)\d+)?(\.post\d+)?)?'.format(base_version)
-            new_req = re.sub(rx, "{}{}".format(base_version, DEV_BUILD_IDENTIFIER), str(req), flags=re.IGNORECASE)
+            new_req = re.sub(rx, "{}{}1".format(base_version, DEV_BUILD_IDENTIFIER), str(req), flags=re.IGNORECASE)
             logging.info("New requirement for package {0}: {1}".format(pkg_name, new_req))
             requirement_to_update[old_req] = new_req
 


### PR DESCRIPTION
Resolves #25490 

Friday of last week I noticed that azure-storage-file-datalake was having some issues on scheduled builds. The error was during installation, throwing out the fact that it couldn't resolve a version of `azure-storage-blob` that meats the requirements for `azure-storage-file-datalake`.

There were two main problems at play here:

1. We need to auth to the dev feed during the nightly build, if we want to actually talk to it! We weren't prior to this PR. This was causing any packages that have an unreleased dependency to fail **building the artifact or docs**.
2. We had an actual bug causing us to not retrieve from the dev feed even if we WERE auth-ing to the feed properly.

Issue for 2) is now properly resolved. Will definitely need to mirror this patch in the [refactor PR](https://github.com/Azure/azure-sdk-for-python/pull/25454) 

The core of the issue. We need up update the specifier to pull in an alpha package when the version is NOT on pypi. To do that, we do a string replacement operation. 

`azure-storage-blob<13.0.0,>=12.14.0b1` -> `azure-storage-blob<13.0.0,>=12.14.0ab1`

Notice the `ab1` that we were inserting? That's straight up wrong. I have implemented the regex to match [PEP440](https://peps.python.org/pep-0440/#pre-releases)

The incorrect prerelease section`ab1` is what was breaking pip's resolution.




