### PR TITLE
[EventHubs] skipping flaky bp test for now

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_buffered_producer_async.py
@@ -491,6 +491,7 @@ async def test_long_sleep(connection_str):
     await consumer.close()
     await receive_thread
 
+@pytest.mark.skip('not testing correctly + flaky, fix during MQ')
 @pytest.mark.liveTest
 @pytest.mark.asyncio
 async def test_long_wait_small_buffer(connection_str):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_buffered_producer.py
@@ -505,6 +505,7 @@ def test_long_sleep(connection_str, uamqp_transport):
     consumer.close()
     receive_thread.join()
 
+@pytest.mark.skip('not testing correctly + flaky, fix during MQ')
 @pytest.mark.liveTest
 def test_long_wait_small_buffer(connection_str):
     received_events = defaultdict(list)


### PR DESCRIPTION
Description of failing tests here: https://github.com/Azure/azure-sdk-for-python/issues/21789#issuecomment-1279219115
related to: #21789 
Will be fixing and re-enabling during MQ.