### PR TITLE
Don't wait in LRO before updating status

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- LRO polling will not wait anymore before doing the first status check  #26376
+
 ## 1.25.1 (2022-09-01)
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/polling/async_base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/async_base_polling.py
@@ -77,6 +77,7 @@ class AsyncLROBasePolling(LROBasePolling):
         :raises: BadResponse if response invalid.
         """
 
+        await self.update_status()
         while not self.finished():
             await self._delay()
             await self.update_status()

--- a/sdk/core/azure-core/azure/core/polling/async_base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/async_base_polling.py
@@ -76,8 +76,8 @@ class AsyncLROBasePolling(LROBasePolling):
         :raises: BadStatus if response status invalid.
         :raises: BadResponse if response invalid.
         """
-
-        await self.update_status()
+        if not self.finished():
+            await self.update_status()
         while not self.finished():
             await self._delay()
             await self.update_status()

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -548,6 +548,7 @@ class LROBasePolling(PollingMethod):  # pylint: disable=too-many-instance-attrib
         :raises: BadResponse if response invalid.
         """
 
+        self.update_status()
         while not self.finished():
             self._delay()
             self.update_status()

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -547,8 +547,8 @@ class LROBasePolling(PollingMethod):  # pylint: disable=too-many-instance-attrib
         :raises: BadStatus if response status invalid.
         :raises: BadResponse if response invalid.
         """
-
-        self.update_status()
+        if not self.finished():
+            self.update_status()
         while not self.finished():
             self._delay()
             self.update_status()


### PR DESCRIPTION
We don't want to wait between the initial response and the first call of status check.