### PR TITLE
[SchemaRegistry] update samples to use asyncio.run

### DIFF
--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/encode_and_decode_event_data_message_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/encode_and_decode_event_data_message_async.py
@@ -126,5 +126,4 @@ async def main():
     await token_credential.close()
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/encode_and_decode_with_message_content_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/encode_and_decode_with_message_content_async.py
@@ -117,5 +117,4 @@ async def main():
     await token_credential.close()
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/eventhub_receive_integration_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/eventhub_receive_integration_async.py
@@ -86,5 +86,4 @@ async def main():
         await eventhub_consumer.close()
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/eventhub_send_integration_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/samples/async_samples/eventhub_send_integration_async.py
@@ -91,5 +91,4 @@ async def main():
     await eventhub_producer.close()
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/schemaregistry/azure-schemaregistry/samples/async_samples/sample_code_schemaregistry_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry/samples/async_samples/sample_code_schemaregistry_async.py
@@ -126,5 +126,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/schemaregistry/azure-schemaregistry/samples/async_samples/schema_registry_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry/samples/async_samples/schema_registry_async.py
@@ -93,5 +93,4 @@ async def main():
         )
 
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+asyncio.run(main())


### PR DESCRIPTION
# Description

As https://github.com/Azure/azure-sdk-for-python/issues/21207 mentions, some samples are using a loop variable for simple callbacks when this can be done by using the new run method of asyncio. This PR remedies the issue for the schemaregistry library.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
