### PR TITLE
[Test Proxy] Update environment_variables scope

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
@@ -94,9 +94,12 @@ class VariableRecorder:
         return self.variables.setdefault(variable, default)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def environment_variables(test_proxy: None) -> EnvironmentVariableSanitizer:
     """Fixture that returns an EnvironmentVariableSanitizer for convenient environment variable fetching and sanitizing.
+
+    This fixture is session-scoped, so a single instance of EnvironmentVariableSanitizer is shared across all
+    tests using this fixture in the test session.
 
     :param test_proxy: The fixture responsible for starting up the test proxy server.
     :type test_proxy: None


### PR DESCRIPTION
This updates the `environment_variables` pytest fixture scope to "session" (as opposed to the default "function" scope) in order to enable users to use it in other session scoped fixtures. Also, for most cases, users will only need one instance of `EnvironmentVariableSanitizer` per test session.

