### PR TITLE
[ML] registries - fix promote model bugs

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
@@ -111,7 +111,7 @@ class ModelOperations(_ScopeDependentOperations):
             sas_uri = None
 
             if self._registry_name:
-                # Case of promote model to registry
+                # Case of copy model to registry
                 if isinstance(model, WorkspaceModelReference):
                     # verify that model is not already in registry
                     try:
@@ -447,10 +447,10 @@ class ModelOperations(_ScopeDependentOperations):
         return Model._from_rest_object(result)
 
     # pylint: disable=no-self-use
-    def _prepare_to_promote(self, model: Model, name: str = None, version: str = None) -> WorkspaceModelReference:
+    def _prepare_to_copy(self, model: Model, name: str = None, version: str = None) -> WorkspaceModelReference:
 
         """Returns WorkspaceModelReference
-        to promote a registered model to registry given the asset id
+        to copy a registered model to registry given the asset id
 
         :param model: Registered model
         :type model: Model
@@ -463,7 +463,7 @@ class ModelOperations(_ScopeDependentOperations):
         workspace = self._service_client.workspaces.get(
             resource_group_name=self._resource_group_name, workspace_name=self._workspace_name
         )
-        workspace_guid = workspace.discovery_url.split("/")[5]
+        workspace_guid = workspace.workspace_id
         workspace_location = workspace.location
 
         # Get model asset ID


### PR DESCRIPTION
# Description

Registries - Fix promote model bugs:
-  Instead of trying to get the workspace GUID from discoveryUrl we should use workspace_id property value.
-  Rename _prepare_to_promote to _prepare_to_copy

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
