### PR TITLE
[tables] update samples to use asyncio.run

### DIFF
--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_authentication_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_authentication_async.py
@@ -95,5 +95,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_batching_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_batching_async.py
@@ -102,5 +102,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_copy_table_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_copy_table_async.py
@@ -129,5 +129,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_create_client_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_create_client_async.py
@@ -69,5 +69,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_create_delete_table_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_create_delete_table_async.py
@@ -105,5 +105,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_insert_delete_entities_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_insert_delete_entities_async.py
@@ -111,5 +111,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_query_table_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_query_table_async.py
@@ -177,5 +177,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_query_tables_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_query_tables_async.py
@@ -86,5 +86,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/sdk/tables/azure-data-tables/samples/async_samples/sample_update_upsert_merge_entities_async.py
+++ b/sdk/tables/azure-data-tables/samples/async_samples/sample_update_upsert_merge_entities_async.py
@@ -195,5 +195,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
# Description

As https://github.com/Azure/azure-sdk-for-python/issues/21207 mentions, some samples are using a loop variable for simple callbacks when this can be done by using the new run method of asyncio. This PR remedies the issue for the tables library.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
