### PR TITLE
[Pyamqp] Fix to Improve Websocket Sync and Async Network Disruption Handling

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -744,4 +744,4 @@ class WebSocketTransport(_AbstractTransport):
             raise ConnectionError('send disconnected by SSL (%s)' % e)
         except WebSocketConnectionClosedException as e:
             raise ConnectionError('send disconnected (%s)' % e)
-
+            

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -713,7 +713,6 @@ class WebSocketTransport(_AbstractTransport):
         try:
             while n:
                 data = self.ws.recv()
-
                 if len(data) <= n:
                     view[length : length + len(data)] = data
                     n -= len(data)
@@ -722,8 +721,8 @@ class WebSocketTransport(_AbstractTransport):
                     self._read_buffer = BytesIO(data[n:])
                     n = 0
             return view
-        except WebSocketTimeoutException:
-            raise TimeoutError()
+        except WebSocketTimeoutException as wte:
+            raise ConnectionError('recv timed out (%s)' % wte)
 
     def _shutdown_transport(self):
         # TODO Sync and Async close functions named differently
@@ -736,4 +735,13 @@ class WebSocketTransport(_AbstractTransport):
         See http://tools.ietf.org/html/rfc5234
         http://tools.ietf.org/html/rfc6455#section-5.2
         """
-        self.ws.send_binary(s)
+        from websocket import WebSocketConnectionClosedException, WebSocketTimeoutException
+        try:
+            self.ws.send_binary(s)
+        except WebSocketTimeoutException as e:
+            raise ConnectionError('send timed out (%s)' % e)
+        except SSLError as e:
+            raise ConnectionError('send disconnected by SSL (%s)' % e)
+        except WebSocketConnectionClosedException as e:
+            raise ConnectionError('send disconnected (%s)' % e)
+

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -82,6 +82,7 @@ class AsyncTransportMixin:
             asyncio.IncompleteReadError,
             asyncio.TimeoutError,
         ):
+            print("receive frame caught tht timeout error")
             return None, None
 
     async def read(self, verify_frame_type=0):
@@ -123,6 +124,7 @@ class AsyncTransportMixin:
                         await self._read(payload_size, buffer=payload)
                     )
             except (TimeoutError, socket.timeout, asyncio.IncompleteReadError):
+                print("async transport read caught the timeout error")
                 read_frame_buffer.write(self._read_buffer.getvalue())
                 self._read_buffer = read_frame_buffer
                 self._read_buffer.seek(0)
@@ -488,6 +490,7 @@ class WebSocketTransportAsync(
                 proxy=http_proxy_host,
                 proxy_auth=http_proxy_auth,
                 ssl=self.sslopts,
+                heartbeat=10,
             )
             self.connected = True
 
@@ -516,8 +519,8 @@ class WebSocketTransportAsync(
                     self._read_buffer = BytesIO(data[n:])
                     n = 0
             return view
-        except asyncio.TimeoutError:
-            raise TimeoutError()
+        except asyncio.TimeoutError as te:
+            raise ConnectionError('recv timed out (%s)' % te)
 
     async def close(self):
         """Do any preliminary work in shutting down the connection."""
@@ -531,4 +534,7 @@ class WebSocketTransportAsync(
         See http://tools.ietf.org/html/rfc5234
         http://tools.ietf.org/html/rfc6455#section-5.2
         """
-        await self.ws.send_bytes(s)
+        try:
+            await self.ws.send_bytes(s)
+        except asyncio.TimeoutError as te:
+            raise ConnectionError('send timed out (%s)' % te)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -40,6 +40,7 @@ import struct
 from ssl import SSLError
 from io import BytesIO
 import logging
+import aiohttp
 
 
 import certifi
@@ -82,7 +83,6 @@ class AsyncTransportMixin:
             asyncio.IncompleteReadError,
             asyncio.TimeoutError,
         ):
-            print("receive frame caught tht timeout error")
             return None, None
 
     async def read(self, verify_frame_type=0):
@@ -124,7 +124,6 @@ class AsyncTransportMixin:
                         await self._read(payload_size, buffer=payload)
                     )
             except (TimeoutError, socket.timeout, asyncio.IncompleteReadError):
-                print("async transport read caught the timeout error")
                 read_frame_buffer.write(self._read_buffer.getvalue())
                 self._read_buffer = read_frame_buffer
                 self._read_buffer.seek(0)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -489,7 +489,6 @@ class WebSocketTransportAsync(
                 proxy=http_proxy_host,
                 proxy_auth=http_proxy_auth,
                 ssl=self.sslopts,
-                heartbeat=10,
             )
             self.connected = True
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -40,7 +40,7 @@ import struct
 from ssl import SSLError
 from io import BytesIO
 import logging
-import aiohttp
+
 
 
 import certifi


### PR DESCRIPTION
**Whats Happening**


We are raising a `TimeoutError` in websocket transport read [here](https://github.com/Azure/azure-sdk-for-python/blob/c3dbace352eb4ed5c3c4c17b737620ac3cda0c9e/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py#L726). This error bubbles up and gets caught by `receive_frame` in `transport` [here](https://github.com/Azure/azure-sdk-for-python/blob/c3dbace352eb4ed5c3c4c17b737620ac3cda0c9e/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py#L468). As you can see the error gets squashed here as we treat `TimeoutErrors` as an empty frame. This is exactly why we never enter the re-connect loop as the error doesnt bubble up further. If one raises from `receive_frame` things work properly and a re-connect loop is started


**What was I seeing yesterday**

Throwing an `OSError` or `ConnectionError` ( also an OSError ) causes the chain of error handling to work properly and enter the reconnect loop.


**Why dont we see this on socket connections?**

[`socket.timeout`](https://docs.python.org/3/library/socket.html#socket.timeout) is an `OSError`, it used to be `TimeoutError` and hence the problem doesnt show there as it propagates up.