### PR TITLE
Updates to Registry Schema Classes

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry.py
@@ -4,12 +4,15 @@
 
 from marshmallow import fields
 
-from azure.ai.ml._schema.core.fields import NestedField, StringTransformedEnum
+from azure.ai.ml._schema.core.fields import NestedField, StringTransformedEnum, UnionField
 from azure.ai.ml._schema.core.resource import ResourceSchema
 from azure.ai.ml._utils.utils import snake_to_pascal
 from azure.ai.ml.constants._common import PublicNetworkAccess
+from azure.ai.ml.constants._registry import AcrAccountSku
+from azure.ai.ml.entities._registry.registry_support_classes import SystemCreatedAcrAccount
 
 from .registry_region_arm_details import RegistryRegionArmDetailsSchema
+from .system_created_acr_account import SystemCreatedAcrAccountSchema
 from .util import acr_format_validator
 
 
@@ -34,7 +37,12 @@ class RegistrySchema(ResourceSchema):
     # in replication_locations. This is different from the internal swagger
     # definition, which has a per-region list of acr accounts.
     # Per-region acr account configuration is NOT possible through yaml configs for now.
-    container_registry = fields.Str(validate=acr_format_validator)
+    container_registry = UnionField(
+        [fields.Str(validate=acr_format_validator), NestedField(SystemCreatedAcrAccountSchema)],
+        required=False,
+        is_strict=True,
+        load_default=SystemCreatedAcrAccount(acr_account_sku=AcrAccountSku.PREMIUM),
+    )
     # managed_resource_group = ignored - output only
     # mlflow_registry_uri = ignored - output only
     # discovery_url = ignored - output only

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_acr_account.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_acr_account.py
@@ -1,0 +1,31 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+from marshmallow import ValidationError, fields, post_load, pre_dump
+
+from azure.ai.ml._schema import StringTransformedEnum
+from azure.ai.ml._schema.core.schema_meta import PatchedSchemaMeta
+from azure.ai.ml.constants._registry import AcrAccountSku
+
+
+class SystemCreatedAcrAccountSchema(metaclass=PatchedSchemaMeta):
+    arm_resource_id = fields.Str(dump_only=True)
+    acr_account_sku = StringTransformedEnum(
+        allowed_values=[sku.value for sku in AcrAccountSku], casing_transform=lambda x: x.lower()
+    )
+
+    @post_load
+    def make(self, data, **kwargs):
+        from azure.ai.ml.entities import SystemCreatedAcrAccount
+
+        data.pop("type", None)
+        return SystemCreatedAcrAccount(**data)
+
+    @pre_dump
+    def predump(self, data, **kwargs):
+        from azure.ai.ml.entities import SystemCreatedAcrAccount
+
+        if not isinstance(data, SystemCreatedAcrAccount):
+            raise ValidationError("Cannot dump non-SystemCreatedAcrAccount object into SystemCreatedAcrAccountSchema")
+        return data

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_storage_account.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_storage_account.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-from marshmallow import ValidationError, fields, post_load, pre_dump, validate
+from marshmallow import ValidationError, fields, post_load, pre_dump
 
 from azure.ai.ml._schema import StringTransformedEnum
 from azure.ai.ml._schema.core.schema_meta import PatchedSchemaMeta
@@ -10,8 +10,7 @@ from azure.ai.ml.constants._registry import StorageAccountType
 
 
 class SystemCreatedStorageAccountSchema(metaclass=PatchedSchemaMeta):
-    # arm_resource_id = ignored - output only
-    # storage_account_count = fields.Int() - disabled until we finish ARM V AME debate.
+    arm_resource_id = fields.Str(dump_only=True)
     storage_account_hns = fields.Bool()
     storage_account_type = StringTransformedEnum(
         allowed_values=[accountType.value for accountType in StorageAccountType], casing_transform=lambda x: x.lower()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_registry.py
@@ -16,6 +16,11 @@ class StorageAccountType(str, Enum):
     PREMIUM_ZRS = "Premium_ZRS".lower()
 
 
+# When will other values be allowed?
+class AcrAccountSku(str, Enum):
+    PREMIUM = "Premium".lower()
+
+
 # based on /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/
 # # ...providers/Microsoft.Storage/storageAccounts/{StorageAccountName}
 STORAGE_ACCOUNT_FORMAT = re.compile(

--- a/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_schema.py
@@ -6,7 +6,7 @@ from marshmallow.exceptions import ValidationError
 
 from azure.ai.ml._schema.registry import RegistrySchema
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, PublicNetworkAccess
-from azure.ai.ml.constants._registry import StorageAccountType
+from azure.ai.ml.constants._registry import AcrAccountSku, StorageAccountType
 from azure.ai.ml.entities import RegistryRegionArmDetails, SystemCreatedAcrAccount, SystemCreatedStorageAccount
 from azure.ai.ml.entities._util import load_from_dict
 
@@ -46,6 +46,26 @@ class TestRegistrySchema:
             assert isinstance(storages[1], SystemCreatedStorageAccount)
             assert not storages[1].storage_account_hns
             assert storages[1].storage_account_type == StorageAccountType.STANDARD_RAGRS
+
+    def test_deserialize_from_yaml_with_system_acr(self) -> None:
+        path = Path("./tests/test_configs/registry/registry_valid_2.yaml")
+        with open(path, "r") as f:
+            target = yaml.safe_load(f)
+            context = {BASE_PATH_CONTEXT_KEY: path.parent}
+            registry = load_from_dict(RegistrySchema, target, context)
+            assert registry
+            assert isinstance(registry["container_registry"], SystemCreatedAcrAccount)
+            assert registry["container_registry"].acr_account_sku == AcrAccountSku.PREMIUM
+
+    def test_deserialize_from_yaml_with_no_acr(self) -> None:
+        path = Path("./tests/test_configs/registry/registry_valid_3.yaml")
+        with open(path, "r") as f:
+            target = yaml.safe_load(f)
+            context = {BASE_PATH_CONTEXT_KEY: path.parent}
+            registry = load_from_dict(RegistrySchema, target, context)
+            assert registry
+            assert isinstance(registry["container_registry"], SystemCreatedAcrAccount)
+            assert registry["container_registry"].acr_account_sku == AcrAccountSku.PREMIUM
 
     def test_deserialize_bad_storage_account_type(self) -> None:
         path = Path("./tests/test_configs/registry/registry_bad_storage_account_type.yaml")

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_2.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_2.yaml
@@ -1,0 +1,17 @@
+description: This is a registry with a system-created acr
+name: registry_name
+id: registry_id
+tags:
+  purpose: testing
+  other_tag: value
+location: EastUS2
+public_network_access: Disabled
+intellectual_property_publisher: registry_publisher
+replication_locations:
+  - location: EastUS
+    storage_config:
+    - /subscriptions/sub_id/resourceGroups/some_rg/providers/Microsoft.Storage/storageAccounts/some_storage_account
+    - storage_account_hns: False
+      storage_account_type: Standard_RAGRS
+container_registry:
+  acr_account_sku: premium

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_3.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_3.yaml
@@ -1,0 +1,15 @@
+description: This is a registry with no acr
+name: registry_name
+id: registry_id
+tags:
+  purpose: testing
+  other_tag: value
+location: EastUS2
+public_network_access: Disabled
+intellectual_property_publisher: registry_publisher
+replication_locations:
+  - location: EastUS
+    storage_config:
+    - /subscriptions/sub_id/resourceGroups/some_rg/providers/Microsoft.Storage/storageAccounts/some_storage_account
+    - storage_account_hns: False
+      storage_account_type: Standard_RAGRS


### PR DESCRIPTION
# Description

Some issues were noted last week with the registry YAML schema classes. This PR addresses those issues and adds a couple extra unit tests to cover them:
 - The container_registry field only accepted user-created ACR accounts (aka a single string input). It also needs to accept a system-created-acr account. At the moment, the only valid value for a system-created ACR account user-assigned value is 'premium'.
 - Both the existing system created storage account and the new system created acr account objects should have a dump only value for their resource id.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
