### PR TITLE
[SchemaRegistry] re-record test

### DIFF
--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/recordings/test_avro_encoder.pyTestAvroEncodertest_parse_record_name.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/recordings/test_avro_encoder.pyTestAvroEncodertest_parse_record_name.json
@@ -7,7 +7,7 @@
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-identity/1.11.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-identity/1.12.0b1 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -17,17 +17,17 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 19 Sep 2022 19:05:03 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:17 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=An1-XPQZGjVCh2uzUrOCWmc; expires=Wed, 19-Oct-2022 19:05:04 GMT; path=/; secure; HttpOnly; SameSite=None",
-          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrTS8qvrJtvpX7YUdKCqZ_QjNi_ooqxBCmQ_0SYnbRj5wkabMwqDQ4ZT3jGCke3dlJQujNCH-aOnK31vXMM8_KYuaG7ZWaI43Ch4LlX1ab16fArXYHqwCluRyewblvkWATXVA8lWDXT6kWUptWV0eW1pxC9eZU6SpbapC1nyZCpOMgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AvNQi4xV8mlHij-SJGiZfow; expires=Thu, 20-Oct-2022 17:57:18 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrbdK9MMENoEywcWk3cdaiXRCONWTwSChr3cjI3KreLOWZGVbDgPqvs-9LvILw4ZpVbq7Ag1ONzNW_ppRjz7m3jFJysZEfetwcecPXv_IXExiLKu3jXlUuFxvWRb9rFI3B6Sbm2NS-fhmGtCQVgN3qwwQa5Vy8HvuxKTK-k_Ofz7kgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "2.1.13672.7 - EUS ProdSlices",
+        "x-ms-ests-server": "2.1.13672.7 - NCUS ProdSlices",
         "X-XSS-Protection": "0"
       },
       "ResponseBody": {
@@ -105,8 +105,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Cookie": "fpc=An1-XPQZGjVCh2uzUrOCWmc; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
-        "User-Agent": "azsdk-python-identity/1.11.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "Cookie": "fpc=AvNQi4xV8mlHij-SJGiZfow; stsservicecookie=estsfd; x-ms-gateway-slice=estsfd",
+        "User-Agent": "azsdk-python-identity/1.12.0b1 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -116,10 +116,10 @@
         "Cache-Control": "max-age=86400, private",
         "Content-Length": "945",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 19 Sep 2022 19:05:03 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:17 GMT",
         "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
         "Set-Cookie": [
-          "fpc=An1-XPQZGjVCh2uzUrOCWmc; expires=Wed, 19-Oct-2022 19:05:04 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "fpc=AvNQi4xV8mlHij-SJGiZfow; expires=Thu, 20-Oct-2022 17:57:18 GMT; path=/; secure; HttpOnly; SameSite=None",
           "x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly",
           "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly"
         ],
@@ -184,7 +184,7 @@
         "Connection": "keep-alive",
         "Content-Length": "166",
         "Content-Type": "application/json; serialization=Avro",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "namespace": "thrownaway",
@@ -200,7 +200,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 19:05:05 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:20 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User.avro/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "cd7b6df270514cdbb3a2f64c126e69db",
@@ -220,13 +220,13 @@
         "Accept": "application/json; serialization=Avro",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; serialization=Avro",
-        "Date": "Mon, 19 Sep 2022 19:05:06 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:20 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User.avro/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "cd7b6df270514cdbb3a2f64c126e69db",
@@ -259,7 +259,7 @@
         "Connection": "keep-alive",
         "Content-Length": "122",
         "Content-Type": "application/json; serialization=Avro",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "User",
@@ -274,7 +274,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 19:05:06 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:21 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "8aa971e1407a4838845220529b0819ce",
@@ -294,13 +294,13 @@
         "Accept": "application/json; serialization=Avro",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; serialization=Avro",
-        "Date": "Mon, 19 Sep 2022 19:05:07 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:21 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "8aa971e1407a4838845220529b0819ce",

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/recordings/test_avro_encoder_async.pyTestAvroEncoderAsynctest_parse_record_name.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/recordings/test_avro_encoder_async.pyTestAvroEncoderAsynctest_parse_record_name.json
@@ -8,7 +8,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "166",
         "Content-Type": "application/json; serialization=Avro",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "namespace": "thrownaway",
@@ -24,7 +24,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 19:03:55 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:07 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User.avro/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "cd7b6df270514cdbb3a2f64c126e69db",
@@ -43,13 +43,13 @@
       "RequestHeaders": {
         "Accept": "application/json; serialization=Avro",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; serialization=Avro",
-        "Date": "Mon, 19 Sep 2022 19:03:56 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:07 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User.avro/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "cd7b6df270514cdbb3a2f64c126e69db",
@@ -81,7 +81,7 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "122",
         "Content-Type": "application/json; serialization=Avro",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": {
         "name": "User",
@@ -96,7 +96,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 19:03:57 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:08 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "8aa971e1407a4838845220529b0819ce",
@@ -115,13 +115,13 @@
       "RequestHeaders": {
         "Accept": "application/json; serialization=Avro",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.10.4 (Windows-10-10.0.22000-SP0)"
+        "User-Agent": "azsdk-python-azureschemaregistry/1.0.0 Python/3.9.0 (Windows-10-10.0.22000-SP0)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; serialization=Avro",
-        "Date": "Mon, 19 Sep 2022 19:03:57 GMT",
+        "Date": "Tue, 20 Sep 2022 17:57:08 GMT",
         "Location": "https://fake_resource.servicebus.windows.net/$schemagroups/fakegroup/schemas/User/versions/1?api-version=2021-10",
         "Schema-Group-Name": "fakegroup",
         "Schema-Id": "8aa971e1407a4838845220529b0819ce",


### PR DESCRIPTION
Potential fix for failing regression test for `test_parse_record_name`, which is failing with error:
`E           Content: {"Message":"Unable to find a record for the request PUT https://fake_resource.servicebus.windows.net/$schemaGroups/fakegroup/schemas/record?api-version=2021-10\nMethod doesn\u0027t match, request \u003CPUT\u003E record \u003CGET\u003E\nUri doesn\u0027t match:\n    request \u003Chttps://fake_resource.servicebus.windows.net/$schemaGroups/fakegroup/schemas/record?api-version=2021-10\u003E\n    record  \u003C***/***/v2.0/.well-known/openid-configuration\u003E\nHeader differences:\n    \u003CAccept\u003E values differ, request \u003Capplication/json\u003E, record \u003C*/*\u003E\n    \u003CContent-Length\u003E is absent in record, value \u003C76\u003E\n    \u003CContent-Type\u003E is absent in record, value \u003Capplication/json; serialization=Avro\u003E\nBody differences:\nRequest has body but record doesn\u0027t\n","Status":"NotFound"}`