### PR TITLE
Remove Pinned Test-Proxy Version Override

### DIFF
--- a/eng/pipelines/templates/jobs/ci.conda.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.conda.tests.yml
@@ -76,8 +76,6 @@ jobs:
 
     - ${{if eq(parameters.TestProxy, true) }}:
       - template: /eng/common/testproxy/test-proxy-tool.yml
-        parameters:
-          targetVersion: 1.0.0-dev.20220810.2
 
     - task: UsePythonVersion@0
       displayName: 'Use Python $(PythonVersion)'

--- a/eng/pipelines/templates/jobs/regression.yml
+++ b/eng/pipelines/templates/jobs/regression.yml
@@ -87,7 +87,6 @@ jobs:
       - template: /eng/common/testproxy/test-proxy-tool.yml
         parameters:
           runProxy: false
-          targetVersion: 1.0.0-dev.20220810.2
 
       - template: ../steps/set-dev-build.yml
         parameters:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -43,7 +43,6 @@ steps:
     - template: /eng/common/testproxy/test-proxy-tool.yml
       parameters:
         runProxy: false
-        targetVersion: 1.0.0-dev.20220810.2
 
   - ${{if eq(variables['System.TeamProject'], 'internal') }}:
     - template: ../steps/auth-dev-feed.yml


### PR DESCRIPTION
@mccoyp we originally added this to unblock the confidential ledger cert feature. That is clean now.