### PR TITLE
Update wrapt pin to be compatible with usage on py311

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -17,7 +17,7 @@ codecov==2.1.0
 beautifulsoup4==4.9.1
 pkginfo==1.5.0.1
 pip==20.3.3
-wrapt==1.12.1
+wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
 markupsafe==2.0.1; python_version > '2.7'
 markupsafe==1.1.1; python_version == '2.7'

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -30,7 +30,7 @@ packaging==20.4
 Jinja2==2.11.2
 markupsafe==2.0.1; python_version > '2.7'
 markupsafe==1.1.1; python_version == '2.7'
-wrapt==1.12.1
+wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
 
 # Locking pylint and required packages


### PR DESCRIPTION
I'm an idiot and created something that will fail on py311.

[example failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1808269&view=logs&j=f70f737a-02bb-5f18-179f-b72db3c46ad6&t=3407d0f5-16c0-5901-94e1-8ea015565a5a&l=616)