### PR TITLE
[Pyamqp] Possible solutions for network disruption using async websocket

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -486,6 +486,7 @@ class WebSocketTransportAsync(
                 proxy=http_proxy_host,
                 proxy_auth=http_proxy_auth,
                 ssl=self.sslopts,
+                heartbeat=self._connect_timeout
             )
             self.connected = True
 
@@ -505,7 +506,7 @@ class WebSocketTransportAsync(
 
         try:
             while n:
-                data = await self.ws.receive_bytes()
+                data = await self.ws.receive_bytes(timeout=self._connect_timeout * 2)
                 if len(data) <= n:
                     view[length : length + len(data)] = data
                     n -= len(data)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/constants.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/constants.py
@@ -85,6 +85,8 @@ SEND_DISPOSITION_REJECT = "rejected"
 AUTH_TYPE_SASL_PLAIN = "AUTH_SASL_PLAIN"
 AUTH_TYPE_CBS = "AUTH_CBS"
 
+DEFAULT_WEBSOCKET_HEARTBEAT_SECONDS = 10
+
 
 class ConnectionState(Enum):
     #: In this state a Connection exists, but nothing has been sent or received. This is the state an


### PR DESCRIPTION
As describes in this PR #26787, there is a possibility for aiohttps websocket implementation to hang during network disconnect & reconnect scenario.

During testing I've observed that if the outage is brief enough itll just continue working from where it was paused.  A longer outage can cause issues and we should prefer a timeout exception, connection reset error etc so that we can retry and succeed or exhaust and fail. 

These are a few possible settings that can be tweaked to mitigate / minimize the chance of us hitting those scenarios:
* Enable heartbeat on the websocket response which does the [following](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession.ws_connect) 

> Send ping message every heartbeat seconds and wait pong response, if pong response is not received then close connection
This raises an error when trying to communicate with the websocket which is no longer active
* Set a timeout on receive. If the information is not received in time, timeout. Right now, based on the issues in aiohttp a timeout exception can take almost 15 mins, this would reduce that. 
* There is a third option to specify a [BaseConnector](https://docs.aiohttp.org/en/stable/client_reference.html#baseconnector)  with `enable_cleanup_closed` which closes the transport after 2 seconds.  This would be initialized when creating a [`ClientSession`](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession)
