### PR TITLE
Catch InvalidRequirement error in CI

### DIFF
--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -28,6 +28,7 @@ from ci_tools.functions import discover_targeted_packages
 from ci_tools.parsing import ParsedSetup
 from ci_tools.build import create_package
 
+from packaging.requirements import InvalidRequirement
 from pkg_resources import parse_requirements, RequirementParseError
 import logging
 
@@ -210,7 +211,7 @@ def inject_custom_reqs(file, injected_packages, package_dir):
             for line in f:
                 try:
                     parsed_req = [req for req in parse_requirements(line)]
-                except RequirementParseError as e:
+                except (RequirementParseError, InvalidRequirement) as e:
                     parsed_req = [None]
                 req_lines.append((line, parsed_req))
 


### PR DESCRIPTION
# Description

@scbedd I'm not entirely sure why, but `azure-identity` CI runs have started failing this week with errors like [this](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1791526&view=logs&j=69e4aa17-e3ec-5e8e-f5e6-813b233ceb48&t=98d2f97b-c6da-559a-a993-fd0651ad9ecf&l=974):
```
INFO:root:Wheel for package azure-devtools is /mnt/vss/_work/1/s/sdk/identity/azure-identity/.tmp_whl_dir/azure_devtools-1.2.1-py2.py3-none-any.whl
INFO:root:Replacing dev requirement. Old requirement:../../../tools/azure-devtools, New requirement:/mnt/vss/_work/1/s/sdk/identity/azure-identity/.tmp_whl_dir/azure_devtools-1.2.1-py2.py3-none-any.whl
INFO:root:New dependency_tools.txt:['/mnt/vss/_work/1/s/sdk/identity/azure-identity/.tmp_whl_dir/azure_sdk_tools-0.0.0-py3-none-any.whl', '/mnt/vss/_work/1/s/sdk/identity/azure-identity/.tmp_whl_dir/azure_devtools-1.2.1-py2.py3-none-any.whl', "aiohttp>=3.0; python_version >= '3.5'"]
INFO:root:Adding custom packages to requirements for /mnt/vss/_work/1/s/sdk/identity/azure-identity
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 102, in __init__
    req = REQUIREMENT.parseString(requirement_string)
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/pkg_resources/_vendor/pyparsing/core.py", line 1141, in parse_string
    raise exc.with_traceback(None)
pkg_resources._vendor.pyparsing.exceptions.ParseException: Expected W:(0-9A-Za-z), found '/'  (at char 0), (line:1, col:1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/mnt/vss/_work/1/s/scripts/devops_tasks/setup_execute_tests.py", line 321, in <module>
    prep_and_run_tox(compatible_targeted_packages, args, extended_pytest_args)
  File "/mnt/vss/_work/1/s/scripts/devops_tasks/tox_harness.py", line 437, in prep_and_run_tox
    destination_dev_req, parsed_args.injected_packages, package_dir
  File "/mnt/vss/_work/1/s/scripts/devops_tasks/tox_harness.py", line 212, in inject_custom_reqs
    parsed_req = [req for req in parse_requirements(line)]
  File "/mnt/vss/_work/1/s/scripts/devops_tasks/tox_harness.py", line 212, in <listcomp>
    parsed_req = [req for req in parse_requirements(line)]
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3102, in __init__
    super(Requirement, self).__init__(requirement_string)
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 105, in __init__
    f'Parse error at "{ requirement_string[e.loc : e.loc + 8]!r}": {e.msg}'
pkg_resources.extern.packaging.requirements.InvalidRequirement: Parse error at "'/mnt/vss'": Expected W:(0-9A-Za-z)
```

We currently catch `RequirementParseError`s, but [according to `setuptools`](https://setuptools.pypa.io/en/latest/history.html?highlight=InvalidRequirement#id557), we should actually be catching this `InvalidRequirement` error instead.

Based on the timing and the `setuptools` changelog, I assume the new failure is coming from a versioning update that was included in the test tools refactor earlier this week.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
