### PR TITLE
Update environment.py

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 - MLClient.from_config can now find the default config.json on Compute Instance when running sample notebooks.
 - Adjust registry experimental tags and imports to avoid warning printouts for unrelated operations.
+- Prevent registering an already existing environment that references conda file.
 
 ### Other Changes
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/environment.py
@@ -232,7 +232,7 @@ class Environment(Asset):
         if rest_env_version.conda_file:
             translated_conda_file = yaml.safe_load(rest_env_version.conda_file)
             environment.conda_file = translated_conda_file
-            environment._translated_conda_file=yaml.dump(translated_conda_file)
+            environment._translated_conda_file = rest_env_version.conda_file
 
         return environment
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/environment.py
@@ -232,6 +232,7 @@ class Environment(Asset):
         if rest_env_version.conda_file:
             translated_conda_file = yaml.safe_load(rest_env_version.conda_file)
             environment.conda_file = translated_conda_file
+            environment._translated_conda_file=yaml.dump(translated_conda_file)
 
         return environment
 


### PR DESCRIPTION
Not setting this object (environment._translated_conda_file) causes a mismatch between the registered env and the loaded one which leads to re-register the existing env.

This issue only happens with environment that includes conda file.

# Description

Not setting this object (environment._translated_conda_file) causes a mismatch between the registered env and the loaded one which leads to re-register the existing env.

This issue only happens with environment that includes conda file.

# All SDK Contribution checklist:
- [X ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ X] Title of the pull request is clear and informative.
- [ X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
