### PR TITLE
[Storage] Another fix to flaky retry test

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_retry.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry.py
@@ -167,8 +167,11 @@ class TestStorageRetry(StorageRecordedTestCase):
             assert 'read timeout' in str(error.value.args[0]), 'Expected socket timeout but got different exception.'
 
         finally:
-            # we must make the timeout normal again to let the delete operation succeed
-            service.delete_container(container_name, connection_timeout=(11, 11))
+            try:
+                # we must make the timeout normal again to let the delete operation succeed
+                service.delete_container(container_name, connection_timeout=(11, 11))
+            except:
+                pass
 
     @BlobPreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-blob/tests/test_retry.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry.py
@@ -167,11 +167,9 @@ class TestStorageRetry(StorageRecordedTestCase):
             assert 'read timeout' in str(error.value.args[0]), 'Expected socket timeout but got different exception.'
 
         finally:
-            try:
-                # we must make the timeout normal again to let the delete operation succeed
-                service.delete_container(container_name, connection_timeout=(11, 11))
-            except:
-                pass
+            # Recreate client with normal timeouts
+            service = self._create_storage_service(BlobServiceClient, storage_account_name, storage_account_key)
+            service.delete_container(container_name)
 
     @BlobPreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-blob/tests/test_retry_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry_async.py
@@ -165,11 +165,9 @@ class TestStorageRetryAsync(AsyncStorageRecordedTestCase):
             assert 'Timeout on reading data from socket' in str(error.value.args[0]), 'Expected socket timeout but got different exception.'
 
         finally:
-            try:
-                # we must make the timeout normal again to let the delete operation succeed
-                service.delete_container(container_name, connection_timeout=(11, 11))
-            except:
-                pass
+            # Recreate client with normal timeouts
+            service = self._create_storage_service(BlobServiceClient, storage_account_name, storage_account_key)
+            service.delete_container(container_name)
 
     @BlobPreparer()
     @recorded_by_proxy_async

--- a/sdk/storage/azure-storage-blob/tests/test_retry_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry_async.py
@@ -165,8 +165,11 @@ class TestStorageRetryAsync(AsyncStorageRecordedTestCase):
             assert 'Timeout on reading data from socket' in str(error.value.args[0]), 'Expected socket timeout but got different exception.'
 
         finally:
-            # we must make the timeout normal again to let the delete operation succeed
-            await service.delete_container(container_name, connection_timeout=11, read_timeout=11)
+            try:
+                # we must make the timeout normal again to let the delete operation succeed
+                service.delete_container(container_name, connection_timeout=(11, 11))
+            except:
+                pass
 
     @BlobPreparer()
     @recorded_by_proxy_async


### PR DESCRIPTION
For some reason the socket retry test was sometimes failing when trying to delete the container saying the resource did not exist. I think this was because the timeout on the client was not properly being reset and so the first request may time out reading the response, but the service would still delete the container. The retry would then get the resource does not exist error.

This change constructs a new client with normal timeouts.