### PR TITLE
[core]: Activate aiothttp auto decompress feature to handle brotli decompression

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -100,7 +100,7 @@ class AioHttpTransport(AsyncHttpTransport):
             clientsession_kwargs = {
                 "trust_env": self._use_env_settings,
                 "cookie_jar": jar,
-                "auto_decompress": False,
+                "auto_decompress": True,
             }
             if self._loop is not None:
                 clientsession_kwargs["loop"] = self._loop


### PR DESCRIPTION
# Description

The `BlobClient` (`from azure.storage.blob`) knows how to decompress brotli data (data with `br` encoding), because behind the scenes the `requests` lib knows how to make the actual decompression.

But when using the asynchronous `BlobClient` (`from azure.storage.blob.aio`), since it's using the `aiohttp` client, it doesn't know, by default, how to decompress brotli encoding.

I then came across this ticket #18539 which talks about the `auto_decompress` flag that you can inject into an `aiohttp` session. It was decided back then to be always `False`, but since the default value of the `aiohttp` session is `True` ([see docs](https://docs.aiohttp.org/en/stable/client_reference.html?highlight=session#client-session)) shouldn't it have that behaviour as well?

I understand the motive is to avoid having a hidden dependency installed, but I'd reckon the behaviour should be the same being applied within the synchronous client: The responsible of installing the dependency should fall over to the service/program that actually needs to compress/decompress with brotli.

I took the liberty of hardcoding to `True`. But eventually, an `ENV_VAR` controlling this might make sense...?

Here's a script to reproduce the issue:
```python

import os
import asyncio

from azure.storage.blob import ContentSettings
from azure.storage.blob import ContainerClient
from azure.storage.blob import BlobClient as SyncBlobClient
from azure.storage.blob.aio import BlobClient
import brotli

CONN_STR = os.environ["AZURE_STORAGE_CONN_STR"]
CONTAINER_NAME = "test-async-brotli"
BLOB_NAME = "brotli.json"
DATA_CONTENT = "[]".encode()


def upload_compressed_data():
    data = brotli.compress(DATA_CONTENT, quality=1)

    with ContainerClient.from_connection_string(
        CONN_STR,
        container_name=CONTAINER_NAME,
        max_single_get_size=64 * 1024 * 1024,
    ) as container_client:
        # comment if container already created.
        container_client.create_container()
        print("Uploading blob...")

        container_client.upload_blob(
            BLOB_NAME,
            data,
            content_settings=ContentSettings(
                content_type="application/json", content_encoding="br"
            ),
            overwrite=True,
        )
        print(f"Blob {BLOB_NAME} uploaded")


def read_sync_data():
    with SyncBlobClient.from_connection_string(
        CONN_STR,
        container_name=CONTAINER_NAME,
        blob_name=BLOB_NAME,
    ) as blob_data:
        sync_data = blob_data.download_blob().readall()

    assert sync_data == DATA_CONTENT, f"unexpected data: {sync_data}"


async def read_async_data():
    async with BlobClient.from_connection_string(
        CONN_STR,
        container_name=CONTAINER_NAME,
        blob_name=BLOB_NAME,
    ) as blob_data:
        async_data = await (await blob_data.download_blob()).readall()

    assert async_data == DATA_CONTENT, f"unexpected data: {async_data}"


async def main():
    upload_compressed_data()

    read_sync_data()

    await read_async_data()


if __name__ == "__main__":
    asyncio.run(main())

```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
