### PR TITLE
[ML] Expose vnet parameters on sdk

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/online_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/online_deployment.py
@@ -63,9 +63,7 @@ class KubernetesOnlineDeploymentSchema(OnlineDeploymentSchema):
 
 class ManagedOnlineDeploymentSchema(OnlineDeploymentSchema):
     instance_type = fields.Str(required=True)
-    egress_public_network_access = ExperimentalField(
-        StringTransformedEnum(allowed_values=[PublicNetworkAccess.ENABLED, PublicNetworkAccess.DISABLED])
-    )
+    egress_public_network_access = StringTransformedEnum(allowed_values=[PublicNetworkAccess.ENABLED, PublicNetworkAccess.DISABLED])
     data_collector = ExperimentalField(NestedField(DataCollectorSchema))
     private_network_connection = ExperimentalField(fields.Bool())
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/online/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/online/online_endpoint.py
@@ -57,9 +57,7 @@ class KubernetesOnlineEndpointSchema(OnlineEndpointSchema):
 
 class ManagedOnlineEndpointSchema(OnlineEndpointSchema):
     provisioning_state = fields.Str()
-    public_network_access = ExperimentalField(
-        StringTransformedEnum(allowed_values=[PublicNetworkAccess.ENABLED, PublicNetworkAccess.DISABLED])
-    )
+    public_network_access = StringTransformedEnum(allowed_values=[PublicNetworkAccess.ENABLED, PublicNetworkAccess.DISABLED])
 
     @post_load
     def make(self, data: Any, **kwargs: Any) -> Any:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
@@ -515,6 +515,9 @@ class ManagedOnlineDeployment(OnlineDeployment):
     :type code_path: Union[str, PathLike], optional
     :param scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script.
     :type scoring_script: Union[str, PathLike], optional
+    :param egress_public_network_access: Whether to allow public deployment connectivity
+        Allowed values are: "enabled", "disabled"
+    :param egress_public_network_access: str
     """
 
     def __init__(
@@ -538,12 +541,12 @@ class ManagedOnlineDeployment(OnlineDeployment):
         instance_count: int = None,
         code_path: Union[str, PathLike] = None,  # promoted property from code_configuration.code
         scoring_script: Union[str, PathLike] = None,  # promoted property from code_configuration.scoring_script
+        egress_public_network_access = None,
         **kwargs,
     ):
 
         kwargs["type"] = EndpointComputeType.MANAGED.value
         self.private_network_connection = kwargs.pop("private_network_connection", None)
-        self.egress_public_network_access = kwargs.pop("egress_public_network_access", None)
         self.data_collector = kwargs.pop("data_collector", None)
 
         super(ManagedOnlineDeployment, self).__init__(
@@ -569,6 +572,7 @@ class ManagedOnlineDeployment(OnlineDeployment):
         )
 
         self.readiness_probe = readiness_probe
+        self.egress_public_network_access = egress_public_network_access
 
     def _to_dict(self) -> Dict:
         return ManagedOnlineDeploymentSchema(context={BASE_PATH_CONTEXT_KEY: "./"}).dump(self)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
@@ -515,8 +515,8 @@ class ManagedOnlineDeployment(OnlineDeployment):
     :type code_path: Union[str, PathLike], optional
     :param scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script.
     :type scoring_script: Union[str, PathLike], optional
-    :param egress_public_network_access: Whether to allow public deployment connectivity
-        Allowed values are: "enabled", "disabled"
+    :param egress_public_network_access: Wether to restrict communication between a deployment 
+    and the Azure resources used to by the deployment. Allowed values are: "enabled", "disabled"
     :param egress_public_network_access: str
     """
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
@@ -363,7 +363,9 @@ class ManagedOnlineEndpoint(OnlineEndpoint):
     :param identity: defaults to SystemAssigned
     :type identity: IdentityConfiguration, optional
     :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
-    :type kind: str, optional
+    :type kind: str, optional,
+    :param public_network_access: Whether to allow public endpoint connectivity
+    :type public_network_access: str
     """
 
     def __init__(
@@ -379,9 +381,10 @@ class ManagedOnlineEndpoint(OnlineEndpoint):
         mirror_traffic: Dict[str, int] = None,
         identity: IdentityConfiguration = None,
         kind: str = None,
+        public_network_access = None,
         **kwargs,
     ):
-        self.public_network_access = kwargs.pop("public_network_access", None)
+        self.public_network_access = public_network_access
 
         super(ManagedOnlineEndpoint, self).__init__(
             name=name,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
@@ -365,6 +365,7 @@ class ManagedOnlineEndpoint(OnlineEndpoint):
     :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
     :type kind: str, optional,
     :param public_network_access: Whether to allow public endpoint connectivity
+        Allowed values are: "enabled", "disabled"
     :type public_network_access: str
     """
 

--- a/sdk/ml/azure-ai-ml/tests/model/e2etests/test_model.py
+++ b/sdk/ml/azure-ai-ml/tests/model/e2etests/test_model.py
@@ -201,6 +201,10 @@ class TestModel(AzureRecordedTestCase):
         model_list = [m.name for m in model_list if m is not None]
         assert model.name in model_list
 
+    @pytest.mark.skipif(
+        condition=not is_live(),
+        reason="Registry uploads do not record well. Investigate later"
+    )
     def test_promote_model(self, randstr: Callable[[], str], client: MLClient, registry_client: MLClient) -> None:
         # Create model in workspace
         model_path = Path("./tests/test_configs/model/model_full.yml")


### PR DESCRIPTION
# Description

The VNET feature is based on two flags: `public_network_access` in the endpoint and `egress_public_network_access` in the deployment. This feature is in PuP and available in the CLI. 
We want to expose them in SDK too

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
