### PR TITLE
refactor: hide private functions of ValidationResult (#26538)

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/_additional_includes.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/_additional_includes.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Union
 
 from azure.ai.ml.entities._util import _general_copy
-from azure.ai.ml.entities._validation import ValidationResult, _ValidationResultBuilder
+from azure.ai.ml.entities._validation import MutableValidationResult, _ValidationResultBuilder
 
 ADDITIONAL_INCLUDES_SUFFIX = "additional_includes"
 
@@ -40,7 +40,7 @@ class _AdditionalIncludes:
         else:
             shutil.copytree(src, dst)
 
-    def validate(self) -> ValidationResult:
+    def _validate(self) -> MutableValidationResult:
         # pylint: disable=too-many-return-statements
         if self._includes is None:
             return _ValidationResultBuilder.success()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/node.py
@@ -16,7 +16,7 @@ from azure.ai.ml.entities._builders import BaseNode
 from azure.ai.ml.entities._job.pipeline._io import NodeInput, NodeOutput, PipelineInput
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict
 
-from ...entities._validation import ValidationResult
+from ...entities._validation import MutableValidationResult
 from .._schema.component import NodeType
 from ._input_outputs import InternalInput
 
@@ -95,7 +95,7 @@ class InternalBaseNode(BaseNode):
     def _load_from_dict(cls, data: Dict, context: Dict, additional_message: str, **kwargs) -> "Job":
         raise RuntimeError("Internal components doesn't support load from dict")
 
-    def _schema_validate(self) -> ValidationResult:
+    def _schema_validate(self) -> MutableValidationResult:
         """Validate the resource with the schema.
 
         return type: ValidationResult

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
@@ -23,7 +23,7 @@ from azure.ai.ml.entities._job.pipeline._pipeline_expression import PipelineExpr
 from azure.ai.ml.entities._job.sweep.search_space import SweepDistribution
 from azure.ai.ml.entities._mixins import YamlTranslatableMixin
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict, resolve_pipeline_parameters
-from azure.ai.ml.entities._validation import SchemaValidatableMixin, ValidationResult
+from azure.ai.ml.entities._validation import SchemaValidatableMixin, MutableValidationResult
 from azure.ai.ml.exceptions import ErrorTarget, ValidationErrorType, ValidationException
 
 module_logger = logging.getLogger(__name__)
@@ -313,7 +313,7 @@ class BaseNode(Job, PipelineNodeIOMixin, YamlTranslatableMixin, _AttrDict, Schem
                 )
         return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
 
-    def _customized_validate(self) -> ValidationResult:
+    def _customized_validate(self) -> MutableValidationResult:
         """Validate the resource with customized logic.
 
         Override this method to add customized validation logic.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/condition_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/condition_node.py
@@ -13,7 +13,7 @@ from azure.ai.ml.entities._builders import BaseNode
 from azure.ai.ml.entities._builders.control_flow_node import ControlFlowNode
 from azure.ai.ml.entities._job.automl.automl_job import AutoMLJob
 from azure.ai.ml.entities._job.pipeline._io import InputOutputBase
-from azure.ai.ml.entities._validation import ValidationResult
+from azure.ai.ml.entities._validation import MutableValidationResult
 
 
 class ConditionNode(ControlFlowNode):
@@ -39,10 +39,10 @@ class ConditionNode(ControlFlowNode):
     def _to_dict(self) -> Dict:
         return self._dump_for_validation()
 
-    def _customized_validate(self) -> ValidationResult:
+    def _customized_validate(self) -> MutableValidationResult:
         return self._validate_params(raise_error=False)
 
-    def _validate_params(self, raise_error=True) -> ValidationResult:
+    def _validate_params(self, raise_error=True) -> MutableValidationResult:
         # pylint disable=protected-access
         validation_result = self._create_empty_validation_result()
         if not isinstance(self.condition, (str, bool, InputOutputBase)):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/command_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/command_component.py
@@ -19,7 +19,7 @@ from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationExcepti
 from ..._schema import PathAwareSchema
 from ..._utils.utils import get_all_data_binding_expressions, parse_args_description_from_docstring
 from .._util import convert_ordered_dict_to_dict, validate_attribute_type
-from .._validation import ValidationResult
+from .._validation import MutableValidationResult
 from .component import Component
 
 
@@ -166,7 +166,7 @@ class CommandComponent(Component, ParameterizedCommand):
     def _customized_validate(self):
         return super(CommandComponent, self)._customized_validate().merge_with(self._validate_command())
 
-    def _validate_command(self) -> ValidationResult:
+    def _validate_command(self) -> MutableValidationResult:
         validation_result = self._create_empty_validation_result()
         # command
         if self.command:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component.py
@@ -31,7 +31,7 @@ from azure.ai.ml.entities._inputs_outputs import Input, Output
 from azure.ai.ml.entities._mixins import RestTranslatableMixin, TelemetryMixin, YamlTranslatableMixin
 from azure.ai.ml.entities._system_data import SystemData
 from azure.ai.ml.entities._util import find_type_in_override
-from azure.ai.ml.entities._validation import SchemaValidatableMixin, ValidationResult
+from azure.ai.ml.entities._validation import SchemaValidatableMixin, MutableValidationResult
 from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
 
 # pylint: disable=protected-access, redefined-builtin
@@ -251,7 +251,7 @@ class Component(
         )
 
     @classmethod
-    def _validate_io_names(cls, io_dict: Dict, raise_error=False) -> ValidationResult:
+    def _validate_io_names(cls, io_dict: Dict, raise_error=False) -> MutableValidationResult:
         """Validate input/output names, raise exception if invalid."""
         validation_result = cls._create_empty_validation_result()
         lower2original_kwargs = {}
@@ -378,7 +378,7 @@ class Component(
         # omit name since name doesn't impact component's uniqueness
         return hash_dict(component_interface_dict, keys_to_omit=["name", "id", "version"])
 
-    def _customized_validate(self) -> ValidationResult:
+    def _customized_validate(self) -> MutableValidationResult:
         validation_result = super(Component, self)._customized_validate()
         # If private features are enable and component has code value of type str we need to check
         # that it is a valid git path case. Otherwise we should throw a ValidationError

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
@@ -30,7 +30,7 @@ from azure.ai.ml.entities._job.pipeline._attr_dict import (
     try_get_non_arbitrary_attr_for_potential_attr_dict,
 )
 from azure.ai.ml.entities._job.pipeline._pipeline_expression import PipelineExpression
-from azure.ai.ml.entities._validation import ValidationResult
+from azure.ai.ml.entities._validation import MutableValidationResult
 from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
 
 module_logger = logging.getLogger(__name__)
@@ -118,7 +118,7 @@ class PipelineComponent(Component):
                 )
         return jobs
 
-    def _customized_validate(self) -> ValidationResult:
+    def _customized_validate(self) -> MutableValidationResult:
         """Validate pipeline component structure."""
         validation_result = super(PipelineComponent, self)._customized_validate()
 
@@ -224,7 +224,7 @@ class PipelineComponent(Component):
                             optional_binding_in_expression_dict[pipeline_input_name].append(pipeline_input_name)
         return binding_dict, optional_binding_in_expression_dict
 
-    def _validate_binding_inputs(self, node: BaseNode) -> ValidationResult:
+    def _validate_binding_inputs(self, node: BaseNode) -> MutableValidationResult:
         """Validate pipeline binding inputs and return all used pipeline input
         names.
 
@@ -321,7 +321,8 @@ class PipelineComponent(Component):
     def _create_schema_for_validation(cls, context) -> Union[PathAwareSchema, Schema]:
         return PipelineComponentSchema(context=context)
 
-    def _get_skip_fields_in_schema_validation(self) -> typing.List[str]:
+    @classmethod
+    def _get_skip_fields_in_schema_validation(cls) -> typing.List[str]:
         # jobs validations are done in _customized_validate()
         return ["jobs"]
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
@@ -54,7 +54,7 @@ from azure.ai.ml.entities._job.pipeline._io import PipelineInput, PipelineIOMixi
 from azure.ai.ml.entities._job.pipeline.pipeline_job_settings import PipelineJobSettings
 from azure.ai.ml.entities._mixins import YamlTranslatableMixin
 from azure.ai.ml.entities._system_data import SystemData
-from azure.ai.ml.entities._validation import SchemaValidatableMixin, ValidationResult
+from azure.ai.ml.entities._validation import SchemaValidatableMixin, MutableValidationResult
 from azure.ai.ml.exceptions import ErrorTarget, UserErrorException
 
 module_logger = logging.getLogger(__name__)
@@ -223,7 +223,8 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineIOMixin, SchemaValidatable
 
         return PipelineJobSchema(context=context)
 
-    def _get_skip_fields_in_schema_validation(self) -> typing.List[str]:
+    @classmethod
+    def _get_skip_fields_in_schema_validation(cls) -> typing.List[str]:
         # jobs validations are done in _customized_validate()
         return ["component", "jobs"]
 
@@ -241,7 +242,7 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineIOMixin, SchemaValidatable
         validation_result.merge_with(self.component._validate_compute_is_set())
         return validation_result
 
-    def _customized_validate(self) -> ValidationResult:
+    def _customized_validate(self) -> MutableValidationResult:
         """Validate that all provided inputs and parameters are valid for
         current pipeline and components in it."""
         validation_result = super(PipelineJob, self)._customized_validate()
@@ -294,7 +295,7 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineIOMixin, SchemaValidatable
                 )
         return validation_result
 
-    def _validate_init_finalize_job(self) -> ValidationResult:
+    def _validate_init_finalize_job(self) -> MutableValidationResult:
         validation_result = self._create_empty_validation_result()
         # subgraph (PipelineComponent) should not have on_init/on_finalize set
         for job_name, job in self.jobs.items():

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
@@ -22,7 +22,7 @@ from azure.ai.ml.entities._mixins import RestTranslatableMixin, TelemetryMixin, 
 from azure.ai.ml.entities._resource import Resource
 from azure.ai.ml.entities._system_data import SystemData
 from azure.ai.ml.entities._util import load_from_dict
-from azure.ai.ml.entities._validation import SchemaValidatableMixin, ValidationResult
+from azure.ai.ml.entities._validation import SchemaValidatableMixin, MutableValidationResult
 
 from ...exceptions import ErrorCategory, ErrorTarget, ScheduleException, ValidationException
 from .trigger import CronTrigger, RecurrenceTrigger, TriggerBase
@@ -192,13 +192,14 @@ class JobSchedule(YamlTranslatableMixin, SchemaValidatableMixin, RestTranslatabl
     def _get_validation_error_target(cls) -> ErrorTarget:
         return ErrorTarget.SCHEDULE
 
-    def _customized_validate(self) -> ValidationResult:
+    def _customized_validate(self) -> MutableValidationResult:
         """Validate the resource with customized logic."""
         if isinstance(self.create_job, PipelineJob):
             return self.create_job._validate()
         return self._create_empty_validation_result()
 
-    def _get_skip_fields_in_schema_validation(self) -> typing.List[str]:
+    @classmethod
+    def _get_skip_fields_in_schema_validation(cls) -> typing.List[str]:
         """Get the fields that should be skipped in schema validation.
 
         Override this method to add customized validation logic.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validate_funcs.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validate_funcs.py
@@ -8,10 +8,10 @@ from marshmallow import ValidationError
 from ..exceptions import ValidationException
 from . import Component, Job
 from ._load_functions import _load_common_raising_marshmallow_error, _try_load_yaml_dict
-from ._validation import SchemaValidatableMixin, _ValidationResultBuilder
+from ._validation import SchemaValidatableMixin, _ValidationResultBuilder, ValidationResult
 
 
-def validate_common(cls, path, validate_func, params_override=None):
+def validate_common(cls, path, validate_func, params_override=None) -> ValidationResult:
     params_override = params_override or []
     yaml_dict = _try_load_yaml_dict(path)
 
@@ -33,7 +33,7 @@ def validate_common(cls, path, validate_func, params_override=None):
         return _ValidationResultBuilder.from_validation_error(err, path)
 
 
-def validate_component(path, ml_client=None, params_override=None):
+def validate_component(path, ml_client=None, params_override=None) -> ValidationResult:
     """Validate a component defined in a local file.
 
     :param path: The path to the component definition file.
@@ -44,7 +44,7 @@ def validate_component(path, ml_client=None, params_override=None):
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :return: The validation result.
-    :rtype: azure.ai.ml.core.ValidationResult
+    :rtype: ValidationResult
     """
     return validate_common(
         cls=Component,
@@ -54,7 +54,7 @@ def validate_component(path, ml_client=None, params_override=None):
     )
 
 
-def validate_job(path, ml_client=None, params_override=None):
+def validate_job(path, ml_client=None, params_override=None) -> ValidationResult:
     """Validate a job defined in a local file.
 
     :param path: The path to the job definition file.
@@ -65,7 +65,7 @@ def validate_job(path, ml_client=None, params_override=None):
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :return: The validation result.
-    :rtype: azure.ai.ml.core.ValidationResult
+    :rtype: ValidationResult
     """
     return validate_common(
         cls=Job,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
@@ -19,8 +19,13 @@ from marshmallow import Schema, ValidationError
 
 from azure.ai.ml._schema import PathAwareSchema
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, OperationStatus
-from azure.ai.ml.entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr_for_potential_attr_dict
-from azure.ai.ml.entities._util import convert_ordered_dict_to_dict, decorate_validation_error
+from azure.ai.ml.entities._job.pipeline._attr_dict import (
+    try_get_non_arbitrary_attr_for_potential_attr_dict,
+)
+from azure.ai.ml.entities._util import (
+    convert_ordered_dict_to_dict,
+    decorate_validation_error,
+)
 from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
 
 module_logger = logging.getLogger(__name__)
@@ -56,6 +61,15 @@ class Diagnostic(object):
         message: str = None,
         error_code: str = None,
     ):
+        """Create a diagnostic instance.
+
+        :param yaml_path: A dash path from root to the target element of the diagnostic. jobs.job_a.inputs.input_str
+        :type yaml_path: str
+        :param message: Error message of diagnostic.
+        :type message: str
+        :param error_code: Error code of diagnostic.
+        :type error_code: str
+        """
         return cls(
             yaml_path=yaml_path,
             message=message,
@@ -67,52 +81,127 @@ class ValidationResult(object):
     """Represents the result of job/asset validation.
 
     This class is used to organize and parse diagnostics from both
-    client & server side before expose them to users. In this way, we
-    may improve user experience without changing the validation logic &
-    API.
+    client & server side before expose them.
+    The result is immutable.
     """
 
-    def __init__(
-        self,
-        diagnostics: typing.List[Diagnostic] = None,
-        data: typing.Dict[str, typing.Any] = None,
-        valid_data: typing.Optional[
-            typing.Union[
-                typing.List[typing.Dict[str, typing.Any]],
-                typing.Dict[str, typing.Any],
-            ]
-        ] = None,
-    ):
-        self._errors: typing.List[Diagnostic] = diagnostics or []
-        self._warnings: typing.List[Diagnostic] = []
-        self._target_obj = data
-        self._valid_data = valid_data
+    def __init__(self):
+        self._target_obj = None
+        self._errors = []
+        self._warnings = []
 
     @property
-    def messages(self):
+    def error_messages(self):
+        """Return all messages of errors in the validation result.
+        For example, if repr(self) is:
+        {
+            "errors": [
+                {
+                    "path": "jobs.job_a.inputs.input_str",
+                    "message": "input_str is required",
+                    "value": None,
+                },
+                {
+                    "path": "jobs.job_a.inputs.input_str",
+                    "message": "input_str must be in the format of xxx",
+                    "value": None,
+                },
+                {
+                    "path": "settings.on_init",
+                    "message": "On_init job name job_b not exists in jobs.",
+                    "value": None,
+                },
+            ],
+            "warnings": [
+                {
+                    "path": "jobs.job_a.inputs.input_str",
+                    "message": "input_str is required",
+                    "value": None,
+                }
+            ]
+        }
+        then the error_messages will be:
+        {
+            "jobs.job_a.inputs.input_str": "input_str is required; input_str must be in the format of xxx",
+            "settings.on_init": "On_init job name job_b not exists in jobs.",
+        }
+        """
         messages = {}
         for diagnostic in self._errors:
-            messages[diagnostic.yaml_path] = diagnostic.message
+            if diagnostic.yaml_path not in messages:
+                messages[diagnostic.yaml_path] = diagnostic.message
+            else:
+                messages[diagnostic.yaml_path] += "; " + diagnostic.message
         return messages
 
     @property
-    def invalid_fields(self):
-        invalid_fields = []
-        for diagnostic in self._errors:
-            invalid_fields.append(diagnostic.yaml_path)
-        return invalid_fields
-
-    @property
     def passed(self):
+        """Return whether the validation passed. If there is no error, then it passed."""
         return not self._errors
 
-    def merge_with(self, other: "ValidationResult", field_name: str = None, condition_skip: typing.Callable = None):
-        """Merge two validation results.
+    def _to_dict(self) -> typing.Dict[str, typing.Any]:
+        result = {
+            "result": OperationStatus.SUCCEEDED
+            if self.passed
+            else OperationStatus.FAILED,
+        }
+        for diagnostic_type, diagnostics in [
+            ("errors", self._errors),
+            ("warnings", self._warnings),
+        ]:
+            messages = []
+            for diagnostic in diagnostics:
+                message = {
+                    "message": diagnostic.message,
+                    "path": diagnostic.yaml_path,
+                    "value": pydash.get(
+                        self._target_obj, diagnostic.yaml_path, diagnostic.value
+                    ),
+                }
+                if diagnostic.local_path:
+                    message["location"] = str(diagnostic.local_path)
+                messages.append(message)
+            if messages:
+                result[diagnostic_type] = messages
+        return result
+
+    def __repr__(self):
+        """Get the string representation of the validation result."""
+        return json.dumps(self._to_dict(), indent=2)
+
+
+class MutableValidationResult(ValidationResult):
+    """Used by the client side to construct a validation result.
+    The result is mutable and should not be exposed to the user.
+    """
+
+    def __init__(self, target_obj: typing.Dict[str, typing.Any] = None):
+        super().__init__()
+        self._target_obj = target_obj
+
+    def merge_with(
+        self,
+        target: "MutableValidationResult",
+        field_name: str = None,
+        condition_skip: typing.Callable = None,
+    ):
+        """Merge errors & warnings in another validation results into current one.
 
         Will update current validation result.
+        If field_name is not None, then yaml_path in the other validation result will be updated accordingly.
+        * => field_name, jobs.job_a => field_name.jobs.job_a e.g.. If None, then no update.
+
+        :param target: Validation result to merge.
+        :type target: MutableValidationResult
+        :param field_name: The base field name for the target to merge.
+        :type field_name: str
+        :param condition_skip: A function to determine whether to skip the merge of a diagnostic in the target.
+        :type condition_skip: typing.Callable
+        :return: The current validation result.
+        :rtype: MutableValidationResult
         """
         for target_attr in ["_errors", "_warnings"]:
-            for diagnostic in getattr(other, target_attr):
+            for diagnostic in getattr(target, target_attr):
                 if condition_skip and condition_skip(diagnostic):
                     continue
                 new_diagnostic = copy.deepcopy(diagnostic)
@@ -120,7 +209,9 @@ class ValidationResult(object):
                     if new_diagnostic.yaml_path == "*":
                         new_diagnostic.yaml_path = field_name
                     else:
-                        new_diagnostic.yaml_path = field_name + "." + new_diagnostic.yaml_path
+                        new_diagnostic.yaml_path = (
+                            field_name + "." + new_diagnostic.yaml_path
+                        )
                 getattr(self, target_attr).append(new_diagnostic)
         return self
 
@@ -132,18 +223,33 @@ class ValidationResult(object):
         schema: Schema = None,
         additional_message: str = "",
         raise_mashmallow_error: bool = False,
-    ) -> "ValidationResult":
+    ) -> "MutableValidationResult":
         """Try to raise an error from the validation result.
 
         If the validation is passed or raise_error is False, this method
         will return the validation result.
+
+        :param error_target: The target of the error.
+        :type error_target: ErrorTarget
+        :param error_category: The category of the error.
+        :type error_category: ErrorCategory
+        :param raise_error: Whether to raise the error.
+        :type raise_error: bool
+        :param schema: The schema to do the validation, will be used in the error message.
+        :type schema: Schema
+        :param additional_message: Additional message to add to the error message.
+        :type additional_message: str
+        :param raise_mashmallow_error: Whether to raise a marshmallow.ValidationError instead of ValidationException.
+        :type raise_mashmallow_error: bool
+        :return: The current validation result.
+        :rtype: MutableValidationResult
         """
         # pylint: disable=logging-not-lazy
         if raise_error is False:
             return self
 
         if self._warnings:
-            module_logger.info("Warnings: {}".format(self._warnings)) # pylint: disable=logging-format-interpolation
+            module_logger.info("Warnings: %s" % str(self._warnings))
 
         if not self.passed:
             message = (
@@ -160,7 +266,8 @@ class ValidationResult(object):
 
             raise ValidationException(
                 message=message,
-                no_personal_data_message="validation failed on the following fields: " + ", ".join(self.invalid_fields),
+                no_personal_data_message="validation failed on the following fields: "
+                + ", ".join(self.error_messages),
                 target=error_target,
                 error_category=error_category,
             )
@@ -172,6 +279,17 @@ class ValidationResult(object):
         message: str = None,
         error_code: str = None,
     ):
+        """Append an error to the validation result.
+
+        :param yaml_path: The yaml path of the error.
+        :type yaml_path: str
+        :param message: The message of the error.
+        :type message: str
+        :param error_code: The error code of the error.
+        :type error_code: str
+        :return: The current validation result.
+        :rtype: MutableValidationResult
+        """
         self._errors.append(
             Diagnostic.create_instance(
                 yaml_path=yaml_path,
@@ -181,9 +299,22 @@ class ValidationResult(object):
         )
         return self
 
-    def resolve_location_for_diagnostics(self, source_path: str, resolve_value: bool = False):
-        """Resolve location for diagnostics."""
-        resolver = YamlLocationResolver(source_path)
+    def resolve_location_for_diagnostics(
+        self, source_path: str, resolve_value: bool = False
+    ):
+        """Resolve location/value for diagnostics based on the source path where the validatable object is loaded.
+        Location includes local path of the exact file (can be different from the source path) & line number of the
+        invalid field.
+        Value of a diagnostic is resolved from the validatable object in transfering to a dict by default;
+        however, when the validatable object is not available for the validation result, validation result is created
+        from marshmallow.ValidationError.messages e.g., it can be resolved from the source path.
+
+        param source_path: The path of the source file.
+        type source_path: str
+        param resolve_value: Whether to resolve the value of the invalid field from source file.
+        type resolve_value: bool
+        """
+        resolver = _YamlLocationResolver(source_path)
         for diagnostic in self._errors + self._warnings:
             diagnostic.local_path, value = resolver.resolve(diagnostic.yaml_path)
             if value is not None and resolve_value:
@@ -195,6 +326,17 @@ class ValidationResult(object):
         message: str = None,
         error_code: str = None,
     ):
+        """Append a warning to the validation result.
+
+        :param yaml_path: The yaml path of the warning.
+        :type yaml_path: str
+        :param message: The message of the warning.
+        :type message: str
+        :param error_code: The error code of the warning.
+        :type error_code: str
+        :return: The current validation result.
+        :rtype: MutableValidationResult
+        """
         self._warnings.append(
             Diagnostic.create_instance(
                 yaml_path=yaml_path,
@@ -204,45 +346,24 @@ class ValidationResult(object):
         )
         return self
 
-    def _to_dict(self) -> typing.Dict[str, typing.Any]:
-        result = {
-            "result": OperationStatus.SUCCEEDED if self.passed else OperationStatus.FAILED,
-        }
-        for diagnostic_type, diagnostics in [
-            ("errors", self._errors),
-            ("warnings", self._warnings),
-        ]:
-            messages = []
-            for diagnostic in diagnostics:
-                message = {
-                    "message": diagnostic.message,
-                    "path": diagnostic.yaml_path,
-                    "value": pydash.get(self._target_obj, diagnostic.yaml_path, diagnostic.value),
-                }
-                if diagnostic.local_path:
-                    message["location"] = str(diagnostic.local_path)
-                messages.append(message)
-            if messages:
-                result[diagnostic_type] = messages
-        return result
-
-    def __repr__(self):
-        return json.dumps(self._to_dict(), indent=2)
-
 
 class SchemaValidatableMixin:
     @classmethod
-    def _create_empty_validation_result(cls) -> ValidationResult:
+    def _create_empty_validation_result(cls) -> MutableValidationResult:
         """Simply create an empty validation result to reduce
         _ValidationResultBuilder importing, which is a private class."""
         return _ValidationResultBuilder.success()
 
     @classmethod
     def _create_schema_for_validation_with_base_path(cls, base_path=None):
-        return cls._create_schema_for_validation(context={BASE_PATH_CONTEXT_KEY: base_path or Path.cwd()})
+        return cls._create_schema_for_validation(
+            context={BASE_PATH_CONTEXT_KEY: base_path or Path.cwd()}
+        )
 
     @classmethod
-    def _create_schema_for_validation(cls, context) -> typing.Union[PathAwareSchema, Schema]:
+    def _create_schema_for_validation(
+        cls, context
+    ) -> typing.Union[PathAwareSchema, Schema]:
         """Create a schema of the resource with specific context. Should be
         overridden by subclass.
 
@@ -252,7 +373,7 @@ class SchemaValidatableMixin:
         raise NotImplementedError()
 
     @property
-    def _base_path_for_validation(self) -> typing.Union[str, PathLike]:
+    def __base_path_for_validation(self) -> typing.Union[str, PathLike]:
         """Get the base path of the resource. It will try to return
         self.base_path, then self._base_path, then Path.cwd() if above attrs
         are non-existent or None.
@@ -282,13 +403,15 @@ class SchemaValidatableMixin:
         return: The schema of the resource.
         return type: PathAwareSchema. PathAwareSchema will add marshmallow.Schema as super class on runtime.
         """
-        return self._create_schema_for_validation_with_base_path(self._base_path_for_validation)
+        return self._create_schema_for_validation_with_base_path(
+            self.__base_path_for_validation
+        )
 
     def _dump_for_validation(self) -> typing.Dict:
         """Convert the resource to a dictionary."""
         return convert_ordered_dict_to_dict(self._schema_for_validation.dump(self))
 
-    def _validate(self, raise_error=False) -> ValidationResult:
+    def _validate(self, raise_error=False) -> MutableValidationResult:
         """Validate the resource. If raise_error is True, raise ValidationError
         if validation fails and log warnings if applicable; Else, return the
         validation result.
@@ -299,23 +422,28 @@ class SchemaValidatableMixin:
         """
         result = self._schema_validate()
         result.merge_with(self._customized_validate())
-        return result.try_raise(raise_error=raise_error, error_target=self._get_validation_error_target())
+        return result.try_raise(
+            raise_error=raise_error, error_target=self._get_validation_error_target()
+        )
 
-    def _customized_validate(self) -> ValidationResult:
+    def _customized_validate(self) -> MutableValidationResult:
         """Validate the resource with customized logic.
 
         Override this method to add customized validation logic.
         """
         return self._create_empty_validation_result()
 
-    def _get_skip_fields_in_schema_validation(self) -> typing.List[str]:  # pylint: disable=no-self-use
+    @classmethod
+    def _get_skip_fields_in_schema_validation(
+        cls,
+    ) -> typing.List[str]:  # pylint: disable=no-self-use
         """Get the fields that should be skipped in schema validation.
 
         Override this method to add customized validation logic.
         """
         return []
 
-    def _schema_validate(self) -> ValidationResult:
+    def _schema_validate(self) -> MutableValidationResult:
         """Validate the resource with the schema.
 
         return type: ValidationResult
@@ -337,17 +465,19 @@ class _ValidationResultBuilder:
     @classmethod
     def success(cls):
         """Create a validation result with success status."""
-        return ValidationResult()
+        return MutableValidationResult()
 
     @classmethod
-    def from_single_message(cls, singular_error_message: str = None, yaml_path: str = "*", data: dict = None):
+    def from_single_message(
+        cls, singular_error_message: str = None, yaml_path: str = "*", data: dict = None
+    ):
         """Create a validation result with only 1 diagnostic.
 
         param singular_error_message: diagnostic.message.
         param yaml_path: diagnostic.yaml_path. param data:
         serialized validation target.
         """
-        obj = ValidationResult(data=data)
+        obj = MutableValidationResult(target_obj=data)
         if singular_error_message:
             obj.append_error(message=singular_error_message, yaml_path=yaml_path)
         return obj
@@ -361,7 +491,6 @@ class _ValidationResultBuilder:
         param error: ValidationError raised by marshmallow.Schema.load.
         """
         obj = cls.from_validation_messages(error.messages, data=error.data)
-        obj._valid_data = error.valid_data
         if source_path:
             obj.resolve_location_for_diagnostics(source_path, resolve_value=True)
         return obj
@@ -375,13 +504,15 @@ class _ValidationResultBuilder:
         marshmallow.Schema.validate. param data: serialized data to
         validate
         """
-        instance = ValidationResult(data=data)
+        instance = MutableValidationResult(target_obj=data)
         errors = copy.deepcopy(errors)
         cls._from_validation_messages_recursively(errors, [], instance)
         return instance
 
     @classmethod
-    def _from_validation_messages_recursively(cls, errors, path_stack, instance: ValidationResult):
+    def _from_validation_messages_recursively(
+        cls, errors, path_stack, instance: MutableValidationResult
+    ):
         cur_path = ".".join(path_stack) if path_stack else "*"
         # single error message
         if isinstance(errors, dict) and "_schema" in errors:
@@ -394,10 +525,14 @@ class _ValidationResultBuilder:
             for field, msgs in errors.items():
                 # fields.Dict
                 if field in ["key", "value"]:
-                    cls._from_validation_messages_recursively(msgs, path_stack, instance)
+                    cls._from_validation_messages_recursively(
+                        msgs, path_stack, instance
+                    )
                 else:
                     path_stack.append(field)
-                    cls._from_validation_messages_recursively(msgs, path_stack, instance)
+                    cls._from_validation_messages_recursively(
+                        msgs, path_stack, instance
+                    )
                     path_stack.pop()
         # detailed error message
         elif isinstance(errors, list) and all(isinstance(msg, str) for msg in errors):
@@ -413,18 +548,25 @@ class _ValidationResultBuilder:
             def msg2str(msg):
                 if isinstance(msg, str):
                     return msg
-                if isinstance(msg, dict) and len(msg) == 1 and "_schema" in msg and len(msg["_schema"]) == 1:
+                if (
+                    isinstance(msg, dict)
+                    and len(msg) == 1
+                    and "_schema" in msg
+                    and len(msg["_schema"]) == 1
+                ):
                     return msg["_schema"][0]
 
                 return str(msg)
 
-            instance.append_error(message="; ".join([msg2str(x) for x in errors]), yaml_path=cur_path)
+            instance.append_error(
+                message="; ".join([msg2str(x) for x in errors]), yaml_path=cur_path
+            )
         # unknown error
         else:
             instance.append_error(message=str(errors), yaml_path=cur_path)
 
 
-class YamlLocationResolver:
+class _YamlLocationResolver:
     def __init__(self, source_path):
         self._source_path = source_path
 
@@ -475,4 +617,7 @@ class YamlLocationResolver:
                     pass
                 # if not, return current section
                 break
-        return f"{source_path.resolve().absolute()}#line {loaded_yaml.start_line}", None if attrs else loaded_yaml.value
+        return (
+            f"{source_path.resolve().absolute()}#line {loaded_yaml.start_line}",
+            None if attrs else loaded_yaml.value,
+        )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -31,9 +31,8 @@ from azure.ai.ml._utils._azureml_polling import AzureMLPolling
 from azure.ai.ml._utils._endpoint_utils import polling_wait
 from azure.ai.ml._utils._logger_utils import OpsLogger
 from azure.ai.ml.constants._common import AzureMLResourceType, LROConfigurations
-from azure.ai.ml.entities import Component
+from azure.ai.ml.entities import Component, ValidationResult
 from azure.ai.ml.entities._assets import Code
-from azure.ai.ml.entities._validation import ValidationResult
 from azure.ai.ml.exceptions import ComponentException, ErrorCategory, ErrorTarget, ValidationException
 
 from .._utils._experimental import experimental

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -63,7 +63,7 @@ from azure.ai.ml.constants._common import (
 )
 from azure.ai.ml.constants._compute import ComputeType
 from azure.ai.ml.constants._job.pipeline import PipelineConstants
-from azure.ai.ml.entities import Compute, Job, PipelineJob, ServiceInstance
+from azure.ai.ml.entities import Compute, Job, PipelineJob, ValidationResult, ServiceInstance
 from azure.ai.ml.entities._assets._artifacts.code import Code
 from azure.ai.ml.entities._builders import BaseNode, Command, DoWhile, Spark
 from azure.ai.ml.entities._datastore._constants import WORKSPACE_BLOB_STORE
@@ -74,7 +74,10 @@ from azure.ai.ml.entities._job.import_job import ImportJob
 from azure.ai.ml.entities._job.job import _is_pipeline_child_job
 from azure.ai.ml.entities._job.parallel.parallel_job import ParallelJob
 from azure.ai.ml.entities._job.to_rest_functions import to_rest_job_object
-from azure.ai.ml.entities._validation import SchemaValidatableMixin
+from azure.ai.ml.entities._validation import (
+    SchemaValidatableMixin,
+    _ValidationResultBuilder,
+)
 from azure.ai.ml.exceptions import (
     ComponentException,
     ErrorCategory,
@@ -96,7 +99,6 @@ from azure.core.tracing.decorator import distributed_trace
 from .._utils._experimental import experimental
 from ..constants._component import ComponentSource
 from ..entities._job.pipeline._io import InputOutputBase, _GroupAttrDict, PipelineInput
-from ..entities._validation import ValidationResult, _ValidationResultBuilder
 from ._component_operations import ComponentOperations
 from ._compute_operations import ComputeOperations
 from ._dataset_dataplane_operations import DatasetDataplaneOperations

--- a/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
@@ -721,7 +721,7 @@ environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1"""
         component.command += " & echo ${{inputs.non_existent}} & echo ${{outputs.non_existent}}"
         validation_result = client.components.validate(component)
         assert validation_result.passed is False
-        assert validation_result.messages == {
+        assert validation_result.error_messages == {
             "name": "Missing data for required field.",
             "command": "Invalid data binding expression: inputs.non_existent, outputs.non_existent",
         }

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_command_component_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_command_component_entity.py
@@ -362,14 +362,14 @@ class TestCommandComponentEntity:
                 {"inputs": {"component_in_number": {"description": "1", "type": "number"}}},
             ],
         )
-        validation_result = component._customized_validate()
+        validation_result = component._validate()
         assert validation_result.passed
 
         # user can still overwrite input name to illegal
         component.inputs["COMPONENT_IN_NUMBER"] = Input(description="1", type="number")
-        validation_result = component._customized_validate()
+        validation_result = component._validate()
         assert not validation_result.passed
-        assert validation_result.invalid_fields[0] == "inputs.COMPONENT_IN_NUMBER"
+        assert "inputs.COMPONENT_IN_NUMBER" in validation_result.error_messages
 
     def test_primitive_output(self):
         expected_rest_component = {

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_validate.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_validate.py
@@ -95,14 +95,14 @@ class TestComponentValidate:
             setattr(component, expected_location, new_asset)
             validation_result = component._validate()
             if should_fail:
-                assert validation_result.passed is False and expected_location in validation_result.messages, (
+                assert validation_result.passed is False and expected_location in validation_result.error_messages, (
                     f"field {expected_location} with value {str(new_asset)} should be invalid, "
-                    f"but validation message is {json.dumps(validation_result._to_dict(), indent=2)}"
+                    f"but validation message is {repr(validation_result)}"
                 )
             else:
                 assert validation_result.passed, (
                     f"field {expected_location} with value {str(new_asset)} should be valid, "
-                    f"but met unexpected error: {json.dumps(validation_result._to_dict(), indent=2)}"
+                    f"but met unexpected error: {repr(validation_result)}"
                 )
 
         # object

--- a/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
@@ -875,7 +875,7 @@ class TestDSLPipeline(AzureRecordedTestCase):
             required_param_with_default=None,
         )
         validate_result = pipeline._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "inputs.required_param_with_default": "Required input 'required_param_with_default' for pipeline 'pipeline_with_default_optional_parameters' not provided."
         }
 

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -3921,9 +3921,9 @@ class TestInitFinalizeJob:
         invalid_pipeline1.settings.on_finalize = "finalize_job"
         validation_result1 = invalid_pipeline1._validate_init_finalize_job()
         assert not validation_result1.passed
-        assert validation_result1.messages["settings.on_init"] == "On_init job name init_job not exists in jobs."
+        assert validation_result1.error_messages["settings.on_init"] == "On_init job name init_job not exists in jobs."
         assert (
-            validation_result1.messages["settings.on_finalize"]
+            validation_result1.error_messages["settings.on_finalize"]
             == "On_finalize job name finalize_job not exists in jobs."
         )
 
@@ -3941,13 +3941,13 @@ class TestInitFinalizeJob:
         invalid_pipeline2.settings.on_finalize = "node1"
         validation_result2 = invalid_pipeline2._validate_init_finalize_job()
         assert not validation_result2.passed
-        assert validation_result2.messages["jobs"] == "No other job except for on_init/on_finalize job."
+        assert validation_result2.error_messages["jobs"] == "No other job except for on_init/on_finalize job."
         assert (
-            validation_result2.messages["settings.on_init"]
+            validation_result2.error_messages["settings.on_init"]
             == "On_init job should not have connection to other execution node."
         )
         assert (
-            validation_result2.messages["settings.on_finalize"]
+            validation_result2.error_messages["settings.on_finalize"]
             == "On_finalize job should not have connection to other execution node."
         )
 
@@ -3991,7 +3991,7 @@ class TestInitFinalizeJob:
             set_pipeline_settings(on_init=init_job, on_finalize=finalize_job)
 
         valid_pipeline = subgraph_init_finalize_job_func()
-        assert valid_pipeline._customized_validate().passed
+        assert valid_pipeline._validate().passed
         assert valid_pipeline.settings.on_init == "init_job"
         assert valid_pipeline.settings.on_finalize == "finalize_job"
 

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -278,14 +278,14 @@ class TestComponent:
     )
     def test_invalid_environment(self, yaml_path: str, invalid_field: str) -> None:
         component = load_component(source=yaml_path)
-        validation_result = component._customized_validate()
+        validation_result = component._validate()
         assert not validation_result.passed
-        assert validation_result.invalid_fields[0] == f"environment.conda.{invalid_field}"
+        assert f"environment.conda.{invalid_field}" in validation_result.error_messages
 
     def test_environment_duplicate_dependencies_warning(self) -> None:
         yaml_path = "./tests/test_configs/internal/env-duplicate-dependencies/component_spec.yaml"
         component = load_component(source=yaml_path)
-        validation_result = component._customized_validate()
+        validation_result = component._validate()
         # pass validate with warning message
         assert validation_result.passed
         expected_warning_message = (
@@ -319,7 +319,7 @@ class TestComponent:
             "./tests/test_configs/internal/component_with_additional_includes/helloworld_additional_includes.yml"
         )
         component: InternalComponent = load_component(source=yaml_path)
-        assert component._customized_validate().passed, component._customized_validate()._to_dict()
+        assert component._validate().passed, component._validate()._to_dict()
         # resolve
         with component._resolve_local_code() as code_path:
             assert code_path.is_dir()
@@ -340,7 +340,7 @@ class TestComponent:
     def test_additional_includes_with_code_specified(self, yaml_path: str, has_additional_includes: bool) -> None:
         yaml_path = os.path.join("./tests/test_configs/internal/component_with_additional_includes/", yaml_path)
         component: InternalComponent = load_component(source=yaml_path)
-        assert component._customized_validate().passed, component._customized_validate()._to_dict()
+        assert component._validate().passed, component._validate()._to_dict()
         # resolve
         with component._resolve_local_code() as code_path:
             assert code_path.is_dir()
@@ -372,9 +372,9 @@ class TestComponent:
         component = load_component(
             os.path.join("./tests/test_configs/internal/component_with_additional_includes", yaml_path)
         )
-        validation_result = component._customized_validate()
+        validation_result = component._validate()
         assert validation_result.passed is False
-        assert validation_result.messages["*"].startswith(expected_error_msg_prefix), validation_result.messages["*"]
+        assert validation_result.error_messages["*"].startswith(expected_error_msg_prefix)
 
     def test_component_input_types(self) -> None:
         yaml_path = "./tests/test_configs/internal/component_with_input_types/component_spec.yaml"
@@ -436,7 +436,7 @@ class TestComponent:
     def test_component_input_list_type(self) -> None:
         yaml_path = "./tests/test_configs/internal/scope-component/component_spec.yaml"
         component: InternalComponent = load_component(yaml_path)
-        assert component._customized_validate().passed is True
+        assert component._validate().passed is True
         input_text_data_type = component._to_rest_object().properties.component_spec["inputs"]["TextData"]["type"]
         # for list type component input, REST object should remain type list for service contract
         assert isinstance(input_text_data_type, list)

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
@@ -113,28 +113,35 @@ class TestPipelineJobValidate:
         assert expected_validation_result.pop("message") in result_dict[0].pop("message")
         assert result_dict[0] == expected_validation_result
 
-    @pytest.mark.skip(reason="migration skip: sync pipeline changes during soft code complete.")
     def test_pipeline_job_type_sensitive_error_message(self):
-        test_path = "./tests/test_configs/pipeline_jobs/helloworld_pipeline_job_inline_comps.yml"
-        pipeline_job: PipelineJob = load_job(test_path)
-        job_dict = pipeline_job._to_dict()
-        unsupported_node_type = "unsupported_node_type"
-        job_dict["jobs"]["hello_world_component_inline"]["type"] = unsupported_node_type
-        del job_dict["jobs"]["hello_world_component_inline_with_schema"]["component"]["environment"]
-        errors = pipeline_job._schema_for_validation.validate(job_dict)
-        type_sensitive_union_field = pipeline_job._schema_for_validation.dump_fields["jobs"].value_field
-        assert errors == {
-            "jobs": {
-                "hello_world_component_inline": {
-                    "value": {
-                        "type": f"Value {unsupported_node_type!r} passed is "
-                        f"not in set {type_sensitive_union_field.allowed_types}",
-                    }
+        test_path = "./tests/test_configs/pipeline_jobs/helloworld_pipeline_job_with_type_sensitive_errors.yml"
+        validation_result = validate_job(test_path)
+        actual_dict = validation_result._to_dict()
+        for error in actual_dict["errors"]:
+            error.pop("location")
+            error.pop("message")
+        assert actual_dict == {
+            "errors": [
+                # error on type only for not supported value on type_field
+                {
+                    "path": "jobs.hello_world_unsupported_type.type",
+                    "value": "unsupported",
                 },
-                "hello_world_component_inline_with_schema": {
-                    "value": {"component": {"environment": ["Missing data for required field."]}}
+                # following errors are from SweepSchema
+                {
+                    "path": "jobs.hello_world_no_env.objective",
+                    "value": None,
                 },
-            }
+                {
+                    "path": "jobs.hello_world_no_env.limits",
+                    "value": None,
+                },
+                {
+                    "path": "jobs.hello_world_no_env.trial",
+                    "value": None,
+                }
+            ],
+            "result": "Failed",
         }
 
     def test_pipeline_node_name_validate(self):
@@ -193,7 +200,7 @@ class TestPipelineJobValidate:
 
     def test_pipeline_job_base_path_resolution(self, mocker: MockFixture):
         job: PipelineJob = load_job("./tests/test_configs/pipeline_jobs/my_exp/azureml-job.yaml")
-        job._validate(raise_error=True)
+        assert job._validate().passed
 
     def test_pipeline_job_validate_compute(self) -> None:
         test_path = "./tests/test_configs/pipeline_jobs/invalid/combo.yml"
@@ -252,7 +259,7 @@ class TestDSLPipelineJobValidate:
         pipeline2 = pipeline(None, None)
         validate_result = pipeline2._validate()
         assert validate_result.passed is False
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "jobs.microsoftsamples_command_component_basic.compute": "Compute not set",
             "inputs.component_in_path": "Required input 'component_in_path' for pipeline 'pipeline' not provided.",
         }
@@ -281,7 +288,7 @@ class TestDSLPipelineJobValidate:
             required_param_with_default=False,
         )
         validate_result = pipeline._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "inputs.required_input": "Required input 'required_input' for pipeline 'pipeline_with_default_optional_parameters' not provided."
         }
 
@@ -304,7 +311,7 @@ class TestDSLPipelineJobValidate:
             required_param_with_default=False,
         )
         validate_result = pipeline._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "jobs.default_optional_component.inputs.required_input": "Required input 'required_input' for component 'default_optional_component' not provided."
         }
 
@@ -327,7 +334,7 @@ class TestDSLPipelineJobValidate:
         )
 
         validate_result = pipeline._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "jobs.default_optional_component.inputs.required_input": "Required input 'required_input' for component 'default_optional_component' not provided."
         }
 
@@ -368,7 +375,7 @@ class TestDSLPipelineJobValidate:
             optional_param="optional_param",
         )
         validate_result = pipeline._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "inputs.optional_param_with_default": "Required input 'optional_param_with_default' for pipeline 'pipeline_with_default_optional_parameters' not provided."
         }
 
@@ -385,7 +392,7 @@ class TestDSLPipelineJobValidate:
 
         pipeline = train_with_sweep_in_pipeline(raw_data=Input(path="/a/path/on/ds"))
         validate_result = pipeline._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "jobs.cmd_node1.inputs.component_in_number": "Input of command cmd_node1 is a SweepDistribution, please use command.sweep to transform the command into a sweep node.",
             "jobs.cmd_node1.compute": "Compute not set",
         }
@@ -420,7 +427,7 @@ class TestDSLPipelineJobValidate:
 
         pipeline_job: PipelineJob = root_pipeline(10, job_input)
         validate_result = pipeline_job._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "jobs.sub_graph.jobs.node1.compute": "Compute not set",
             "jobs.sub_pipeline1.jobs.node1.compute": "Compute not set",
             "jobs.sub_pipeline1.jobs.sub_pipeline0.jobs.node1.compute": "Compute not set",
@@ -449,7 +456,7 @@ class TestDSLPipelineJobValidate:
         pipeline_job: PipelineJob = root_pipeline(10, job_input)
         validate_result = pipeline_job._validate()
         # Note: top level input will not raise type unknown error here
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "jobs.sub_pipeline.inputs.component_in_number": "Parameter type unknown, "
             "please add type annotation or specify input default value.",
             "jobs.sub_pipeline.inputs.component_in_path": "Parameter type unknown, "
@@ -489,7 +496,7 @@ class TestDSLPipelineJobValidate:
             optional_param="optional_param",
         )
         validate_result = pipeline._validate()
-        assert validate_result.messages == {
+        assert validate_result.error_messages == {
             "inputs.required_input": "Pipeline optional Input binding to required inputs: ['default_optional_component.inputs.required_input']"
         }
 
@@ -536,8 +543,8 @@ class TestDSLPipelineJobValidate:
         dsl_pipeline: PipelineJob = pipeline(10, job_input)
 
         validation_result = dsl_pipeline._validate()
-        assert "jobs.node2.limits.max_total_trials" in validation_result.messages
-        assert validation_result.messages["jobs.node2.limits.max_total_trials"] == "Missing data for required field."
+        assert "jobs.node2.limits.max_total_trials" in validation_result.error_messages
+        assert validation_result.error_messages["jobs.node2.limits.max_total_trials"] == "Missing data for required field."
 
     def test_node_schema_validation(self) -> None:
         path = "./tests/test_configs/dsl_pipeline/parallel_component_with_file_input/score.yml"

--- a/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/helloworld_pipeline_job_with_type_sensitive_errors.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/helloworld_pipeline_job_with_type_sensitive_errors.yml
@@ -1,0 +1,41 @@
+type: pipeline
+
+name: simplePipelineJobWithInlineComps
+description: The hello world pipeline job with inline components
+tags:
+  tag: tagvalue
+  owner: sdkteam
+
+compute: azureml:cpu-cluster
+
+inputs:
+  # examples of inputs that take values such as int, string, etc.
+  job_in_number: 10.01
+  job_in_other_number:
+    value: 15
+
+jobs:
+  hello_world_unsupported_type:
+    type: unsupported
+    inputs:
+      component_in_number: ${{parent.inputs.job_in_number}}
+    compute: azureml:cpu-cluster
+
+    component:
+      command: >-
+        echo Hello World &
+        echo ${{inputs.component_in_number}}
+      environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1
+      code: "../python"
+      inputs:
+        component_in_number:
+          description: Am integer
+          type: integer
+          default: 10
+          optional: false
+
+  hello_world_no_env:
+    type: sweep
+    inputs:
+      component_in_number: ${{parent.inputs.job_in_number}}
+    compute: azureml:cpu-cluster


### PR DESCRIPTION
move private functions of ValidationResult to a subclass (MutableValidationResult)

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
