### PR TITLE
Moved entry points to setup.py

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Moved OpenTelemetry `entry_points` to setup.py
+    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
 - Added storage configuration options
     ([#25633](https://github.com/Azure/azure-sdk-for-python/pull/25633))
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Moved OpenTelemetry `entry_points` to setup.py
-    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+    ([#25674](https://github.com/Azure/azure-sdk-for-python/pull/25674))
 - Added storage configuration options
     ([#25633](https://github.com/Azure/azure-sdk-for-python/pull/25633))
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.cfg
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.cfg
@@ -1,10 +1,2 @@
 [bdist_wheel]
 universal=1
-
-[options.entry_points]
-opentelemetry_traces_exporter =
-    azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorTraceExporter
-opentelemetry_logs_exporter =
-    azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorLogExporter
-opentelemetry_metrics_exporter =
-    azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorMetricExporter

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -7,7 +7,6 @@
 # --------------------------------------------------------------------------
 
 
-from importlib.metadata import entry_points
 import os
 import re
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -7,6 +7,7 @@
 # --------------------------------------------------------------------------
 
 
+from importlib.metadata import entry_points
 import os
 import re
 
@@ -85,5 +86,16 @@ setup(
         "opentelemetry-api<2.0.0,>=1.12.0",
         "opentelemetry-sdk<2.0.0,>=1.12.0",
     ],
+    entry_points={
+        "opentelemetry_traces_exporter": [
+            "azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorTraceExporter"
+        ],
+        "opentelemetry_logs_exporter": [
+            "azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorLogExporter"
+        ],
+        "opentelemetry_metrics_exporter": [
+            "azure_monitor_opentelemetry_exporter = azure.monitor.opentelemetry.exporter:AzureMonitorMetricExporter"
+        ]
+    }
 )
 


### PR DESCRIPTION
# Description

Moved the OpenTelemetry entry points from setup.cfg to setup.py.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
