### PR TITLE
Split ML livetest configurations

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -95,6 +95,7 @@
     "tools/azure-sdk-tools/setup.py"
   ],
   "words": [
+    "automl",
     "pyyaml",
     "CONLL",
     "pyjwt",

--- a/sdk/ml/automl.tests.yml
+++ b/sdk/ml/automl.tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+extends:
+  template: ./tests.yml
+  parameters:
+    TestMarkArgument: "automl_test"

--- a/sdk/ml/core-sdk.tests.yml
+++ b/sdk/ml/core-sdk.tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+extends:
+  template: ./tests.yml
+  parameters:
+    TestMarkArgument: "core_sdk_test"

--- a/sdk/ml/data-experiences.tests.yml
+++ b/sdk/ml/data-experiences.tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+extends:
+  template: ./tests.yml
+  parameters:
+    TestMarkArgument: "data_experiences_test"

--- a/sdk/ml/pipeline.tests.yml
+++ b/sdk/ml/pipeline.tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+extends:
+  template: ./tests.yml
+  parameters:
+    TestMarkArgument: "pipeline_test"

--- a/sdk/ml/production-experiences.tests.yml
+++ b/sdk/ml/production-experiences.tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+extends:
+  template: ./tests.yml
+  parameters:
+    TestMarkArgument: "production_experiences_test"

--- a/sdk/ml/tests.yml
+++ b/sdk/ml/tests.yml
@@ -1,4 +1,7 @@
-trigger: none
+parameters:
+  - name: TestMarkArgument
+    type: string
+    default: ''
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -8,6 +11,7 @@ stages:
       MatrixReplace:
         - TestSamples=.*/true
       TestTimeoutInMinutes: 270
+      TestMarkArgument: ${{ parameters.TestMarkArgument }}
       CloudConfig:
         Public:
           SubscriptionConfiguration: $(python-ml-subscription-scope-configuration)

--- a/sdk/ml/training-experiences.tests.yml
+++ b/sdk/ml/training-experiences.tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+extends:
+  template: ./tests.yml
+  parameters:
+    TestMarkArgument: "training_experiences_test"


### PR DESCRIPTION
We want to run one livetest pipeline per mark. per @needuv's recommendation.

The marks are:

- `automl_test`
- `production_experiences_test`
- `training_experiences_test`
- `pipeline_test`
- `data_experiences_test`
- `core_sdk_test`

This PR:

- adds the mark parameter to the **existing** `tests.yml` configuration. 
- Creates new yaml definitions so that codeowners can be associated with them individually.

Remaining:

- [x] Confirm passed mark is properly honored ([build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1940455&view=results))
- [x] Create a single new build def from a newly added tests.yml, ensure that the parameterization/`extends` methodology works as expected. ([pending](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1940506&view=results))
- [ ] Merge. Create the remaining 5 build definitions.
- [ ] Delete existing `python - ml - tests` build definition.


