### PR TITLE
Ensure Broken Setup.py still immediately visible

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -65,6 +65,7 @@ steps:
   - pwsh: |
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}}
     displayName: 'Generate Packages'
+    condition: succeededOrFailed()
 
   - script: |
       twine check $(Build.ArtifactStagingDirectory)/**/*.whl


### PR DESCRIPTION
The ml folks recently had a commit where their `setup.py` was in an unbuildable state. However, they never _saw_ this because the very first step `Dump-Package-Properties` failed. This step provides metadata to the rest of the build, and ideally should never fail.

However, when there is a real error, it definitely _can_. All this PR does is to make it so that the packaging step will still happen even in that case. If we do that, the setup.py failure will be diagnosable to the partner teams.