### PR TITLE
Handle when a `specifier` is not set for a targeted package within setup.py

### DIFF
--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -233,11 +233,6 @@ if __name__ == "__main__":
                             if req_specifier is None:
                                 addition_necessary = False
 
-                            # if the package we're installing doesn't require a specific version (indicated by req_specifier) for the requiremeent (req_name)
-                            # then its presence is enough. No reason to add it to necessary installations.
-                            if req_specifier is None:
-                                addition_necessary = False
-
                             # ...do we need to install the new version? if the existing specifier matches, we're fine
                             if req_specifier is not None and installed_pkgs[req_name] in req_specifier:
                                 addition_necessary = False

--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -233,8 +233,13 @@ if __name__ == "__main__":
                             if req_specifier is None:
                                 addition_necessary = False
 
+                            # if the package we're installing doesn't require a specific version (indicated by req_specifier) for the requiremeent (req_name)
+                            # then its presence is enough. No reason to add it to necessary installations.
+                            if req_specifier is None:
+                                addition_necessary = False
+
                             # ...do we need to install the new version? if the existing specifier matches, we're fine
-                            if installed_pkgs[req_name] in req_specifier:
+                            if req_specifier is not None and installed_pkgs[req_name] in req_specifier:
                                 addition_necessary = False
 
                         if addition_necessary:


### PR DESCRIPTION
After merging my refactor PR, I discovered that `azure-ai-ml` [ran into issues with their sphinx build.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1785070&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=e3f8f308-6e5f-58aa-3a2a-fe425958de32&l=2910)

They depend on `azure-identity` with no version specifier. Without that version specifier, we were hitting an issue where we were _Expecting_ one to be present.

This PR updates the behavior so that if we ARE in that situation, we won't force a reinstall if any version is already installed.