### PR TITLE
Fix code asset issue not included in hash

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
@@ -104,6 +104,7 @@ class IgnoreFile(object):
             self._path_spec = self._create_pathspec()
         file_path = Path(file_path)
         if file_path.is_absolute():
+            file_path = file_path.resolve()
             ignore_dirname = self._path.parent
             if len(os.path.commonprefix([file_path, ignore_dirname])) != len(str(ignore_dirname)):
                 return True

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
@@ -103,14 +103,15 @@ class IgnoreFile(object):
         if not self._path_spec:
             self._path_spec = self._create_pathspec()
         file_path = Path(file_path)
+        ignore_dirname = self._path.parent
+
         if file_path.is_absolute():
             file_path = file_path.resolve()
             ignore_dirname = self._path.parent
             if len(os.path.commonprefix([file_path, ignore_dirname])) != len(str(ignore_dirname)):
                 return True
-            file_path = os.path.relpath(file_path, ignore_dirname)
 
-        file_path = str(file_path)
+        file_path = os.path.relpath(file_path, ignore_dirname)
         norm_file = normalize_file(file_path)
         for pattern in self._path_spec:
             if pattern.include is not None:

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_asset_utils.py
@@ -103,6 +103,14 @@ class TestAssetUtils:
         amlignore_hash = get_object_hash(path=storage_test_directory, ignore_file=amlignore_file)
         gitignore_hash = get_object_hash(path=storage_test_directory, ignore_file=gitignore_file)
 
+        storage_test_directory_abs = os.path.abspath(storage_test_directory)
+        storage_test_directory_abs = (os.path.sep).join(storage_test_directory_abs.split(os.path.sep)[:3] + ['..', '..'] + storage_test_directory_abs.split(os.path.sep)[1:])
+        aialtered_hash = get_object_hash(
+            path=storage_test_directory_abs, 
+            ignore_file=amlignore_file
+        )
+
+        assert amlignore_hash == aialtered_hash
         assert no_ignore_hash != amlignore_hash != gitignore_hash
 
     def test_exclude(


### PR DESCRIPTION
# Description

The issue is that when using paths containing redirect to parent directories (i.e. including "\\..\\"), the `commonprefix` is resolved to the earliest common parent before "\\..\\", which results in ignoring files when calculating hash for Code asset.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
