### PR TITLE
[Test Proxy] Support AsyncioRequestsTransport

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
+++ b/tools/azure-sdk-tools/devtools_testutils/aio/proxy_testcase_async.py
@@ -8,7 +8,7 @@ import urllib.parse as url_parse
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.core.pipeline.policies import ContentDecodePolicy
-from azure.core.pipeline.transport import AioHttpTransport
+from azure.core.pipeline.transport import AioHttpTransport, AsyncioRequestsTransport
 
 from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
 from ..helpers import is_live_and_not_recording
@@ -44,11 +44,15 @@ def recorded_by_proxy_async(test_func):
 
         test_id = get_test_id()
         recording_id, variables = start_record_or_playback(test_id)
-        original_transport_func = AioHttpTransport.send
+        original_aio_transport_func = AioHttpTransport.send
+        original_asyncio_transport_func = AsyncioRequestsTransport.send
 
         async def combined_call(*args, **kwargs):
             adjusted_args, adjusted_kwargs = transform_args(*args, **kwargs)
-            result = await original_transport_func(*adjusted_args, **adjusted_kwargs)
+            try:
+                result = await original_aio_transport_func(*adjusted_args, **adjusted_kwargs)
+            except TypeError:  # if awaiting AioHttpTransport.send fails, it means we're using AsyncioRequestsTransport
+                result = await original_asyncio_transport_func(*adjusted_args, **adjusted_kwargs)
 
             # make the x-recording-upstream-base-uri the URL of the request
             # this makes the request look like it was made to the original endpoint instead of to the proxy
@@ -65,6 +69,7 @@ def recorded_by_proxy_async(test_func):
             return result
 
         AioHttpTransport.send = combined_call
+        AsyncioRequestsTransport.send = combined_call
 
         # call the modified function
         # we define test_output before invoking the test so the variable is defined in case of an exception
@@ -85,7 +90,8 @@ def recorded_by_proxy_async(test_func):
             error_with_message = ResourceNotFoundError(message=message, response=error.response)
             raise error_with_message from error
         finally:
-            AioHttpTransport.send = original_transport_func
+            AioHttpTransport.send = original_aio_transport_func
+            AsyncioRequestsTransport.send = original_asyncio_transport_func
             stop_record_or_playback(test_id, recording_id, test_output)
 
         return test_output


### PR DESCRIPTION
# Description

We currently only patch `AioHttpTransport`, the most common async transport in the SDK. App Configuration uses `AsyncioRequestsTransport` as its async transport though -- whether or not it should hard code this is being discussed separately, but in any case our test proxy infrastructure should support any transport that clients choose to use.

This adds support for `AsyncioRequestsTransport` by patching its `send` method during recorded tests, just as we currently do for `AioHttpTransport`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - Tested using App Configuration tests.
