### PR TITLE
[Pyamqp] Intial TODOS Clean Up

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
@@ -395,7 +395,15 @@ class Connection(object):
             self._remote_idle_timeout_send_frame = self._idle_timeout_empty_frame_send_ratio * self._remote_idle_timeout
 
         if frame[2] < 512:  # Ensure minimum max frame size.
-            pass  # TODO: error
+            #Close with error
+            #Codes_S_R_S_CONNECTION_01_143: [If any of the values in the received open frame are invalid then the connection shall be closed.]
+            #Codes_S_R_S_CONNECTION_01_220: [The error amqp:invalid-field shall be set in the error.condition field of the CLOSE frame.] 
+            self.close(error=AMQPConnectionError(
+                condition=ErrorCondition.InvalidField, 
+                description="connection_endpoint_frame_received::failed parsing OPEN frame"))
+            _LOGGER.error("connection_endpoint_frame_received::failed parsing OPEN frame")
+        else:
+            self._remote_max_frame_size = frame[2]
         self._remote_max_frame_size = frame[2]
         if self.state == ConnectionState.OPEN_SENT:
             self._set_state(ConnectionState.OPENED)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -389,7 +389,7 @@ class _AbstractTransport(object):
             self.sock = None
         self.connected = False
 
-    def read(self, verify_frame_type=0, **kwargs):  # TODO: verify frame type?
+    def read(self, verify_frame_type=0, **kwargs):
         read = self._read
         read_frame_buffer = BytesIO()
         try:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -446,7 +446,6 @@ class _AbstractTransport(object):
                 decoded = decode_empty_frame(header)
             else:
                 decoded = decode_frame(payload)
-            # TODO: Catch decode error and return amqp:decode-error
             return channel, decoded
         except (socket.timeout, TimeoutError):
             return None, None

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -508,14 +508,7 @@ class SSLTransport(_AbstractTransport):
         # Setup the right SSL version; default to optimal versions across
         # ssl implementations
         if ssl_version is None:
-            # older versions of python 2.7 and python 2.6 do not have the
-            # ssl.PROTOCOL_TLS defined the equivalent is ssl.PROTOCOL_SSLv23
-            # we default to PROTOCOL_TLS and fallback to PROTOCOL_SSLv23
-            # TODO: Drop this once we drop Python 2.7 support
-            if hasattr(ssl, 'PROTOCOL_TLS'):
-                ssl_version = ssl.PROTOCOL_TLS
-            else:
-                ssl_version = ssl.PROTOCOL_SSLv23
+            ssl_version = ssl.PROTOCOL_TLS
 
         opts = {
             'sock': sock,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -384,7 +384,7 @@ class _AbstractTransport(object):
             except Exception as exc:
                 # TODO: shutdown could raise OSError, Transport endpoint is not connected if the endpoint is already
                 #  disconnected. can we safely ignore the errors since the close operation is initiated by us.
-                _LOGGER.info("An error occurred when shutting down the socket: %r", exc)
+                _LOGGER.info("Transport endpoint is already disconnected: %r", exc)
             self.sock.close()
             self.sock = None
         self.connected = False

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
@@ -162,11 +162,9 @@ class AMQPClientAsync(AMQPClientSync):
                     await asyncio.sleep(self._retry_policy.get_backoff_time(retry_settings, exc))
                     if exc.condition == ErrorCondition.LinkDetachForced:
                         await self._close_link_async()  # if link level error, close and open a new link
-                        # TODO: check if there's any other code that we want to close link?
                     if exc.condition in (ErrorCondition.ConnectionCloseForced, ErrorCondition.SocketError):
                         # if connection detach or socket error, close and open a new connection
                         await self.close_async()
-                        # TODO: check if there's any other code we want to close connection
             except Exception:
                 raise
             finally:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
@@ -383,8 +383,6 @@ class SendClientAsync(SendClientSync, AMQPClientAsync):
             raise RuntimeError("Message is not sent.")
 
     async def _on_send_complete_async(self, message_delivery, reason, state):
-        # TODO: check whether the callback would be called in case of message expiry or link going down
-        #  and if so handle the state in the callback
         message_delivery.reason = reason
         if reason == LinkDeliverySettleReason.DISPOSITION_RECEIVED:
             if state and SEND_DISPOSITION_ACCEPT in state:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -289,8 +289,15 @@ class Connection(object):
             self.remote_idle_timeout_send_frame = self.idle_timeout_empty_frame_send_ratio * self.remote_idle_timeout
 
         if frame[2] < 512:
-            pass  # TODO: error
-        self._remote_max_frame_size = frame[2]
+            #Close with error
+            #Codes_S_R_S_CONNECTION_01_143: [If any of the values in the received open frame are invalid then the connection shall be closed.]
+            #Codes_S_R_S_CONNECTION_01_220: [The error amqp:invalid-field shall be set in the error.condition field of the CLOSE frame.] 
+            await self.close(error=AMQPConnectionError(
+                condition=ErrorCondition.InvalidField, 
+                description="connection_endpoint_frame_received::failed parsing OPEN frame"))
+            _LOGGER.error("connection_endpoint_frame_received::failed parsing OPEN frame")
+        else:
+            self._remote_max_frame_size = frame[2]
         if self.state == ConnectionState.OPEN_SENT:
             await self._set_state(ConnectionState.OPENED)
         elif self.state == ConnectionState.HDR_EXCH:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_link_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_link_async.py
@@ -146,7 +146,7 @@ class Link(object):
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
 
-    async def _remove_pending_deliveries(self):  # TODO: move to sender
+    async def _remove_pending_deliveries(self):
         futures = []
         for delivery in self._pending_deliveries.values():
             futures.append(asyncio.ensure_future(delivery.on_settled(LinkDeliverySettleReason.NOT_DELIVERED, None)))
@@ -189,10 +189,10 @@ class Link(object):
             _LOGGER.info("<- %r", AttachFrame(*frame), extra=self.network_trace_params)
         if self._is_closed:
             raise ValueError("Invalid link")
-        elif not frame[5] or not frame[6]:  # TODO: not sure if we should check here
+        elif not frame[5] or not frame[6]:
             _LOGGER.info("Cannot get source or target. Detaching link")
             await self._remove_pending_deliveries()
-            await self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+            await self._set_state(LinkState.DETACHED)
             raise ValueError("Invalid link")
         self.remote_handle = frame[1]
         self.remote_max_message_size = frame[10]
@@ -264,7 +264,7 @@ class Link(object):
             return
         try:
             await self._check_if_closed()
-            await self._remove_pending_deliveries()  # TODO: Keep?
+            await self._remove_pending_deliveries()
             if self.state in [LinkState.ATTACH_SENT, LinkState.ATTACH_RCVD]:
                 await self._outgoing_detach(close=close, error=error)
                 await self._set_state(LinkState.DETACHED)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -162,7 +162,8 @@ class Session(object):
             _LOGGER.info("<- %r", EndFrame(*frame), extra=self.network_trace_params)
         if self.state not in [SessionState.END_RCVD, SessionState.END_SENT, SessionState.DISCARDING]:
             await self._set_state(SessionState.END_RCVD)
-            # TODO: Clean up all links
+            for _, link in self.links.items():
+                await link.detach()
             await self._outgoing_end()
         await self._set_state(SessionState.UNMAPPED)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -185,7 +185,8 @@ class Session(object):
             self._output_handles[outgoing_handle] = new_link
             self._input_handles[frame[1]] = new_link
         except ValueError:
-            pass  # TODO: Reject link
+            # Reject Link
+            await new_link.detach()
     
     async def _outgoing_flow(self, frame=None):
         link_flow = frame or {}

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -343,7 +343,8 @@ class Session(object):
         try:
             if self.state not in [SessionState.UNMAPPED, SessionState.DISCARDING]:
                 await self._outgoing_end(error=error)
-            # TODO: destroy all links
+            for _, link in self.links.items():
+                await link.detach()
             new_state = SessionState.DISCARDING if error else SessionState.END_SENT
             await self._set_state(new_state)
             await self._wait_for_response(wait, SessionState.UNMAPPED)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -186,7 +186,7 @@ class Session(object):
             self._input_handles[frame[1]] = new_link
         except ValueError:
             # Reject Link
-            await new_link.detach()
+            await self._input_handles[frame[1]].detach()
     
     async def _outgoing_flow(self, frame=None):
         link_flow = frame or {}

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -92,7 +92,6 @@ class AsyncTransportMixin():
                 decoded = decode_empty_frame(header)
             else:
                 decoded = decode_frame(payload)
-            # TODO: Catch decode error and return amqp:decode-error
             #_LOGGER.info("ICH%d <- %r", channel, decoded)
             return channel, decoded
         except (TimeoutError, socket.timeout, asyncio.IncompleteReadError, asyncio.TimeoutError):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -98,7 +98,7 @@ class AsyncTransportMixin():
         except (TimeoutError, socket.timeout, asyncio.IncompleteReadError, asyncio.TimeoutError):
             return None, None
 
-    async def read(self, verify_frame_type=0, **kwargs):  # TODO: verify frame type?
+    async def read(self, verify_frame_type=0, **kwargs):
         async with self.socket_lock:
             read_frame_buffer = BytesIO()
             try:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -482,11 +482,8 @@ class WebSocketTransportAsync(AsyncTransportMixin):
 
     def close(self):
         """Do any preliminary work in shutting down the connection."""
-        # TODO: async close doesn't:
-        # 1) shutdown socket and close. --> self.sock.shutdown(socket.SHUT_RDWR) and self.sock.close()
-        # 2) set self.connected = False
-        # I think we need to do this, like in sync
         self.ws.close()
+        self.connected = False
 
     async def write(self, s):
         """Completely write a string to the peer.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -92,7 +92,7 @@ class AsyncTransportMixin():
                 decoded = decode_empty_frame(header)
             else:
                 decoded = decode_frame(payload)
-            #_LOGGER.info("ICH%d <- %r", channel, decoded)
+            _LOGGER.info("ICH%d <- %r", channel, decoded)
             return channel, decoded
         except (TimeoutError, socket.timeout, asyncio.IncompleteReadError, asyncio.TimeoutError):
             return None, None

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
@@ -457,8 +457,6 @@ class SendClient(AMQPClient):
         message_delivery.error = error
 
     def _on_send_complete(self, message_delivery, reason, state):
-        # TODO: check whether the callback would be called in case of message expiry or link going down
-        #  and if so handle the state in the callback
         message_delivery.reason = reason
         if reason == LinkDeliverySettleReason.DISPOSITION_RECEIVED:
             if state and SEND_DISPOSITION_ACCEPT in state:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
@@ -212,11 +212,9 @@ class AMQPClient(object):
                     time.sleep(self._retry_policy.get_backoff_time(retry_settings, exc))
                     if exc.condition == ErrorCondition.LinkDetachForced:
                         self._close_link()  # if link level error, close and open a new link
-                        # TODO: check if there's any other code that we want to close link?
                     if exc.condition in (ErrorCondition.ConnectionCloseForced, ErrorCondition.SocketError):
                         # if connection detach or socket error, close and open a new connection
                         self.close()
-                        # TODO: check if there's any other code we want to close connection
             except Exception:
                 raise
             finally:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/link.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/link.py
@@ -149,7 +149,7 @@ class Link(object):
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.error("Link state change callback failed: '%r'", e, extra=self.network_trace_params)
 
-    def _remove_pending_deliveries(self):  # TODO: move to sender
+    def _remove_pending_deliveries(self):
         for delivery in self._pending_deliveries.values():
             delivery.on_settled(LinkDeliverySettleReason.NOT_DELIVERED, None)
         self._pending_deliveries = {}
@@ -190,10 +190,10 @@ class Link(object):
             _LOGGER.info("<- %r", AttachFrame(*frame), extra=self.network_trace_params)
         if self._is_closed:
             raise ValueError("Invalid link")
-        elif not frame[5] or not frame[6]:  # TODO: not sure if we should source + target check here
+        elif not frame[5] or not frame[6]:
             _LOGGER.info("Cannot get source or target. Detaching link")
             self._remove_pending_deliveries()
-            self._set_state(LinkState.DETACHED)  # TODO: Send detach now?
+            self._set_state(LinkState.DETACHED)
             raise ValueError("Invalid link")
         self.remote_handle = frame[1]  # handle
         self.remote_max_message_size = frame[10]  # max_message_size
@@ -265,7 +265,7 @@ class Link(object):
             return
         try:
             self._check_if_closed()
-            self._remove_pending_deliveries()  # TODO: Keep?
+            self._remove_pending_deliveries()
             if self.state in [LinkState.ATTACH_SENT, LinkState.ATTACH_RCVD]:
                 self._outgoing_detach(close=close, error=error)
                 self._set_state(LinkState.DETACHED)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sender.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sender.py
@@ -131,7 +131,7 @@ class SenderLink(Link):
             if delivery:
                 delivery.on_settled(LinkDeliverySettleReason.DISPOSITION_RECEIVED, frame[4])  # state
 
-    def _update_pending_delivery_status(self):  # TODO
+    def _update_pending_delivery_status(self):
         now = time.time()
         expired = []
         for delivery in self._pending_deliveries.values():

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sender.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/sender.py
@@ -104,7 +104,6 @@ class SenderLink(Link):
             'payload': output
         }
         if self.network_trace:
-            # TODO: whether we should move frame tracing into centralized place e.g. connection.py
             _LOGGER.info("-> %r", TransferFrame(delivery_id='<pending>', **delivery.frame), extra=self.network_trace_params)
         self._session._outgoing_transfer(delivery)
         if delivery.transfer_state == SessionTransferState.OKAY:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -182,7 +182,8 @@ class Session(object):
             self._output_handles[outgoing_handle] = new_link
             self._input_handles[frame[1]] = new_link
         except ValueError:
-            pass  # TODO: Reject link
+            # Reject Link
+            new_link.detach()
     
     def _outgoing_flow(self, frame=None):
         link_flow = frame or {}

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -337,7 +337,8 @@ class Session(object):
         try:
             if self.state not in [SessionState.UNMAPPED, SessionState.DISCARDING]:
                 self._outgoing_end(error=error)
-            # TODO: destroy all links
+            for _, link in self.links.items():
+                link.detach()
             new_state = SessionState.DISCARDING if error else SessionState.END_SENT
             self._set_state(new_state)
             self._wait_for_response(wait, SessionState.UNMAPPED)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -158,7 +158,8 @@ class Session(object):
             _LOGGER.info("<- %r", EndFrame(*frame), extra=self.network_trace_params)
         if self.state not in [SessionState.END_RCVD, SessionState.END_SENT, SessionState.DISCARDING]:
             self._set_state(SessionState.END_RCVD)
-            # TODO: Clean up all links
+            for _, link in self.links.items():
+                link.detach()
             # TODO: handling error
             self._outgoing_end()
         self._set_state(SessionState.UNMAPPED)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -183,7 +183,7 @@ class Session(object):
             self._input_handles[frame[1]] = new_link
         except ValueError:
             # Reject Link
-            new_link.detach()
+            self._input_handles[frame[1]].detach()
     
     def _outgoing_flow(self, frame=None):
         link_flow = frame or {}


### PR DESCRIPTION
* `ws.close` on async does close the socket in the library -> [link](https://github.com/websocket-client/websocket-client/blob/61171591b08ee031e02cc6cb129952259062f502/websocket/_core.py#L4580)
* I kept the py2 comment in `_transport.py` about `from os import set_cloexec`. Looks like its not in py3 ( yet ) and that import will throw an `ImportError` across Windows, Mac & Linux.
* Rejecting `links` on a `ValueError` in `_incoming_attach`. Is that the proper way?