### PR TITLE
Minor fix for registry CLI LIST command

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry_region_arm_details.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry_region_arm_details.py
@@ -4,19 +4,24 @@
 
 from marshmallow import ValidationError, fields, post_load, pre_dump
 
-from azure.ai.ml._schema.core.fields import NestedField, UnionField
+from azure.ai.ml._schema.core.fields import NestedField, UnionField, DumpableStringField
 from azure.ai.ml._schema.core.schema_meta import PatchedSchemaMeta
 
 from .system_created_storage_account import SystemCreatedStorageAccountSchema
-from .util import storage_account_validator
+from .system_created_acr_account import SystemCreatedAcrAccountSchema
+from .util import storage_account_validator, acr_format_validator
 
 
 # Differs from the swagger def in that the acr_details can only be supplied as a
 # single registry-wide instance, rather than a per-region list.
 class RegistryRegionArmDetailsSchema(metaclass=PatchedSchemaMeta):
+    acr_config = fields.List(
+        UnionField([DumpableStringField(validate=acr_format_validator), NestedField(SystemCreatedAcrAccountSchema)],
+        dump_only=True, is_strict=True)
+    )
     location = fields.Str()
     storage_config = fields.List(
-        UnionField([fields.Str(validate=storage_account_validator), NestedField(SystemCreatedStorageAccountSchema)])
+        UnionField([DumpableStringField(validate=storage_account_validator), NestedField(SystemCreatedStorageAccountSchema)], is_strict=True)
     )
 
     @post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
@@ -85,6 +85,9 @@ class Registry(Resource):
         # pylint: disable=no-member
         schema = RegistrySchema(context={BASE_PATH_CONTEXT_KEY: "./"})
         self.replication_locations = self.region_details
+        #if self.replication_locations and len(self.replication_locations) > 0:
+        #    if self.replication_locations[0].acr_config and len(self.replication_locations[0].acr_config) > 0:
+        #        self.container_registry = self.replication_locations[0].acr_config[0]
         return schema.dump(self)
 
     @classmethod

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
@@ -83,7 +83,9 @@ class Registry(Resource):
 
     def _to_dict(self) -> Dict:
         # pylint: disable=no-member
-        return RegistrySchema(context={BASE_PATH_CONTEXT_KEY: "./"}).dump(self)
+        schema = RegistrySchema(context={BASE_PATH_CONTEXT_KEY: "./"})
+        self.replication_locations = self.region_details
+        return schema.dump(self)
 
     @classmethod
     def _load(
@@ -116,10 +118,10 @@ class Registry(Resource):
             region_details = [
                 RegistryRegionArmDetails._from_rest_object(details) for details in real_registry.region_details
             ]
-        return Registry(
+        result = Registry(
             name=rest_obj.name,
             description=real_registry.description,
-            tags=real_registry.tags,
+            tags=rest_obj.tags,
             location=rest_obj.location,
             public_network_access=real_registry.public_network_access,
             discovery_url=real_registry.discovery_url,
@@ -128,6 +130,7 @@ class Registry(Resource):
             mlflow_registry_uri=real_registry.ml_flow_registry_uri,
             region_details=region_details,
         )
+        return result
 
     # There are differences between what our registry validation schema
     # accepts, and how we actually represent things internally.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
@@ -56,8 +56,12 @@ class RegistryOperations:
         :return: An iterator like instance of Registry objects
         :rtype: ~azure.core.paging.ItemPaged[Registry]
         """
-
-        return self._operation.list_by_subscription(cls=lambda objs: [Registry._from_rest_object(obj) for obj in objs])
+        # TODO add scope variable to allow calls to either list or
+        # list_by_subscription once the backend work for this is complete.
+        return self._operation.list(
+            resource_group_name=self._resource_group_name,
+            cls=lambda objs: [Registry._from_rest_object(obj) for obj in objs],
+        )
 
     @monitor_with_activity(logger, "Registry.Get", ActivityType.PUBLICAPI)
     def get(self, name: str = None, **kwargs: Dict) -> Registry:

--- a/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_operations.py
@@ -30,10 +30,10 @@ def mock_registry_operation(
 class TestRegistryOperation:
     def test_list(self, mock_registry_operation: RegistryOperations) -> None:
         mock_registry_operation.list()
-        mock_registry_operation._operation.list_by_subscription.assert_called_once()
+        mock_registry_operation._operation.list.assert_called_once()
 
-    def test_get(self, mock_registry_operation: RegistryOperations) -> None:
-        mock_registry_operation.get("random_name")
+    def test_get(self, mock_registry_operation: RegistryOperations, randstr: Callable[[], str]) -> None:
+        mock_registry_operation.get(randstr())
         mock_registry_operation._operation.get.assert_called_once()
 
     def test_check_registry_name(self, mock_registry_operation: RegistryOperations):


### PR DESCRIPTION
# Description

Minor changes to the registry LIST operation's SDK code to use the autorest 'list' function instead of the 'list_by_subscription' function, which although preferrable, doesn't have an implemented backend yet.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.

e2e Test coverage for registry operations is dependent on a few more other PRs, and is out-of-scope of a minor repo sync/fix PR.