### PR TITLE
[Pyamqp] Revert back to websocket-client

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -212,7 +212,7 @@ class Connection(object):  # pylint:disable=too-many-instance-attributes
         if self.state == ConnectionState.END:
             return
         await self._set_state(ConnectionState.END)
-        await self._transport.close()
+        self._transport.close()
 
     def _can_read(self):
         # type: () -> bool

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -378,7 +378,8 @@ class AsyncTransport(
 
     async def _write(self, s):
         """Write a string out to the SSL socket fully."""
-        self.writer.write(s)
+        self.loop.run_in_executor(None, self.writer.write,s)
+        await self.writer.drain()
 
     async def close(self):
         if self.writer is not None:
@@ -386,6 +387,7 @@ class AsyncTransport(
                 # see issue: https://github.com/encode/httpx/issues/914
                 self.writer.transport.abort()
             self.writer.close()
+            await self.writer.wait_closed()
             self.writer, self.reader = None, None
         self.sock = None
         self.connected = False

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -425,16 +425,25 @@ class AsyncTransport(
 
 
 class WebSocketTransportAsync(AsyncTransportMixin): # pylint: disable=too-many-instance-attributes
-    def __init__(self, host, port=WEBSOCKET_PORT, connect_timeout=None, ssl=None, **kwargs):
+    def __init__(
+        self,
+        host,
+        *,
+        port=WEBSOCKET_PORT,
+        connect_timeout=None,
+        ssl_opts=None,
+        **kwargs
+    ): # pylint: disable=unused-argument
         self._read_buffer = BytesIO()
         self.loop = asyncio.get_running_loop()
         self.socket_lock = asyncio.Lock()
-        self.sslopts = ssl if isinstance(ssl, dict) else {}
+        self.sslopts = ssl_opts if isinstance(ssl_opts, dict) else {}
         self._connect_timeout = connect_timeout or TIMEOUT_INTERVAL
         self._custom_endpoint = kwargs.get("custom_endpoint")
         self.host = host
         self.ws = None
         self._http_proxy = kwargs.get("http_proxy", None)
+        self.connected = False
 
     async def connect(self):
         http_proxy_host, http_proxy_port, http_proxy_auth = None, None, None
@@ -458,6 +467,7 @@ class WebSocketTransportAsync(AsyncTransportMixin): # pylint: disable=too-many-i
                 http_proxy_port=http_proxy_port,
                 http_proxy_auth=http_proxy_auth,
             )
+            self.connected = True
         except ImportError:
             raise ValueError("Please install websocket-client library to use websocket transport.")
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -381,13 +381,12 @@ class AsyncTransport(
         self.loop.run_in_executor(None, self.writer.write,s)
         await self.writer.drain()
 
-    async def close(self):
+    def close(self):
         if self.writer is not None:
             if self.sslopts:
                 # see issue: https://github.com/encode/httpx/issues/914
                 self.writer.transport.abort()
             self.writer.close()
-            await self.writer.wait_closed()
             self.writer, self.reader = None, None
         self.sock = None
         self.connected = False
@@ -498,7 +497,7 @@ class WebSocketTransportAsync(AsyncTransportMixin): # pylint: disable=too-many-i
         except WebSocketTimeoutException:
             raise TimeoutError()
 
-    async def close(self):
+    def close(self):
         """Do any preliminary work in shutting down the connection."""
         self.ws.close()
         self.connected = False

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -424,7 +424,7 @@ class AsyncTransport(
             )
 
 
-class WebSocketTransportAsync(AsyncTransportMixin):
+class WebSocketTransportAsync(AsyncTransportMixin): # pylint: disable=too-many-instance-attributes
     def __init__(self, host, port=WEBSOCKET_PORT, connect_timeout=None, ssl=None, **kwargs):
         self._read_buffer = BytesIO()
         self.loop = asyncio.get_running_loop()
@@ -461,7 +461,7 @@ class WebSocketTransportAsync(AsyncTransportMixin):
         except ImportError:
             raise ValueError("Please install websocket-client library to use websocket transport.")
 
-    async def _read(self, n, buffer=None, **kwargs):  # pylint: disable=unused-arguments
+    async def _read(self, n, buffer=None, **kwargs):  # pylint: disable=unused-argument
         """Read exactly n bytes from the peer."""
         from websocket import WebSocketTimeoutException
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -500,7 +500,7 @@ class WebSocketTransportAsync(AsyncTransportMixin): # pylint: disable=too-many-i
 
     async def close(self):
         """Do any preliminary work in shutting down the connection."""
-        await self.loop.run_in_executor(None, self.ws.close)
+        self.ws.close()
         self.connected = False
 
     async def write(self, s):


### PR DESCRIPTION
aiohttp websocket has 2 bugs when a connection is abruptly cut:

* websocket send does not throw an exception -> [issue](https://github.com/aio-libs/aiohttp/issues/2309) -> known since 2017

* websocket receive gets stuck if network is suddenly disconnected -> [PR](https://github.com/aio-libs/aiohttp/pull/5860) -> unmerged since July 2021

Reverting back to websocket-client in async as that is what most are using. There is another async websocket client but it doesnt support proxies.

