### PR TITLE
[Maps] Add 'include_package_data' field to setup

### DIFF
--- a/sdk/maps/azure-maps-render/setup.py
+++ b/sdk/maps/azure-maps-render/setup.py
@@ -79,6 +79,7 @@ setup(
         'azure',
         'azure.maps',
     ]),
+    include_package_data=True,
     install_requires=[
         'msrest>=0.6.21',
         'azure-common~=1.1',

--- a/sdk/maps/azure-maps-route/setup.py
+++ b/sdk/maps/azure-maps-route/setup.py
@@ -78,6 +78,7 @@ setup(
         'azure',
         'azure.maps',
     ]),
+    include_package_data=True,
     install_requires=[
         'msrest>=0.6.21',
         'azure-common~=1.1',


### PR DESCRIPTION
A recent [fix ](https://github.com/Azure/azure-sdk-for-python/pull/26626/files) to the py.typed verification script that is called in the CI now fails if the field `include_package_data` does not exist or does not equal `True` in a package's setup.py.

This adds this file to recently onboarded packages that did not have this.
