### PR TITLE
Remove requests dependency from PyPIClient

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -222,10 +222,11 @@ deps =
   {[packaging]pkgs}
   requests
   cryptography<4
+  urllib3
 commands =
     {envbindir}/python -m pip install {toxinidir}/../../../tools/azure-sdk-tools --no-deps
     {envbindir}/python {toxinidir}/../../../eng/tox/sanitize_setup.py -t {toxinidir}
-    {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py \
+    {envbindir}/python {toxinidir}/../../../eng/tox/create_package_anlk,,,,,,,,,,,,,,,,,,p;[[[[[[[[[[[[[[[[[[[[[[d_install.py \
       -d {envtmpdir} \
       -p {toxinidir} \
       -w {envtmpdir} \

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -226,7 +226,7 @@ deps =
 commands =
     {envbindir}/python -m pip install {toxinidir}/../../../tools/azure-sdk-tools --no-deps
     {envbindir}/python {toxinidir}/../../../eng/tox/sanitize_setup.py -t {toxinidir}
-    {envbindir}/python {toxinidir}/../../../eng/tox/create_package_anlk,,,,,,,,,,,,,,,,,,p;[[[[[[[[[[[[[[[[[[[[[[d_install.py \
+    {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py \
       -d {envtmpdir} \
       -p {toxinidir} \
       -w {envtmpdir} \

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -220,7 +220,6 @@ setenv =
   PROXY_URL=http://localhost:5008
 deps =
   {[packaging]pkgs}
-  requests
   cryptography<4
   urllib3
 commands =

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -38,6 +38,7 @@ deps =
 pkgs =
     wheel==0.37.0
     packaging==20.4
+    urllib3==1.26.12
 
 
 [testenv]
@@ -221,7 +222,6 @@ setenv =
 deps =
   {[packaging]pkgs}
   cryptography<4
-  urllib3
 commands =
     {envbindir}/python -m pip install {toxinidir}/../../../tools/azure-sdk-tools --no-deps
     {envbindir}/python {toxinidir}/../../../eng/tox/sanitize_setup.py -t {toxinidir}

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -20,6 +20,7 @@ DEPENDENCIES = [
     "pyopenssl",
     "python-dotenv",
     "PyYAML",
+    "urllib3"
 ]
 
 setup(

--- a/tools/azure-sdk-tools/tests/test_pypi_client.py
+++ b/tools/azure-sdk-tools/tests/test_pypi_client.py
@@ -1,0 +1,45 @@
+from pypi_tools.pypi import PyPIClient
+from unittest.mock import patch
+import os
+import pytest
+import pdb
+
+
+class TestPyPiClient:
+    @pytest.mark.skipif(
+        os.environ.get("TF_BUILD", "None") == True,
+        reason=f"This test isn't worth recording and could be flaky. Skipping in CI.",
+    )
+    def test_package_retrieve(self):
+        client = PyPIClient()
+        result = client.project("azure-core")
+
+        # we won't _exhaustively_ check this, but we can sanity check a few proxy values to ensure we haven't broken anything
+        assert result["info"]["name"] == "azure-core"
+        assert len(result["releases"].keys()) > 47
+        assert "1.25.1" in result["releases"]
+        assert "1.10.0" in result["releases"]
+
+    @pytest.mark.skipif(
+        os.environ.get("TF_BUILD", "None") == True,
+        reason=f"This test isn't worth recording and could be flaky. Skipping in CI.",
+    )
+    def test_package_version_retrieve(self):
+        client = PyPIClient()
+        result = client.project_release("azure-core", "1.8.0")
+
+        assert result["info"]["name"] == "azure-core"
+        assert result["info"]["release_url"] == "https://pypi.org/project/azure-core/1.8.0/"
+
+    @pytest.mark.skipif(
+        os.environ.get("TF_BUILD", "None") == True,
+        reason=f"This test isn't worth recording and could be flaky. Skipping in CI.",
+    )
+    @patch("pypi_tools.pypi.sys")
+    def test_package_filter_for_compatibility(self, mock_sys):
+        mock_sys.version_info = (2, 7, 0)
+        client = PyPIClient()
+        result = client.get_ordered_versions("azure-core", True)
+        unfiltered_results = client.get_ordered_versions("azure-core", False)
+
+        assert len(result) < len(unfiltered_results)


### PR DESCRIPTION
This should fix `latestdependency` from failing. @kristapratico @xiangyan99 

