### PR TITLE
[ML] fix bugs introduced by refactor

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -105,8 +105,9 @@ def camel_case_transformer(key, value):
 
 
 def create_requests_pipeline_with_retry(*, requests_pipeline: HttpPipeline, retries: int = 3) -> HttpPipeline:
-    """Creates an HttpPipeline identical to the provided one, except
-       with a new override
+    """Creates an HttpPipeline that reuses the same configuration as the
+    supplied pipeline (including the transport), but overwrites the
+    retry policy
 
     Args:
         requests_pipeline (HttpPipeline): Pipeline to base new one off of.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
@@ -337,7 +337,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
 
         response = self._requests_pipeline.post(endpoint.properties.scoring_uri, json=data, headers=headers)
         validate_response(response)
-        return response.text
+        return response.text()
 
     def _get_workspace_location(self) -> str:
         return self._all_operations.all_operations[AzureMLResourceType.WORKSPACE].get(self._workspace_name).location

--- a/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_online_endpoints.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_online_endpoints.py
@@ -375,7 +375,7 @@ class TestOnlineEndpointsOperations:
             properties=RestOnlineEndpoint(auth_mode="Key", scoring_uri="xxx"),
         )
         mockresponse = Mock()
-        mockresponse.text = '{"key": "value"}'
+        mockresponse.text = lambda: '{"key": "value"}'
         mockresponse.status_code = 200
 
         mocker.patch.object(mock_online_endpoint_operations._requests_pipeline, "post", return_value=mockresponse)


### PR DESCRIPTION
# Description

This pull request fixes 2 bugs introduced by a recent refactor of an http client used to send requests in the sdk:

* `ml_client.jobs.stream` no longer closes the session of the http transport
* `ml_client.online_endpoint.invoke` once again returns a `str` instead of a method.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
