### PR TITLE
[ML] Update batch endpoint/deployment operations to return LROPoller

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
@@ -32,6 +32,17 @@ module_logger = logging.getLogger(__name__)
 initialize_logger_info(module_logger, terminator="")
 
 
+def get_duration(start_time: float) -> None:
+    """Calculates the duration of the Long running operation took to finish
+
+    :param start_time: Start time
+    :type start_time: float
+    """
+    end_time = time.time()
+    duration = divmod(int(round(end_time - start_time)), 60)
+    module_logger.warning("(%sm %ss)\n", duration[0], duration[1])
+
+
 def polling_wait(
     poller: Union[LROPoller, Future],
     message: str = None,
@@ -67,9 +78,7 @@ def polling_wait(
         module_logger.warning("Timeout waiting for long running operation")
 
     if start_time:
-        end_time = time.time()
-        duration = divmod(int(round(end_time - start_time)), 60)
-        module_logger.warning("(%sm %ss)\n", duration[0], duration[1])
+        get_duration(start_time)
 
 
 def local_endpoint_polling_wrapper(func: Callable, message: str, **kwargs) -> Any:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -4,14 +4,14 @@
 
 # pylint: disable=protected-access
 
-import time
-from typing import Any, Dict, Union
+from typing import Dict, List
 
+from azure.ai.ml._restclient.v2020_09_01_dataplanepreview.models import BatchJobResource
 from azure.ai.ml._restclient.v2022_05_01 import AzureMachineLearningWorkspaces as ServiceClient052022
 from azure.ai.ml._scope_dependent_operations import OperationsContainer, OperationScope, _ScopeDependentOperations
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._utils._azureml_polling import AzureMLPolling
-from azure.ai.ml._utils._endpoint_utils import polling_wait, upload_dependencies
+from azure.ai.ml._utils._endpoint_utils import upload_dependencies
 from azure.ai.ml._utils._http_utils import HttpPipeline
 from azure.ai.ml._utils._logger_utils import OpsLogger
 from azure.ai.ml._utils.utils import _get_mfe_base_url_from_discovery_service, modified_operation_client
@@ -20,6 +20,7 @@ from azure.ai.ml.entities import BatchDeployment
 from azure.core.credentials import TokenCredential
 from azure.core.paging import ItemPaged
 from azure.core.polling import LROPoller
+from azure.core.tracing.decorator import distributed_trace
 
 from ._operation_orchestrator import OperationOrchestrator
 
@@ -54,17 +55,17 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
 
         self._requests_pipeline: HttpPipeline = kwargs.pop("requests_pipeline")
 
+    @distributed_trace
     @monitor_with_activity(logger, "BatchDeployment.BeginCreateOrUpdate", ActivityType.PUBLICAPI)
-    def begin_create_or_update(self, deployment: BatchDeployment, **kwargs: Any) -> Union[BatchDeployment, LROPoller]:
+    def begin_create_or_update(self, deployment: BatchDeployment) -> LROPoller[BatchDeployment]:
         """Create or update a batch deployment.
 
-        :param endpoint: The deployment entity.
-        :type endpoint: BatchDeployment
+        :param deployment: The deployment entity.
+        :type deployment: ~azure.ai.ml.entities.BatchDeployment
         :return: A poller to track the operation status.
-        :rtype: LROPoller
+        :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.BatchDeployment]
         """
 
-        no_wait = kwargs.get("no_wait", False)
         module_logger.debug("Checking endpoint %s exists", deployment.endpoint_name)
         self._batch_endpoint_operations.get(
             endpoint_name=deployment.endpoint_name,
@@ -87,23 +88,15 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                 endpoint_name=deployment.endpoint_name,
                 deployment_name=deployment.name,
                 body=deployment_rest,
-                polling=not no_wait,
                 **self._init_kwargs,
+                cls=lambda response, deserialized, headers: BatchDeployment._from_rest_object(deserialized),
             )
-            if no_wait:
-                module_logger.info(
-                    "Batch deployment create/update request initiated. "
-                    "Status can be checked using "
-                    "`az ml batch-deployment show -e %s -n %s`\n",
-                    deployment.endpoint_name,
-                    deployment.name,
-                )
-                return poller
-            return BatchDeployment._from_rest_object(poller.result())
+            return poller
 
         except Exception as ex:
             raise ex
 
+    @distributed_trace
     @monitor_with_activity(logger, "BatchDeployment.Get", ActivityType.PUBLICAPI)
     def get(self, name: str, endpoint_name: str) -> BatchDeployment:
         """Get a deployment resource.
@@ -113,7 +106,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
         :return: a deployment entity
-        :rtype: BatchDeployment
+        :rtype: ~azure.ai.ml.entities.BatchDeployment
         """
 
         deployment = BatchDeployment._from_rest_object(
@@ -128,22 +121,23 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
         deployment.endpoint_name = endpoint_name
         return deployment
 
+    @distributed_trace
     @monitor_with_activity(logger, "BatchDeployment.BeginDelete", ActivityType.PUBLICAPI)
-    def begin_delete(self, name: str, endpoint_name: str, **kwargs: Any) -> Union[None, LROPoller]:
+    def begin_delete(self, name: str, endpoint_name: str) -> LROPoller[None]:
         """Delete a batch deployment.
 
-        :param name: Name of the batch endpoint.
+        :param name: Name of the batch deployment.
         :type name: str
+        :param endpoint_name: Name of the batch endpoint
+        :type endpoint_name: str
         :return: A poller to track the operation status.
-        :rtype: Optional[LROPoller]
+        :rtype: ~azure.core.polling.LROPoller[None]
         """
-        start_time = time.time()
         path_format_arguments = {
             "endpointName": name,
             "resourceGroupName": self._resource_group_name,
             "workspaceName": self._workspace_name,
         }
-        no_wait = kwargs.get("no_wait", False)
 
         delete_poller = self._batch_deployment.begin_delete(
             resource_group_name=self._resource_group_name,
@@ -154,24 +148,13 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                 LROConfigurations.POLL_INTERVAL,
                 path_format_arguments=path_format_arguments,
                 **self._init_kwargs,
-            )
-            if not no_wait
-            else False,
+            ),
             polling_interval=LROConfigurations.POLL_INTERVAL,
             **self._init_kwargs,
         )
-        if no_wait:
-            module_logger.info(
-                "Delete request initiated. "
-                "Status can be checked using "
-                "`az ml batch-deployment show -e %s -n %s`\n",
-                endpoint_name,
-                name,
-            )
-            return delete_poller
-        message = f"Deleting batch deployment {name} "
-        polling_wait(poller=delete_poller, start_time=start_time, message=message)
+        return delete_poller
 
+    @distributed_trace
     @monitor_with_activity(logger, "BatchDeployment.List", ActivityType.PUBLICAPI)
     def list(self, endpoint_name: str) -> ItemPaged[BatchDeployment]:
         """List a deployment resource.
@@ -189,18 +172,19 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
             **self._init_kwargs,
         )
 
+    @distributed_trace
     @monitor_with_activity(logger, "BatchDeployment.ListJobs", ActivityType.PUBLICAPI)
-    def list_jobs(self, endpoint_name: str, name: str = None) -> list:
+    def list_jobs(self, endpoint_name: str, *, name: str = None) -> List[BatchJobResource]:
         """List jobs under the provided batch endpoint deployment. This is only
         valid for batch endpoint.
 
-        :param endpoint_name: Name of the endpoint.
+        :param endpoint_name: Name of endpoint.
         :type endpoint_name: str
-        :param name: Name of the deployment.
+        :param name: (Optional) Name of deployment.
         :type name: str
         :raise: Exception if endpoint_type is not BATCH_ENDPOINT_TYPE
         :return: List of jobs
-        :rtype: list
+        :rtype: List[BatchJobResource]
         """
 
         workspace_operations = self._all_operations.all_operations[AzureMLResourceType.WORKSPACE]

--- a/sdk/ml/azure-ai-ml/tests/batch_services/e2etests/test_batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/tests/batch_services/e2etests/test_batch_deployment.py
@@ -25,12 +25,14 @@ def deployEndpointAndDeployment(client: MLClient, endpoint: BatchEndpoint, deplo
     :param BatchDeployment deployment: _description_
     :yield _type_: _description_
     """
-    client.batch_endpoints.begin_create_or_update(endpoint)
-    client.batch_deployments.begin_create_or_update(deployment)
+    endpoint_res = client.batch_endpoints.begin_create_or_update(endpoint)
+    endpoint_res = endpoint_res.result()
+    deployment_res = client.batch_deployments.begin_create_or_update(deployment)
+    deployment_res = deployment_res.result()
 
     yield (endpoint, deployment)
 
-    client.batch_endpoints.begin_delete(name=endpoint.name, no_wait=True)
+    client.batch_endpoints.begin_delete(name=endpoint.name)
 
 
 @pytest.mark.skip(
@@ -71,7 +73,7 @@ class TestBatchDeployment(AzureRecordedTestCase):
             deployment_name=deployment.name,
             input=":".join((data_with_2_versions, "1")),
         )
-        client.batch_endpoints.begin_delete(name=endpoint.name, no_wait=True)
+        client.batch_endpoints.begin_delete(name=endpoint.name)
 
     @pytest.mark.e2etest
     def test_batch_deployment_dependency_label_resolution(self, client: MLClient, randstr: Callable[[], str]) -> None:
@@ -114,11 +116,13 @@ class TestBatchDeployment(AzureRecordedTestCase):
         )
 
         # create an endpoint
-        client.batch_endpoints.begin_create_or_update(endpoint)
+        endpoint_res = client.batch_endpoints.begin_create_or_update(endpoint)
+        endpoint_res = endpoint_res.result()
         # create a deployment
-        client.batch_deployments.begin_create_or_update(deployment)
+        deployment_res = client.batch_deployments.begin_create_or_update(deployment)
+        deployment_res = deployment_res.result()
         dep = client.batch_deployments.get(name=deployment.name, endpoint_name=endpoint.name)
-        client.batch_endpoints.begin_delete(name=endpoint.name, no_wait=True)
+        client.batch_endpoints.begin_delete(name=endpoint.name)
 
         resolved_environment = AMLVersionedArmId(dep.environment)
         resolved_model = AMLVersionedArmId(dep.model)

--- a/sdk/ml/azure-ai-ml/tests/batch_services/e2etests/test_batch_endpoint.py
+++ b/sdk/ml/azure-ai-ml/tests/batch_services/e2etests/test_batch_endpoint.py
@@ -25,6 +25,7 @@ class TestBatchEndpoint(AzureRecordedTestCase):
         endpoint.name = name
         # endpoint.properties = properties
         obj = client.batch_endpoints.begin_create_or_update(endpoint=endpoint, no_wait=False)
+        obj = obj.result()
         assert obj is not None
         assert name == obj.name
         # assert obj.properties == properties
@@ -32,7 +33,8 @@ class TestBatchEndpoint(AzureRecordedTestCase):
         get_obj = client.batch_endpoints.get(name=name)
         assert get_obj.name == name
 
-        client.batch_endpoints.begin_delete(name=name)
+        delete_res = client.batch_endpoints.begin_delete(name=name)
+        delete_res = delete_res.result()
         try:
             client.batch_endpoints.get(name=name)
         except Exception as e:
@@ -50,14 +52,16 @@ class TestBatchEndpoint(AzureRecordedTestCase):
         name = "be-e2e-" + uuid.uuid4().hex[:25]
         endpoint = load_batch_endpoint(endpoint_yaml)
         endpoint.name = name
-        obj = client.batch_endpoints.begin_create_or_update(endpoint=endpoint, no_wait=False)
+        obj = client.batch_endpoints.begin_create_or_update(endpoint=endpoint)
+        obj = obj.result()
         assert obj is not None
         assert name == obj.name
 
         get_obj = client.batch_endpoints.get(name=name)
         assert get_obj.name == name
 
-        client.batch_endpoints.begin_delete(name=name)
+        delete_res = client.batch_endpoints.begin_delete(name=name)
+        delete_res = delete_res.result()
         try:
             client.batch_endpoints.get(name=name)
         except Exception as e:


### PR DESCRIPTION
# Description

Update batch endpoint and batch deployment operations that start with `begin` prefix to return a LROPoller 

Ex. 
begin_create_or_update
begin_delete

Update documentation to reflect the changes and update e2etests accordingly.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
