### PR TITLE
Ensure bandit always installs its requirements

### DIFF
--- a/eng/pipelines/templates/steps/run_bandit.yml
+++ b/eng/pipelines/templates/steps/run_bandit.yml
@@ -10,6 +10,11 @@ parameters:
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
+  - script: |
+      pip install -r eng/ci_tools.txt
+    displayName: 'Prep Environment'
+    condition: and(succeededOrFailed(), ne(variables['Skip.Bandit'],'true'))
+
   - task: PythonScript@0
     displayName: 'Run Bandit'
     inputs:


### PR DESCRIPTION
Given that we can enable disable any of these pieces, we really need each step to install the tools it requires.

