### PR TITLE
[Storage] Add datetime util

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/storage/testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/testcase.py
@@ -372,6 +372,10 @@ class StorageRecordedTestCase(AzureRecordedTestCase):
         kwargs["_additional_pipeline_policies"] = [ApiVersionAssertPolicy(kwargs["api_version"])]
         return client.from_connection_string(*args, **kwargs)
 
+    def get_datetime_variable(self, variables, name, dt):
+        dt_string = variables.setdefault(name, dt.isoformat())
+        return datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S.%f")
+
 
 class LogCaptured(object):
     def __init__(self, test_case=None):


### PR DESCRIPTION
Moving out the helper to the utils so that we don't have to copy paste the helper everywhere 😄 

Issue tracking the list of tests that possibly use the copy pasted helper: https://github.com/Azure/azure-sdk-for-python/issues/25586
