### PR TITLE
Check status in initial response for O-L and A-AO LRO flow

### DIFF
--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -268,6 +268,11 @@ class OperationResourcePolling(LongRunningOperation):
 
         self._set_async_url_if_present(response)
 
+        try:
+            return self.get_status(pipeline_response)
+        except BadResponse:
+            pass
+
         if response.status_code in {200, 201, 202, 204} and self._async_url:
             return "InProgress"
         raise OperationFailed("Operation failed or canceled")

--- a/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
@@ -182,7 +182,7 @@ async def test_post(async_pipeline_client_builder, deserialization_cb, http_requ
                 'location': 'http://example.org/location',
                 'operation-location': 'http://example.org/async_monitor',
             },
-            ''
+            None
         )
 
         async def send(request, **kwargs):
@@ -268,7 +268,7 @@ async def test_post_resource_location(async_pipeline_client_builder, deserializa
             {
                 'operation-location': 'http://example.org/async_monitor',
             },
-            ''
+            None
         )
 
         async def send(request, **kwargs):
@@ -621,7 +621,7 @@ async def test_long_running_delete(http_request, http_response):
         http_response,
         'DELETE', 202,
         {'operation-location': ASYNC_URL},
-        body=""
+        body=None
     )
     polling_method = AsyncLROBasePolling(0)
     poll = await async_poller(CLIENT, response,
@@ -765,7 +765,7 @@ async def test_post_final_state_via(async_pipeline_client_builder, deserializati
             'location': 'http://example.org/location',
             'operation-location': 'http://example.org/async_monitor',
         },
-        ''
+        None
     )
 
     async def send(request, **kwargs):

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -202,7 +202,7 @@ def test_post(pipeline_client_builder, deserialization_cb, http_request, http_re
                 'location': 'http://example.org/location',
                 'operation-location': 'http://example.org/async_monitor',
             },
-            ''
+            None
         )
 
         def send(request, **kwargs):
@@ -287,7 +287,7 @@ def test_post_resource_location(pipeline_client_builder, deserialization_cb, htt
             {
                 'operation-location': 'http://example.org/async_monitor',
             },
-            ''
+            None
         )
 
         def send(request, **kwargs):
@@ -630,7 +630,7 @@ class TestBasePolling(object):
             http_response,
             'DELETE', 202,
             {'operation-location': ASYNC_URL},
-            body=""
+            body=None
         )
         CLIENT.http_request_type = http_request
         CLIENT.http_response_type = http_response
@@ -773,7 +773,7 @@ class TestBasePolling(object):
                 'location': 'http://example.org/location',
                 'operation-location': 'http://example.org/async_monitor',
             },
-            ''
+            None
         )
 
         def send(request, **kwargs):


### PR DESCRIPTION
For LRO, in presence of Operation-Location or Azure-AsyncOperation and a 2xx status code of the initial response, polling algorithm must check the “status” key for success. If success, do not poll on the header but return immediately (could be doing a GET on resourceLocation or returning the payload directly).
This is a change of behavior from today, as right now the mere presence of Operation-Location or Azure-AsyncOperation by itself triggers a polling, irrespectively of which exact 2xx or “status” is received in the initial response.
 
