### PR TITLE
same training and validation URI is causing path not found issue for Text classification

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/automl_job/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/conftest.py
@@ -134,7 +134,7 @@ def image_segmentation_dataset() -> Tuple[str, str]:
 @pytest.fixture
 def newsgroup() -> Tuple[Input, Input, str]:
     training_data = Input(type=AssetTypes.MLTABLE, path=NEWSGROUP_TRAIN_DATASET_PATH)
-    validation_data = Input(type=AssetTypes.MLTABLE, path=NEWSGROUP_TRAIN_DATASET_PATH)
+    validation_data = Input(type=AssetTypes.MLTABLE, path=NEWSGROUP_VALID_DATASET_PATH)
     target_column_name = "y"
 
     return training_data, validation_data, target_column_name


### PR DESCRIPTION
# Description

There is ongoing bug on service end, where automl run fails due to path not found error in case, input data point to same data URI. We had a different validation input path, which we were not using here, triggering failure. 

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
