### PR TITLE
[Identity] Move RequestsTransport Import

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/pipeline.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/pipeline.py
@@ -15,7 +15,7 @@ from azure.core.pipeline.policies import (
     UserAgentPolicy,
     HttpLoggingPolicy,
 )
-from azure.core.pipeline.transport import RequestsTransport
+
 
 from .user_agent import USER_AGENT
 
@@ -62,6 +62,7 @@ def build_pipeline(transport=None, policies=None, **kwargs):
         config.retry_policy = RetryPolicy(**kwargs)
         policies = _get_policies(config, **kwargs)
     if not transport:
+        from azure.core.pipeline.transport import RequestsTransport
         transport = RequestsTransport(**kwargs)
 
     return Pipeline(transport, policies=policies)


### PR DESCRIPTION
In an environment without `requests` and only `aiohttp` the import `from azure.identity.aio import EnvironmentCredential` throws an `ImportError: requests package is not installed`. 

Moving the RequestsTransports import inside `build_pipeline` so its imported when needed.