### PR TITLE
[Pyamqp] Fix Async Socket Reconnection Error

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -380,6 +380,7 @@ class AsyncTransport(
     async def _write(self, s):
         """Write a string out to the SSL socket fully."""
         self.writer.write(s)
+        await self.writer.drain()
 
     async def close(self):
         if self.writer is not None:
@@ -387,6 +388,7 @@ class AsyncTransport(
                 # see issue: https://github.com/encode/httpx/issues/914
                 self.writer.transport.abort()
             self.writer.close()
+            await self.writer.wait_closed()
             self.writer, self.reader = None, None
         self.sock = None
         self.connected = False


### PR DESCRIPTION
During stress testing there were times when a memory leak and high CPU usage would show around the time of a brief network interruption. 

The reason why that was happening is because `StreamWriter.write` was being called without awaiting on 'StreamWriter.drain` as mentioned in the [docs](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.write). Exceptions would be raised that the underlying connection has been disconnected but they would not be accessible to the main event loop and thus ending up in an infinite loop. 

drain also does an `asyncio.sleep(0)` which causes the event loop to pick up any underlying exceptions, which then get bubbled up in to our retry mechanism.


Another fix for closing sockets, close has to paired with [wait_closed](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.wait_closed) to wait till the underlying connection is closed. 