### PR TITLE
[EventHubs] Fix Sleep Time on Test

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_buffered_producer.py
@@ -534,7 +534,6 @@ def test_long_wait_small_buffer(connection_str):
     with producer:
         for i in range(100):
             producer.send_event(EventData("test"))
-            time.sleep(.1)
 
     time.sleep(60)
 


### PR DESCRIPTION
Removing the additional sleep between message sends as its causing trouble with the builds, leading to assert fails on Windows