### PR TITLE
[PyAMQP] removing pypy filter

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_negative_async.py
@@ -174,5 +174,5 @@ async def test_invalid_proxy_server(connection_str):
 
     client = EventHubProducerClient.from_connection_string(connection_str, http_proxy=HTTP_PROXY)
     async with client:
-        with pytest.raises(ConnectError):
+        with pytest.raises(EventHubError):
             batch = await client.create_batch()

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_receive_async.py
@@ -137,7 +137,6 @@ async def test_receive_owner_level_async(connstr_senders):
 @pytest.mark.liveTest
 @pytest.mark.asyncio
 async def test_receive_over_websocket_async(connstr_senders):
-    pytest.skip("websocket not supported")
     app_prop = {"raw_prop": "raw_value"}
     content_type = "text/plain"
     message_id_base = "mess_id_sample_"

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -202,7 +202,6 @@ async def test_send_partition_async(connstr_receivers):
 
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_1) >= 2
     assert len(partition_0) + len(partition_1) == 2
 
     async with client:
@@ -211,14 +210,13 @@ async def test_send_partition_async(connstr_receivers):
         await client.send_batch(batch)
 
     async with client:
-        batch = await client.create_batch(partition_id="0")
+        batch = await client.create_batch(partition_id="1")
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
 
     time.sleep(5)
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_0) >= 2
     assert len(partition_0) + len(partition_1) == 2
 
 

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -217,7 +217,7 @@ async def test_send_partition_async(connstr_receivers):
     time.sleep(5)
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_0) + len(partition_1) == 2
+    assert len(partition_0) + len(partition_1) == 4
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -194,36 +194,32 @@ async def test_send_partition_async(connstr_receivers):
         batch = await client.create_batch()
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
-        await client.send_event(EventData(b"Data"))
 
     async with client:
         batch = await client.create_batch(partition_id="1")
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
-        await client.send_event(EventData(b"Data"), partition_id="1")
 
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
     assert len(partition_1) >= 2
-    assert len(partition_0) + len(partition_1) == 4
+    assert len(partition_0) + len(partition_1) == 2
 
     async with client:
         batch = await client.create_batch()
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
-        await client.send_event(EventData(b"Data"))
 
     async with client:
         batch = await client.create_batch(partition_id="0")
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
-        await client.send_event(EventData(b"Data"), partition_id="0")
 
     time.sleep(5)
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
     assert len(partition_0) >= 2
-    assert len(partition_0) + len(partition_1) == 4
+    assert len(partition_0) + len(partition_1) == 2
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -194,29 +194,36 @@ async def test_send_partition_async(connstr_receivers):
         batch = await client.create_batch()
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
+        await client.send_event(EventData(b"Data"))
 
     async with client:
         batch = await client.create_batch(partition_id="1")
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
+        await client.send_event(EventData(b"Data"), partition_id="1")
 
-    partition_0 = receivers[0].receive_message_batch(timeout=5)
-    partition_1 = receivers[1].receive_message_batch(timeout=5)
-    assert len(partition_0) + len(partition_1) == 2
+    partition_0 = receivers[0].receive_message_batch(timeout=5000)
+    partition_1 = receivers[1].receive_message_batch(timeout=5000)
+    assert len(partition_1) >= 2
+    assert len(partition_0) + len(partition_1) == 4
 
     async with client:
         batch = await client.create_batch()
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
+        await client.send_event(EventData(b"Data"))
 
     async with client:
-        batch = await client.create_batch(partition_id="1")
+        batch = await client.create_batch(partition_id="0")
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
+        await client.send_event(EventData(b"Data"), partition_id="0")
 
-    partition_0 = receivers[0].receive_message_batch(timeout=5)
-    partition_1 = receivers[1].receive_message_batch(timeout=5)
-    assert len(partition_0) + len(partition_1) == 2
+    time.sleep(5)
+    partition_0 = receivers[0].receive_message_batch(timeout=5000)
+    partition_1 = receivers[1].receive_message_batch(timeout=5000)
+    assert len(partition_0) >= 2
+    assert len(partition_0) + len(partition_1) == 4
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -273,7 +273,6 @@ async def test_send_multiple_partition_with_app_prop_async(connstr_receivers):
 @pytest.mark.liveTest
 @pytest.mark.asyncio
 async def test_send_over_websocket_async(connstr_receivers):
-    pytest.skip("websocket unsupported")
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str,
                                                            transport_type=TransportType.AmqpOverWebsocket)

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -200,8 +200,8 @@ async def test_send_partition_async(connstr_receivers):
         batch.add(EventData(b"Data"))
         await client.send_batch(batch)
 
-    partition_0 = receivers[0].receive_message_batch(timeout=5000)
-    partition_1 = receivers[1].receive_message_batch(timeout=5000)
+    partition_0 = receivers[0].receive_message_batch(timeout=10)
+    partition_1 = receivers[1].receive_message_batch(timeout=10)
     assert len(partition_0) + len(partition_1) == 2
 
     async with client:
@@ -215,9 +215,9 @@ async def test_send_partition_async(connstr_receivers):
         await client.send_batch(batch)
 
     time.sleep(5)
-    partition_0 = receivers[0].receive_message_batch(timeout=5000)
-    partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_0) + len(partition_1) == 4
+    partition_0 = receivers[0].receive_message_batch(timeout=10)
+    partition_1 = receivers[1].receive_message_batch(timeout=10)
+    assert len(partition_0) + len(partition_1) == 2
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
@@ -15,7 +15,8 @@ from azure.eventhub import (
 from azure.eventhub.exceptions import (
     ConnectError,
     AuthenticationError,
-    EventDataSendError
+    EventDataSendError,
+    EventHubError
 )
 from azure.eventhub import EventHubConsumerClient
 from azure.eventhub import EventHubProducerClient
@@ -129,6 +130,6 @@ def test_invalid_proxy_server(connection_str):
 
     client = EventHubProducerClient.from_connection_string(connection_str, http_proxy=HTTP_PROXY)
     with client:
-        with pytest.raises(ConnectError):
+        with pytest.raises(EventHubError):
             batch = client.create_batch()
 

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_receive.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_receive.py
@@ -130,7 +130,6 @@ def test_receive_owner_level(connstr_senders):
 
 @pytest.mark.liveTest
 def test_receive_over_websocket_sync(connstr_senders):
-    pytest.skip("websocket not supported")
     app_prop = {"raw_prop": "raw_value"}
     content_type = "text/plain"
     message_id_base = "mess_id_sample_"

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -211,30 +211,36 @@ def test_send_partition(connstr_receivers):
         batch = client.create_batch()
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
+        client.send_event(EventData(b"Data"))
 
     with client:
         batch = client.create_batch(partition_id="1")
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
+        client.send_event(EventData(b"Data"), partition_id="1")
 
-    partition_0 = receivers[0].receive_message_batch(timeout=5)
-    partition_1 = receivers[1].receive_message_batch(timeout=5)
-    assert len(partition_0) + len(partition_1) == 2
+    partition_0 = receivers[0].receive_message_batch(timeout=5000)
+    partition_1 = receivers[1].receive_message_batch(timeout=5000)
+    assert len(partition_1) >= 2
+    assert len(partition_0) + len(partition_1) == 4
 
     with client:
         batch = client.create_batch()
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
+        client.send_event(EventData(b"Data"))
 
     with client:
-        batch = client.create_batch(partition_id="1")
+        batch = client.create_batch(partition_id="0")
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
+        client.send_event(EventData(b"Data"), partition_id="0")
 
-    partition_0 = receivers[0].receive_message_batch(timeout=5)
-    partition_1 = receivers[1].receive_message_batch(timeout=5)
-    assert len(partition_0) + len(partition_1) == 2
-
+    time.sleep(5)
+    partition_0 = receivers[0].receive_message_batch(timeout=5000)
+    partition_1 = receivers[1].receive_message_batch(timeout=5000)
+    assert len(partition_0) >= 2
+    assert len(partition_0) + len(partition_1) == 4
 
 @pytest.mark.liveTest
 def test_send_non_ascii(connstr_receivers):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -211,36 +211,32 @@ def test_send_partition(connstr_receivers):
         batch = client.create_batch()
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
-        client.send_event(EventData(b"Data"))
 
     with client:
         batch = client.create_batch(partition_id="1")
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
-        client.send_event(EventData(b"Data"), partition_id="1")
 
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
     assert len(partition_1) >= 2
-    assert len(partition_0) + len(partition_1) == 4
+    assert len(partition_0) + len(partition_1) == 2
 
     with client:
         batch = client.create_batch()
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
-        client.send_event(EventData(b"Data"))
 
     with client:
         batch = client.create_batch(partition_id="0")
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
-        client.send_event(EventData(b"Data"), partition_id="0")
 
     time.sleep(5)
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
     assert len(partition_0) >= 2
-    assert len(partition_0) + len(partition_1) == 4
+    assert len(partition_0) + len(partition_1) == 2
 
 @pytest.mark.liveTest
 def test_send_non_ascii(connstr_receivers):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -234,7 +234,7 @@ def test_send_partition(connstr_receivers):
     time.sleep(5)
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_0) + len(partition_1) == 2
+    assert len(partition_0) + len(partition_1) == 4
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -219,7 +219,6 @@ def test_send_partition(connstr_receivers):
 
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_1) >= 2
     assert len(partition_0) + len(partition_1) == 2
 
     with client:
@@ -228,15 +227,15 @@ def test_send_partition(connstr_receivers):
         client.send_batch(batch)
 
     with client:
-        batch = client.create_batch(partition_id="0")
+        batch = client.create_batch(partition_id="1")
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
 
     time.sleep(5)
     partition_0 = receivers[0].receive_message_batch(timeout=5000)
     partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_0) >= 2
     assert len(partition_0) + len(partition_1) == 2
+
 
 @pytest.mark.liveTest
 def test_send_non_ascii(connstr_receivers):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -286,7 +286,6 @@ def test_send_multiple_partitions_with_app_prop(connstr_receivers):
 
 @pytest.mark.liveTest
 def test_send_over_websocket_sync(connstr_receivers):
-    pytest.skip("websocket not supported")
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, transport_type=TransportType.AmqpOverWebsocket)
 

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -217,8 +217,8 @@ def test_send_partition(connstr_receivers):
         batch.add(EventData(b"Data"))
         client.send_batch(batch)
 
-    partition_0 = receivers[0].receive_message_batch(timeout=5000)
-    partition_1 = receivers[1].receive_message_batch(timeout=5000)
+    partition_0 = receivers[0].receive_message_batch(timeout=10)
+    partition_1 = receivers[1].receive_message_batch(timeout=10)
     assert len(partition_0) + len(partition_1) == 2
 
     with client:
@@ -232,9 +232,9 @@ def test_send_partition(connstr_receivers):
         client.send_batch(batch)
 
     time.sleep(5)
-    partition_0 = receivers[0].receive_message_batch(timeout=5000)
-    partition_1 = receivers[1].receive_message_batch(timeout=5000)
-    assert len(partition_0) + len(partition_1) == 4
+    partition_0 = receivers[0].receive_message_batch(timeout=10)
+    partition_1 = receivers[1].receive_message_batch(timeout=10)
+    assert len(partition_0) + len(partition_1) == 2
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -35,8 +35,6 @@ extends:
         Path: eng/pipelines/templates/stages/platform-matrix-cryptography-dependency.json
         Selection: sparse
         GenerateVMJobs: true
-    MatrixFilters:
-      - PythonVersion=^(?!pypy3).*
     Artifacts:
     - name: azure-eventhub
       safeName: azureeventhub

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,8 +7,6 @@ stages:
       BuildTargetingString: azure-eventhub
       MatrixReplace:
         - TestSamples=.*/true
-      MatrixFilters:
-        - PythonVersion=^(?!pypy3).*
       EnvVars:
         AZURE_STORAGE_DATA_LAKE_ENABLED_CONN_STR: $(python-eh-livetest-event-hub-storage-data-lake-enabled-conn-str)
         IOTHUB_CONNECTION_STR: $(python-eh-livetest-event-hub-iothub-connection-str)


### PR DESCRIPTION
+ No need to filter out pypy for pyamqp
+ error fix for invalid_proxy tests -- EventhubError instead of ConnectError
+ Going to unskip websocket test -- we do support it 
+ Aligning send_partition sync test with main 