### PR TITLE
[Test Proxy] Fix parameter reference in `stop_record_or_playback`

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -90,7 +90,7 @@ def stop_record_or_playback(test_id: str, recording_id: str, test_variables: "Di
                 "x-recording-save": "true",
                 "Content-Type": "application/json",
             },
-            json=test_output or {},  # tests don't record successfully unless test_output is a dictionary
+            json=test_variables or {},  # tests don't record successfully unless test_variables is a dictionary
         )
     else:
         response = requests.post(


### PR DESCRIPTION
# Description

The `test_output` parameter in the test proxy infra's `stop_record_or_playback` method was recently changed to (more accurately) be `test_variables`. As part of the test tooling refactor, this name change got mismatched such that this code raises an error over an undefined `test_output` variable.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
