### PR TITLE
[ML] Enable SDK data and datastore get calls to use new error message format

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
@@ -152,9 +152,8 @@ class DataOperations(_ScopeDependentOperations):
                 **self._init_kwargs,
             )
             return Data._from_rest_object(data_version_resource)
-        except Exception as ex:
-            if isinstance(ex, (ValidationException, SchemaValidationError)):
-                log_and_raise_error(ex)
+        except (ValidationException, SchemaValidationError) as ex:
+            log_and_raise_error(ex)
 
     # @monitor_with_activity(logger, "Data.CreateOrUpdate", ActivityType.PUBLICAPI)
     def create_or_update(self, data: Data) -> Data:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -111,9 +111,8 @@ class DatastoreOperations(_ScopeDependentOperations):
             if include_secrets:
                 self._fetch_and_populate_secret(datastore_resource)
             return Datastore._from_rest_object(datastore_resource)
-        except Exception as ex:
-            if isinstance(ex, (ValidationException, SchemaValidationError)):
-                log_and_raise_error(ex)
+        except (ValidationException, SchemaValidationError) as ex:
+            log_and_raise_error(ex)
 
     def _fetch_and_populate_secret(self, datastore_resource: DatastoreData) -> None:
         if datastore_resource.name and not isinstance(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -101,16 +101,19 @@ class DatastoreOperations(_ScopeDependentOperations):
         :return: Datastore with the specified name.
         :rtype: Datastore
         """
-
-        datastore_resource = self._operation.get(
-            name=name,
-            resource_group_name=self._operation_scope.resource_group_name,
-            workspace_name=self._workspace_name,
-            **self._init_kwargs
-        )
-        if include_secrets:
-            self._fetch_and_populate_secret(datastore_resource)
-        return Datastore._from_rest_object(datastore_resource)
+        try:
+            datastore_resource = self._operation.get(
+                name=name,
+                resource_group_name=self._operation_scope.resource_group_name,
+                workspace_name=self._workspace_name,
+                **self._init_kwargs
+            )
+            if include_secrets:
+                self._fetch_and_populate_secret(datastore_resource)
+            return Datastore._from_rest_object(datastore_resource)
+        except Exception as ex:
+            if isinstance(ex, (ValidationException, SchemaValidationError)):
+                log_and_raise_error(ex)
 
     def _fetch_and_populate_secret(self, datastore_resource: DatastoreData) -> None:
         if datastore_resource.name and not isinstance(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -130,16 +130,18 @@ class DatastoreOperations(_ScopeDependentOperations):
         :return: The default datastore.
         :rtype: Datastore
         """
-
-        datastore_resource = self._operation.list(
-            resource_group_name=self._operation_scope.resource_group_name,
-            workspace_name=self._workspace_name,
-            is_default=True,
-            **self._init_kwargs
-        ).next()
-        if include_secrets:
-            self._fetch_and_populate_secret(datastore_resource)
-        return Datastore._from_rest_object(datastore_resource)
+        try:
+            datastore_resource = self._operation.list(
+                resource_group_name=self._operation_scope.resource_group_name,
+                workspace_name=self._workspace_name,
+                is_default=True,
+                **self._init_kwargs
+            ).next()
+            if include_secrets:
+                self._fetch_and_populate_secret(datastore_resource)
+            return Datastore._from_rest_object(datastore_resource)
+        except (ValidationException, SchemaValidationError) as ex:
+            log_and_raise_error(ex)
 
     # @monitor_with_activity(logger, "Datastore.CreateOrUpdate", ActivityType.PUBLICAPI)
     def create_or_update(self, datastore: Datastore) -> Datastore:

--- a/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_operations.py
@@ -86,8 +86,9 @@ class TestDataOperations:
 
     def test_get_no_version(self, mock_data_operations: DataOperations) -> None:
         name = "random_name"
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as ex:
             mock_data_operations.get(name=name)
+        assert "At least one required parameter is missing" in str(ex.value)
 
     def test_create_with_spec_file(
         self,


### PR DESCRIPTION
# Description

The initial phase of the Error Workstream piloted error message improvement for create/update calls only. After positive feedback in users studies and a decrease in errors in the most recent release, we're extending the error message improvements to other methods in the SDK/CLI. This PR handles Data and Datastore. Upcoming PRs for other entities will be handled by their Area teams.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
