### PR TITLE
[communication-identity] [Reland] Add methods to translate CommunicationIdentifier to / from a stable string format

### DIFF
--- a/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
@@ -103,8 +103,7 @@ class PhoneNumberIdentifier(object):
 _PHONE_NUMBER_PREFIX = re.compile(r'^\+')
 
 
-def _phone_number_raw_id(identifier):
-    # type (PhoneNumberIdentifier) -> str
+def _phone_number_raw_id(identifier: PhoneNumberIdentifier) -> str:
     value = identifier.properties['value']
     # strip the leading +. We just assume correct E.164 format here because
     # validation should only happen server-side, not client-side.
@@ -172,8 +171,7 @@ class MicrosoftTeamsUserIdentifier(object):
             self.raw_id = _microsoft_teams_user_raw_id(self)
 
 
-def _microsoft_teams_user_raw_id(identifier):
-    # type (MicrosoftTeamsUserIdentifier) -> str
+def _microsoft_teams_user_raw_id(identifier: MicrosoftTeamsUserIdentifier) -> str:
     user_id = identifier.properties['user_id']
     if identifier.properties['is_anonymous']:
         return '8:teamsvisitor:{}'.format(user_id)
@@ -187,15 +185,14 @@ def _microsoft_teams_user_raw_id(identifier):
     return '8:orgid:{}'.format(user_id)
 
 
-def identifier_from_raw_id(raw_id):
+def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:
     """
     Creates a CommunicationIdentifier from a given raw ID.
 
     When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
 
-    :param raw ID to construct the CommunicationIdentifier from.
+    :param str raw_id: A raw ID to construct the CommunicationIdentifier from.
     """
-    # type (str) -> CommunicationIdentifier
     if raw_id.startswith('4:'):
         return PhoneNumberIdentifier(
             value='+{}'.format(raw_id[len('4:'):])

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
@@ -5,6 +5,7 @@
 # pylint: skip-file
 
 from enum import Enum, EnumMeta
+import re
 from six import with_metaclass
 from typing import Mapping, Optional, Union, Any
 try:
@@ -67,7 +68,7 @@ class CommunicationUserIdentifier(object):
 
     def __init__(self, id, **kwargs):
         # type: (str, Any) -> None
-        self.raw_id = kwargs.get('raw_id')
+        self.raw_id = kwargs.get('raw_id', id)
         self.properties = CommunicationUserProperties(id=id)
 
 
@@ -95,6 +96,19 @@ class PhoneNumberIdentifier(object):
         # type: (str, Any) -> None
         self.raw_id = kwargs.get('raw_id')
         self.properties = PhoneNumberProperties(value=value)
+        if self.raw_id is None:
+            self.raw_id = _phone_number_raw_id(self)
+
+
+_PHONE_NUMBER_PREFIX = re.compile(r'^\+')
+
+
+def _phone_number_raw_id(identifier):
+    # type (PhoneNumberIdentifier) -> str
+    value = identifier.properties['value']
+    # strip the leading +. We just assume correct E.164 format here because
+    # validation should only happen server-side, not client-side.
+    return '4:{}'.format(_PHONE_NUMBER_PREFIX.sub('', value))
 
 
 class UnknownIdentifier(object):
@@ -154,3 +168,72 @@ class MicrosoftTeamsUserIdentifier(object):
             is_anonymous=kwargs.get('is_anonymous', False),
             cloud=kwargs.get('cloud') or CommunicationCloudEnvironment.PUBLIC
         )
+        if self.raw_id is None:
+            self.raw_id = _microsoft_teams_user_raw_id(self)
+
+
+def _microsoft_teams_user_raw_id(identifier):
+    # type (MicrosoftTeamsUserIdentifier) -> str
+    user_id = identifier.properties['user_id']
+    if identifier.properties['is_anonymous']:
+        return '8:teamsvisitor:{}'.format(user_id)
+    cloud = identifier.properties['cloud']
+    if cloud == CommunicationCloudEnvironment.DOD:
+        return '8:dod:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.GCCH:
+        return '8:gcch:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.PUBLIC:
+        return '8:orgid:{}'.format(user_id)
+    return '8:orgid:{}'.format(user_id)
+
+
+def identifier_from_raw_id(raw_id):
+    """
+    Creates a CommunicationIdentifier from a given raw ID.
+
+    When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
+
+    :param raw ID to construct the CommunicationIdentifier from.
+    """
+    # type (str) -> CommunicationIdentifier
+    if raw_id.startswith('4:'):
+        return PhoneNumberIdentifier(
+            value='+{}'.format(raw_id[len('4:'):])
+        )
+
+    segments = raw_id.split(':', maxsplit=2)
+    if len(segments) < 3:
+        return UnknownIdentifier(identifier=raw_id)
+
+    prefix = '{}:{}:'.format(segments[0], segments[1])
+    suffix = raw_id[len(prefix):]
+    if prefix == '8:teamsvisitor:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=True
+        )
+    elif prefix == '8:orgid:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='PUBLIC'
+        )
+    elif prefix == '8:dod:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='DOD'
+        )
+    elif prefix == '8:gcch:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='GCCH'
+        )
+    elif prefix in ['8:acs:', '8:spool:', '8:dod-acs:', '8:gcch-acs:']:
+        return CommunicationUserIdentifier(
+            id=raw_id
+        )
+    return UnknownIdentifier(
+        identifier=raw_id
+    )

--- a/sdk/communication/azure-communication-identity/CHANGELOG.md
+++ b/sdk/communication/azure-communication-identity/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Exported types `MicrosoftTeamsUserIdentifier`, `PhoneNumberIdentifier`, `UnknownIdentifier` for non Azure Communication Services `CommunicationIdentifier` identities.
+- Added `identifier_from_raw_id` and ensured that `CommunicationIdentifier.raw_id` is populated on creation. Together, these can be used to translate between a `CommunicationIdentifier` and its underlying canonical raw ID representation. Developers can now use the raw ID as an encoded format for identifiers to store in their databases or as stable keys in general.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/__init__.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/__init__.py
@@ -14,7 +14,11 @@ from ._shared.models import (
     CommunicationIdentifier,
     CommunicationIdentifierKind,
     CommunicationUserIdentifier,
-    CommunicationUserProperties
+    CommunicationUserProperties,
+    MicrosoftTeamsUserIdentifier,
+    PhoneNumberIdentifier,
+    UnknownIdentifier,
+    identifier_from_raw_id
 )
 
 __all__ = [
@@ -27,5 +31,9 @@ __all__ = [
     'CommunicationIdentifier',
     'CommunicationIdentifierKind',
     'CommunicationUserIdentifier',
-    'CommunicationUserProperties'
+    'CommunicationUserProperties',
+    'MicrosoftTeamsUserIdentifier',
+    'PhoneNumberIdentifier',
+    'UnknownIdentifier',
+    'identifier_from_raw_id'
 ]

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/__init__.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/__init__.py
@@ -11,6 +11,7 @@ from ._generated.models import (
 )
 
 from ._shared.models import (
+    CommunicationCloudEnvironment,
     CommunicationIdentifier,
     CommunicationIdentifierKind,
     CommunicationUserIdentifier,
@@ -28,6 +29,7 @@ __all__ = [
     'CommunicationTokenScope',
 
     # from _shared
+    'CommunicationCloudEnvironment',
     'CommunicationIdentifier',
     'CommunicationIdentifierKind',
     'CommunicationUserIdentifier',

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
@@ -103,8 +103,7 @@ class PhoneNumberIdentifier(object):
 _PHONE_NUMBER_PREFIX = re.compile(r'^\+')
 
 
-def _phone_number_raw_id(identifier):
-    # type (PhoneNumberIdentifier) -> str
+def _phone_number_raw_id(identifier: PhoneNumberIdentifier) -> str:
     value = identifier.properties['value']
     # strip the leading +. We just assume correct E.164 format here because
     # validation should only happen server-side, not client-side.
@@ -172,8 +171,7 @@ class MicrosoftTeamsUserIdentifier(object):
             self.raw_id = _microsoft_teams_user_raw_id(self)
 
 
-def _microsoft_teams_user_raw_id(identifier):
-    # type (MicrosoftTeamsUserIdentifier) -> str
+def _microsoft_teams_user_raw_id(identifier: MicrosoftTeamsUserIdentifier) -> str:
     user_id = identifier.properties['user_id']
     if identifier.properties['is_anonymous']:
         return '8:teamsvisitor:{}'.format(user_id)
@@ -187,15 +185,14 @@ def _microsoft_teams_user_raw_id(identifier):
     return '8:orgid:{}'.format(user_id)
 
 
-def identifier_from_raw_id(raw_id):
+def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:
     """
     Creates a CommunicationIdentifier from a given raw ID.
 
     When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
 
-    :param raw ID to construct the CommunicationIdentifier from.
+    :param str raw_id: A raw ID to construct the CommunicationIdentifier from.
     """
-    # type (str) -> CommunicationIdentifier
     if raw_id.startswith('4:'):
         return PhoneNumberIdentifier(
             value='+{}'.format(raw_id[len('4:'):])

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
@@ -5,6 +5,7 @@
 # pylint: skip-file
 
 from enum import Enum, EnumMeta
+import re
 from six import with_metaclass
 from typing import Mapping, Optional, Union, Any
 try:
@@ -67,7 +68,7 @@ class CommunicationUserIdentifier(object):
 
     def __init__(self, id, **kwargs):
         # type: (str, Any) -> None
-        self.raw_id = kwargs.get('raw_id')
+        self.raw_id = kwargs.get('raw_id', id)
         self.properties = CommunicationUserProperties(id=id)
 
 
@@ -95,6 +96,19 @@ class PhoneNumberIdentifier(object):
         # type: (str, Any) -> None
         self.raw_id = kwargs.get('raw_id')
         self.properties = PhoneNumberProperties(value=value)
+        if self.raw_id is None:
+            self.raw_id = _phone_number_raw_id(self)
+
+
+_PHONE_NUMBER_PREFIX = re.compile(r'^\+')
+
+
+def _phone_number_raw_id(identifier):
+    # type (PhoneNumberIdentifier) -> str
+    value = identifier.properties['value']
+    # strip the leading +. We just assume correct E.164 format here because
+    # validation should only happen server-side, not client-side.
+    return '4:{}'.format(_PHONE_NUMBER_PREFIX.sub('', value))
 
 
 class UnknownIdentifier(object):
@@ -154,3 +168,72 @@ class MicrosoftTeamsUserIdentifier(object):
             is_anonymous=kwargs.get('is_anonymous', False),
             cloud=kwargs.get('cloud') or CommunicationCloudEnvironment.PUBLIC
         )
+        if self.raw_id is None:
+            self.raw_id = _microsoft_teams_user_raw_id(self)
+
+
+def _microsoft_teams_user_raw_id(identifier):
+    # type (MicrosoftTeamsUserIdentifier) -> str
+    user_id = identifier.properties['user_id']
+    if identifier.properties['is_anonymous']:
+        return '8:teamsvisitor:{}'.format(user_id)
+    cloud = identifier.properties['cloud']
+    if cloud == CommunicationCloudEnvironment.DOD:
+        return '8:dod:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.GCCH:
+        return '8:gcch:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.PUBLIC:
+        return '8:orgid:{}'.format(user_id)
+    return '8:orgid:{}'.format(user_id)
+
+
+def identifier_from_raw_id(raw_id):
+    """
+    Creates a CommunicationIdentifier from a given raw ID.
+
+    When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
+
+    :param raw ID to construct the CommunicationIdentifier from.
+    """
+    # type (str) -> CommunicationIdentifier
+    if raw_id.startswith('4:'):
+        return PhoneNumberIdentifier(
+            value='+{}'.format(raw_id[len('4:'):])
+        )
+
+    segments = raw_id.split(':', maxsplit=2)
+    if len(segments) < 3:
+        return UnknownIdentifier(identifier=raw_id)
+
+    prefix = '{}:{}:'.format(segments[0], segments[1])
+    suffix = raw_id[len(prefix):]
+    if prefix == '8:teamsvisitor:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=True
+        )
+    elif prefix == '8:orgid:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='PUBLIC'
+        )
+    elif prefix == '8:dod:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='DOD'
+        )
+    elif prefix == '8:gcch:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='GCCH'
+        )
+    elif prefix in ['8:acs:', '8:spool:', '8:dod-acs:', '8:gcch-acs:']:
+        return CommunicationUserIdentifier(
+            id=raw_id
+        )
+    return UnknownIdentifier(
+        identifier=raw_id
+    )

--- a/sdk/communication/azure-communication-identity/tests/test_identifier_raw_id.py
+++ b/sdk/communication/azure-communication-identity/tests/test_identifier_raw_id.py
@@ -1,0 +1,238 @@
+# coding: utf-8
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import pytest
+import unittest
+from azure.communication.identity import *
+
+class IdentifierRawIdTest(unittest.TestCase):
+    def test_raw_id(self):
+        _assert_raw_id(
+            CommunicationUserIdentifier(
+                id='8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+            ),
+            '8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            CommunicationUserIdentifier(
+                id='8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+            ),
+            '8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            CommunicationUserIdentifier(
+                id='someFutureFormat'
+            ),
+            'someFutureFormat'
+        )
+        _assert_raw_id(
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130'
+            ),
+            '8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                cloud='PUBLIC'
+            ),
+            '8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                cloud='DOD'
+            ),
+            '8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                cloud='GCCH'
+            ),
+            '8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                is_anonymous=False
+            ),
+            '8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                is_anonymous=True
+            ),
+            '8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+        _assert_raw_id(
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                raw_id='8:orgid:legacyFormat'
+            ),
+            '8:orgid:legacyFormat'
+        )
+        _assert_raw_id(
+            PhoneNumberIdentifier(
+                value='+112345556789'
+            ),
+            '4:112345556789'
+        )
+        _assert_raw_id(
+            PhoneNumberIdentifier(
+                value='112345556789'
+            ),
+            '4:112345556789'
+        )
+        _assert_raw_id(
+            PhoneNumberIdentifier(
+                value='+112345556789',
+                raw_id='4:otherFormat'
+            ),
+            '4:otherFormat'
+        )
+        _assert_raw_id(
+            UnknownIdentifier(
+                identifier='28:45ab2481-1c1c-4005-be24-0ffb879b1130'
+            ),
+            '28:45ab2481-1c1c-4005-be24-0ffb879b1130'
+        )
+
+    def test_identifier_from_raw_id(self):
+        _assert_communication_identifier(
+            '8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130',
+            CommunicationUserIdentifier(
+                id='8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+            )
+        )
+        _assert_communication_identifier(
+            '8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130',
+            CommunicationUserIdentifier(
+                id='8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+            )
+        )
+        _assert_communication_identifier(
+            '8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130',
+            CommunicationUserIdentifier(
+                id='8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+            )
+        )
+        _assert_communication_identifier(
+            '8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130',
+            CommunicationUserIdentifier(
+                id='8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130'
+            )
+        )
+        _assert_communication_identifier(
+            '8:acs:something',
+            CommunicationUserIdentifier(
+                id='8:acs:something'
+            )
+        )
+        _assert_communication_identifier(
+            '8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130',
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                cloud='PUBLIC',
+                is_anonymous=False
+            )
+        )
+        _assert_communication_identifier(
+            '8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130',
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                cloud='DOD',
+                is_anonymous=False
+            )
+        )
+        _assert_communication_identifier(
+            '8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130',
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                cloud='GCCH',
+                is_anonymous=False
+            )
+        )
+        _assert_communication_identifier(
+            '8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130',
+            MicrosoftTeamsUserIdentifier(
+                user_id='45ab2481-1c1c-4005-be24-0ffb879b1130',
+                is_anonymous=True
+            )
+        )
+        _assert_communication_identifier(
+            '8:orgid:legacyFormat',
+            MicrosoftTeamsUserIdentifier(
+                user_id='legacyFormat',
+                cloud='PUBLIC',
+                is_anonymous=False
+            )
+        )
+        _assert_communication_identifier(
+            '4:112345556789',
+            PhoneNumberIdentifier(
+                value='+112345556789'
+            )
+        )
+        _assert_communication_identifier(
+            '4:otherFormat',
+            PhoneNumberIdentifier(
+                value='+otherFormat'
+            )
+        )
+        _assert_communication_identifier(
+            '28:45ab2481-1c1c-4005-be24-0ffb879b1130',
+            UnknownIdentifier(
+                identifier='28:45ab2481-1c1c-4005-be24-0ffb879b1130'
+            )
+        )
+        _assert_communication_identifier(
+            '',
+            UnknownIdentifier(
+                identifier=''
+            )
+        )
+        with pytest.raises(Exception):
+            identifier_from_raw_id(None)
+
+    def test_roundtrip(self):
+        _assert_roundtrip('8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:acs:something')
+        _assert_roundtrip('8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('8:orgid:legacyFormat')
+        _assert_roundtrip('4:112345556789')
+        _assert_roundtrip('4:otherFormat')
+        _assert_roundtrip('28:45ab2481-1c1c-4005-be24-0ffb879b1130')
+        _assert_roundtrip('')
+
+
+def _assert_raw_id(identifier, want):
+    # type: (CommunicationIdentifier, str) -> None
+    assert identifier.raw_id == want
+
+
+def _assert_communication_identifier(raw_id, want):
+    # type: (str, CommunicationIdentifier) -> None
+    got = identifier_from_raw_id(raw_id)
+    assert got.raw_id == want.raw_id
+    assert got.kind == want.kind
+    assert len(got.properties) == len(want.properties)
+    for key in want.properties:
+        assert key in got.properties
+        assert got.properties[key] == want.properties[key]
+
+
+def _assert_roundtrip(raw_id):
+    # type: (str) -> None
+    assert identifier_from_raw_id(raw_id).raw_id == raw_id

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/models.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/models.py
@@ -103,8 +103,7 @@ class PhoneNumberIdentifier(object):
 _PHONE_NUMBER_PREFIX = re.compile(r'^\+')
 
 
-def _phone_number_raw_id(identifier):
-    # type (PhoneNumberIdentifier) -> str
+def _phone_number_raw_id(identifier: PhoneNumberIdentifier) -> str:
     value = identifier.properties['value']
     # strip the leading +. We just assume correct E.164 format here because
     # validation should only happen server-side, not client-side.
@@ -172,8 +171,7 @@ class MicrosoftTeamsUserIdentifier(object):
             self.raw_id = _microsoft_teams_user_raw_id(self)
 
 
-def _microsoft_teams_user_raw_id(identifier):
-    # type (MicrosoftTeamsUserIdentifier) -> str
+def _microsoft_teams_user_raw_id(identifier: MicrosoftTeamsUserIdentifier) -> str:
     user_id = identifier.properties['user_id']
     if identifier.properties['is_anonymous']:
         return '8:teamsvisitor:{}'.format(user_id)
@@ -187,15 +185,14 @@ def _microsoft_teams_user_raw_id(identifier):
     return '8:orgid:{}'.format(user_id)
 
 
-def identifier_from_raw_id(raw_id):
+def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:
     """
     Creates a CommunicationIdentifier from a given raw ID.
 
     When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
 
-    :param raw ID to construct the CommunicationIdentifier from.
+    :param str raw_id: A raw ID to construct the CommunicationIdentifier from.
     """
-    # type (str) -> CommunicationIdentifier
     if raw_id.startswith('4:'):
         return PhoneNumberIdentifier(
             value='+{}'.format(raw_id[len('4:'):])

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/models.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/models.py
@@ -5,6 +5,7 @@
 # pylint: skip-file
 
 from enum import Enum, EnumMeta
+import re
 from six import with_metaclass
 from typing import Mapping, Optional, Union, Any
 try:
@@ -67,7 +68,7 @@ class CommunicationUserIdentifier(object):
 
     def __init__(self, id, **kwargs):
         # type: (str, Any) -> None
-        self.raw_id = kwargs.get('raw_id')
+        self.raw_id = kwargs.get('raw_id', id)
         self.properties = CommunicationUserProperties(id=id)
 
 
@@ -95,6 +96,19 @@ class PhoneNumberIdentifier(object):
         # type: (str, Any) -> None
         self.raw_id = kwargs.get('raw_id')
         self.properties = PhoneNumberProperties(value=value)
+        if self.raw_id is None:
+            self.raw_id = _phone_number_raw_id(self)
+
+
+_PHONE_NUMBER_PREFIX = re.compile(r'^\+')
+
+
+def _phone_number_raw_id(identifier):
+    # type (PhoneNumberIdentifier) -> str
+    value = identifier.properties['value']
+    # strip the leading +. We just assume correct E.164 format here because
+    # validation should only happen server-side, not client-side.
+    return '4:{}'.format(_PHONE_NUMBER_PREFIX.sub('', value))
 
 
 class UnknownIdentifier(object):
@@ -154,3 +168,72 @@ class MicrosoftTeamsUserIdentifier(object):
             is_anonymous=kwargs.get('is_anonymous', False),
             cloud=kwargs.get('cloud') or CommunicationCloudEnvironment.PUBLIC
         )
+        if self.raw_id is None:
+            self.raw_id = _microsoft_teams_user_raw_id(self)
+
+
+def _microsoft_teams_user_raw_id(identifier):
+    # type (MicrosoftTeamsUserIdentifier) -> str
+    user_id = identifier.properties['user_id']
+    if identifier.properties['is_anonymous']:
+        return '8:teamsvisitor:{}'.format(user_id)
+    cloud = identifier.properties['cloud']
+    if cloud == CommunicationCloudEnvironment.DOD:
+        return '8:dod:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.GCCH:
+        return '8:gcch:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.PUBLIC:
+        return '8:orgid:{}'.format(user_id)
+    return '8:orgid:{}'.format(user_id)
+
+
+def identifier_from_raw_id(raw_id):
+    """
+    Creates a CommunicationIdentifier from a given raw ID.
+
+    When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
+
+    :param raw ID to construct the CommunicationIdentifier from.
+    """
+    # type (str) -> CommunicationIdentifier
+    if raw_id.startswith('4:'):
+        return PhoneNumberIdentifier(
+            value='+{}'.format(raw_id[len('4:'):])
+        )
+
+    segments = raw_id.split(':', maxsplit=2)
+    if len(segments) < 3:
+        return UnknownIdentifier(identifier=raw_id)
+
+    prefix = '{}:{}:'.format(segments[0], segments[1])
+    suffix = raw_id[len(prefix):]
+    if prefix == '8:teamsvisitor:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=True
+        )
+    elif prefix == '8:orgid:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='PUBLIC'
+        )
+    elif prefix == '8:dod:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='DOD'
+        )
+    elif prefix == '8:gcch:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='GCCH'
+        )
+    elif prefix in ['8:acs:', '8:spool:', '8:dod-acs:', '8:gcch-acs:']:
+        return CommunicationUserIdentifier(
+            id=raw_id
+        )
+    return UnknownIdentifier(
+        identifier=raw_id
+    )

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
@@ -103,8 +103,7 @@ class PhoneNumberIdentifier(object):
 _PHONE_NUMBER_PREFIX = re.compile(r'^\+')
 
 
-def _phone_number_raw_id(identifier):
-    # type (PhoneNumberIdentifier) -> str
+def _phone_number_raw_id(identifier: PhoneNumberIdentifier) -> str:
     value = identifier.properties['value']
     # strip the leading +. We just assume correct E.164 format here because
     # validation should only happen server-side, not client-side.
@@ -172,8 +171,7 @@ class MicrosoftTeamsUserIdentifier(object):
             self.raw_id = _microsoft_teams_user_raw_id(self)
 
 
-def _microsoft_teams_user_raw_id(identifier):
-    # type (MicrosoftTeamsUserIdentifier) -> str
+def _microsoft_teams_user_raw_id(identifier: MicrosoftTeamsUserIdentifier) -> str:
     user_id = identifier.properties['user_id']
     if identifier.properties['is_anonymous']:
         return '8:teamsvisitor:{}'.format(user_id)
@@ -187,15 +185,14 @@ def _microsoft_teams_user_raw_id(identifier):
     return '8:orgid:{}'.format(user_id)
 
 
-def identifier_from_raw_id(raw_id):
+def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:
     """
     Creates a CommunicationIdentifier from a given raw ID.
 
     When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
 
-    :param raw ID to construct the CommunicationIdentifier from.
+    :param str raw_id: A raw ID to construct the CommunicationIdentifier from.
     """
-    # type (str) -> CommunicationIdentifier
     if raw_id.startswith('4:'):
         return PhoneNumberIdentifier(
             value='+{}'.format(raw_id[len('4:'):])

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
@@ -5,6 +5,7 @@
 # pylint: skip-file
 
 from enum import Enum, EnumMeta
+import re
 from six import with_metaclass
 from typing import Mapping, Optional, Union, Any
 try:
@@ -67,7 +68,7 @@ class CommunicationUserIdentifier(object):
 
     def __init__(self, id, **kwargs):
         # type: (str, Any) -> None
-        self.raw_id = kwargs.get('raw_id')
+        self.raw_id = kwargs.get('raw_id', id)
         self.properties = CommunicationUserProperties(id=id)
 
 
@@ -95,6 +96,19 @@ class PhoneNumberIdentifier(object):
         # type: (str, Any) -> None
         self.raw_id = kwargs.get('raw_id')
         self.properties = PhoneNumberProperties(value=value)
+        if self.raw_id is None:
+            self.raw_id = _phone_number_raw_id(self)
+
+
+_PHONE_NUMBER_PREFIX = re.compile(r'^\+')
+
+
+def _phone_number_raw_id(identifier):
+    # type (PhoneNumberIdentifier) -> str
+    value = identifier.properties['value']
+    # strip the leading +. We just assume correct E.164 format here because
+    # validation should only happen server-side, not client-side.
+    return '4:{}'.format(_PHONE_NUMBER_PREFIX.sub('', value))
 
 
 class UnknownIdentifier(object):
@@ -154,3 +168,72 @@ class MicrosoftTeamsUserIdentifier(object):
             is_anonymous=kwargs.get('is_anonymous', False),
             cloud=kwargs.get('cloud') or CommunicationCloudEnvironment.PUBLIC
         )
+        if self.raw_id is None:
+            self.raw_id = _microsoft_teams_user_raw_id(self)
+
+
+def _microsoft_teams_user_raw_id(identifier):
+    # type (MicrosoftTeamsUserIdentifier) -> str
+    user_id = identifier.properties['user_id']
+    if identifier.properties['is_anonymous']:
+        return '8:teamsvisitor:{}'.format(user_id)
+    cloud = identifier.properties['cloud']
+    if cloud == CommunicationCloudEnvironment.DOD:
+        return '8:dod:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.GCCH:
+        return '8:gcch:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.PUBLIC:
+        return '8:orgid:{}'.format(user_id)
+    return '8:orgid:{}'.format(user_id)
+
+
+def identifier_from_raw_id(raw_id):
+    """
+    Creates a CommunicationIdentifier from a given raw ID.
+
+    When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
+
+    :param raw ID to construct the CommunicationIdentifier from.
+    """
+    # type (str) -> CommunicationIdentifier
+    if raw_id.startswith('4:'):
+        return PhoneNumberIdentifier(
+            value='+{}'.format(raw_id[len('4:'):])
+        )
+
+    segments = raw_id.split(':', maxsplit=2)
+    if len(segments) < 3:
+        return UnknownIdentifier(identifier=raw_id)
+
+    prefix = '{}:{}:'.format(segments[0], segments[1])
+    suffix = raw_id[len(prefix):]
+    if prefix == '8:teamsvisitor:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=True
+        )
+    elif prefix == '8:orgid:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='PUBLIC'
+        )
+    elif prefix == '8:dod:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='DOD'
+        )
+    elif prefix == '8:gcch:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='GCCH'
+        )
+    elif prefix in ['8:acs:', '8:spool:', '8:dod-acs:', '8:gcch-acs:']:
+        return CommunicationUserIdentifier(
+            id=raw_id
+        )
+    return UnknownIdentifier(
+        identifier=raw_id
+    )

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
@@ -103,8 +103,7 @@ class PhoneNumberIdentifier(object):
 _PHONE_NUMBER_PREFIX = re.compile(r'^\+')
 
 
-def _phone_number_raw_id(identifier):
-    # type (PhoneNumberIdentifier) -> str
+def _phone_number_raw_id(identifier: PhoneNumberIdentifier) -> str:
     value = identifier.properties['value']
     # strip the leading +. We just assume correct E.164 format here because
     # validation should only happen server-side, not client-side.
@@ -172,8 +171,7 @@ class MicrosoftTeamsUserIdentifier(object):
             self.raw_id = _microsoft_teams_user_raw_id(self)
 
 
-def _microsoft_teams_user_raw_id(identifier):
-    # type (MicrosoftTeamsUserIdentifier) -> str
+def _microsoft_teams_user_raw_id(identifier: MicrosoftTeamsUserIdentifier) -> str:
     user_id = identifier.properties['user_id']
     if identifier.properties['is_anonymous']:
         return '8:teamsvisitor:{}'.format(user_id)
@@ -187,15 +185,14 @@ def _microsoft_teams_user_raw_id(identifier):
     return '8:orgid:{}'.format(user_id)
 
 
-def identifier_from_raw_id(raw_id):
+def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:
     """
     Creates a CommunicationIdentifier from a given raw ID.
 
     When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
 
-    :param raw ID to construct the CommunicationIdentifier from.
+    :param str raw_id: A raw ID to construct the CommunicationIdentifier from.
     """
-    # type (str) -> CommunicationIdentifier
     if raw_id.startswith('4:'):
         return PhoneNumberIdentifier(
             value='+{}'.format(raw_id[len('4:'):])

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
@@ -5,6 +5,7 @@
 # pylint: skip-file
 
 from enum import Enum, EnumMeta
+import re
 from six import with_metaclass
 from typing import Mapping, Optional, Union, Any
 try:
@@ -67,7 +68,7 @@ class CommunicationUserIdentifier(object):
 
     def __init__(self, id, **kwargs):
         # type: (str, Any) -> None
-        self.raw_id = kwargs.get('raw_id')
+        self.raw_id = kwargs.get('raw_id', id)
         self.properties = CommunicationUserProperties(id=id)
 
 
@@ -95,6 +96,19 @@ class PhoneNumberIdentifier(object):
         # type: (str, Any) -> None
         self.raw_id = kwargs.get('raw_id')
         self.properties = PhoneNumberProperties(value=value)
+        if self.raw_id is None:
+            self.raw_id = _phone_number_raw_id(self)
+
+
+_PHONE_NUMBER_PREFIX = re.compile(r'^\+')
+
+
+def _phone_number_raw_id(identifier):
+    # type (PhoneNumberIdentifier) -> str
+    value = identifier.properties['value']
+    # strip the leading +. We just assume correct E.164 format here because
+    # validation should only happen server-side, not client-side.
+    return '4:{}'.format(_PHONE_NUMBER_PREFIX.sub('', value))
 
 
 class UnknownIdentifier(object):
@@ -154,3 +168,72 @@ class MicrosoftTeamsUserIdentifier(object):
             is_anonymous=kwargs.get('is_anonymous', False),
             cloud=kwargs.get('cloud') or CommunicationCloudEnvironment.PUBLIC
         )
+        if self.raw_id is None:
+            self.raw_id = _microsoft_teams_user_raw_id(self)
+
+
+def _microsoft_teams_user_raw_id(identifier):
+    # type (MicrosoftTeamsUserIdentifier) -> str
+    user_id = identifier.properties['user_id']
+    if identifier.properties['is_anonymous']:
+        return '8:teamsvisitor:{}'.format(user_id)
+    cloud = identifier.properties['cloud']
+    if cloud == CommunicationCloudEnvironment.DOD:
+        return '8:dod:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.GCCH:
+        return '8:gcch:{}'.format(user_id)
+    elif cloud == CommunicationCloudEnvironment.PUBLIC:
+        return '8:orgid:{}'.format(user_id)
+    return '8:orgid:{}'.format(user_id)
+
+
+def identifier_from_raw_id(raw_id):
+    """
+    Creates a CommunicationIdentifier from a given raw ID.
+
+    When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
+
+    :param raw ID to construct the CommunicationIdentifier from.
+    """
+    # type (str) -> CommunicationIdentifier
+    if raw_id.startswith('4:'):
+        return PhoneNumberIdentifier(
+            value='+{}'.format(raw_id[len('4:'):])
+        )
+
+    segments = raw_id.split(':', maxsplit=2)
+    if len(segments) < 3:
+        return UnknownIdentifier(identifier=raw_id)
+
+    prefix = '{}:{}:'.format(segments[0], segments[1])
+    suffix = raw_id[len(prefix):]
+    if prefix == '8:teamsvisitor:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=True
+        )
+    elif prefix == '8:orgid:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='PUBLIC'
+        )
+    elif prefix == '8:dod:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='DOD'
+        )
+    elif prefix == '8:gcch:':
+        return MicrosoftTeamsUserIdentifier(
+            user_id=suffix,
+            is_anonymous=False,
+            cloud='GCCH'
+        )
+    elif prefix in ['8:acs:', '8:spool:', '8:dod-acs:', '8:gcch-acs:']:
+        return CommunicationUserIdentifier(
+            id=raw_id
+        )
+    return UnknownIdentifier(
+        identifier=raw_id
+    )

--- a/sdk/communication/cspell.json
+++ b/sdk/communication/cspell.json
@@ -1,0 +1,6 @@
+{
+    "version": "0.2",
+    "ignoreWords": [
+        "orgid"
+    ]
+}


### PR DESCRIPTION
This PR relands #25668 (with a minor fix on top from #24460)

Previous PR was reverted in order to allow an unrelated release from `main` while the API in this PR was under active API council review (across all languages).

# Description

This PR address the [API review council feedback](https://apiview.dev/Assemblies/Review/fce877aea4a4400391f55e985f1d92b4/1b734e3549974121b9705a8f8bdb4ac6?diffRevisionId=ad28b2d974a747acb32f28539a10a2a6&doc=False&diffOnly=True) on this feature branch.

The changes are minimial:

- Add a previously missing type in the package exports.
- Add type annotations to newly added functions.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
