### PR TITLE
Fix py.typed verification script

### DIFF
--- a/eng/tox/verify_sdist.py
+++ b/eng/tox/verify_sdist.py
@@ -97,10 +97,9 @@ def verify_sdist_pytyped(
     if os.path.exists(manifest_location):
         with open(manifest_location, "r") as f:
             lines = f.readlines()
-            result = any([include for include in lines if "py.typed" in include])
-
-            if not result:
+            if not any([include for include in lines if "py.typed" in include]):
                 logging.info("Ensure that the MANIFEST.in includes at least one path that leads to a py.typed file.")
+                result = False
 
     pytyped_file_path = os.path.join(pkg_dir, *namespace.split("."), "py.typed")
     if not os.path.exists(pytyped_file_path):

--- a/sdk/maps/azure-maps-geolocation/setup.py
+++ b/sdk/maps/azure-maps-geolocation/setup.py
@@ -78,6 +78,7 @@ setup(
         'azure',
         'azure.maps',
     ]),
+    include_package_data=True,
     install_requires=[
         'msrest>=0.6.21',
         'azure-common~=1.1',

--- a/sdk/maps/azure-maps-search/setup.py
+++ b/sdk/maps/azure-maps-search/setup.py
@@ -76,6 +76,7 @@ setup(
         'azure',
         'azure.maps',
     ]),
+    include_package_data=True,
     install_requires=[
         'msrest>=0.6.21',
         'azure-common~=1.1',

--- a/sdk/monitor/azure-monitor-ingestion/setup.py
+++ b/sdk/monitor/azure-monitor-ingestion/setup.py
@@ -80,6 +80,7 @@ setup(
         'azure',
         'azure.monitor',
     ]),
+    include_package_data=True,
     install_requires=[
         'msrest>=0.6.19',
         'azure-core<2.0.0,>=1.24.0',


### PR DESCRIPTION
In order to ensure that a py.typed file is packaged with both source and binary distributions of a package, we have a script that verifies various configurations. This script had a bug that would validate a package as passing as long as the MANIFEST.in file was correctly configured, disregarding issues in the setup.py file.

This fixes the issue and updates pertinent impacted setup.py files.

Note that the following packages also have issues with their configurations, and their pipelines have been failing for a while due to the verify_sdist check failing. Presumably we'd want to disable the CI for these entirely since they are no longer maintained.

- applicationinsights/azure-applicationinsights
- loganalytics/azure-loganalytics


