### PR TITLE
[Communication] - Phone Numbers - Use static connection string in azure-communication-phonenumber tests

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/test/_shared/testcase.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/_shared/testcase.py
@@ -87,9 +87,11 @@ class CommunicationTestCase(AzureTestCase):
         super(CommunicationTestCase, self).setUp()
         if self.is_playback():
             self.connection_str = "endpoint=https://sanitized.communication.azure.com/;accesskey=fake==="
+            self.static_connection_str = self.connection_str
         else:
             self.connection_str = os.getenv('COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING') or \
                                   os.getenv('COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING')
+            self.static_connection_str = os.getenv('COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING')
             endpoint, _ = parse_connection_str(self.connection_str)
             self._resource_name = endpoint.split(".")[0]
             self.scrubber.register_name_pair(self._resource_name, "sanitized")

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_get_purchased_phone_number.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_get_purchased_phone_number.yaml
@@ -9,9 +9,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:24:18 GMT
+      - Wed, 12 Oct 2022 01:00:59 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -19,26 +19,26 @@ interactions:
   response:
     body:
       string: '{"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US",
-        "phoneNumberType": "tollFree", "capabilities": {"calling": "inbound", "sms":
+        "phoneNumberType": "tollFree", "capabilities": {"calling": "none", "sms":
         "outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:24:17 GMT
+      - Wed, 12 Oct 2022 01:01:01 GMT
       ms-cv:
-      - RUviUhanXUuedvHl+aoPpg.0
-      request-context:
-      - appId=
+      - CmoReVse+UaDMfLQ3HYBAQ.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 3192ms
+      - 1646ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_get_purchased_phone_number_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_get_purchased_phone_number_from_managed_identity.yaml
@@ -9,32 +9,32 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized?api-version=2022-01-11-preview2
   response:
     body:
       string: '{"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US",
-        "phoneNumberType": "tollFree", "capabilities": {"calling": "inbound", "sms":
+        "phoneNumberType": "tollFree", "capabilities": {"calling": "none", "sms":
         "outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:24:22 GMT
+      - Wed, 12 Oct 2022 01:01:03 GMT
       ms-cv:
-      - vyQH496Y/0OFVUm/apv27Q.0
-      request-context:
-      - appId=
+      - G0yrk9BudEKWDdQjKoMpgA.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 3489ms
+      - 1398ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_get_purchased_phone_number_with_invalid_phone_number.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_get_purchased_phone_number_with_invalid_phone_number.yaml
@@ -9,9 +9,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:24:27 GMT
+      - Wed, 12 Oct 2022 01:01:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -22,21 +22,21 @@ interactions:
         cannot be found.", "target": "phonenumber"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json
       date:
-      - Wed, 12 Jan 2022 16:24:25 GMT
+      - Wed, 12 Oct 2022 01:01:04 GMT
       ms-cv:
-      - eRnvsvQ0s0ymZOrVnZ56wQ.0
-      request-context:
-      - appId=
+      - /gpFm/xhKEKUwge+13cKKQ.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1712ms
+      - 664ms
     status:
       code: 404
       message: Not Found

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_list_purchased_phone_numbers.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_list_purchased_phone_numbers.yaml
@@ -9,9 +9,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:24:30 GMT
+      - Wed, 12 Oct 2022 01:01:04 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -199,7 +199,7 @@ interactions:
         "assignmentType": "application", "purchaseDate": "2021-06-23T23:41:22.1720088+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
-        "tollFree", "capabilities": {"calling": "inbound", "sms": "outbound"}, "assignmentType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "outbound"}, "assignmentType":
         "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00", "cost":
         {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}, {"id":
         "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
@@ -421,21 +421,21 @@ interactions:
         "nextLink": "/phoneNumbers?skip=100&top=100&api-version=2022-01-11-preview2"}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:24:31 GMT
+      - Wed, 12 Oct 2022 01:01:09 GMT
       ms-cv:
-      - uncxAwNo6UCrwN7VxlhXCQ.0
-      request-context:
-      - appId=
+      - mBVgKYRrpEmdgx61MQF9xQ.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 4822ms
+      - 4322ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_list_purchased_phone_numbers_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_list_purchased_phone_numbers_from_managed_identity.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers?skip=0&top=100&api-version=2022-01-11-preview2
   response:
@@ -195,7 +195,7 @@ interactions:
         "assignmentType": "application", "purchaseDate": "2021-06-23T23:41:22.1720088+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
-        "tollFree", "capabilities": {"calling": "inbound", "sms": "outbound"}, "assignmentType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "outbound"}, "assignmentType":
         "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00", "cost":
         {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}, {"id":
         "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
@@ -417,21 +417,21 @@ interactions:
         "nextLink": "/phoneNumbers?skip=100&top=100&api-version=2022-01-11-preview2"}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:24:40 GMT
+      - Wed, 12 Oct 2022 01:01:15 GMT
       ms-cv:
-      - WlkpBqUX40yEpeTVct8OPg.0
-      request-context:
-      - appId=
+      - SXSxZMQlL0ezI0szYhCEvg.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 7286ms
+      - 5185ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_search_available_phone_numbers.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_search_available_phone_numbers.yaml
@@ -14,9 +14,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:24:45 GMT
+      - Wed, 12 Oct 2022 01:01:14 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: POST
@@ -28,25 +28,25 @@ interactions:
       access-control-expose-headers:
       - Location,Operation-Location,operation-id,search-id
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-length:
       - '0'
       date:
-      - Wed, 12 Jan 2022 16:24:47 GMT
+      - Wed, 12 Oct 2022 01:01:35 GMT
       ms-cv:
-      - 8tw5TPAY2UWd5E7y6FEjKQ.0
+      - Lija3zCczEWL9xrP1DQopQ.0
       operation-id:
-      - search_e1784c92-5251-4e28-af6c-8a7566d6cd33
+      - search_2553f1fa-fdf2-40d9-b3aa-d867515b04b7
       operation-location:
-      - /phoneNumbers/operations/search_e1784c92-5251-4e28-af6c-8a7566d6cd33?api-version=2022-01-11-preview2
-      request-context:
-      - appId=
+      - /phoneNumbers/operations/search_2553f1fa-fdf2-40d9-b3aa-d867515b04b7?api-version=2022-01-11-preview2
       search-id:
-      - e1784c92-5251-4e28-af6c-8a7566d6cd33
+      - 2553f1fa-fdf2-40d9-b3aa-d867515b04b7
+      strict-transport-security:
+      - max-age=2592000
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 4862ms
+      - 20599ms
     status:
       code: 202
       message: Accepted
@@ -60,38 +60,38 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:25:21 GMT
+      - Wed, 12 Oct 2022 01:02:05 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
-    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/search_e1784c92-5251-4e28-af6c-8a7566d6cd33?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/search_2553f1fa-fdf2-40d9-b3aa-d867515b04b7?api-version=2022-01-11-preview2
   response:
     body:
       string: '{"operationType": "search", "status": "succeeded", "resourceLocation":
-        "/availablePhoneNumbers/searchResults/e1784c92-5251-4e28-af6c-8a7566d6cd33?api-version=2022-01-11-preview2",
-        "createdDateTime": "2022-01-12T16:24:46.0297367+00:00", "id": "sanitized",
+        "/availablePhoneNumbers/searchResults/2553f1fa-fdf2-40d9-b3aa-d867515b04b7?api-version=2022-01-11-preview2",
+        "createdDateTime": "2022-10-12T01:01:35.4752168+00:00", "id": "sanitized",
         "lastActionDateTime": "0001-01-01T00:00:00+00:00"}'
     headers:
       access-control-expose-headers:
       - Location
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-11-15-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:25:18 GMT
+      - Wed, 12 Oct 2022 01:02:06 GMT
       ms-cv:
-      - ChuaJbw9x0aeoEex20Zetg.0
-      request-context:
-      - appId=
+      - GBk8bcqy20+tx4hDyTjYaA.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1361ms
+      - 628ms
     status:
       code: 200
       message: OK
@@ -106,37 +106,37 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:25:23 GMT
+      - Wed, 12 Oct 2022 01:02:06 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
-    uri: https://sanitized.communication.azure.com/availablePhoneNumbers/searchResults/e1784c92-5251-4e28-af6c-8a7566d6cd33?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/availablePhoneNumbers/searchResults/2553f1fa-fdf2-40d9-b3aa-d867515b04b7?api-version=2022-01-11-preview2
   response:
     body:
-      string: '{"searchId": "e1784c92-5251-4e28-af6c-8a7566d6cd33", "phoneNumbers":
+      string: '{"searchId": "2553f1fa-fdf2-40d9-b3aa-d867515b04b7", "phoneNumbers":
         ["sanitized"], "phoneNumberType": "tollFree", "assignmentType": "application",
         "capabilities": {"calling": "inbound", "sms": "inbound+outbound"}, "cost":
         {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}, "searchExpiresBy":
-        "2022-01-12T16:40:52.5420073+00:00"}'
+        "2022-10-12T01:17:39.3633663+00:00"}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:25:20 GMT
+      - Wed, 12 Oct 2022 01:02:08 GMT
       ms-cv:
-      - pNLF2RdqV0ybtZdMisqs5g.0
-      request-context:
-      - appId=
+      - IODqCCYl9Uuzj/VUceDsQw.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1946ms
+      - 1835ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_search_available_phone_numbers_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_search_available_phone_numbers_from_managed_identity.yaml
@@ -14,7 +14,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://sanitized.communication.azure.com/availablePhoneNumbers/countries/US/:search?api-version=2022-01-11-preview2
   response:
@@ -24,25 +24,25 @@ interactions:
       access-control-expose-headers:
       - Location,Operation-Location,operation-id,search-id
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-length:
       - '0'
       date:
-      - Wed, 12 Jan 2022 16:25:26 GMT
+      - Wed, 12 Oct 2022 01:02:13 GMT
       ms-cv:
-      - bIqcEAhPLkmuKMW8Xrm/Ag.0
+      - AQpioIIwLUWrMMl3qO1tpA.0
       operation-id:
-      - search_8f101839-2948-4645-b582-f3223caac87d
+      - search_7095a400-a981-4f68-ac3c-80f2a3ac2bbe
       operation-location:
-      - /phoneNumbers/operations/search_8f101839-2948-4645-b582-f3223caac87d?api-version=2022-01-11-preview2
-      request-context:
-      - appId=
+      - /phoneNumbers/operations/search_7095a400-a981-4f68-ac3c-80f2a3ac2bbe?api-version=2022-01-11-preview2
       search-id:
-      - 8f101839-2948-4645-b582-f3223caac87d
+      - 7095a400-a981-4f68-ac3c-80f2a3ac2bbe
+      strict-transport-security:
+      - max-age=2592000
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 4715ms
+      - 3816ms
     status:
       code: 202
       message: Accepted
@@ -56,34 +56,34 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/search_8f101839-2948-4645-b582-f3223caac87d?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/search_7095a400-a981-4f68-ac3c-80f2a3ac2bbe?api-version=2022-01-11-preview2
   response:
     body:
       string: '{"operationType": "search", "status": "succeeded", "resourceLocation":
-        "/availablePhoneNumbers/searchResults/8f101839-2948-4645-b582-f3223caac87d?api-version=2022-01-11-preview2",
-        "createdDateTime": "2022-01-12T16:25:26.3451951+00:00", "id": "sanitized",
+        "/availablePhoneNumbers/searchResults/7095a400-a981-4f68-ac3c-80f2a3ac2bbe?api-version=2022-01-11-preview2",
+        "createdDateTime": "2022-10-12T01:02:12.6552926+00:00", "id": "sanitized",
         "lastActionDateTime": "0001-01-01T00:00:00+00:00"}'
     headers:
       access-control-expose-headers:
       - Location
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-11-15-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:25:58 GMT
+      - Wed, 12 Oct 2022 01:02:44 GMT
       ms-cv:
-      - KpxWsON6rUOsc5DHiLfVXQ.0
-      request-context:
-      - appId=
+      - ldIatOsxIkqffTu4V0afkA.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1309ms
+      - 939ms
     status:
       code: 200
       message: OK
@@ -98,33 +98,33 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://sanitized.communication.azure.com/availablePhoneNumbers/searchResults/8f101839-2948-4645-b582-f3223caac87d?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/availablePhoneNumbers/searchResults/7095a400-a981-4f68-ac3c-80f2a3ac2bbe?api-version=2022-01-11-preview2
   response:
     body:
-      string: '{"searchId": "8f101839-2948-4645-b582-f3223caac87d", "phoneNumbers":
+      string: '{"searchId": "7095a400-a981-4f68-ac3c-80f2a3ac2bbe", "phoneNumbers":
         ["sanitized"], "phoneNumberType": "tollFree", "assignmentType": "application",
         "capabilities": {"calling": "inbound", "sms": "inbound+outbound"}, "cost":
         {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}, "searchExpiresBy":
-        "2022-01-12T16:41:31.7326328+00:00"}'
+        "2022-10-12T01:18:14.9747183+00:00"}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:26:00 GMT
+      - Wed, 12 Oct 2022 01:02:45 GMT
       ms-cv:
-      - Zvz2FrcVYkiAaDOHoyZ3ew.0
-      request-context:
-      - appId=
+      - 79y/6oLsrkmoc1jboQ/sKQ.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1771ms
+      - 1122ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_search_available_phone_numbers_with_invalid_country_code.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_search_available_phone_numbers_with_invalid_country_code.yaml
@@ -14,9 +14,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:26:05 GMT
+      - Wed, 12 Oct 2022 01:02:44 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: POST
@@ -27,21 +27,21 @@ interactions:
         code.", "target": "countrycode"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json
       date:
-      - Wed, 12 Jan 2022 16:26:01 GMT
+      - Wed, 12 Oct 2022 01:02:45 GMT
       ms-cv:
-      - 6wQ+SNvlcU6YgG6cPUm/EA.0
-      request-context:
-      - appId=
+      - umlRgrxq6Ue7ekMyMYyehQ.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 60ms
+      - 65ms
     status:
       code: 400
       message: Bad Request

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_update_phone_number_capabilities.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_update_phone_number_capabilities.yaml
@@ -9,9 +9,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:26:06 GMT
+      - Wed, 12 Oct 2022 01:02:45 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -19,26 +19,26 @@ interactions:
   response:
     body:
       string: '{"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US",
-        "phoneNumberType": "tollFree", "capabilities": {"calling": "inbound", "sms":
+        "phoneNumberType": "tollFree", "capabilities": {"calling": "none", "sms":
         "outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:26:05 GMT
+      - Wed, 12 Oct 2022 01:02:47 GMT
       ms-cv:
-      - UzBaL0woM0m/cu+FtswX1g.0
-      request-context:
-      - appId=
+      - yL8GlReR+UWLSwUPKyHgBA.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 3301ms
+      - 1866ms
     status:
       code: 200
       message: OK
@@ -57,41 +57,41 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:26:10 GMT
+      - Wed, 12 Oct 2022 01:02:47 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized/capabilities?api-version=2022-01-11-preview2
   response:
     body:
-      string: '{"capabilitiesUpdateId": "d28a40f1-66d5-4133-8e11-4f7fc8bbd08f"}'
+      string: '{"capabilitiesUpdateId": "6d87d40e-8613-4622-8bc9-d1e6e06cc7e5"}'
     headers:
       access-control-expose-headers:
       - Operation-Location,Location,operation-id,capabilities-id
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       capabilities-id:
-      - d28a40f1-66d5-4133-8e11-4f7fc8bbd08f
+      - 6d87d40e-8613-4622-8bc9-d1e6e06cc7e5
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:26:10 GMT
+      - Wed, 12 Oct 2022 01:02:49 GMT
       ms-cv:
-      - tbx43u61xE2YTUNz7Bs6Xg.0
+      - KSUW+5HywU6raOkzRUwxBg.0
       operation-id:
-      - capabilities_d28a40f1-66d5-4133-8e11-4f7fc8bbd08f
+      - capabilities_6d87d40e-8613-4622-8bc9-d1e6e06cc7e5
       operation-location:
-      - /phoneNumbers/operations/capabilities_d28a40f1-66d5-4133-8e11-4f7fc8bbd08f?api-version=2022-01-11-preview2
-      request-context:
-      - appId=
+      - /phoneNumbers/operations/capabilities_6d87d40e-8613-4622-8bc9-d1e6e06cc7e5?api-version=2022-01-11-preview2
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 4481ms
+      - 1880ms
     status:
       code: 202
       message: Accepted
@@ -106,38 +106,38 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:26:45 GMT
+      - Wed, 12 Oct 2022 01:03:18 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
-    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_d28a40f1-66d5-4133-8e11-4f7fc8bbd08f?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_6d87d40e-8613-4622-8bc9-d1e6e06cc7e5?api-version=2022-01-11-preview2
   response:
     body:
       string: '{"operationType": "updatePhoneNumberCapabilities", "status": "succeeded",
         "resourceLocation": "/phoneNumbers/+18332321221?api-version=2022-01-11-preview2",
-        "createdDateTime": "2022-01-12T16:26:09.5472497+00:00", "id": "sanitized",
+        "createdDateTime": "2022-10-12T01:02:49.3006536+00:00", "id": "sanitized",
         "lastActionDateTime": "0001-01-01T00:00:00+00:00"}'
     headers:
       access-control-expose-headers:
       - Location
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-11-15-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:26:41 GMT
+      - Wed, 12 Oct 2022 01:03:20 GMT
       ms-cv:
-      - gIHzQi2ypESlgV631bCnqQ.0
-      request-context:
-      - appId=
+      - h65YzO0UWEyWyHsNHACKyw.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1262ms
+      - 387ms
     status:
       code: 200
       message: OK
@@ -152,9 +152,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:26:46 GMT
+      - Wed, 12 Oct 2022 01:03:19 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -167,21 +167,21 @@ interactions:
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:26:45 GMT
+      - Wed, 12 Oct 2022 01:03:21 GMT
       ms-cv:
-      - gMMy44dhBkiso4ydULM3HA.0
-      request-context:
-      - appId=
+      - f4iJqhqGQkuxbJuAIGF5Gw.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 3495ms
+      - 1301ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_update_phone_number_capabilities_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_update_phone_number_capabilities_from_managed_identity.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized?api-version=2022-01-11-preview2
   response:
@@ -20,21 +20,21 @@ interactions:
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:26:51 GMT
+      - Wed, 12 Oct 2022 01:03:23 GMT
       ms-cv:
-      - l3PFBCj65UK5MEuHLlag7w.0
-      request-context:
-      - appId=
+      - IOr8gOACKUupPAG63rkZKA.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 3356ms
+      - 1831ms
     status:
       code: 200
       message: OK
@@ -53,37 +53,37 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized/capabilities?api-version=2022-01-11-preview2
   response:
     body:
-      string: '{"capabilitiesUpdateId": "803a4beb-117f-47cd-8044-916b7a1882a5"}'
+      string: '{"capabilitiesUpdateId": "90559d47-c8f4-4882-b363-32e10a4d74ec"}'
     headers:
       access-control-expose-headers:
       - Operation-Location,Location,operation-id,capabilities-id
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       capabilities-id:
-      - 803a4beb-117f-47cd-8044-916b7a1882a5
+      - 90559d47-c8f4-4882-b363-32e10a4d74ec
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:26:55 GMT
+      - Wed, 12 Oct 2022 01:03:25 GMT
       ms-cv:
-      - jZqUtT+zEUu70Wx69t1qsQ.0
+      - oJuIoI5I+UelxEpndsKe2Q.0
       operation-id:
-      - capabilities_803a4beb-117f-47cd-8044-916b7a1882a5
+      - capabilities_90559d47-c8f4-4882-b363-32e10a4d74ec
       operation-location:
-      - /phoneNumbers/operations/capabilities_803a4beb-117f-47cd-8044-916b7a1882a5?api-version=2022-01-11-preview2
-      request-context:
-      - appId=
+      - /phoneNumbers/operations/capabilities_90559d47-c8f4-4882-b363-32e10a4d74ec?api-version=2022-01-11-preview2
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 4557ms
+      - 1806ms
     status:
       code: 202
       message: Accepted
@@ -98,34 +98,34 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_803a4beb-117f-47cd-8044-916b7a1882a5?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_90559d47-c8f4-4882-b363-32e10a4d74ec?api-version=2022-01-11-preview2
   response:
     body:
       string: '{"operationType": "updatePhoneNumberCapabilities", "status": "succeeded",
         "resourceLocation": "/phoneNumbers/+18332321221?api-version=2022-01-11-preview2",
-        "createdDateTime": "2022-01-12T16:26:55.3873792+00:00", "id": "sanitized",
+        "createdDateTime": "2022-10-12T01:03:25.6352763+00:00", "id": "sanitized",
         "lastActionDateTime": "0001-01-01T00:00:00+00:00"}'
     headers:
       access-control-expose-headers:
       - Location
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-11-15-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:27:27 GMT
+      - Wed, 12 Oct 2022 01:03:56 GMT
       ms-cv:
-      - ltowox5+50O1r2QCv/3cDA.0
-      request-context:
-      - appId=
+      - kXLNmgfOFkybMltIlZcPwQ.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1277ms
+      - 391ms
     status:
       code: 200
       message: OK
@@ -140,7 +140,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers/+18332321221?api-version=2022-01-11-preview2
   response:
@@ -151,21 +151,21 @@ interactions:
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jan 2022 16:27:30 GMT
+      - Wed, 12 Oct 2022 01:03:57 GMT
       ms-cv:
-      - O2/LasFBh0+PlpESK8HqFg.0
-      request-context:
-      - appId=
+      - QhpekX7GKkijUMm9EHw9Mw.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 3081ms
+      - 1256ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_update_phone_number_capabilities_with_invalid_phone_number.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client.test_update_phone_number_capabilities_with_invalid_phone_number.yaml
@@ -13,9 +13,9 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:27:36 GMT
+      - Wed, 12 Oct 2022 01:03:56 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
@@ -26,21 +26,21 @@ interactions:
         an internal error."}}'
     headers:
       api-supported-versions:
-      - 2021-03-07, 2022-01-11-preview2
+      - 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01
       content-type:
       - application/json
       date:
-      - Wed, 12 Jan 2022 16:27:31 GMT
+      - Wed, 12 Oct 2022 01:03:57 GMT
       ms-cv:
-      - zHkqjgmtiU6jWCK9tJRVrA.0
-      request-context:
-      - appId=
+      - xM4tpXqX/kC9PhW1eAug8g.0
+      strict-transport-security:
+      - max-age=2592000
       transfer-encoding:
       - chunked
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 58ms
+      - 483ms
     status:
       code: 404
       message: Not Found

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_get_purchased_phone_number.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_get_purchased_phone_number.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:27:37 GMT
+      - Wed, 12 Oct 2022 01:03:57 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -19,14 +19,15 @@ interactions:
         "outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:27:36 GMT
-      ms-cv: dDLp/5276kWnQ0cDCp3RAQ.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:01 GMT
+      ms-cv: UJ8HKfzJxEiM+moKkAuD6Q.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 3179ms
+      x-processing-time: 3503ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_get_purchased_phone_number_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_get_purchased_phone_number_from_managed_identity.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized?api-version=2022-01-11-preview2
   response:
@@ -15,14 +15,15 @@ interactions:
         "outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:27:41 GMT
-      ms-cv: 6VqlTa3mt0u+fagstWOcLQ.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:03 GMT
+      ms-cv: ZqIUQYeKKEO2C6Hl41yo2w.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 3222ms
+      x-processing-time: 1482ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_get_purchased_phone_number_with_invalid_phone_number.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_get_purchased_phone_number_with_invalid_phone_number.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:27:45 GMT
+      - Wed, 12 Oct 2022 01:04:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -17,14 +17,15 @@ interactions:
       string: '{"error": {"code": "NotFound", "message": "Input phoneNumber +14255550123
         cannot be found.", "target": "phonenumber"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json
-      date: Wed, 12 Jan 2022 16:27:42 GMT
-      ms-cv: UnFd7B6EzEKUG7l992jUlg.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:04 GMT
+      ms-cv: tJDIXTUVykq9JeZj42xeUw.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 1558ms
+      x-processing-time: 491ms
     status:
       code: 404
       message: Not Found

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_list_purchased_phone_numbers.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_list_purchased_phone_numbers.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:27:48 GMT
+      - Wed, 12 Oct 2022 01:04:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -416,14 +416,15 @@ interactions:
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}],
         "nextLink": "/phoneNumbers?skip=100&top=100&api-version=2022-01-11-preview2"}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:27:48 GMT
-      ms-cv: AjJ5StT5mE+KFQOh7ftn4w.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:06 GMT
+      ms-cv: CBE/GZxaJUmsFbmW3cGnMw.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 4572ms
+      x-processing-time: 2568ms
     status:
       code: 200
       message: OK
@@ -431,12 +432,10 @@ interactions:
 - request:
     body: ''
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:27:53 GMT
+      - Wed, 12 Oct 2022 01:04:06 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -459,6 +458,10 @@ interactions:
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:39:13.0650895+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2022-08-09T21:31:11.7335307+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
@@ -829,31 +832,28 @@ interactions:
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:19:13.3153527+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2022-08-10T00:33:17.3724362+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:34:45.0763318+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:40:14.5388708+00:00",
-        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
-        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
-        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
-        "assignmentType": "application", "purchaseDate": "2021-06-24T00:38:13.7766563+00:00",
-        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
-        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
-        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
-        "assignmentType": "application", "purchaseDate": "2021-06-23T23:42:00.1600209+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}],
         "nextLink": "/phoneNumbers?skip=200&top=100&api-version=2022-01-11-preview2"}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:27:52 GMT
-      ms-cv: 7w6yfKaIsUaVIgnfD8ogXg.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:08 GMT
+      ms-cv: 1Q4j+GlSi0KrlmQ9Ri6+1A.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 4063ms
+      x-processing-time: 2096ms
     status:
       code: 200
       message: OK
@@ -861,12 +861,10 @@ interactions:
 - request:
     body: ''
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:27:57 GMT
+      - Wed, 12 Oct 2022 01:04:08 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -876,13 +874,21 @@ interactions:
       string: '{"phoneNumbers": [{"id": "sanitized", "phoneNumber": "sanitized", "countryCode":
         "US", "phoneNumberType": "tollFree", "capabilities": {"calling": "inbound+outbound",
         "sms": "inbound+outbound"}, "assignmentType": "application", "purchaseDate":
-        "2021-06-23T23:42:15.9484758+00:00", "cost": {"amount": 2.0, "currencyCode":
+        "2021-06-24T00:38:13.7766563+00:00", "cost": {"amount": 2.0, "currencyCode":
         "USD", "billingFrequency": "monthly"}}, {"id": "sanitized", "phoneNumber":
         "sanitized", "countryCode": "US", "phoneNumberType": "tollFree", "capabilities":
         {"calling": "inbound+outbound", "sms": "inbound+outbound"}, "assignmentType":
-        "application", "purchaseDate": "2021-06-23T23:42:23.3515457+00:00", "cost":
+        "application", "purchaseDate": "2021-06-23T23:42:00.1600209+00:00", "cost":
         {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}, {"id":
         "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2021-06-23T23:42:15.9484758+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2021-06-23T23:42:23.3515457+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:42:13.7459585+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
@@ -949,16 +955,21 @@ interactions:
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-23T23:50:43.5645432+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2022-08-09T18:34:21.0065235+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}]}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:27:56 GMT
-      ms-cv: vtLd12KSR0KIjU4OLZaZdA.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:10 GMT
+      ms-cv: FDq4GRZuOE+xPQZ8WiCFuQ.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 4158ms
+      x-processing-time: 1750ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_list_purchased_phone_numbers_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_list_purchased_phone_numbers_from_managed_identity.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers?skip=0&top=100&api-version=2022-01-11-preview2
   response:
@@ -412,14 +412,15 @@ interactions:
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}],
         "nextLink": "/phoneNumbers?skip=100&top=100&api-version=2022-01-11-preview2"}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:28:04 GMT
-      ms-cv: OrSCnaL4VUehLMUyGoGiEQ.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:14 GMT
+      ms-cv: kqXSA2oDQUyTovwjvrg+Ng.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 5044ms
+      x-processing-time: 3637ms
     status:
       code: 200
       message: OK
@@ -427,10 +428,8 @@ interactions:
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers?skip=100&top=100&api-version=2022-01-11-preview2
   response:
@@ -451,6 +450,10 @@ interactions:
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:39:13.0650895+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2022-08-09T21:31:11.7335307+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
@@ -821,31 +824,28 @@ interactions:
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:19:13.3153527+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2022-08-10T00:33:17.3724362+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:34:45.0763318+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:40:14.5388708+00:00",
-        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
-        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
-        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
-        "assignmentType": "application", "purchaseDate": "2021-06-24T00:38:13.7766563+00:00",
-        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
-        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
-        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
-        "assignmentType": "application", "purchaseDate": "2021-06-23T23:42:00.1600209+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}],
         "nextLink": "/phoneNumbers?skip=200&top=100&api-version=2022-01-11-preview2"}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:28:08 GMT
-      ms-cv: v2lN/9uVJkWe8iBFI86YsQ.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:17 GMT
+      ms-cv: yPjQcEYQE0WLqUrRVIEOpw.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 4275ms
+      x-processing-time: 3034ms
     status:
       code: 200
       message: OK
@@ -853,10 +853,8 @@ interactions:
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers?skip=200&top=100&api-version=2022-01-11-preview2
   response:
@@ -864,13 +862,21 @@ interactions:
       string: '{"phoneNumbers": [{"id": "sanitized", "phoneNumber": "sanitized", "countryCode":
         "US", "phoneNumberType": "tollFree", "capabilities": {"calling": "inbound+outbound",
         "sms": "inbound+outbound"}, "assignmentType": "application", "purchaseDate":
-        "2021-06-23T23:42:15.9484758+00:00", "cost": {"amount": 2.0, "currencyCode":
+        "2021-06-24T00:38:13.7766563+00:00", "cost": {"amount": 2.0, "currencyCode":
         "USD", "billingFrequency": "monthly"}}, {"id": "sanitized", "phoneNumber":
         "sanitized", "countryCode": "US", "phoneNumberType": "tollFree", "capabilities":
         {"calling": "inbound+outbound", "sms": "inbound+outbound"}, "assignmentType":
-        "application", "purchaseDate": "2021-06-23T23:42:23.3515457+00:00", "cost":
+        "application", "purchaseDate": "2021-06-23T23:42:00.1600209+00:00", "cost":
         {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}, {"id":
         "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2021-06-23T23:42:15.9484758+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2021-06-23T23:42:23.3515457+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-24T00:42:13.7459585+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
@@ -937,16 +943,21 @@ interactions:
         {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
         "tollFree", "capabilities": {"calling": "inbound+outbound", "sms": "inbound+outbound"},
         "assignmentType": "application", "purchaseDate": "2021-06-23T23:50:43.5645432+00:00",
+        "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}},
+        {"id": "sanitized", "phoneNumber": "sanitized", "countryCode": "US", "phoneNumberType":
+        "tollFree", "capabilities": {"calling": "none", "sms": "inbound+outbound"},
+        "assignmentType": "application", "purchaseDate": "2022-08-09T18:34:21.0065235+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}]}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:28:13 GMT
-      ms-cv: HylY67nKrk+Hag4trcoNsA.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:20 GMT
+      ms-cv: khz15E8K4UGAN83TChWS8g.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 3918ms
+      x-processing-time: 3144ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_search_available_phone_numbers.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_search_available_phone_numbers.yaml
@@ -10,9 +10,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:28:17 GMT
+      - Wed, 12 Oct 2022 01:04:20 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: POST
@@ -22,16 +22,17 @@ interactions:
       string: ''
     headers:
       access-control-expose-headers: Location,Operation-Location,operation-id,search-id
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-length: '0'
-      date: Wed, 12 Jan 2022 16:28:18 GMT
-      ms-cv: j0wnfJQmYkCRbaw5ds3lrg.0
-      operation-id: search_8c7b9296-ccca-468a-90ca-d51bcbbed8d3
-      operation-location: /phoneNumbers/operations/search_8c7b9296-ccca-468a-90ca-d51bcbbed8d3?api-version=2022-01-11-preview2
-      request-context: appId=
-      search-id: 8c7b9296-ccca-468a-90ca-d51bcbbed8d3
+      date: Wed, 12 Oct 2022 01:04:24 GMT
+      ms-cv: AQgj0X5Yp0O5qkelIx8YMA.0
+      operation-id: search_27a3c75f-11d0-40e0-b730-9a252d65c485
+      operation-location: /phoneNumbers/operations/search_27a3c75f-11d0-40e0-b730-9a252d65c485?api-version=2022-01-11-preview2
+      search-id: 27a3c75f-11d0-40e0-b730-9a252d65c485
+      strict-transport-security: max-age=2592000
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 4646ms
+      x-processing-time: 3669ms
     status:
       code: 202
       message: Accepted

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_search_available_phone_numbers_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_search_available_phone_numbers_from_managed_identity.yaml
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://sanitized.communication.azure.com/availablePhoneNumbers/countries/US/:search?api-version=2022-01-11-preview2
   response:
@@ -18,16 +18,17 @@ interactions:
       string: ''
     headers:
       access-control-expose-headers: Location,Operation-Location,operation-id,search-id
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-length: '0'
-      date: Wed, 12 Jan 2022 16:28:25 GMT
-      ms-cv: Pu6E9lzjbEWKCYHq9GOCvA.0
-      operation-id: search_77ee81ae-6452-4675-be80-0567fe588343
-      operation-location: /phoneNumbers/operations/search_77ee81ae-6452-4675-be80-0567fe588343?api-version=2022-01-11-preview2
-      request-context: appId=
-      search-id: 77ee81ae-6452-4675-be80-0567fe588343
+      date: Wed, 12 Oct 2022 01:04:28 GMT
+      ms-cv: qiaPd0htrUSXk3iDj3zAwg.0
+      operation-id: search_cb684629-9a79-4243-8a65-df57ad9b77a1
+      operation-location: /phoneNumbers/operations/search_cb684629-9a79-4243-8a65-df57ad9b77a1?api-version=2022-01-11-preview2
+      search-id: cb684629-9a79-4243-8a65-df57ad9b77a1
+      strict-transport-security: max-age=2592000
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 5729ms
+      x-processing-time: 2905ms
     status:
       code: 202
       message: Accepted

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_search_available_phone_numbers_with_invalid_country_code.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_search_available_phone_numbers_with_invalid_country_code.yaml
@@ -10,9 +10,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:28:30 GMT
+      - Wed, 12 Oct 2022 01:04:27 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: POST
@@ -22,14 +22,15 @@ interactions:
       string: '{"error": {"code": "InvalidInput", "message": "Unable to parse country
         code.", "target": "countrycode"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json
-      date: Wed, 12 Jan 2022 16:28:25 GMT
-      ms-cv: f3yG1KE9DkKrgvVICL38Vg.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:28 GMT
+      ms-cv: Ro+6hCTw9ky7LlEPgtcY7Q.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 53ms
+      x-processing-time: 24ms
     status:
       code: 400
       message: Bad Request

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_update_phone_number_capabilities.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_update_phone_number_capabilities.yaml
@@ -5,9 +5,9 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:28:30 GMT
+      - Wed, 12 Oct 2022 01:04:27 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -19,14 +19,15 @@ interactions:
         "outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:28:29 GMT
-      ms-cv: ozmCkEcIpkupIIFU9XgyIg.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:29 GMT
+      ms-cv: 2PV4LYqC6k+adEPIvuU7bQ.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 3306ms
+      x-processing-time: 1803ms
     status:
       code: 200
       message: OK
@@ -41,29 +42,30 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:28:34 GMT
+      - Wed, 12 Oct 2022 01:04:29 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized/capabilities?api-version=2022-01-11-preview2
   response:
     body:
-      string: '{"capabilitiesUpdateId": "a31f7ba0-f997-44bc-869a-3bcf05a8cfb5"}'
+      string: '{"capabilitiesUpdateId": "8418f561-7ca6-443d-92ee-e0e268a6a1f0"}'
     headers:
       access-control-expose-headers: Operation-Location,Location,operation-id,capabilities-id
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
-      capabilities-id: a31f7ba0-f997-44bc-869a-3bcf05a8cfb5
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
+      capabilities-id: 8418f561-7ca6-443d-92ee-e0e268a6a1f0
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:28:34 GMT
-      ms-cv: oAS87KWL4UCKh4UPlKiRbQ.0
-      operation-id: capabilities_a31f7ba0-f997-44bc-869a-3bcf05a8cfb5
-      operation-location: /phoneNumbers/operations/capabilities_a31f7ba0-f997-44bc-869a-3bcf05a8cfb5?api-version=2022-01-11-preview2
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:04:32 GMT
+      ms-cv: gXA/z6i0OkGfnwU8TyEpHQ.0
+      operation-id: capabilities_8418f561-7ca6-443d-92ee-e0e268a6a1f0
+      operation-location: /phoneNumbers/operations/capabilities_8418f561-7ca6-443d-92ee-e0e268a6a1f0?api-version=2022-01-11-preview2
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 4505ms
+      x-processing-time: 2743ms
     status:
       code: 202
       message: Accepted
@@ -72,29 +74,30 @@ interactions:
     body: ''
     headers:
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:29:09 GMT
+      - Wed, 12 Oct 2022 01:05:02 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
-    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_a31f7ba0-f997-44bc-869a-3bcf05a8cfb5?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_8418f561-7ca6-443d-92ee-e0e268a6a1f0?api-version=2022-01-11-preview2
   response:
     body:
       string: '{"operationType": "updatePhoneNumberCapabilities", "status": "succeeded",
         "resourceLocation": "/phoneNumbers/+18332321221?api-version=2022-01-11-preview2",
-        "createdDateTime": "2022-01-12T16:28:34.0845568+00:00", "id": "sanitized",
+        "createdDateTime": "2022-10-12T01:04:32.6863281+00:00", "id": "sanitized",
         "lastActionDateTime": "0001-01-01T00:00:00+00:00"}'
     headers:
       access-control-expose-headers: Location
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-11-15-preview, 2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:29:06 GMT
-      ms-cv: utOJoUOu+EGOm1vqiXFVmQ.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:05:03 GMT
+      ms-cv: NhVUiJ6M+ECJT7sIliGEdA.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 1332ms
+      x-processing-time: 1225ms
     status:
       code: 200
       message: OK
@@ -103,9 +106,9 @@ interactions:
     body: ''
     headers:
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:29:11 GMT
+      - Wed, 12 Oct 2022 01:05:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
@@ -117,14 +120,15 @@ interactions:
         "inbound+outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:29:09 GMT
-      ms-cv: 7iIVtF6m20W+mjph3x7+0w.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:05:06 GMT
+      ms-cv: /9fv/jBgmEO0Mq0DEc41BQ.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 3014ms
+      x-processing-time: 2638ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_update_phone_number_capabilities_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_update_phone_number_capabilities_from_managed_identity.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized?api-version=2022-01-11-preview2
   response:
@@ -15,14 +15,15 @@ interactions:
         "inbound+outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:29:14 GMT
-      ms-cv: JWHcCbXhhEm4tV0tzQGbXw.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:05:09 GMT
+      ms-cv: P0YCFmL8zku6PNdL9gf51Q.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 3208ms
+      x-processing-time: 1447ms
     status:
       code: 200
       message: OK
@@ -37,25 +38,26 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
     uri: https://sanitized.communication.azure.com/phoneNumbers/sanitized/capabilities?api-version=2022-01-11-preview2
   response:
     body:
-      string: '{"capabilitiesUpdateId": "d641bec4-efed-4176-923c-b5ab7a4d9c39"}'
+      string: '{"capabilitiesUpdateId": "2eecdad5-22f8-4784-a50d-e2c7fb6714af"}'
     headers:
       access-control-expose-headers: Operation-Location,Location,operation-id,capabilities-id
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
-      capabilities-id: d641bec4-efed-4176-923c-b5ab7a4d9c39
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
+      capabilities-id: 2eecdad5-22f8-4784-a50d-e2c7fb6714af
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:29:19 GMT
-      ms-cv: injP470/g0iBXAQ6JGR91w.0
-      operation-id: capabilities_d641bec4-efed-4176-923c-b5ab7a4d9c39
-      operation-location: /phoneNumbers/operations/capabilities_d641bec4-efed-4176-923c-b5ab7a4d9c39?api-version=2022-01-11-preview2
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:05:10 GMT
+      ms-cv: 5X0ENo3t8E+t3XNvI9ZImQ.0
+      operation-id: capabilities_2eecdad5-22f8-4784-a50d-e2c7fb6714af
+      operation-location: /phoneNumbers/operations/capabilities_2eecdad5-22f8-4784-a50d-e2c7fb6714af?api-version=2022-01-11-preview2
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 4354ms
+      x-processing-time: 1650ms
     status:
       code: 202
       message: Accepted
@@ -64,25 +66,26 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_d641bec4-efed-4176-923c-b5ab7a4d9c39?api-version=2022-01-11-preview2
+    uri: https://sanitized.communication.azure.com/phoneNumbers/operations/capabilities_2eecdad5-22f8-4784-a50d-e2c7fb6714af?api-version=2022-01-11-preview2
   response:
     body:
       string: '{"operationType": "updatePhoneNumberCapabilities", "status": "succeeded",
         "resourceLocation": "/phoneNumbers/+18332321221?api-version=2022-01-11-preview2",
-        "createdDateTime": "2022-01-12T16:29:18.2638106+00:00", "id": "sanitized",
+        "createdDateTime": "2022-10-12T01:05:10.5751911+00:00", "id": "sanitized",
         "lastActionDateTime": "0001-01-01T00:00:00+00:00"}'
     headers:
       access-control-expose-headers: Location
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-11-15-preview, 2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:29:50 GMT
-      ms-cv: ytFfqgE+m0KA1xfddz6imw.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:05:40 GMT
+      ms-cv: Mhnw2sXKlU656Gg1gI6bcg.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 1298ms
+      x-processing-time: 399ms
     status:
       code: 200
       message: OK
@@ -91,7 +94,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://sanitized.communication.azure.com/phoneNumbers/+18332321221?api-version=2022-01-11-preview2
   response:
@@ -101,14 +104,15 @@ interactions:
         "outbound"}, "assignmentType": "application", "purchaseDate": "2021-06-23T23:38:41.0997634+00:00",
         "cost": {"amount": 2.0, "currencyCode": "USD", "billingFrequency": "monthly"}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json; charset=utf-8
-      date: Wed, 12 Jan 2022 16:29:54 GMT
-      ms-cv: Ht0RF257akCmMHZuAzZOQQ.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:05:42 GMT
+      ms-cv: ebd3/KYyPkKLNjUcQVoCQQ.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 3239ms
+      x-processing-time: 1488ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_update_phone_number_capabilities_with_invalid_phone_number.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_phone_number_administration_client_async.test_update_phone_number_capabilities_with_invalid_phone_number.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.0.2 Python/3.9.9 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Wed, 12 Jan 2022 16:29:59 GMT
+      - Wed, 12 Oct 2022 01:05:42 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
@@ -21,14 +21,15 @@ interactions:
       string: '{"error": {"code": "InternalError", "message": "The server encountered
         an internal error."}}'
     headers:
-      api-supported-versions: 2021-03-07, 2022-01-11-preview2
+      api-supported-versions: 2021-03-07, 2022-01-11-preview2, 2022-06-01-preview,
+        2022-12-01
       content-type: application/json
-      date: Wed, 12 Jan 2022 16:29:55 GMT
-      ms-cv: igJCkxSOY0yowJlnNAOQRw.0
-      request-context: appId=
+      date: Wed, 12 Oct 2022 01:05:43 GMT
+      ms-cv: 8bpgF10DTEWhweX1+x6LSQ.0
+      strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 55ms
+      x-processing-time: 297ms
     status:
       code: 404
       message: Not Found

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
@@ -26,6 +26,8 @@ INT_PHONE_NUMBER_TEST_SKIP_REASON = "Phone numbers setting SMS capability does n
 SKIP_UPDATE_CAPABILITIES_TESTS = os.getenv("COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST", "false") == "true"
 SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities are skipped."
 
+API_VERSION="2022-01-11-preview2"
+
 def get_test_phone_number():
     if SKIP_UPDATE_CAPABILITIES_TESTS:
         return os.getenv("AZURE_PHONE_NUMBER")
@@ -43,9 +45,10 @@ class PhoneNumbersClientTest(CommunicationTestCase):
             self.phone_number = get_test_phone_number()
             self.country_code = os.getenv("AZURE_COMMUNICATION_SERVICE_COUNTRY_CODE", "US")
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
-            self.connection_str, 
+            self.static_connection_str, 
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=API_VERSION
         )
         self.recording_processors.extend([
             BodyReplacerProcessor(
@@ -55,13 +58,14 @@ class PhoneNumbersClientTest(CommunicationTestCase):
             PhoneNumberResponseReplacerProcessor()])
 
     def _get_managed_identity_phone_number_client(self):
-        endpoint, access_key = parse_connection_str(self.connection_str)
+        endpoint, access_key = parse_connection_str(self.static_connection_str)
         credential = create_token_credential()
         return PhoneNumbersClient(
             endpoint, 
             credential, 
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=API_VERSION
         )
 
     def test_list_purchased_phone_numbers_from_managed_identity(self):

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
@@ -27,6 +27,8 @@ INT_PHONE_NUMBER_TEST_SKIP_REASON = "Phone numbers setting SMS capability does n
 SKIP_UPDATE_CAPABILITIES_TESTS = os.getenv("COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST", "false") == "true"
 SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities are skipped."
 
+API_VERSION="2022-01-11-preview2"
+
 def get_test_phone_number():
     if SKIP_UPDATE_CAPABILITIES_TESTS:
         return os.getenv("AZURE_PHONE_NUMBER")
@@ -44,9 +46,10 @@ class PhoneNumbersClientTestAsync(AsyncCommunicationTestCase):
             self.phone_number = get_test_phone_number()
             self.country_code = os.getenv("AZURE_COMMUNICATION_SERVICE_COUNTRY_CODE", "US")
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
-            self.connection_str, 
+            self.static_connection_str, 
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=API_VERSION
         )
         self.recording_processors.extend([
             BodyReplacerProcessor(
@@ -56,13 +59,14 @@ class PhoneNumbersClientTestAsync(AsyncCommunicationTestCase):
             PhoneNumberResponseReplacerProcessor()])
 
     def _get_managed_identity_phone_number_client(self):
-        endpoint, access_key = parse_connection_str(self.connection_str)
+        endpoint, access_key = parse_connection_str(self.static_connection_str)
         credential = async_create_token_credential()
         return PhoneNumbersClient(
             endpoint, 
             credential, 
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=API_VERSION
         )
 
     @AsyncCommunicationTestCase.await_prepared_test


### PR DESCRIPTION
Fixes an issue in which the live tests for the azure-communication-phonenumbers package were using the connection string for the dynamically created resource instead of the static pre-configured one. This caused problems since those tests require a resource that already has acquired phone numbers in order to fully test all of the features.