### PR TITLE
Ensure trailing / in PROXY_URL isn't an issue

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/config.py
+++ b/tools/azure-sdk-tools/devtools_testutils/config.py
@@ -5,5 +5,5 @@
 # --------------------------------------------------------------------------
 import os
 
-PROXY_URL = os.getenv("PROXY_URL", "https://localhost:5001")
+PROXY_URL = os.getenv("PROXY_URL", "https://localhost:5001").rstrip("/")
 TEST_SETTING_FILENAME = "testsettings_local.cfg"

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -28,7 +28,7 @@ WINDOWS_IMAGE_SOURCE_PREFIX = "azsdkengsys.azurecr.io/engsys/testproxy-win"
 CONTAINER_STARTUP_TIMEOUT = 6000
 PROXY_MANUALLY_STARTED = os.getenv("PROXY_MANUAL_START", False)
 
-PROXY_CHECK_URL = PROXY_URL.rstrip("/") + "/Info/Available"
+PROXY_CHECK_URL = PROXY_URL + "/Info/Available"
 TOOL_ENV_VAR = "PROXY_PID"
 
 


### PR DESCRIPTION
The timing of @0mza987 running into this issue right as we're having a different conversation about our autorest generator having the same issue....hilarious.

@mccoyp This ensures that setting `PROXY_URL=http://localhost:5000/` doesn't break our sanitizers being added.

Just doing it once where we retrieve, save ourselves the effort of needing to do a proper url concatenation.
