### PR TITLE
Repair Broken Reference to `run_check_call`

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from subprocess32 import TimeoutExpired, check_call, CalledProcessError
 from ci_tools.functions import compare_python_version
+from common_tasks import run_check_call
 
 logging.getLogger().setLevel(logging.INFO)
 


### PR DESCRIPTION
Error prompting this PR is visible [in this PR,](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1785258&view=logs&j=4f81fff1-e645-5c70-43ca-8617659eb31f&t=5a10b420-5905-59c5-6810-619e6a5a1e3b&l=124)