### PR TITLE
Update setup.py

### DIFF
--- a/sdk/template/azure-template/setup.py
+++ b/sdk/template/azure-template/setup.py
@@ -45,7 +45,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -64,12 +63,12 @@ setup(
     ),
     include_package_data=True,
     package_data={
-        'pytyped': ['py.typed'],
+        'azure.template': ['py.typed'],
     },
     install_requires=[
         "azure-core<2.0.0,>=1.10.0",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
         "Source": "https://github.com/Azure/azure-sdk-python",


### PR DESCRIPTION
Fixing the key for package_data when including py.typed. Also removing python 3.6 since we dropped support awhile ago.