### PR TITLE
Clarify CloudEvent.source property meaning

### DIFF
--- a/sdk/core/azure-core/azure/core/messaging.py
+++ b/sdk/core/azure-core/azure/core/messaging.py
@@ -28,7 +28,7 @@ class CloudEvent(object):  # pylint:disable=too-many-instance-attributes
     All required parameters must be populated in order to send to Azure.
 
     :param source: Required. Identifies the context in which an event happened. The combination of id and source must
-     be unique for each distinct event. If publishing to a domain topic, source must be the domain name.
+     be unique for each distinct event. If publishing to a domain topic, source must be the domain topic name.
     :type source: str
     :param type: Required. Type of event related to the originating occurrence.
     :type type: str
@@ -53,7 +53,7 @@ class CloudEvent(object):  # pylint:disable=too-many-instance-attributes
      and must not exceed the length of 20 characters.
     :type extensions: Optional[Dict]
     :ivar source: Identifies the context in which an event happened. The combination of id and source must
-     be unique for each distinct event. If publishing to a domain topic, source must be the domain name.
+     be unique for each distinct event. If publishing to a domain topic, source must be the domain topic name.
     :vartype source: str
     :ivar data: Event data specific to the event type.
     :vartype data: object


### PR DESCRIPTION
# Description

This caused me much confusion: the source should not contain the domain name, it should contain the domain topic (name). As far as I can tell, this particular comment was not generated from the swagger definition (I couldn't find it anywhere else on github anyway).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
