### PR TITLE
[MixedReality] Remove support for Python 3.6

### DIFF
--- a/sdk/mixedreality/azure-mixedreality-authentication/CHANGELOG.md
+++ b/sdk/mixedreality/azure-mixedreality-authentication/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Python 2.7 is no longer supported. Please use Python version 3.6 or later.
+- Python 2.7 is no longer supported. Please use Python version 3.7 or later.
 
 ## 1.0.0b1 (2021-11-12)
 

--- a/sdk/mixedreality/azure-mixedreality-authentication/README.md
+++ b/sdk/mixedreality/azure-mixedreality-authentication/README.md
@@ -12,7 +12,7 @@ token from the STS that can be used to access Mixed Reality services.
 
 ## Currently supported environments
 
-This package has been tested with Python 3.6+.
+This package has been tested with Python 3.7+.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ This package has been tested with Python 3.6+.
   - [Azure Remote Rendering](https://docs.microsoft.com/azure/remote-rendering/)
   - [Azure Spatial Anchors](https://docs.microsoft.com/azure/spatial-anchors/)
 - Familiarity with the authentication and credential concepts from the [Azure Identity library][azure_identity].
-- Python 3.6 or later is required to use this package.
+- Python 3.7 or later is required to use this package.
 
 ## Install the package
 

--- a/sdk/mixedreality/azure-mixedreality-authentication/dev_requirements.txt
+++ b/sdk/mixedreality/azure-mixedreality-authentication/dev_requirements.txt
@@ -1,5 +1,4 @@
 -e ../../../tools/azure-sdk-tools
-../../nspkg/azure-mixedreality-nspkg
 ../../core/azure-core
 aiohttp>=3.0
 -e ../../../tools/azure-devtools

--- a/sdk/mixedreality/azure-mixedreality-authentication/setup.py
+++ b/sdk/mixedreality/azure-mixedreality-authentication/setup.py
@@ -47,7 +47,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -64,7 +63,7 @@ setup(
     package_data={
         'pytyped': ['py.typed'],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         'azure-core<2.0.0,>=1.4.0',
         'msrest>=0.6.21'


### PR DESCRIPTION
For `azure-mixedreality-authentication`, necessary files were updated to reflect that Python 3.7 is now the minimum supported version. The mixedreality-nspkg requirement was also removed from the dev_requirements.txt file since it is no longer needed.

