### PR TITLE
[chore] Remove CI for unmaintained packages

### DIFF
--- a/sdk/applicationinsights/ci.yml
+++ b/sdk/applicationinsights/ci.yml
@@ -27,6 +27,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: applicationinsights
+    BuildTargetingString: azure-mgmt-applicationinsights
     Artifacts:
     - name: azure-mgmt-applicationinsights
       safeName: azuremgmtapplicationinsights

--- a/sdk/loganalytics/ci.yml
+++ b/sdk/loganalytics/ci.yml
@@ -27,9 +27,8 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: loganalytics
+    BuildTargetingString: azure-mgmt-loganalytics
     TestProxy: true
     Artifacts:
-    - name: azure-loganalytics
-      safeName: azureloganalytics
     - name: azure-mgmt-loganalytics
       safeName: azuremgmtloganalytics


### PR DESCRIPTION
ApplicationInsights and LogAnalytics packages are no longer being maintained and the nightly CI continually fail for these. Here, the CI configuration is removed to disable the pipelines from running.

