### PR TITLE
[Storage] Fix duplicate sample tag in `blob_samples_authentication.py`

### DIFF
--- a/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
@@ -144,7 +144,6 @@ class AuthSamples(object):
 
 if __name__ == '__main__':
     sample = AuthSamples()
-    # Uncomment the methods you want to execute.
     sample.auth_connection_string()
     sample.auth_active_directory()
     sample.auth_shared_access_signature()

--- a/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
@@ -122,7 +122,7 @@ class AuthSamples(object):
         # [END create_sas_token]
 
     def auth_default_azure_credential(self):
-        # [START create_blob_service_client_oauth]
+        # [START create_blob_service_client_oauth_default_credential]
         # Get a credential for authentication
         # Default Azure Credentials attempt a chained set of authentication methods, per documentation here: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity
         # For example user (who must be an Azure Event Hubs Data Owner role) to be logged in can be specified by the environment variable AZURE_USERNAME
@@ -137,13 +137,14 @@ class AuthSamples(object):
             account_url=self.oauth_url,
             credential=default_credential
         )
-        # [END create_blob_service_client_oauth]
+        # [END create_blob_service_client_oauth_default_credential]
 
         # Get account information for the Blob Service
         account_info = blob_service_client.get_service_properties()
 
 if __name__ == '__main__':
     sample = AuthSamples()
+    # Uncomment the methods you want to execute.
     sample.auth_connection_string()
     sample.auth_active_directory()
     sample.auth_shared_access_signature()

--- a/sdk/storage/azure-storage-blob/samples/blob_samples_authentication_async.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_authentication_async.py
@@ -84,8 +84,11 @@ class AuthSamplesAsync(object):
         # [START create_blob_service_client_oauth]
         # Get a token credential for authentication
         from azure.identity.aio import ClientSecretCredential
-        token_credential = ClientSecretCredential(self.active_directory_tenant_id, self.active_directory_application_id,
-                                                  self.active_directory_application_secret)
+        token_credential = ClientSecretCredential(
+            self.active_directory_tenant_id,
+            self.active_directory_application_id,
+            self.active_directory_application_secret
+        )
 
         # Instantiate a BlobServiceClient using a token credential
         from azure.storage.blob.aio import BlobServiceClient
@@ -111,11 +114,31 @@ class AuthSamplesAsync(object):
         )
         # [END create_sas_token]
 
+    async def auth_default_azure_credential(self):
+        # [START create_blob_service_client_oauth_default_credential]
+        # Get a credential for authentication
+        # Default Azure Credentials attempt a chained set of authentication methods, per documentation here: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity
+        # For example user (who must be an Azure Event Hubs Data Owner role) to be logged in can be specified by the environment variable AZURE_USERNAME
+        # Alternately, one can specify the AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET to use the EnvironmentCredentialClass.
+        # The docs above specify all mechanisms which the defaultCredential internally support.
+        from azure.identity.aio import DefaultAzureCredential
+        default_credential = DefaultAzureCredential()
+
+        # Instantiate a BlobServiceClient using a token credential
+        from azure.storage.blob.aio import BlobServiceClient
+        blob_service_client = BlobServiceClient(
+            account_url=self.oauth_url,
+            credential=default_credential
+        )
+        # [END create_blob_service_client_oauth_default_credential]
+
+        # Get account information for the Blob Service
+        account_info = blob_service_client.get_service_properties()
+
 async def main():
     sample = AuthSamplesAsync()
-    # Uncomment the methods you want to execute.
     await sample.auth_connection_string_async()
-    # await sample.auth_active_directory()
+    await sample.auth_active_directory_async()
     await sample.auth_shared_access_signature_async()
     await sample.auth_blob_url_async()
 

--- a/sdk/storage/azure-storage-blob/samples/blob_samples_authentication_async.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_authentication_async.py
@@ -141,6 +141,7 @@ async def main():
     await sample.auth_active_directory_async()
     await sample.auth_shared_access_signature_async()
     await sample.auth_blob_url_async()
+    await sample.auth_default_azure_credential()
 
 if __name__ == '__main__':
     asyncio.run(main())


### PR DESCRIPTION
As raised in #26900 , this PR fixes the duplicate sample tag that appears and may cause confusion if customers refer to a sample case simply by the sample tag. Additionally, this adds the missing sample to the `async` sample file and some other small changes to unify the samples to match more closely.