### PR TITLE
[ServiceBus] remove pytest ini file

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/pytest.ini
+++ b/sdk/servicebus/azure-servicebus/tests/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_files = test_mgmt_*.py


### PR DESCRIPTION
@kashifkhan's find: The pytest ini file seems to be causing the uamqp pipeline to only run mgmt tests. Seeing if removing it will cause all SB tests to run in the uamqp pipeline.