### PR TITLE
[pipeline] upgrade autorest-core to `3.9.2`, modelerfour to `4.24.3`

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "autorest_options": {
-      "version": "3.8.4",
-      "use": ["@autorest/python@6.1.6", "@autorest/modelerfour@4.23.5"],
+      "version": "3.9.2",
+      "use": ["@autorest/python@6.1.6", "@autorest/modelerfour@4.24.3"],
       "python": "",
       "sdkrel:python-sdks-folder": "./sdk/.",
       "version-tolerant": false


### PR DESCRIPTION
fix pipeline failure of python: https://github.com/Azure/azure-rest-api-specs/pull/20557/checks?check_run_id=8585903827