### PR TITLE
[Test Proxy] Always return dict from recorded_test fixture

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
@@ -116,7 +116,7 @@ def environment_variables(test_proxy: None) -> EnvironmentVariableSanitizer:
 
 
 @pytest.fixture
-async def recorded_test(test_proxy: None, request: "FixtureRequest") -> "Optional[Dict[str, Any]]":
+async def recorded_test(test_proxy: None, request: "FixtureRequest") -> "Dict[str, Any]":
     """Fixture that redirects network requests to target the azure-sdk-tools test proxy.
 
     Use with recorded tests. For more details and usage examples, refer to
@@ -131,7 +131,7 @@ async def recorded_test(test_proxy: None, request: "FixtureRequest") -> "Optiona
         If the current test session is live but recording is disabled, yields None.
     """
     if is_live_and_not_recording():
-        yield
+        yield {"variables": {}}  # yield an empty set of variables since recordings aren't used
     else:
         test_id, recording_id, variables = start_proxy_session()
 


### PR DESCRIPTION
# Description

The `recorded_test` fixture was recently optimized to yield immediately when live tests are run with recording skipped, since we don't need to load recordings in that scenario. This did introduce a bug though, since the `variable_recorder` fixture always attempts to fetch variables from `recorded_test`'s return value.

One option would be to check if a `variables` key is present in `recorded_test` inside of `variable_recorder`. But, I think that things are simpler and more consistent if we enforce always returning a certain set of information about the test via `recorded_test` -- for now, that just includes `variables`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
