### PR TITLE
test time increase

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_buffered_producer_async.py
@@ -410,7 +410,7 @@ async def test_send_with_timing_configuration(connection_str):
         await producer.send_event(EventData('data'))
         await asyncio.sleep(5)
         assert not sent_events
-        await asyncio.sleep(10)
+        await asyncio.sleep(20)
         assert sum([len(sent_events[pid]) for pid in partitions]) == 1
 
     assert not on_error.err


### PR DESCRIPTION
Increasing the time on the sleep, since I suspect that on Windows and MacOS where this particular test fails consistently on the pipeline fails, is due to the fact that asyncio.sleep is waking up a few ms before the actual sleep time. This causes the assert to fail since the increments havent been made to send_events

After the time, the test is consistenly passing on subsequent runs on mac, windows & linux.

More info here https://bugs.python.org/issue31539