### PR TITLE
[ML] Add type discriminator for scale_settings subclasses

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/scale_settings_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/scale_settings_schema.py
@@ -18,7 +18,7 @@ module_logger = logging.getLogger(__name__)
 
 
 class DefaultScaleSettingsSchema(metaclass=PatchedSchemaMeta):
-    scale_type = StringTransformedEnum(
+    type = StringTransformedEnum(
         required=True,
         allowed_values=ScaleType.DEFAULT,
         casing_transform=camel_to_snake,
@@ -33,7 +33,7 @@ class DefaultScaleSettingsSchema(metaclass=PatchedSchemaMeta):
 
 
 class TargetUtilizationScaleSettingsSchema(metaclass=PatchedSchemaMeta):
-    scale_type = StringTransformedEnum(
+    type = StringTransformedEnum(
         required=True,
         allowed_values=ScaleType.TARGET_UTILIZATION,
         casing_transform=camel_to_snake,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/scale_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/scale_settings.py
@@ -23,12 +23,12 @@ module_logger = logging.getLogger(__name__)
 class OnlineScaleSettings(RestTranslatableMixin):
     """Scale settings for online deployment.
 
-    :param scale_type: Type of the scale settings, allowed values are "default" and "target_utilization".
-    :type scale_type: str
+    :param type: Type of the scale settings, allowed values are "default" and "target_utilization".
+    :type type: str
     """
 
-    def __init__(self, scale_type: str, **kwargs):  # pylint: disable=unused-argument
-        self.scale_type = camel_to_snake(scale_type)
+    def __init__(self, type: str, **kwargs):  # pylint: disable=unused-argument
+        self.type = camel_to_snake(type)
 
     @abstractmethod
     def _to_rest_object(self) -> RestOnlineScaleSettings:
@@ -36,7 +36,7 @@ class OnlineScaleSettings(RestTranslatableMixin):
 
     def _merge_with(self, other: "OnlineScaleSettings") -> None:
         if other:
-            self.scale_type = other.scale_type or self.scale_type
+            self.type = other.type or self.type
 
     @classmethod
     def _from_rest_object(  # pylint: disable=arguments-renamed
@@ -47,7 +47,7 @@ class OnlineScaleSettings(RestTranslatableMixin):
         if isinstance(settings, RestTargetUtilizationScaleSettings):
             return TargetUtilizationScaleSettings._from_rest_object(settings)
 
-        msg = f"Unsupported online scale setting type {settings.scale_type}."
+        msg = f"Unsupported online scale setting type {settings.type}."
         raise DeploymentException(
             message=msg,
             target=ErrorTarget.ONLINE_DEPLOYMENT,
@@ -57,11 +57,15 @@ class OnlineScaleSettings(RestTranslatableMixin):
 
 
 class DefaultScaleSettings(OnlineScaleSettings):
-    """Default scale settings."""
+    """Default scale settings.
+
+    :ivar type: Default scale settings type. Set automatically to "default" for this class.
+    :vartype type: str
+    """
 
     def __init__(self, **kwargs):
         super(DefaultScaleSettings, self).__init__(
-            scale_type=ScaleType.DEFAULT.value,  # pylint: disable=no-member
+            type=ScaleType.DEFAULT.value,  # pylint: disable=no-member
         )
 
     def _to_rest_object(self) -> RestDefaultScaleSettings:
@@ -77,7 +81,7 @@ class DefaultScaleSettings(OnlineScaleSettings):
         if not other:
             return False
         # only compare mutable fields
-        return self.scale_type.lower() == other.scale_type.lower()
+        return self.type.lower() == other.type.lower()
 
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
@@ -95,6 +99,8 @@ class TargetUtilizationScaleSettings(OnlineScaleSettings):
     :type polling_interval: str
     :param target_utilization_percentage:
     :type target_utilization_percentage: int
+    :ivar type: Target utilization scale settings type. Set automatically to "target_utilization" for this class.
+    :vartype type: str
     """
 
     def __init__(
@@ -107,7 +113,7 @@ class TargetUtilizationScaleSettings(OnlineScaleSettings):
         **kwargs,
     ):
         super(TargetUtilizationScaleSettings, self).__init__(
-            scale_type=ScaleType.TARGET_UTILIZATION.value,  # pylint: disable=no-member
+            type=ScaleType.TARGET_UTILIZATION.value,  # pylint: disable=no-member
         )
         self.min_instances = min_instances
         self.max_instances = max_instances
@@ -148,7 +154,7 @@ class TargetUtilizationScaleSettings(OnlineScaleSettings):
             return False
         # only compare mutable fields
         return (
-            self.scale_type.lower() == other.scale_type.lower()
+            self.type.lower() == other.type.lower()
             and self.min_instances == other.min_instances
             and self.max_instances == other.max_instances
             and self.polling_interval == other.polling_interval

--- a/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_scale_settings.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_scale_settings.py
@@ -1,8 +1,5 @@
 import pytest
-import yaml
-from marshmallow import RAISE
 
-from azure.ai.ml._restclient.v2021_10_01.models import DefaultScaleSettings as RestDefaultScaleSettings
 from azure.ai.ml._restclient.v2021_10_01.models import (
     TargetUtilizationScaleSettings as RestTargetUtilizationScaleSettings,
 )
@@ -20,7 +17,7 @@ class TestScaleSettings:
             target_utilization_percentage=30,
         )
         scale_settings = TargetUtilizationScaleSettings._from_rest_object(settings=rest_scale_settings)
-        assert scale_settings.scale_type == camel_to_snake(rest_scale_settings.scale_type)
+        assert scale_settings.type == camel_to_snake(rest_scale_settings.scale_type)
         assert scale_settings.min_instances == rest_scale_settings.min_instances
         assert scale_settings.max_instances == rest_scale_settings.max_instances
         assert scale_settings.polling_interval == 1
@@ -29,4 +26,4 @@ class TestScaleSettings:
     def test_auto_scale_settings_to_objects(self) -> None:
         scale_settings = DefaultScaleSettings()
         rest_scale_settings = scale_settings._to_rest_object()
-        assert camel_to_snake(rest_scale_settings.scale_type) == scale_settings.scale_type
+        assert camel_to_snake(rest_scale_settings.scale_type) == scale_settings.type

--- a/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_scale_settings_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_scale_settings_schema.py
@@ -1,5 +1,4 @@
 import pytest
-import yaml
 from marshmallow.exceptions import ValidationError
 from marshmallow.schema import Schema
 
@@ -65,4 +64,4 @@ class TestScaleSettingsSchema:
             }
         }
         data = schema.load(input_data)
-        assert data["scale_settings"].scale_type == "target_utilization"
+        assert data["scale_settings"].type == "target_utilization"


### PR DESCRIPTION
# Description

Adding type discriminator for scale_settings type for `DefaultScaleSettings` and `TargetUtilizationScaleSettings`

Renamed `scale_type` to `type`

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
