### PR TITLE
use renamed parameter in function

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -80,7 +80,7 @@ def start_record_or_playback(test_id: str) -> "Tuple[str, Dict[str, str]]":
     return (recording_id, variables)
 
 
-def stop_record_or_playback(test_id: str, recording_id: str, test_variables: "Dict[str, str]") -> None:
+def stop_record_or_playback(test_id: str, recording_id: str, test_output: "Dict[str, str]") -> None:
     if is_live():
         response = requests.post(
             RECORDING_STOP_URL,


### PR DESCRIPTION
@scbedd

L93 renamed test_variables to test_output so updating the parameter name as well. Works locally to generate recordings, but let me know if this isn't what we should do