### PR TITLE
Regression Runs Proxy prior to invoking tests

### DIFF
--- a/eng/pipelines/templates/jobs/regression.yml
+++ b/eng/pipelines/templates/jobs/regression.yml
@@ -86,7 +86,7 @@ jobs:
 
       - template: /eng/common/testproxy/test-proxy-tool.yml
         parameters:
-          runProxy: false
+          runProxy: true
 
       - template: ../steps/set-dev-build.yml
         parameters:
@@ -108,6 +108,10 @@ jobs:
             --whl-dir="${{ parameters.BuildStagingDirectory }}"
             --mark-arg="not cosmosEmulator"
 
+      - pwsh: |
+          Invoke-RestMethod -Method POST -Uri http://localhost:5000/Admin/Reset
+        displayName: "Reset Proxy Settings"
+
       - task: PythonScript@0
         displayName: 'Test Oldest Released Dependents'
         inputs:
@@ -119,3 +123,13 @@ jobs:
             --whl-dir="${{ parameters.BuildStagingDirectory }}"
             --verify-latest=False
             --mark-arg="not cosmosEmulator"
+
+      - pwsh: |
+          $files = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter _proxy_log_*.log
+          foreach($file in $files){
+              Write-Host "##[group]$file"
+              cat $file
+              Write-Host "##[endgroup]"
+          }
+        displayName: Dump Test-Proxy Logs
+        condition: always()


### PR DESCRIPTION
We dealt with a [breaking change](https://github.com/Azure/azure-sdk-for-python/pull/26494) for running the test-proxy in CI. The problem is, the regression tests are now hitting this as well because they use the engsys at the time of writing. That would mean that the `sdk-tools` startup of the test-proxy will hit issues from these older branches.

An alternative is to go in and apply the `proxy_startup.py` patch to each old tag/branch that doesn't have this adjustment. I'd rather save myself that effort. This PR is an attempt to avoid a couple dozen manual patches.