### PR TITLE
[containerregistry] update samples to use asyncio.run

### DIFF
--- a/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_delete_images_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_delete_images_async.py
@@ -57,5 +57,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_delete_tags_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_delete_tags_async.py
@@ -58,5 +58,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_hello_world_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_hello_world_async.py
@@ -58,5 +58,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_list_tags_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_list_tags_async.py
@@ -55,5 +55,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_set_image_properties_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/async_samples/sample_set_image_properties_async.py
@@ -61,5 +61,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
Co-authored-by: kyc5644 <kyc5644@naver.com>

# Description

As https://github.com/Azure/azure-sdk-for-python/issues/21207 mentions, some samples are using a loop variable for simple callbacks when this can be done by using the new run method of asyncio. This PR remedies the issue for the monitor library.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
