### PR TITLE
Update CHANGELOG to prepare for 1.0.0b7 release

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b7 (Unreleased)
+## 1.0.0b7 (2022-08-12)
 
 ### Features Added
 
@@ -16,8 +16,6 @@
 
 - Opentelemetry span events have wrong ParentId in Azure Monitor logs
     ([#25369](https://github.com/Azure/azure-sdk-for-python/pull/25369))
-
-### Other Changes
 
 ## 1.0.0b6 (2022-06-10)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -30,7 +30,7 @@ To use this package, you must have:
 Interaction with Azure monitor exporter starts with an instance of the `AzureMonitorTraceExporter` class for distributed tracing, `AzureMonitorLogExporter` for logging and `AzureMonitorMetricExporter` for metrics. You will need a **connection_string** to instantiate the object.
 Please find the samples linked below for demonstration as to how to construct the exporter using a connection string.
 
-#### Logging
+#### Logging (experimental)
 
 NOTE: The logging signal for the `AzureMonitorLogExporter` is currently in an EXPERIMENTAL state. Possible breaking changes may ensue in the future.
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -59,10 +59,10 @@ setup(
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: MIT License',
     ],
     zip_safe=False,
@@ -78,7 +78,7 @@ setup(
     package_data={
         'pytyped': ['py.typed'],
     },
-    python_requires=">=3.6.0",
+    python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.23.0",
         "msrest>=0.6.10",


### PR DESCRIPTION
Also drops Python 3.6 support and adds 3.10 as defined by azure sdk standards and OpenTelemetry api/sdk.

https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy
https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/setup.cfg#L35