### PR TITLE
[ServiceBus] Bug Fix: connection_verify not being passed on async

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_utils.py
@@ -55,6 +55,9 @@ async def create_authentication(client):
             timeout=client._config.auth_timeout,
             http_proxy=client._config.http_proxy,
             transport_type=client._config.transport_type,
+            custom_endpoint_hostname=client._config.custom_endpoint_hostname,
+            port=client._config.connection_port,
+            verify=client._config.connection_verify
         )
         await auth.update_token()
         return auth
@@ -67,6 +70,9 @@ async def create_authentication(client):
         http_proxy=client._config.http_proxy,
         transport_type=client._config.transport_type,
         refresh_window=300,
+        custom_endpoint_hostname=client._config.custom_endpoint_hostname,
+        port=client._config.connection_port,
+        verify=client._config.connection_verify
     )
 
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -526,7 +526,7 @@ class ServiceBusClientAsyncTests(AzureMgmtTestCase):
     @CachedResourceGroupPreparer()
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    async def test_connection_verify_exception(self,
+    async def test_connection_verify_exception_async(self,
                                    servicebus_queue,
                                    servicebus_namespace,
                                    servicebus_namespace_key_name,

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -521,3 +521,24 @@ class ServiceBusClientAsyncTests(AzureMgmtTestCase):
             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
             assert subscription_receiver.client_identifier is not None
             assert subscription_receiver.client_identifier == custom_id
+
+    @pytest.mark.liveTest
+    @CachedResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    async def test_connection_verify_exception(self,
+                                   servicebus_queue,
+                                   servicebus_namespace,
+                                   servicebus_namespace_key_name,
+                                   servicebus_namespace_primary_key,
+                                   servicebus_namespace_connection_string,
+                                   **kwargs):
+        hostname = "{}.servicebus.windows.net".format(servicebus_namespace.name)
+        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+
+        client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem")
+        async with client:
+            with pytest.raises(ServiceBusError):
+                async with client.get_queue_sender(servicebus_queue.name) as sender:
+                    await sender.send_messages(ServiceBusMessage("foo"))
+

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -555,3 +555,24 @@ class ServiceBusClientTests(AzureMgmtTestCase):
             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
             assert subscription_receiver.client_identifier is not None
             assert subscription_receiver.client_identifier == custom_id
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    def test_connection_verify_exception(self,
+                                   servicebus_queue,
+                                   servicebus_namespace,
+                                   servicebus_namespace_key_name,
+                                   servicebus_namespace_primary_key,
+                                   servicebus_namespace_connection_string,
+                                   **kwargs):
+        hostname = "{}.servicebus.windows.net".format(servicebus_namespace.name)
+        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+
+        client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem")
+        with client:
+            with pytest.raises(ServiceBusError):
+                with client.get_queue_sender(servicebus_queue.name) as sender:
+                    sender.send_messages(ServiceBusMessage("foo"))


### PR DESCRIPTION
It was passed through [here](https://github.com/Azure/azure-sdk-for-python/blob/9fc7eb5c2967c8d8ec177a434037dd528231f995/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py#L176) in sync 

Fixes #26015