### PR TITLE
None-check when computing md5

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -13,6 +13,7 @@ This version and all future versions will require Python 3.7+. Python 3.6 is no 
 - Removed dead retry meachism from async `azure.storage.blob.aio.StorageStreamDownloader`.
 - Updated exception catching of `azure.storage.blob.StorageStreamDownloader`'s retry mechanism.
 - Adjusted type hints for `upload_blob` and `StorageStreamDownloader.readall`.
+- Fixed bug where `BlobClient` couldn't upload empty blob with `validate_content=True`.
 
 ## 12.13.1 (2022-08-04)
 

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -13,7 +13,7 @@ This version and all future versions will require Python 3.7+. Python 3.6 is no 
 - Removed dead retry meachism from async `azure.storage.blob.aio.StorageStreamDownloader`.
 - Updated exception catching of `azure.storage.blob.StorageStreamDownloader`'s retry mechanism.
 - Adjusted type hints for `upload_blob` and `StorageStreamDownloader.readall`.
-- Fixed bug where `BlobClient` couldn't upload empty blob with `validate_content=True`.
+- Fixed a bug where uploading an empty blob via `upload_blob` would fail with `validate_content=True`.
 
 ## 12.13.1 (2022-08-04)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -350,6 +350,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
 
     @staticmethod
     def get_content_md5(data):
+        # Since HTTP does not differentiate between no content and empty content,
+        # we have to perform a None check.
+        data = data or b""
         md5 = hashlib.md5() # nosec
         if isinstance(data, bytes):
             md5.update(data)

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_validate_empty_blob.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.test_validate_empty_blob.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainer613510ca?restype=container&timeout=5
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      etag:
+      - '"0x8DA7BB2AE7B53DB"'
+      last-modified:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainersource613510ca?restype=container&timeout=5
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      etag:
+      - '"0x8DA7BB2AE814670"'
+      last-modified:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-MD5:
+      - 1B2M2Y8AsgTpgAmY7PhCfg==
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainer613510ca/utcontainer613510ca
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - 1B2M2Y8AsgTpgAmY7PhCfg==
+      date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      etag:
+      - '"0x8DA7BB2AE856487"'
+      last-modified:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - AAAAAAAAAAA=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/utcontainer613510ca/utcontainer613510ca
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '0'
+      content-md5:
+      - 1B2M2Y8AsgTpgAmY7PhCfg==
+      content-type:
+      - application/octet-stream
+      date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      etag:
+      - '"0x8DA7BB2AE856487"'
+      last-modified:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier:
+      - Hot
+      x-ms-access-tier-inferred:
+      - 'true'
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/utcontainer613510ca/utcontainer613510ca
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '0'
+      content-md5:
+      - 1B2M2Y8AsgTpgAmY7PhCfg==
+      content-type:
+      - application/octet-stream
+      date:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      etag:
+      - '"0x8DA7BB2AE856487"'
+      last-modified:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier:
+      - Hot
+      x-ms-access-tier-inferred:
+      - 'true'
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Thu, 11 Aug 2022 16:00:58 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_validate_empty_blob.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.test_validate_empty_blob.yaml
@@ -1,0 +1,170 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:01:01 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainercfe91347?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Thu, 11 Aug 2022 16:01:01 GMT
+      etag: '"0x8DA7BB2B056F50D"'
+      last-modified: Thu, 11 Aug 2022 16:01:01 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-08-06'
+    status:
+      code: 201
+      message: Created
+    url: https://tsjinxuansdktestaccount.blob.core.windows.net/utcontainercfe91347?restype=container
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:01:01 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainersourcecfe91347?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Thu, 11 Aug 2022 16:01:01 GMT
+      etag: '"0x8DA7BB2B05D83C4"'
+      last-modified: Thu, 11 Aug 2022 16:01:01 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-08-06'
+    status:
+      code: 201
+      message: Created
+    url: https://tsjinxuansdktestaccount.blob.core.windows.net/utcontainersourcecfe91347?restype=container
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Content-Length:
+      - '0'
+      Content-MD5:
+      - 1B2M2Y8AsgTpgAmY7PhCfg==
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:01:01 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainercfe91347/utcontainercfe91347
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      content-md5: 1B2M2Y8AsgTpgAmY7PhCfg==
+      date: Thu, 11 Aug 2022 16:01:01 GMT
+      etag: '"0x8DA7BB2B061CEED"'
+      last-modified: Thu, 11 Aug 2022 16:01:01 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64: AAAAAAAAAAA=
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 201
+      message: Created
+    url: https://tsjinxuansdktestaccount.blob.core.windows.net/utcontainercfe91347/utcontainercfe91347
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:01:01 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/utcontainercfe91347/utcontainercfe91347
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges: bytes
+      content-length: '0'
+      content-md5: 1B2M2Y8AsgTpgAmY7PhCfg==
+      content-type: application/octet-stream
+      date: Thu, 11 Aug 2022 16:01:01 GMT
+      etag: '"0x8DA7BB2B061CEED"'
+      last-modified: Thu, 11 Aug 2022 16:01:01 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier: Hot
+      x-ms-access-tier-inferred: 'true'
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Thu, 11 Aug 2022 16:01:01 GMT
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 200
+      message: OK
+    url: https://tsjinxuansdktestaccount.blob.core.windows.net/utcontainercfe91347/utcontainercfe91347
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.0b1 Python/3.7.13 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-debian-bullseye-sid)
+      x-ms-date:
+      - Thu, 11 Aug 2022 16:01:01 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/utcontainercfe91347/utcontainercfe91347
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges: bytes
+      content-length: '0'
+      content-md5: 1B2M2Y8AsgTpgAmY7PhCfg==
+      content-type: application/octet-stream
+      date: Thu, 11 Aug 2022 16:01:01 GMT
+      etag: '"0x8DA7BB2B061CEED"'
+      last-modified: Thu, 11 Aug 2022 16:01:01 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier: Hot
+      x-ms-access-tier-inferred: 'true'
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Thu, 11 Aug 2022 16:01:01 GMT
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 200
+      message: OK
+    url: https://tsjinxuansdktestaccount.blob.core.windows.net/utcontainercfe91347/utcontainercfe91347
+version: 1

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client.py
@@ -711,24 +711,4 @@ class TestStorageClient(StorageRecordedTestCase):
                 self.account_url(storage_account_name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
             service.close()
 
-    @BlobPreparer()
-    def test_validate_empty_blob(self, **kwargs):
-        """Test that we can upload an empty blob with validate=True."""
-        storage_account_name = kwargs.pop("storage_account_name")
-        storage_account_key = kwargs.pop("storage_account_key")
-
-        service = BlobServiceClient(
-            self.account_url(storage_account_name, "blob"), credential=storage_account_key) 
-
-        container_name = "utcontainermycontainer"
-        container: ContainerClient = service.get_container_client(container_name)
-        container.create_container()
-        assert container.exists()
-
-        blob_name = "myblob"
-        container.upload_blob(blob_name, b"", validate_content=True)
-        blob_client: BlobClient = container.get_blob_client(blob_name)
-        assert blob_client.exists()
-        assert blob_client.get_blob_properties().size == 0
-
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client.py
@@ -711,4 +711,24 @@ class TestStorageClient(StorageRecordedTestCase):
                 self.account_url(storage_account_name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
             service.close()
 
+    @BlobPreparer()
+    def test_validate_empty_blob(self, **kwargs):
+        """Test that we can upload an empty blob with validate=True."""
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        service = BlobServiceClient(
+            self.account_url(storage_account_name, "blob"), credential=storage_account_key) 
+
+        container_name = "utcontainermycontainer"
+        container: ContainerClient = service.get_container_client(container_name)
+        container.create_container()
+        assert container.exists()
+
+        blob_name = "myblob"
+        container.upload_blob(blob_name, b"", validate_content=True)
+        blob_client: BlobClient = container.get_blob_client(blob_name)
+        assert blob_client.exists()
+        assert blob_client.get_blob_properties().size == 0
+
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -2835,4 +2835,17 @@ class StorageCommonBlobTest(StorageTestCase):
             blob.delete_blob()
             mgmt_client.blob_containers.delete(storage_resource_group_name, versioned_storage_account_name, container_name)
 
+    @BlobPreparer()
+    def test_validate_empty_blob(self, storage_account_name, storage_account_key):
+        """Test that we can upload an empty blob with validate=True."""
+        self._setup(storage_account_name, storage_account_key)
+
+        blob_name = self.get_resource_name("utcontainer")
+        container_client = self.bsc.get_container_client(self.container_name)
+        container_client.upload_blob(blob_name, b"", validate_content=True)
+
+        blob_client: BlobClient = container_client.get_blob_client(blob_name)
+
+        assert blob_client.exists()
+        assert blob_client.get_blob_properties().size == 0
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -2844,7 +2844,7 @@ class StorageCommonBlobTest(StorageTestCase):
         container_client = self.bsc.get_container_client(self.container_name)
         container_client.upload_blob(blob_name, b"", validate_content=True)
 
-        blob_client: BlobClient = container_client.get_blob_client(blob_name)
+        blob_client = container_client.get_blob_client(blob_name)
 
         assert blob_client.exists()
         assert blob_client.get_blob_properties().size == 0

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -2866,4 +2866,18 @@ class StorageCommonBlobAsyncTest(AsyncStorageTestCase):
             await blob.delete_blob()
             await mgmt_client.blob_containers.delete(storage_resource_group_name, versioned_storage_account_name, container_name)
 
+    @BlobPreparer()
+    async def test_validate_empty_blob(self, storage_account_name, storage_account_key):
+        """Test that we can upload an empty blob with validate=True."""
+        await self._setup(storage_account_name, storage_account_key)
+
+        blob_name = self.get_resource_name("utcontainer")
+        container_client = self.bsc.get_container_client(self.container_name)
+        await container_client.upload_blob(blob_name, b"", validate_content=True)
+
+        blob_client: BlobClient = container_client.get_blob_client(blob_name)
+
+        assert await blob_client.exists()
+        assert (await blob_client.get_blob_properties()).size == 0
+
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -2875,7 +2875,7 @@ class StorageCommonBlobAsyncTest(AsyncStorageTestCase):
         container_client = self.bsc.get_container_client(self.container_name)
         await container_client.upload_blob(blob_name, b"", validate_content=True)
 
-        blob_client: BlobClient = container_client.get_blob_client(blob_name)
+        blob_client = container_client.get_blob_client(blob_name)
 
         assert await blob_client.exists()
         assert (await blob_client.get_blob_properties()).size == 0

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
@@ -336,6 +336,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
 
     @staticmethod
     def get_content_md5(data):
+        # Since HTTP does not differentiate between no content and empty content,
+        # we have to perform a None check.
+        data = data or b""
         md5 = hashlib.md5() # nosec
         if isinstance(data, bytes):
             md5.update(data)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
@@ -336,6 +336,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
 
     @staticmethod
     def get_content_md5(data):
+        # Since HTTP does not differentiate between no content and empty content,
+        # we have to perform a None check.
+        data = data or b""
         md5 = hashlib.md5() # nosec
         if isinstance(data, bytes):
             md5.update(data)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -342,6 +342,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
 
     @staticmethod
     def get_content_md5(data):
+        # Since HTTP does not differentiate between no content and empty content,
+        # we have to perform a None check.
+        data = data or b""
         md5 = hashlib.md5() # nosec
         if isinstance(data, bytes):
             md5.update(data)


### PR DESCRIPTION
# Description

Fix for #25489. Our md5 method was not considering the possibility that a request's content could be `None` instead of `b""`. Since from an HTTP perspective `None` and `b""` are the same, we just add a simple `None`-check,

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
