### PR TITLE
[cognitivelanguage] remove unused test dependency

### DIFF
--- a/sdk/cognitivelanguage/azure-ai-language-conversations/dev_requirements.txt
+++ b/sdk/cognitivelanguage/azure-ai-language-conversations/dev_requirements.txt
@@ -2,5 +2,4 @@
 -e ../../../tools/azure-devtools
 ../../core/azure-core
 -e ../../identity/azure-identity
--e ../../cognitiveservices/azure-mgmt-cognitiveservices
 aiohttp>=3.0

--- a/sdk/cognitivelanguage/azure-ai-language-conversations/tests/testcase.py
+++ b/sdk/cognitivelanguage/azure-ai-language-conversations/tests/testcase.py
@@ -14,7 +14,6 @@ from devtools_testutils import (
     FakeResource,
     ResourceGroupPreparer,
 )
-from devtools_testutils.cognitiveservices_testcase import CognitiveServicesAccountPreparer
 from azure_devtools.scenario_tests import ReplayableTest
 
 

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/dev_requirements.txt
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/dev_requirements.txt
@@ -1,7 +1,6 @@
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
 -e ../../../tools/azure-devtools
--e ../../cognitiveservices/azure-mgmt-cognitiveservices
 -e ../../identity/azure-identity
 aiohttp>=3.0
 ../../nspkg/azure-ai-nspkg

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/tests/testcase.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/tests/testcase.py
@@ -15,7 +15,6 @@ from devtools_testutils import (
     FakeResource,
     ResourceGroupPreparer,
 )
-from devtools_testutils.cognitiveservices_testcase import CognitiveServicesAccountPreparer
 from azure_devtools.scenario_tests import ReplayableTest
 
 from azure.ai.language.questionanswering import QuestionAnsweringClient


### PR DESCRIPTION
We're failing mindep because of a test dependency on azure-mgmt-cognitiveservices. Thing is, we don't actually use this library in tests so we can safely remove it.