### PR TITLE
[Pyamqp] Remember Proxy Params

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_sasl_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_sasl_async.py
@@ -117,13 +117,11 @@ class SASLWithWebSocket(WebSocketTransportAsync, SASLTransportMixinAsync):
     ):
         self.credential = credential
         ssl = ssl or True
-        http_proxy = kwargs.pop('http_proxy', None)
         self._transport = WebSocketTransportAsync(
             host,
             port=port,
             connect_timeout=connect_timeout,
             ssl=ssl,
-            http_proxy=http_proxy,
             **kwargs
         )
         super().__init__(host, port, connect_timeout, ssl, **kwargs)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sasl.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sasl.py
@@ -111,13 +111,11 @@ class SASLWithWebSocket(WebSocketTransport, SASLTransportMixin):
     def __init__(self, host, credential, port=WEBSOCKET_PORT, connect_timeout=None, ssl=None, **kwargs):
         self.credential = credential
         ssl = ssl or True
-        http_proxy = kwargs.pop('http_proxy', None)
         self._transport = WebSocketTransport(
             host,
             port=port,
             connect_timeout=connect_timeout,
             ssl=ssl,
-            http_proxy=http_proxy,
             **kwargs
         )
         super().__init__(host, port, connect_timeout, ssl, **kwargs)

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
@@ -163,3 +163,16 @@ async def test_create_batch_with_too_large_size_async(connection_str):
     async with client:
         with pytest.raises(ValueError):
             await client.create_batch(max_size_in_bytes=5 * 1024 * 1024)
+
+pytest.mark.liveTest
+@pytest.mark.asyncio
+async def test_invalid_proxy_server(connection_str):
+    HTTP_PROXY = {
+    'proxy_hostname': 'fakeproxy',  # proxy hostname.
+    'proxy_port': 3128,  # proxy port.
+    }
+
+    client = EventHubProducerClient.from_connection_string(connection_str)
+    async with client:
+        with pytest.raises(ConnectError):
+            batch = await client.create_batch()

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
@@ -164,7 +164,7 @@ async def test_create_batch_with_too_large_size_async(connection_str):
         with pytest.raises(ValueError):
             await client.create_batch(max_size_in_bytes=5 * 1024 * 1024)
 
-pytest.mark.liveTest
+@pytest.mark.liveTest
 @pytest.mark.asyncio
 async def test_invalid_proxy_server(connection_str):
     HTTP_PROXY = {
@@ -172,7 +172,7 @@ async def test_invalid_proxy_server(connection_str):
     'proxy_port': 3128,  # proxy port.
     }
 
-    client = EventHubProducerClient.from_connection_string(connection_str)
+    client = EventHubProducerClient.from_connection_string(connection_str, http_proxy=HTTP_PROXY)
     async with client:
         with pytest.raises(ConnectError):
             batch = await client.create_batch()

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
@@ -127,7 +127,7 @@ def test_invalid_proxy_server(connection_str):
     'proxy_port': 3128,  # proxy port.
     }
 
-    client = EventHubProducerClient.from_connection_string(connection_str)
+    client = EventHubProducerClient.from_connection_string(connection_str, http_proxy=HTTP_PROXY)
     with client:
         with pytest.raises(ConnectError):
             batch = client.create_batch()

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
@@ -132,6 +132,3 @@ def test_invalid_proxy_server(connection_str):
         with pytest.raises(ConnectError):
             batch = client.create_batch()
 
-
-
-

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
@@ -119,3 +119,19 @@ def test_create_batch_with_too_large_size_sync(connection_str):
     with client:
         with pytest.raises(ValueError):
             client.create_batch(max_size_in_bytes=5 * 1024 * 1024)
+
+@pytest.mark.liveTest
+def test_invalid_proxy_server(connection_str):
+    HTTP_PROXY = {
+    'proxy_hostname': 'fakeproxy',  # proxy hostname.
+    'proxy_port': 3128,  # proxy port.
+    }
+
+    client = EventHubProducerClient.from_connection_string(connection_str)
+    with client:
+        with pytest.raises(ConnectError):
+            batch = client.create_batch()
+
+
+
+


### PR DESCRIPTION
This is a fix for where proxy parameters were not being applied while creating a new websockets connection. 

- local var `http_proxy` was popping `http_proxy` from `kwargs` and then passed in to the `WebSocketTransport`. 
- The first call when inside the `__init__` for `WebSocketTransport`, it would look for proxy information and populate `self._http_proxy` properly, but only for the `self._transport` .
- When the `super` init was called, also a `WebSocketTransport`, `kwargs` would no longer have any proxy information and the overall `SASLWithWebSocket` would be left without any proxy information in `self._http_proxy`.
- When connect was called in `WebSocketTransport`, it would check against `if self._http_proxy:` which is now None, causing it to connect directly using the EH conn string rather than routing over the proxy.