### PR TITLE
[EH] Stress tests update to pg cluster

### DIFF
--- a/sdk/eventhub/azure-eventhub/stress/Chart.lock
+++ b/sdk/eventhub/azure-eventhub/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.13
-digest: sha256:007ec9983233e0f8c8ad8aa7f1df5f57b1b4c127d223d59d233b3c5366bd5173
-generated: "2021-12-02T16:05:20.2152434-05:00"
+  version: 0.1.20
+digest: sha256:174a2f4b768cb47718d4b3d5a506330aa781abb31803fbeaeba3b7eef87a9f38
+generated: "2022-07-29T10:58:25.2774398-07:00"

--- a/sdk/eventhub/azure-eventhub/stress/Chart.yaml
+++ b/sdk/eventhub/azure-eventhub/stress/Chart.yaml
@@ -9,5 +9,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.13
+  version: 0.1.20
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/eventhub/azure-eventhub/stress/templates/network_loss.yaml
+++ b/sdk/eventhub/azure-eventhub/stress/templates/network_loss.yaml
@@ -1,5 +1,5 @@
-{{- include "stress-test-addons.chaos-wrapper.tpl" (list . "stress.eh-network-chaos") -}}
-{{- define "stress.eh-network-chaos" -}}
+{{- include "stress-test-addons.chaos-wrapper.tpl" (list . "stress.python-eh-network-chaos") -}}
+{{- define "stress.python-eh-network-chaos" -}}
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 
@@ -7,11 +7,11 @@ spec:
   action: loss
   direction: to
   externalTargets:
-    - servicebus.windows.net
+    - '{{ .Stress.ResourceGroupName }}.servicebus.windows.net'
   mode: one
   selector:
     labelSelectors:
-      testInstance: "eh-network-loss-{{ .Release.Name }}-{{ .Release.Revision }}"
+      testInstance: "eventhub-{{ .Release.Name }}-{{ .Release.Revision }}"
       chaos: "true"
     namespaces:
       - {{ .Release.Namespace }}

--- a/sdk/eventhub/azure-eventhub/stress/templates/network_loss.yaml
+++ b/sdk/eventhub/azure-eventhub/stress/templates/network_loss.yaml
@@ -1,31 +1,21 @@
+{{- include "stress-test-addons.chaos-wrapper.tpl" (list . "stress.eh-network-chaos") -}}
+{{- define "stress.eh-network-chaos" -}}
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
-metadata:
-  name: '{{ .Release.Name }}-{{ .Release.Revision }}'
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    experiment.chaos-mesh.org/pause: 'true'
-  labels:
-    scenario: 'stress'
-    release: '{{ .Release.Name }}'
-    revision: '{{ .Release.Revision }}'
+
 spec:
-  scheduler:
-    cron: '@every 30s'
-  duration: '10s'
   action: loss
   direction: to
   externalTargets:
-    - 'servicebus.windows.net'
+    - servicebus.windows.net
   mode: one
   selector:
     labelSelectors:
-      testInstance: "eventhub-{{ .Release.Name }}-{{ .Release.Revision }}"
-      chaos: 'true'
+      testInstance: "eh-network-loss-{{ .Release.Name }}-{{ .Release.Revision }}"
+      chaos: "true"
     namespaces:
       - {{ .Release.Namespace }}
-    podPhaseSelectors:
-      - 'Running'
   loss:
-    loss: '100'
-    correlation: '100'
+    loss: "100"
+    correlation: "100"
+{{- end -}}

--- a/sdk/eventhub/azure-eventhub/stress/templates/testjob.yaml
+++ b/sdk/eventhub/azure-eventhub/stress/templates/testjob.yaml
@@ -10,7 +10,7 @@ spec:
     - name: python-eh-stress
       image: {{ .Values.image }}
       imagePullPolicy: Always
-      command: ['bash', '-c', 'python3 azure_eventhub_producer_stress.py & python3 azure_eventhub_consumer_stress_sync.py']
+      command: ['bash', '-c', 'python azure_eventhub_producer_stress.py & python azure_eventhub_consumer_stress_sync.py']
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
       # async test command
       # command: ['bash', '-c', 'python3 azure_eventhub_producer_stress.py -m stress_send_list_async & python3 azure_eventhub_consumer_stress_async.py']

--- a/sdk/eventhub/azure-eventhub/stress/templates/testjob.yaml
+++ b/sdk/eventhub/azure-eventhub/stress/templates/testjob.yaml
@@ -9,6 +9,7 @@ spec:
   containers:
     - name: python-eh-stress
       image: {{ .Values.image }}
+      imagePullPolicy: Always
       command: ['bash', '-c', 'python3 azure_eventhub_producer_stress.py & python3 azure_eventhub_consumer_stress_sync.py']
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
       # async test command


### PR DESCRIPTION
Taking steps to update stress tests in main for failing prod deployment

- [x] Update to pg cluster
- [x] Need to check about Network loss.yml, not sure it is being used in EH -- for now it is updated based off of the sample example shown in the stress testing documentation #26243 