### PR TITLE
[Storage] Adjust DataLake Samples

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_access_control_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_access_control_async.py
@@ -76,7 +76,7 @@ async def create_child_files(directory_client, num_child_files):
     print("Created {} files under the directory '{}'.".format(num_child_files, directory_client.path_name))
 
 
-async def run():
+async def main():
     account_name = os.getenv('STORAGE_ACCOUNT_NAME', "")
     account_key = os.getenv('STORAGE_ACCOUNT_KEY', "")
 
@@ -103,4 +103,4 @@ async def run():
 
 
 if __name__ == '__main__':
-    asyncio.run(run())
+    asyncio.run(main())

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_access_control_recursive_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_access_control_recursive_async.py
@@ -101,7 +101,7 @@ async def create_child_files(directory_client, num_child_files):
     print("Created {} files under the directory '{}'.".format(num_child_files, directory_client.path_name))
 
 
-async def run():
+async def main():
     account_name = os.getenv('STORAGE_ACCOUNT_NAME', "")
     account_key = os.getenv('STORAGE_ACCOUNT_KEY', "")
 
@@ -128,4 +128,4 @@ async def run():
 
 
 if __name__ == '__main__':
-    asyncio.run(run())
+    asyncio.run(main())

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_directory_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_directory_async.py
@@ -85,7 +85,7 @@ async def create_child_files(directory_client, num_child_files):
     print("Created {} files under the directory '{}'.".format(num_child_files, directory_client.path_name))
 
 
-async def run():
+async def main():
     account_name = os.getenv('STORAGE_ACCOUNT_NAME', "")
     account_key = os.getenv('STORAGE_ACCOUNT_KEY', "")
 
@@ -111,4 +111,4 @@ async def run():
             await filesystem_client.delete_file_system()
 
 if __name__ == '__main__':
-    asyncio.run(run())
+    asyncio.run(main())

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system_async.py
@@ -217,7 +217,7 @@ class FileSystemSamplesAsync(object):
 
             await file_system_client.delete_file_system()
 
-async def run():
+async def main():
     sample = FileSystemSamplesAsync()
     await sample.file_system_sample()
     await sample.acquire_lease_on_file_system()
@@ -227,4 +227,4 @@ async def run():
     await sample.create_file_from_file_system()
 
 if __name__ == '__main__':
-    asyncio.run(run())
+    asyncio.run(main())

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_instantiate_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_instantiate_client_async.py
@@ -40,4 +40,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    asyncio.run(run())
+    asyncio.run(main())

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_service_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_service_async.py
@@ -37,7 +37,7 @@ active_directory_tenant_id = os.getenv("ACTIVE_DIRECTORY_TENANT_ID")
 
 #--Begin DataLake Service Samples-----------------------------------------------------------------
 
-async def data_lake_service_sample():
+async def main():
 
     # Instantiate a DataLakeServiceClient using a connection string
     # [START create_datalake_service_client]
@@ -113,4 +113,4 @@ async def data_lake_service_sample():
     await token_credential.close()
 
 if __name__ == '__main__':
-    asyncio.run(data_lake_service_sample())
+    asyncio.run(main())

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_upload_download_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_upload_download_async.py
@@ -98,7 +98,7 @@ def get_random_bytes(size):
     return bytes(result)
 
 
-async def run():
+async def main():
     account_name = os.getenv('STORAGE_ACCOUNT_NAME', "")
     account_key = os.getenv('STORAGE_ACCOUNT_KEY', "")
 
@@ -125,4 +125,4 @@ async def run():
 
 
 if __name__ == '__main__':
-    asyncio.run(run())
+    asyncio.run(main())


### PR DESCRIPTION
As raised in #26442 , DataLake samples have recently been adjusted but cannot be run out of the box. While the more trivial change would be from `__main__` to `__run__`, I have gone ahead and moved back to the `asyncio.run(main())` nomenclature to match our samples that exist on our other packages 😄  