### PR TITLE
[Storage] Attempt to fix flaky retry test with larger blob

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_retry.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry.py
@@ -144,7 +144,7 @@ class TestStorageRetry(StorageRecordedTestCase):
         # Upload a blob that can be downloaded to test read timeout
         service = self._create_storage_service(BlobServiceClient, storage_account_name, storage_account_key)
         container = service.create_container(container_name)
-        container.upload_blob(blob_name, b'a' * 5 * 1025, overwrite=True)
+        container.upload_blob(blob_name, b'a' * 1024 * 1024, overwrite=True)
 
         retry = LinearRetry(backoff=1, random_jitter_range=1)
         retry_transport = RetryRequestTransport(connection_timeout=11, read_timeout=0.000000000001)

--- a/sdk/storage/azure-storage-blob/tests/test_retry_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry_async.py
@@ -142,7 +142,7 @@ class TestStorageRetryAsync(AsyncStorageRecordedTestCase):
         # Upload a blob that can be downloaded to test read timeout
         service = self._create_storage_service(BlobServiceClient, storage_account_name, storage_account_key)
         container = await service.create_container(container_name)
-        await container.upload_blob(blob_name, b'a' * 5 * 1025, overwrite=True)
+        await container.upload_blob(blob_name, b'a' * 1024 * 1024, overwrite=True)
 
         retry = LinearRetry(backoff=1, random_jitter_range=1)
         retry_transport = AiohttpRetryTestTransport(connection_timeout=11, read_timeout=0.000000000001)


### PR DESCRIPTION
In a past change I made `test_retry_on_socket_timeout` use a blob download in attempt to make it less flaky by making it timeout more consistently. It turns out this made it flakier, so this change increases the blob download size by a lot in hopes to make the test less flaky.