### PR TITLE
[Storage] Raise error if download response does not contain Content-Range

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -431,6 +431,8 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
                 # Parse the total file size and adjust the download size if ranges
                 # were specified
                 self._file_size = parse_length_from_content_range(response.properties.content_range)
+                if not self._file_size:
+                    raise ValueError("Required Content-Range response header is missing or malformed.")
                 # Remove any extra encryption data size from blob size
                 self._file_size = adjust_blob_size_for_encryption(self._file_size, self._encryption_data)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -353,6 +353,8 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
             # Parse the total file size and adjust the download size if ranges
             # were specified
             self._file_size = parse_length_from_content_range(response.properties.content_range)
+            if not self._file_size:
+                raise ValueError("Required Content-Range response header is missing or malformed.")
             # Remove any extra encryption data size from blob size
             self._file_size = adjust_blob_size_for_encryption(self._file_size, self._encryption_data)
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
@@ -311,6 +311,9 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
             # Parse the total file size and adjust the download size if ranges
             # were specified
             self._file_size = parse_length_from_content_range(response.properties.content_range)
+            if not self._file_size:
+                raise ValueError("Required Content-Range response header is missing or malformed.")
+
             if self._end_range is not None:
                 # Use the end range index unless it is over the end of the file
                 self.size = min(self._file_size, self._end_range - self._start_range + 1)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -264,6 +264,9 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
             # Parse the total file size and adjust the download size if ranges
             # were specified
             self._file_size = parse_length_from_content_range(response.properties.content_range)
+            if not self._file_size:
+                raise ValueError("Required Content-Range response header is missing or malformed.")
+
             if self._end_range is not None:
                 # Use the length unless it is over the end of the file
                 self.size = min(self._file_size, self._end_range - self._start_range + 1)


### PR DESCRIPTION
As discovered in #22297, downloading a blob through the Microsoft CDN can return a response that does not contain a `Content-Range` header. This causes an unhelpful `NoneType` exception to occur while we are processing the download in `StorageStreamDownloader`.

The missing `Content-Range` is an unexpected case but this change aims to handle it more gracefully by raising a `ValueError` if we do not get a valid `Content-Range` in the response.