### PR TITLE
[Storage] Add `read` to datalake `StorageStreamDownloader`

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -9,6 +9,7 @@ This version and all future versions will require Python 3.7+. Python 3.6 is no 
 - Added support for `flush` to `append_data` API, allowing for append and flush in one operation.
 - Encryption Scope is now supported for both `create_file_system` APIs (`FileSystemClient`, `DataLakeServiceClient`).
 - Encryption Scope is now supported as a SAS permission.
+- Added standard `read` method to `StorageStreamDownloader`.
 
 ## 12.8.0 (2022-07-07)
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_download.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_download.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import Iterator
+from typing import Iterator, Optional
 
 from ._deserialize import from_blob_properties
 
@@ -30,16 +30,28 @@ class StorageStreamDownloader(object):
     def __len__(self):
         return self.size
 
-    def chunks(self):
-        # type: () -> Iterator[bytes]
+    def chunks(self) -> Iterator[bytes]:
         """Iterate over chunks in the download stream.
 
         :rtype: Iterator[bytes]
         """
         return self._downloader.chunks()
 
-    def readall(self):
-        # type: () -> bytes
+    def read(self, size: Optional[int] = -1) -> bytes:
+        """
+        Read up to size bytes from the stream and return them. If size
+        is unspecified or is -1, all bytes will be read.
+
+        :param size:
+            The number of bytes to download from the stream. Leave unsepcified
+            or set to -1 to download all bytes.
+        :returns:
+            The requsted data as bytes. If the return value is empty, there is no more data to read.
+        :rtype: bytes
+        """
+        return self._downloader.read(size)
+
+    def readall(self) -> bytes:
         """Download the contents of this file.
 
         This operation is blocking until all data is downloaded.
@@ -47,7 +59,7 @@ class StorageStreamDownloader(object):
         """
         return self._downloader.readall()
 
-    def readinto(self, stream):
+    def readinto(self, stream) -> int:
         """Download the contents of this file to a stream.
 
         :param stream:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_download_async.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 
 from .._deserialize import from_blob_properties
 
@@ -30,16 +30,28 @@ class StorageStreamDownloader(object):
     def __len__(self):
         return self.size
 
-    def chunks(self):
-        # type: () -> AsyncIterator[bytes]
+    def chunks(self) -> AsyncIterator[bytes]:
         """Iterate over chunks in the download stream.
 
         :rtype: AsyncIterator[bytes]
         """
         return self._downloader.chunks()
 
-    async def readall(self):
-        # type: () -> bytes
+    async def read(self, size: Optional[int] = -1) -> bytes:
+        """
+        Read up to size bytes from the stream and return them. If size
+        is unspecified or is -1, all bytes will be read.
+
+        :param size:
+            The number of bytes to download from the stream. Leave unsepcified
+            or set to -1 to download all bytes.
+        :returns:
+            The requsted data as bytes. If the return value is empty, there is no more data to read.
+        :rtype: bytes
+        """
+        return await self._downloader.read(size)
+
+    async def readall(self) -> bytes:
         """Download the contents of this file.
 
         This operation is blocking until all data is downloaded.
@@ -47,7 +59,7 @@ class StorageStreamDownloader(object):
         """
         return await self._downloader.readall()
 
-    async def readinto(self, stream):
+    async def readinto(self, stream) -> int:
         """Download the contents of this file to a stream.
 
         :param stream:

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_read_file_read.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.test_read_file_read.yaml
@@ -1,0 +1,794 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:31 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3?restype=container&timeout=5
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      etag:
+      - '"0x8DA7F022B8D7068"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesystemafe20ba3/fileafe20ba3?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      etag:
+      - '"0x8DA7F022BD82E53"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '1234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PATCH
+    uri: https://storagename.dfs.core.windows.net/filesystemafe20ba3/fileafe20ba3?action=append&position=0&flush=true
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=0-1023
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '1234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '1024'
+      content-range:
+      - bytes 0-1023/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=1024-1535
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '51234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 1024-1535/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=1536-2047
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '23451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 1536-2047/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=2048-2559
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '45123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 2048-2559/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=2560-3071
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '12345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 2560-3071/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=3072-3583
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '34512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 3072-3583/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=3584-4095
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '51234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 3584-4095/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      x-ms-range:
+      - bytes=4096-4607
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '23451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 4096-4607/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:34 GMT
+      x-ms-range:
+      - bytes=4608-5119
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '45123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '512'
+      content-range:
+      - bytes 4608-5119/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      If-Match:
+      - '"0x8DA7F022BF1B06E"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:34 GMT
+      x-ms-range:
+      - bytes=5120-5124
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3/fileafe20ba3
+  response:
+    body:
+      string: '12345'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '5'
+      content-range:
+      - bytes 5120-5124/5125
+      content-type:
+      - application/json
+      date:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      etag:
+      - '"0x8DA7F022BF1B06E"'
+      last-modified:
+      - Mon, 15 Aug 2022 21:07:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 15 Aug 2022 21:07:32 GMT
+      x-ms-group:
+      - $superuser
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-owner:
+      - $superuser
+      x-ms-permissions:
+      - rw-r-----
+      x-ms-resource-type:
+      - file
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:07:34 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystemafe20ba3?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 21:07:34 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_read_file_read.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.test_read_file_read.yaml
@@ -1,0 +1,542 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:47 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20?restype=container&timeout=5
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Mon, 15 Aug 2022 21:06:47 GMT
+      etag: '"0x8DA7F0210D08EFD"'
+      last-modified: Mon, 15 Aug 2022 21:06:47 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-08-06'
+    status:
+      code: 201
+      message: Created
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20?restype=container&timeout=5
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:47 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/filesystemca0e20/fileca0e20?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Mon, 15 Aug 2022 21:06:47 GMT
+      etag: '"0x8DA7F021123397D"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 201
+      message: Created
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/filesystemca0e20/fileca0e20?resource=file
+- request:
+    body: '1234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '5125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: PATCH
+    uri: https://storagename.dfs.core.windows.net/filesystemca0e20/fileca0e20?action=append&position=0&flush=true
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Mon, 15 Aug 2022 21:06:47 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 202
+      message: Accepted
+    url: https://jalauzoncanaryadls.dfs.core.windows.net/filesystemca0e20/fileca0e20?action=append&position=0&flush=true
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=0-1023
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '1234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234'
+    headers:
+      accept-ranges: bytes
+      content-length: '1024'
+      content-range: bytes 0-1023/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=1024-1535
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '51234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 1024-1535/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=1536-2047
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '23451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 1536-2047/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=2048-2559
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '45123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 2048-2559/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=2560-3071
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '12345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 2560-3071/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=3072-3583
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '34512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 3072-3583/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=3584-4095
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '51234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 3584-4095/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=4096-4607
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '23451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 4096-4607/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-range:
+      - bytes=4608-5119
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '45123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345123451234512345'
+    headers:
+      accept-ranges: bytes
+      content-length: '512'
+      content-range: bytes 4608-5119/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      If-Match:
+      - '"0x8DA7F02113DBAE9"'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:49 GMT
+      x-ms-range:
+      - bytes=5120-5124
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20/fileca0e20
+  response:
+    body:
+      string: '12345'
+    headers:
+      accept-ranges: bytes
+      content-length: '5'
+      content-range: bytes 5120-5124/5125
+      content-type: application/json
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      etag: '"0x8DA7F02113DBAE9"'
+      last-modified: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type: BlockBlob
+      x-ms-creation-time: Mon, 15 Aug 2022 21:06:48 GMT
+      x-ms-group: $superuser
+      x-ms-lease-state: available
+      x-ms-lease-status: unlocked
+      x-ms-owner: $superuser
+      x-ms-permissions: rw-r-----
+      x-ms-resource-type: file
+      x-ms-server-encrypted: 'true'
+      x-ms-version: '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20/fileca0e20
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-dfs/12.9.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Mon, 15 Aug 2022 21:06:49 GMT
+      x-ms-version:
+      - '2021-08-06'
+    method: DELETE
+    uri: https://storagename.blob.core.windows.net/filesystemca0e20?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Mon, 15 Aug 2022 21:06:48 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2021-08-06'
+    status:
+      code: 202
+      message: Accepted
+    url: https://jalauzoncanaryadls.blob.core.windows.net/filesystemca0e20?restype=container
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -7,6 +7,7 @@
 # --------------------------------------------------------------------------
 import unittest
 from datetime import datetime, timedelta
+from math import ceil
 import pytest
 
 from azure.core import MatchConditions
@@ -1083,6 +1084,33 @@ class FileTest(StorageTestCase):
 
         with self.assertRaises(HttpResponseError):
             f3.download_file().readall()
+
+    @DataLakePreparer()
+    def test_read_file_read(self, datalake_storage_account_name, datalake_storage_account_key):
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+        self.dsc._config.max_single_get_size = 1024
+        self.dsc._config.max_chunk_get_size = 1024
+
+        file_client = self._create_file_and_return_client()
+        data = b'12345' * 205 * 5  # 5125 bytes
+
+        file_client.append_data(data, 0, len(data), flush=True)
+        stream = file_client.download_file()
+
+        # Act
+        result = bytearray()
+        read_size = 512
+        num_chunks = int(ceil(len(data) / read_size))
+        for i in range(num_chunks):
+            content = stream.read(read_size)
+            start = i * read_size
+            end = start + read_size
+            assert data[start:end] == content
+            result.extend(content)
+
+        # Assert
+        assert result == data
+
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':


### PR DESCRIPTION
As a follow-up to #24275, this adds the `read` method to the `StorageStreamDownloader` for datalake. This was fairly trivial since datalake's downloader just calls into blob. Added one basic test to ensure functionality but more advanced testing is handled in blob tests.