### PR TITLE
Hotfix `ml-samples-submission`

### DIFF
--- a/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
+++ b/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
@@ -44,7 +44,7 @@ jobs:
       displayName: 'Prep Environment'
 
     - pwsh: |
-        sdk_build -d "$(Build.ArtifactStagingDirectory)" --repo "$(Build.SourcesDirectory)" --service=${{parameters.ServiceDirectory}}" "$(TargetingString)"
+        sdk_build -d "$(Build.ArtifactStagingDirectory)" --repo="$(Build.SourcesDirectory)" --service="${{parameters.ServiceDirectory}}"" "$(TargetingString)"
       displayName: Generate Packages
 
     - pwsh: |

--- a/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
+++ b/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
@@ -44,7 +44,7 @@ jobs:
       displayName: 'Prep Environment'
 
     - pwsh: |
-        sdk_build -d "$(Build.ArtifactStagingDirectory)" --repo="$(Build.SourcesDirectory)" --service="${{parameters.ServiceDirectory}}"" "$(TargetingString)"
+        sdk_build -d "$(Build.ArtifactStagingDirectory)" --repo="$(Build.SourcesDirectory)" --service="${{parameters.ServiceDirectory}}" "$(TargetingString)"
       displayName: Generate Packages
 
     - pwsh: |


### PR DESCRIPTION
As verified under [this build.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1816067&view=logs&j=41973b2a-913a-52a3-33b2-21df9bd9b31d&t=41973b2a-913a-52a3-33b2-21df9bd9b31d) An unmatched quotation was causing wonky powershell crashes.