### PR TITLE
Add registry delete operation

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/v2022_10_01_preview/aio/operations/_registries_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/v2022_10_01_preview/aio/operations/_registries_operations.py
@@ -260,7 +260,7 @@ class RegistriesOperations:
         )
         response = pipeline_response.http_response
 
-        if response.status_code not in [200, 204]:
+        if response.status_code not in [200, 202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
             error = self._deserialize.failsafe_deserialize(_models.ErrorResponse, pipeline_response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
@@ -385,12 +385,16 @@ class RegistriesOperations:
         )
         response = pipeline_response.http_response
 
-        if response.status_code not in [200]:
+        if response.status_code not in [200, 202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
             error = self._deserialize.failsafe_deserialize(_models.ErrorResponse, pipeline_response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
-        deserialized = self._deserialize('Registry', pipeline_response)
+        if response.status_code == 200:
+            deserialized = self._deserialize('Registry', pipeline_response)
+
+        if response.status_code == 202:
+            deserialized = self._deserialize('Registry', pipeline_response)
 
         if cls:
             return cls(pipeline_response, deserialized, {})

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/v2022_10_01_preview/operations/_registries_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/v2022_10_01_preview/operations/_registries_operations.py
@@ -499,7 +499,7 @@ class RegistriesOperations(object):
         )
         response = pipeline_response.http_response
 
-        if response.status_code not in [200, 204]:
+        if response.status_code not in [200, 202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
             error = self._deserialize.failsafe_deserialize(_models.ErrorResponse, pipeline_response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
@@ -626,12 +626,16 @@ class RegistriesOperations(object):
         )
         response = pipeline_response.http_response
 
-        if response.status_code not in [200]:
+        if response.status_code not in [200, 202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
             error = self._deserialize.failsafe_deserialize(_models.ErrorResponse, pipeline_response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
-        deserialized = self._deserialize('Registry', pipeline_response)
+        if response.status_code == 200:
+            deserialized = self._deserialize('Registry', pipeline_response)
+
+        if response.status_code == 202:
+            deserialized = self._deserialize('Registry', pipeline_response)
 
         if cls:
             return cls(pipeline_response, deserialized, {})

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
@@ -129,3 +129,20 @@ class RegistryOperations:
         )
 
         return poller
+
+
+    # @monitor_with_activity(logger, "Registry.Delete", ActivityType.PUBLICAPI)
+    def delete(self, *, registry_name: str, **kwargs: Dict) -> LROPoller:
+        """Delete a registry.
+
+        :param registry_name: Name of the registry
+        :type registry_name: str
+        :return: A poller to track the operation status.
+        :rtype: ~azure.core.polling.LROPoller[None]
+        """
+        resource_group = kwargs.get("resource_group") or self._resource_group_name
+        return self._operation.delete(
+            resource_group_name=resource_group,
+            registry_name=registry_name,
+            **self._init_kwargs,
+        )

--- a/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2022-10-01-preview/registries.json
+++ b/sdk/ml/azure-ai-ml/swagger/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2022-10-01-preview/registries.json
@@ -143,6 +143,9 @@
           "200": {
             "description": "Success"
           },
+          "202": {
+            "description": "Success"
+          },
           "204": {
             "description": "No Content"
           }
@@ -255,6 +258,12 @@
             "schema": {
               "$ref": "#/definitions/RegistryTrackedResource"
             }
+          },
+          "202": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/RegistryTrackedResource"
+            }
           }
         },
         "x-ms-examples": {
@@ -324,6 +333,12 @@
             }
           },
           "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/RegistryTrackedResource"
+            }
+          },
+          "202": {
             "description": "Created",
             "schema": {
               "$ref": "#/definitions/RegistryTrackedResource"

--- a/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_operations.py
@@ -54,3 +54,8 @@ class TestRegistryOperations:
         # valid creation of new registry
         mock_registry_operation.begin_create(registry=reg)
         mock_registry_operation._operation.begin_create_or_update.assert_called_once()
+
+    def test_delete(self, mock_registry_operation: RegistryOperations, randstr: Callable[[], str]) -> None:
+
+        mock_registry_operation.delete(registry_name="some registry")
+        mock_registry_operation._operation.delete.assert_called_once()


### PR DESCRIPTION
# Description

Adds a new registry operation - delete. This includes some manual swagger changes, since the swagger's listed response codes for the delete operation are wrong, and needed to be updated to include the actual return options. I included a couple other similar registry swagger corrections here as well. These changes are all manual fixes, not based on an official spec.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
