### PR TITLE
[Tables] Consume the error message with typo

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -394,7 +394,8 @@
         "myasynctable",
         "mytableasync",
         "mytable",
-        "edmtypes"
+        "edmtypes",
+        "specifed"
       ]
     },
     {

--- a/sdk/tables/azure-data-tables/azure/data/tables/_error.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_error.py
@@ -92,6 +92,11 @@ def _validate_tablename_error(decoded_error, table_name):
         # This error is raised by Storage for any table/entity operations where the table name contains
         # forbidden characters.
         _validate_storage_tablename(table_name)
+    elif (decoded_error.error_code == 'InvalidResourceName' and
+        'The specifed resource name contains invalid characters' in decoded_error.message):
+        # This error is raised by Storage for any table/entity operations where the table name contains
+        # forbidden characters.
+        _validate_storage_tablename(table_name)
     elif (decoded_error.error_code == 'OutOfRangeInput' and
           'The specified resource name length is not within the permissible limits' in decoded_error.message):
         # This error is raised by Storage for any table/entity operations where the table name is < 3 or > 63

--- a/sdk/tables/azure-data-tables/tests/test_table.py
+++ b/sdk/tables/azure-data-tables/tests/test_table.py
@@ -464,7 +464,7 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
         tsc = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
         invalid_table_name = u'啊齄丂狛狜'
 
-        with pytest.raises(HttpResponseError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             tsc.create_table(invalid_table_name)
             assert "Storage table names must be alphanumeric, cannot begin with a number, and must be between 3-63 characters long." in str(
                 excinfo)
@@ -476,7 +476,7 @@ class TestTable(AzureRecordedTestCase, TableTestCase):
         tsc = TableServiceClient(credential=tables_primary_storage_account_key, endpoint=account_url)
         invalid_table_name = "my_table"
 
-        with pytest.raises(HttpResponseError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             tsc.create_table(invalid_table_name)
             assert "Storage table names must be alphanumeric, cannot begin with a number, and must be between 3-63 characters long." in str(
                 excinfo)

--- a/sdk/tables/azure-data-tables/tests/test_table_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_async.py
@@ -410,7 +410,7 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
         tsc = TableServiceClient(account_url, credential=tables_primary_storage_account_key)
         invalid_table_name = u'啊齄丂狛狜'
 
-        with pytest.raises(HttpResponseError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             async with tsc:
                 await tsc.create_table(invalid_table_name)
             assert "Storage table names must be alphanumeric, cannot begin with a number, and must be between 3-63 characters long.""" in str(
@@ -423,7 +423,7 @@ class TestTableAsync(AzureRecordedTestCase, AsyncTableTestCase):
         tsc = TableServiceClient(account_url, credential=tables_primary_storage_account_key)
         invalid_table_name = "my_table"
 
-        with pytest.raises(HttpResponseError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             async with tsc:
                 await tsc.create_table(table_name=invalid_table_name)
             assert "Storage table names must be alphanumeric, cannot begin with a number, and must be between 3-63 characters long.""" in str(


### PR DESCRIPTION
Instead of waiting for service team get the typo fixed (tracked by https://github.com/Azure/azure-sdk-for-python/issues/26402), we decide to absorb the error message typo to hide the return type change to customers and make pipelines pass.

We'll drop the typo consuming once it fixed.