### PR TITLE
Duplicate success response to remove race condition in test

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/recordings/test_client.test_simple_conversion.yaml
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/recordings/test_client.test_simple_conversion.yaml
@@ -484,6 +484,42 @@ interactions:
       User-Agent:
       - azsdk-python-mixedreality-remoterendering/1.0.0b1 Python/3.9.1 (Windows-10-10.0.19041-SP0)
     method: GET
+    uri: https://remoterendering.eastus.mixedreality.azure.com/accounts/70a8e4d2-816a-4d03-a800-aeb20126ae51/conversions/11b5d55d-b228-4291-8883-df3865a32088?api-version=2021-01-01
+  response:
+    body:
+      string: '{"id":"11b5d55d-b228-4291-8883-df3865a32088","creationTime":"2021-03-22T19:46:49.6665492Z","settings":{"inputLocation":{"storageContainerUri":"https://arrstorageaccount.blob.core.windows.net/test","blobPrefix":"Input/","relativeInputAssetPath":"testBox.fbx"},"outputLocation":{"storageContainerUri":"https://arrstorageaccount.blob.core.windows.net/test","blobPrefix":"11b5d55d-b228-4291-8883-df3865a32088/","outputAssetFilename":"testBox.arrAsset"}},"output":{"outputAssetUri":"https://arrstorageaccount.blob.core.windows.net/test/11b5d55d-b228-4291-8883-df3865a32088/testBox.arrAsset"},"error":null,"status":"Succeeded"}'
+    headers:
+      api-supported-versions:
+      - 2021-01-01-preview, 2021-01-01
+      cache-control:
+      - no-store,no-cache
+      content-length:
+      - '615'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 22 Mar 2021 19:47:45 GMT
+      ms-cv:
+      - 1SGpcqRTHUqxmSbnjZBo0Q.0
+      pragma:
+      - no-cache
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mixedreality-remoterendering/1.0.0b1 Python/3.9.1 (Windows-10-10.0.19041-SP0)
+    method: GET
     uri: https://remoterendering.eastus.mixedreality.azure.com/accounts/70a8e4d2-816a-4d03-a800-aeb20126ae51/conversions?api-version=2021-01-01
   response:
     body:

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -141,11 +141,6 @@ class ClientTests(AzureTestCase):
             conversion_id=conversion_id,  input_settings=input_settings, output_settings=output_settings
         )
 
-        conversion = client.get_asset_conversion(conversion_id)
-        assert conversion.id == conversion_id
-        assert conversion.settings.input_settings.relative_input_asset_path == input_settings.relative_input_asset_path
-        assert conversion.status != AssetConversionStatus.FAILED
-
         finished_conversion = conversion_poller.result()
 
         assert finished_conversion.id == conversion_id

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -141,6 +141,11 @@ class ClientTests(AzureTestCase):
             conversion_id=conversion_id,  input_settings=input_settings, output_settings=output_settings
         )
 
+        conversion = client.get_asset_conversion(conversion_id)
+        assert conversion.id == conversion_id
+        assert conversion.settings.input_settings.relative_input_asset_path == input_settings.relative_input_asset_path
+        assert conversion.status != AssetConversionStatus.FAILED
+
         finished_conversion = conversion_poller.result()
 
         assert finished_conversion.id == conversion_id


### PR DESCRIPTION
# Description

Remove one step in the test, that can fail if the previous step was too fast.

The tests rely on cassettes for the http requests/responses and we have two threads, that access these cassettes. One is a background poller started with begin_asset_conversion(...) and the other one is the get_asset_conversion() method. As we have requests that are identical, but produce a different outcome (running vs. succeeded state of the conversion) we run into a race condition.

This bug happens if:
1. The background poller gets started.
2. It uses up all the recorded GET requests.
3. get_asset_conversion() gets called.
4. No cassettes are left, thus the test breaks.

To prevent this we either can remove the get_asset_conversion() call or duplicate the succeeded response cassette. I prefer the latter as it is much closer to the live response we would get if it weren't for the cassettes.

This approach works, because the background poller stops once it gets an either succeeded or failed state as a response. Thus, there are enough cassettes for both calls.

This is nothing that would impact customers, as testing all of this against a live conversion would just return the succeeded call twice, as now represented in the cassettes.