### PR TITLE
[Storage] Fix `AttributeError` when calling download with invalid key

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Features Added
 - Stable release of features from 12.14.0b1 and 12.14.0b2.
 
+### Bugs Fixed
+- Fixed an issue where calling `download_blob` with an invalid base64-encoded account key would cause an
+`AttributeError` rather than the proper `AzureSigningError`.
+
 ### Other Changes
 - Changed the default value for `read_timeout` to 60 seconds for all clients.
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -445,7 +445,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
                     self.size = self._file_size
 
             except HttpResponseError as error:
-                if self._start_range is None and error.response.status_code == 416:
+                if self._start_range is None and error.response and error.response.status_code == 416:
                     # Get range will fail on an empty file. If the user did not
                     # request a range, do a regular get request in order to get
                     # any properties.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -367,7 +367,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
                 self.size = self._file_size
 
         except HttpResponseError as error:
-            if self._start_range is None and error.status_code == 416:
+            if self._start_range is None and error.response and error.status_code == 416:
                 # Get range will fail on an empty file. If the user did not
                 # request a range, do a regular get request in order to get
                 # any properties.

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Features Added
 - Stable release of features from 12.10.0b1.
 
+### Bugs Fixed
+- Fixed an issue where calling `download_file` with an invalid base64-encoded account key would raise an
+`AttributeError` rather than the proper `AzureSigningError`.
+
 ### Other Changes
 - Changed the default value for `read_timeout` to 60 seconds for all clients.
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
@@ -323,7 +323,7 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                 self.size = self._file_size
 
         except HttpResponseError as error:
-            if self._start_range is None and error.response.status_code == 416:
+            if self._start_range is None and error.response and error.response.status_code == 416:
                 # Get range will fail on an empty file. If the user did not
                 # request a range, do a regular get request in order to get
                 # any properties.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -276,7 +276,7 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                 self.size = self._file_size
 
         except HttpResponseError as error:
-            if self._start_range is None and error.response.status_code == 416:
+            if self._start_range is None and error.response and error.response.status_code == 416:
                 # Get range will fail on an empty file. If the user did not
                 # request a range, do a regular get request in order to get
                 # any properties.


### PR DESCRIPTION
Resolves #26028.

When calling `download_blob` (or `download_file`) with an invalid base64-encoded account key an `AttributeError` would be raised instead of the expected `ClientAuthenticationError` (`AzureSigningError`). This was caused by the fact that download operations do an extra check for status code on any `HttpResponseError` but `AzureSigningError` does not have a response attached since no request was made. This change simply adds a None check for the response before accesssing `status_code`.