### PR TITLE
[AppConfig] Drop msrest

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Python 2.7 is no longer supported. Please use Python version 3.6 or later.
 - Bumped mininum dependency on `azure-core` to `>=1.24.0`.
 - Changed the default async transport from `AsyncioRequestsTransport` to the one used in current `azure-core` (`AioHttpTransport`). ([#26427](https://github.com/Azure/azure-sdk-for-python/issues/26427))
+- Dropped `msrest` requirement.
 
 ## 1.3.0 (2021-11-10)
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import json
 from typing import Any, Union
-from msrest.serialization import Model
+from ._generated._serialization import Model
 from ._generated.models import KeyValue
 
 try:

--- a/sdk/appconfiguration/azure-appconfiguration/setup.py
+++ b/sdk/appconfiguration/azure-appconfiguration/setup.py
@@ -72,7 +72,6 @@ setup(
     packages=find_packages(exclude=exclude_packages),
     python_requires=">=3.6",
     install_requires=[
-        "msrest>=0.6.10",
         "azure-core<2.0.0,>=1.24.0",
     ],
 )

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -184,7 +184,6 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-eventhub-checkpointstoreblob-aio aiohttp<4.0,>=3.0
 #override azure-eventhub-checkpointstoretable azure-core<2.0.0,>=1.14.0
 #override azure-eventhub uamqp>=1.6.0,<2.0.0
-#override azure-appconfiguration msrest>=0.6.10
 #override azure-appconfiguration azure-core<2.0.0,>=1.24.0
 #override azure-servicebus uamqp>=1.5.1,<2.0.0
 #override azure-servicebus msrest>=0.6.17,<2.0.0


### PR DESCRIPTION
AppConfig package was regenerated with latest version of `autorest`(https://github.com/Azure/azure-sdk-for-python/pull/26375), which doesn't use `msrest`. So we can drop this requirement.