### PR TITLE
[CognitiveLanguage] Strip trailing endpoint slashes

### DIFF
--- a/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/_patch.py
@@ -76,6 +76,11 @@ class ConversationAnalysisClient(GeneratedConversationAnalysisClient): # pylint:
     """
 
     def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, TokenCredential], **kwargs: Any) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore

--- a/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/aio/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/aio/_patch.py
@@ -79,6 +79,11 @@ class ConversationAnalysisClient(GeneratedConversationAnalysisClient): # pylint:
     def __init__(
         self, endpoint: str, credential: Union[AzureKeyCredential, AsyncTokenCredential], **kwargs: Any
     ) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore

--- a/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/_patch.py
@@ -53,6 +53,11 @@ class ConversationAuthoringClient(GeneratedConversationAuthoringClient): # pylin
     """
 
     def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, TokenCredential], **kwargs: Any) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore

--- a/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/aio/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/aio/_patch.py
@@ -56,6 +56,11 @@ class ConversationAuthoringClient(GeneratedConversationAuthoringClient): # pylin
     def __init__(
         self, endpoint: str, credential: Union[AzureKeyCredential, AsyncTokenCredential], **kwargs: Any
     ) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/_patch.py
@@ -47,6 +47,11 @@ class QuestionAnsweringClient(QuestionAnsweringClientGenerated):
     """
 
     def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, TokenCredential], **kwargs: Any) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/aio/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/aio/_patch.py
@@ -52,6 +52,11 @@ class QuestionAnsweringClient(QuestionAnsweringClientGenerated):
     def __init__(
         self, endpoint: str, credential: Union[AzureKeyCredential, AsyncTokenCredential], **kwargs: Any
     ) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/projects/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/projects/_patch.py
@@ -77,6 +77,11 @@ class QuestionAnsweringProjectsClient(QuestionAnsweringProjectsClientGenerated):
     """
 
     def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, TokenCredential], **kwargs: Any) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/projects/aio/_patch.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/projects/aio/_patch.py
@@ -78,6 +78,11 @@ class QuestionAnsweringProjectsClient(QuestionAnsweringProjectsClientGenerated):
     """
 
     def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, AsyncTokenCredential], **kwargs: Any) -> None:
+        try:
+            endpoint = endpoint.rstrip("/")
+        except AttributeError:
+            raise ValueError("Parameter 'endpoint' must be a string.")
+
         super().__init__(
             endpoint=endpoint,
             credential=credential,  # type: ignore


### PR DESCRIPTION
# Description

When the user passes in an endpoint with a trailing slash to the various clients, the resulting URIs for the various operations begin with two leading '/'. For example:

"https://languagesdkresource.cognitiveservices.azure.com//language/..."

Although these URIs still resolve, it's better not to depend on this and ensure that the URIs are constructed correctly. Here, we ensure that when a user passes in an endpoint to any of the Cognitive Language clients, any trailing slashes are removed.
