### PR TITLE
[Cosmos] remove wrongly placed ayncs

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 #### Bugs Fixed
 - Fixed parsing of args for overloaded `container.read()` method.
-- Fixed `validate_cache_staleness_value()` method to allow max_integrated_cache_staleness to be an integer greater than or equal to 0
+- Fixed `validate_cache_staleness_value()` method to allow max_integrated_cache_staleness to be an integer greater than or equal to 0.
+- Fixed `__aiter__()` method by removing the async keyword.
 
 ### 4.3.0 (2022-05-23)
 #### Features Added

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/base_execution_context.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/base_execution_context.py
@@ -84,7 +84,7 @@ class _QueryExecutionContextBase(object):
     async def _fetch_next_block(self):
         raise NotImplementedError
 
-    async def __aiter__(self):
+    def __aiter__(self):
         """Returns itself as an iterator"""
         return self
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/document_producer.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/document_producer.py
@@ -62,7 +62,7 @@ class _DocumentProducer(object):
 
         self._ex_context = _DefaultQueryExecutionContext(client, self._options, fetch_fn)
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/endpoint_component.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/aio/endpoint_component.py
@@ -40,7 +40,7 @@ class _QueryExecutionEndpointComponent(object):
     def __init__(self, execution_context):
         self._execution_context = execution_context
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):


### PR DESCRIPTION
# Description
removing some wrongly placed `async` in our files to fix a bug, documentation below.
https://docs.python.org/3.9/reference/datamodel.html#asynchronous-iterators
