### PR TITLE
[Storage] Fix flaky retry test once and for all (hopefully)

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_retry.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry.py
@@ -11,35 +11,35 @@ from azure.core.exceptions import (
     AzureError,
     ClientAuthenticationError,
     HttpResponseError,
-    ResourceExistsError
+    ResourceExistsError,
+    ServiceResponseError
 )
 from azure.core.pipeline.transport import RequestsTransport
 from azure.storage.blob import (
-    BlobClient,
     BlobServiceClient,
-    ContainerClient,
     ExponentialRetry,
     LinearRetry,
     LocationMode
 )
 from requests import Response
-from requests.exceptions import ContentDecodingError, ChunkedEncodingError
+from requests.exceptions import ContentDecodingError, ChunkedEncodingError, ReadTimeout
 
 from devtools_testutils import RetryCounter, ResponseCallback, recorded_by_proxy
 from devtools_testutils.storage import StorageRecordedTestCase
 from settings.testcase import BlobPreparer
 
 
-class RetryRequestTransport(RequestsTransport):
-    """Transport to test retry"""
+class TimeoutRequestsTransport(RequestsTransport):
+    """Transport to test read timeout"""
     def __init__(self, *args, **kwargs):
-        super(RetryRequestTransport, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.count = 0
 
     def send(self, request, **kwargs):
         self.count += 1
-        response = super(RetryRequestTransport, self).send(request, **kwargs)
-        return response
+        timeout_error = ReadTimeout("Read timed out", request=request)
+        raise ServiceResponseError(timeout_error, error=timeout_error)
+
 
 # --Test Class -----------------------------------------------------------------
 class TestStorageRetry(StorageRecordedTestCase):
@@ -120,7 +120,6 @@ class TestStorageRetry(StorageRecordedTestCase):
             assert kwargs.get('response') is not None
             assert kwargs['response'].status_code == 408
 
-
         # Act
         try:
             # The initial create will return 201, but we overwrite it and retry.
@@ -144,31 +143,27 @@ class TestStorageRetry(StorageRecordedTestCase):
         # Upload a blob that can be downloaded to test read timeout
         service = self._create_storage_service(BlobServiceClient, storage_account_name, storage_account_key)
         container = service.create_container(container_name)
-        container.upload_blob(blob_name, b'a' * 1024 * 1024, overwrite=True)
+        container.upload_blob(blob_name, b'Hello World', overwrite=True)
 
         retry = LinearRetry(backoff=1, random_jitter_range=1)
-        retry_transport = RetryRequestTransport(connection_timeout=11, read_timeout=0.000000000001)
-        # make the connect timeout reasonable, but packet timeout truly small, to make sure the request always times out
-        service = self._create_storage_service(
-            BlobServiceClient, storage_account_name, storage_account_key, retry_policy=retry, transport=retry_transport)
-        blob = service.get_blob_client(container_name, blob_name)
-
-        assert service._client._client._pipeline._transport.connection_config.timeout == 11
-        assert service._client._client._pipeline._transport.connection_config.read_timeout == 0.000000000001
+        timeout_transport = TimeoutRequestsTransport()
+        timeout_service = self._create_storage_service(
+            BlobServiceClient,
+            storage_account_name,
+            storage_account_key,
+            retry_policy=retry,
+            transport=timeout_transport)
+        blob = timeout_service.get_blob_client(container_name, blob_name)
 
         # Act
         try:
-            with pytest.raises(AzureError) as error:
+            with pytest.raises(AzureError):
                 blob.download_blob()
             # Assert
             # 3 retries + 1 original == 4
-            assert retry_transport.count == 4
-            # This call should succeed on the server side, but fail on the client side due to socket timeout
-            assert 'read timeout' in str(error.value.args[0]), 'Expected socket timeout but got different exception.'
+            assert timeout_transport.count == 4
 
         finally:
-            # Recreate client with normal timeouts
-            service = self._create_storage_service(BlobServiceClient, storage_account_name, storage_account_key)
             service.delete_container(container_name)
 
     @BlobPreparer()

--- a/sdk/storage/azure-storage-blob/tests/test_retry_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_retry_async.py
@@ -8,35 +8,36 @@ import functools
 import pytest
 from unittest import mock
 
+from aiohttp.client_exceptions import ClientPayloadError, ServerTimeoutError
+from aiohttp.streams import StreamReader
 from azure.core.exceptions import (
     AzureError,
     ClientAuthenticationError,
     HttpResponseError,
-    ResourceExistsError
+    ResourceExistsError,
+    ServiceResponseError
 )
 from azure.core.pipeline.transport import AioHttpTransport
 from azure.storage.blob import LocationMode
 from azure.storage.blob._shared.policies_async import ExponentialRetry, LinearRetry
 from azure.storage.blob.aio import BlobServiceClient
 
-from aiohttp.client_exceptions import ClientPayloadError
-from aiohttp.streams import StreamReader
 from devtools_testutils import ResponseCallback, RetryCounter
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase
 from settings.testcase import BlobPreparer
 
-class AiohttpRetryTestTransport(AioHttpTransport):
-    """Mock transport for testing retry
-    """
+
+class TimeoutAioHttpTransport(AioHttpTransport):
+    """Transport to test read timeout"""
     def __init__(self, *args, **kwargs):
-        super(AiohttpRetryTestTransport, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.count = 0
 
     async def send(self, request, **config):
         self.count += 1
-        response = await super(AiohttpRetryTestTransport, self).send(request, **config)
-        return response
+        timeout_error = ServerTimeoutError("Timeout on reading data from socket")
+        raise ServiceResponseError(timeout_error, error=timeout_error) from timeout_error
 
 
 # --Test Class -----------------------------------------------------------------
@@ -118,7 +119,6 @@ class TestStorageRetryAsync(AsyncStorageRecordedTestCase):
             assert kwargs.get('response') is not None
             assert kwargs['response'].status_code == 408
 
-
         # Act
         try:
             # The initial create will return 201, but we overwrite it and retry.
@@ -142,27 +142,25 @@ class TestStorageRetryAsync(AsyncStorageRecordedTestCase):
         # Upload a blob that can be downloaded to test read timeout
         service = self._create_storage_service(BlobServiceClient, storage_account_name, storage_account_key)
         container = await service.create_container(container_name)
-        await container.upload_blob(blob_name, b'a' * 1024 * 1024, overwrite=True)
+        await container.upload_blob(blob_name, b'Hello World', overwrite=True)
 
         retry = LinearRetry(backoff=1, random_jitter_range=1)
-        retry_transport = AiohttpRetryTestTransport(connection_timeout=11, read_timeout=0.000000000001)
-        # make the connect timeout reasonable, but packet timeout truly small, to make sure the request always times out
-        service = self._create_storage_service(
-            BlobServiceClient, storage_account_name, storage_account_key, retry_policy=retry, transport=retry_transport)
-        blob = service.get_blob_client(container_name, blob_name)
-
-        assert service._client._client._pipeline._transport.connection_config.timeout == 11
-        assert service._client._client._pipeline._transport.connection_config.read_timeout == 0.000000000001
+        timeout_transport = TimeoutAioHttpTransport()
+        timeout_service = self._create_storage_service(
+            BlobServiceClient,
+            storage_account_name,
+            storage_account_key,
+            retry_policy=retry,
+            transport=timeout_transport)
+        blob = timeout_service.get_blob_client(container_name, blob_name)
 
         # Act
         try:
-            with pytest.raises(AzureError) as error:
+            with pytest.raises(AzureError):
                 await blob.download_blob()
             # Assert
             # 3 retries + 1 original == 4
-            assert retry_transport.count == 4
-            # This call should succeed on the server side, but fail on the client side due to socket timeout
-            assert 'Timeout on reading data from socket' in str(error.value.args[0]), 'Expected socket timeout but got different exception.'
+            assert timeout_transport.count == 4
 
         finally:
             # Recreate client with normal timeouts


### PR DESCRIPTION
After many failed attempts to fix the flaky read timeout retry test, this change will hopefully be the final fix. This changes the test to essentially mock raising a timeout exception rather than relying on actually causing a read timeout as causing a real read timeout was difficult to achieve in the Live test environment (likely because inter-datacenter requests were just too fast).

I tried to make the raised timeout exceptions as close as possible to what they would be in a real timeout scenario to test that our retry mechanism is catching them. This meant wrapping the correct underlying transport's (`requests` or `aiohttp`) read timeout exception with the core `ServiceResponseError`.

Hopefully this should eliminate the flakiness in this test for good.