### PR TITLE
[Cosmos] change tags for Cosmos SDK team

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1910,13 +1910,13 @@
           },
           {
             "labels": [
-              "Service Attention",
+              "Client",
               "Cosmos"
             ],
             "mentionees": [
               "simorenoh",
               "gahl-levy",
-              "pjohari-ms"
+              "JericHunter"
             ]
           },
           {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1910,6 +1910,18 @@
           },
           {
             "labels": [
+              "Service Attention",
+              "Cosmos"
+            ],
+            "mentionees": [
+              "simorenoh",
+              "gahl-levy",
+              "pjohari-ms",
+              "JericHunter"
+            ]
+          },
+          {
+            "labels": [
               "Client",
               "Cosmos"
             ],


### PR DESCRIPTION
Most of the issues filed for the SDK team get the tags Cosmos and Client by the azure-bot, rather than Service Attention. These changes would help us get notified faster than having to be manually checking or getting manually tagged by others.
