### PR TITLE
[Storage] Mark Blob service stats test playback only

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_stats.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_stats.py
@@ -30,9 +30,13 @@ class TestServiceStats(StorageRecordedTestCase):
         assert stats['geo_replication']['last_sync_time'] is None
     # --------------------------------------------------------------------------
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy
     def test_blob_service_stats(self, **kwargs):
+        # The accounts created in the Live test pipeline do not have time to finish
+        # setting up GRS by the time this test runs so this test will return a different
+        # response. Therefore can only run in playback.
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_stats_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_stats_async.py
@@ -30,9 +30,13 @@ class TestServiceStatsAsync(AsyncStorageRecordedTestCase):
         assert stats['geo_replication']['last_sync_time'] is None
     # --------------------------------------------------------------------------
 
+    @pytest.mark.playback_test_only
     @BlobPreparer()
     @recorded_by_proxy_async
     async def test_blob_service_stats(self, **kwargs):
+        # The accounts created in the Live test pipeline do not have time to finish
+        # setting up GRS by the time this test runs so this test will return a different
+        # response. Therefore can only run in playback.
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 


### PR DESCRIPTION
When migrating `test_blob_service_stats` to test proxy I changed a playback test to run live after making an adjustment thinking it would work in the Live test pipeline. This was incorrect as in the live test pipeline, new storage accounts are created immediately before running tests and therefore GRS does not have time to transition from `bootstrap` to `live`. This causes the test to fail as it expects GRS to be in `live` state.

Marking this test as playback only to address this.