### PR TITLE
[Test Proxy] Use string sanitizers for environment variable values

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
+++ b/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
@@ -9,7 +9,7 @@ import os
 from . import AzureMgmtPreparer
 from azure_devtools.scenario_tests.exceptions import AzureTestError
 from dotenv import load_dotenv, find_dotenv
-from .sanitizers import add_general_regex_sanitizer
+from .sanitizers import add_general_string_sanitizer
 
 
 class EnvironmentVariableLoader(AzureMgmtPreparer):
@@ -76,9 +76,9 @@ class EnvironmentVariableLoader(AzureMgmtPreparer):
                         # test proxy tests have no scrubber, and instead register sanitizers using fake values
                         else:
                             try:
-                                add_general_regex_sanitizer(
+                                add_general_string_sanitizer(
                                     value=scrubbed_value,
-                                    regex=self.real_values[key.lower()],
+                                    target=self.real_values[key.lower()],
                                 )
                             except:
                                 logger = logging.getLogger()

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
@@ -20,7 +20,7 @@ from azure.core.pipeline.transport import RequestsTransport
 from .helpers import get_test_id, is_live, is_live_and_not_recording
 from .proxy_testcase import start_record_or_playback, stop_record_or_playback, transform_request
 from .proxy_startup import test_proxy
-from .sanitizers import add_general_regex_sanitizer
+from .sanitizers import add_general_string_sanitizer
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Optional, Tuple
@@ -45,7 +45,7 @@ class EnvironmentVariableSanitizer:
         self._fake_values[variable] = value
         real_value = os.getenv(variable)
         if real_value:
-            add_general_regex_sanitizer(regex=real_value, value=value)
+            add_general_string_sanitizer(target=real_value, value=value)
         else:
             _LOGGER.info(f"No value for {variable} was found, so a sanitizer could not be registered for the variable.")
 


### PR DESCRIPTION
# Description

Since we now have a general string sanitizer, we should use that instead of regex sanitizers when sanitizing environment variable values. We know these values will always be strings, and using a regex sanitizer has caused issues with ML cases where environment variable values happen to produce invalid or incorrect regex expressions (things don't get sanitized as expected).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - Verified locally with migrated tests using the EnvironmentVariableLoader
