### PR TITLE
[formrecognizer] Add skip flaky test decorator to FRC and FTC tests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from devtools_testutils import recorded_by_proxy, set_custom_default_matcher
 from azure.ai.formrecognizer import FormRecognizerClient, FormContentType, FormRecognizerApiVersion
 from testcase import FormRecognizerTest
+from conftest import skip_flaky_test
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
 
@@ -20,6 +21,7 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 class TestBusinessCard(FormRecognizerTest):
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -65,6 +67,7 @@ class TestBusinessCard(FormRecognizerTest):
                 content_type="application/jpeg"
             )
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -127,6 +130,7 @@ class TestBusinessCard(FormRecognizerTest):
         assert len(business_card.fields.get("CompanyNames").value) == 1
         assert business_card.fields.get("CompanyNames").value[0].value == "Contoso"
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_async.py
@@ -11,6 +11,7 @@ from devtools_testutils.aio import recorded_by_proxy_async
 from azure.ai.formrecognizer.aio import FormRecognizerClient
 from azure.ai.formrecognizer import FormContentType, FormRecognizerApiVersion
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 
@@ -20,6 +21,7 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 class TestBusinessCardAsync(AsyncFormRecognizerTest):
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -71,6 +73,7 @@ class TestBusinessCardAsync(AsyncFormRecognizerTest):
                 )
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url.py
@@ -9,6 +9,7 @@ import functools
 from devtools_testutils import recorded_by_proxy
 from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersion
 from testcase import FormRecognizerTest
+from conftest import skip_flaky_test
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
 
@@ -18,6 +19,7 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestBusinessCardFromUrl(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_business_card_from_url_async.py
@@ -10,6 +10,7 @@ from devtools_testutils.aio import recorded_by_proxy_async
 from azure.ai.formrecognizer import FormRecognizerApiVersion
 from azure.ai.formrecognizer.aio import FormRecognizerClient
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 
@@ -18,6 +19,7 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestBusinessCardFromUrlAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content.py
@@ -15,6 +15,7 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormContentType, FormR
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
@@ -37,6 +38,7 @@ class TestContentFromStream(FormRecognizerTest):
         with pytest.raises(ClientAuthenticationError):
             poller = client.begin_recognize_content(b"xx", content_type="application/pdf")
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -84,6 +86,7 @@ class TestContentFromStream(FormRecognizerTest):
                 my_file
             )
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -109,6 +112,7 @@ class TestContentFromStream(FormRecognizerTest):
         # Check form pages
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -122,6 +126,7 @@ class TestContentFromStream(FormRecognizerTest):
         result = poller.result()
         assert result
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -147,6 +152,7 @@ class TestContentFromStream(FormRecognizerTest):
         # Check form pages
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -165,6 +171,7 @@ class TestContentFromStream(FormRecognizerTest):
         assert layout.tables[0].page_number == 1
         assert layout.tables[1].page_number== 1
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -177,6 +184,7 @@ class TestContentFromStream(FormRecognizerTest):
         assert len(result) == 3
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -203,6 +211,7 @@ class TestContentFromStream(FormRecognizerTest):
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_content_continuation_token(self, **kwargs):
@@ -218,6 +227,7 @@ class TestContentFromStream(FormRecognizerTest):
         initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -243,6 +253,7 @@ class TestContentFromStream(FormRecognizerTest):
         # Check form pages
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -257,6 +268,7 @@ class TestContentFromStream(FormRecognizerTest):
         assert layout.page_number == 1
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy
@@ -271,6 +283,7 @@ class TestContentFromStream(FormRecognizerTest):
         assert layout.page_number == 1
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -295,6 +308,7 @@ class TestContentFromStream(FormRecognizerTest):
         result = poller.result()
         assert len(result) == 3
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_async.py
@@ -16,7 +16,7 @@ from azure.ai.formrecognizer import FormContentType, FormRecognizerApiVersion
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
-
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
@@ -44,6 +44,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
                 result = await poller.result()
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -100,6 +101,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
                 result = await poller.result()
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -127,6 +129,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -154,6 +157,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -176,6 +180,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
         assert layout.tables[1].page_number== 1
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -190,6 +195,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
         self.assertFormPagesHasValues(result)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -217,6 +223,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     async def test_content_continuation_token(self, **kwargs):
@@ -233,6 +240,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
 
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -261,6 +269,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
         self.assertFormPagesHasValues(result)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -278,6 +287,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
 
     @pytest.mark.skip()
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy_async
@@ -294,6 +304,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
         self.assertFormPagesHasValues(result)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -319,6 +330,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
             assert len(result) == 3
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -334,6 +346,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
             assert result
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url.py
@@ -15,7 +15,7 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersi
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
-
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
@@ -37,6 +37,7 @@ class TestContentFromUrl(FormRecognizerTest):
             with pytest.raises(HttpResponseError):
                 poller = client.begin_recognize_content_from_url(receipt)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -59,6 +60,7 @@ class TestContentFromUrl(FormRecognizerTest):
         # Check form pages
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -73,6 +75,7 @@ class TestContentFromUrl(FormRecognizerTest):
         assert layout.tables[0].column_count== 5
         assert layout.tables[0].page_number == 1
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -95,6 +98,7 @@ class TestContentFromUrl(FormRecognizerTest):
         # Check form pages
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -112,6 +116,7 @@ class TestContentFromUrl(FormRecognizerTest):
         assert layout.tables[0].page_number == 1
         assert layout.tables[1].page_number== 1
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -122,6 +127,7 @@ class TestContentFromUrl(FormRecognizerTest):
         assert len(result) == 3
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -145,6 +151,7 @@ class TestContentFromUrl(FormRecognizerTest):
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_content_continuation_token(self, **kwargs):
@@ -157,6 +164,7 @@ class TestContentFromUrl(FormRecognizerTest):
         assert result is not None
         initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -181,6 +189,7 @@ class TestContentFromUrl(FormRecognizerTest):
         assert layout.tables[0].page_number == 2
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -192,6 +201,7 @@ class TestContentFromUrl(FormRecognizerTest):
         assert layout.page_number == 1
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy
@@ -203,6 +213,7 @@ class TestContentFromUrl(FormRecognizerTest):
         assert layout.page_number == 1
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -223,6 +234,7 @@ class TestContentFromUrl(FormRecognizerTest):
         result = poller.result()
         assert len(result) == 3
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -233,6 +245,7 @@ class TestContentFromUrl(FormRecognizerTest):
         result = poller.result()
         assert result
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_content_from_url_async.py
@@ -16,7 +16,7 @@ from azure.ai.formrecognizer import FormRecognizerApiVersion
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
-
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
@@ -44,6 +44,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
                 poller = await client.begin_recognize_content_from_url(receipt)
                 result = await poller.result()
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -67,6 +68,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
         # Check form pages
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -82,6 +84,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
         assert layout.tables[0].column_count== 5
         assert layout.tables[0].page_number == 1
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -92,6 +95,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
         assert len(result) == 3
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -116,6 +120,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
         self.assertFormPagesTransformCorrect(layout, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     async def test_content_continuation_token(self, **kwargs):
@@ -129,6 +134,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
             assert result is not None
             await initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -154,6 +160,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
         assert layout.tables[0].page_number == 2
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -166,6 +173,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
         assert layout.page_number == 1
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer(client_kwargs={"api_version": FormRecognizerApiVersion.V2_0})
     @recorded_by_proxy_async
@@ -178,6 +186,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
         assert layout.page_number == 1
         self.assertFormPagesHasValues(result)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -199,6 +208,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
             result = await poller.result()
             assert len(result) == 3
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -210,6 +220,7 @@ class TestContentFromUrlAsync(AsyncFormRecognizerTest):
             result = await poller.result()
             assert result
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms.py
@@ -13,12 +13,14 @@ from azure.ai.formrecognizer._response_handlers import prepare_form_result
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
 
 
 class TestCustomForms(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -39,6 +41,7 @@ class TestCustomForms(FormRecognizerTest):
         assert form[0].form_type ==  "form-0"
         self.assertUnlabeledRecognizedFormHasValues(form[0], model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -62,6 +65,7 @@ class TestCustomForms(FormRecognizerTest):
             assert form.form_type == "form-0"
             self.assertUnlabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -84,6 +88,7 @@ class TestCustomForms(FormRecognizerTest):
         assert form[0].form_type ==  "custom:labeled"
         self.assertLabeledRecognizedFormHasValues(form[0], model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -110,6 +115,7 @@ class TestCustomForms(FormRecognizerTest):
             assert form.form_type ==  "custom:"+model.model_id
             self.assertLabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -164,6 +170,7 @@ class TestCustomForms(FormRecognizerTest):
         assert recognized_form.model_id is not None
         self.assertUnlabeledFormFieldDictTransformCorrect(recognized_form.fields, actual_fields, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -206,6 +213,7 @@ class TestCustomForms(FormRecognizerTest):
             self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     def test_custom_form_continuation_token(self, **kwargs):
@@ -233,6 +241,7 @@ class TestCustomForms(FormRecognizerTest):
         initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -274,6 +283,7 @@ class TestCustomForms(FormRecognizerTest):
             self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_async.py
@@ -14,13 +14,14 @@ from azure.ai.formrecognizer._response_handlers import prepare_form_result
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
-
+from conftest import skip_flaky_test
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
 
 
 class TestCustomFormsAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -40,6 +41,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
         assert form[0].form_type ==  "form-0"
         self.assertUnlabeledRecognizedFormHasValues(form[0], model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -66,6 +68,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
             assert form.form_type == "form-0"
             self.assertUnlabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -93,6 +96,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
             assert form.form_type ==  "custom:"+model.model_id
             self.assertLabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -138,6 +142,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
 
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     async def test_custom_form_continuation_token(self, **kwargs):
@@ -168,6 +173,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
                 await initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -211,6 +217,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
             self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url.py
@@ -13,12 +13,14 @@ from azure.ai.formrecognizer._response_handlers import prepare_form_result
 from testcase import FormRecognizerTest, _get_blob_url
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
 
 
 class TestCustomFormsFromUrl(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -41,6 +43,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
             assert form.form_type == "form-0"
             self.assertUnlabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -64,6 +67,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
             assert form.form_type ==  "custom:"+model.model_id
             self.assertLabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -102,6 +106,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
             assert form.model_id ==  model.model_id
             self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -142,6 +147,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
             self.assertFormFieldsTransformCorrect(form.fields, actual.fields, read_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     def test_custom_form_continuation_token(self, **kwargs):
@@ -167,6 +173,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
         assert result is not None
         initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -205,6 +212,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
             assert form.model_id ==  model.model_id
             self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy
@@ -244,6 +252,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
             assert form.model_id ==  model.model_id
             self.assertFormFieldsTransformCorrect(form.fields, actual.fields, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_custom_forms_from_url_async.py
@@ -14,12 +14,13 @@ from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from testcase import _get_blob_url
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
-
+from conftest import skip_flaky_test
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
 
 
 class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -43,6 +44,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
             assert form.form_type == "form-0"
             self.assertUnlabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -67,6 +69,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
             assert form.form_type ==  "custom:"+model.model_id
             self.assertLabeledRecognizedFormHasValues(form, model)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -108,6 +111,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
             assert form.model_id ==  model.model_id
             self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -151,6 +155,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
             self.assertFormFieldsTransformCorrect(form.fields, actual.fields, read_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     async def test_custom_form_continuation_token(self, **kwargs):
@@ -177,6 +182,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
                 assert result is not None
                 await initial_poller.wait()  # necessary so azure-devtools doesn't throw assertion error
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -216,6 +222,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
             assert form.model_id ==  model.model_id
             self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async
@@ -257,6 +264,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
             assert form.model_id ==  model.model_id
             self.assertFormFieldsTransformCorrect(form.fields, actual.fields, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents.py
@@ -16,6 +16,7 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersi
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
@@ -75,6 +76,7 @@ class TestIdDocument(FormRecognizerTest):
                 my_file
             )
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -114,6 +116,7 @@ class TestIdDocument(FormRecognizerTest):
         # Check page metadata
         self.assertFormPagesTransformCorrect(id_document.pages, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -138,6 +141,7 @@ class TestIdDocument(FormRecognizerTest):
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_identity_document_continuation_token(self, **kwargs):
@@ -162,6 +166,7 @@ class TestIdDocument(FormRecognizerTest):
             client.begin_recognize_identity_documents(id_document)
         assert "Method 'begin_recognize_identity_documents' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_async.py
@@ -17,6 +17,7 @@ from azure.ai.formrecognizer import FormRecognizerApiVersion
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import FormRecognizerPreparer
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
@@ -81,6 +82,7 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
                     my_file
                 )
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -121,6 +123,7 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
         # Check page metadata
         self.assertFormPagesTransformCorrect(id_document.pages, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -146,6 +149,7 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     async def test_identity_document_continuation_token(self, **kwargs):
@@ -171,6 +175,7 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
                 await client.begin_recognize_identity_documents(id_document)
         assert "Method 'begin_recognize_identity_documents' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url.py
@@ -15,12 +15,14 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersi
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
 
 class TestIdDocumentsFromUrl(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
@@ -34,6 +36,7 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
         poller2.wait()
         assert poller2._polling_method._timeout ==  7  # goes back to client default
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -70,6 +73,7 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
         # Check page metadata
         self.assertFormPagesTransformCorrect(id_document.pages, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -92,6 +96,7 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_identity_document_continuation_token(self, **kwargs):
@@ -111,6 +116,7 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
             client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg)
         assert "Method 'begin_recognize_identity_documents_from_url' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_identity_documents_from_url_async.py
@@ -15,12 +15,14 @@ from azure.ai.formrecognizer.aio import FormRecognizerClient
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import FormRecognizerPreparer
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
 
 class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
@@ -35,6 +37,7 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
             await poller2.wait()
             assert poller2._polling_method._timeout ==  7  # goes back to client default
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -72,6 +75,7 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
         # Check page metadata
         self.assertFormPagesTransformCorrect(id_document.pages, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -95,6 +99,7 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     async def test_identity_document_continuation_token(self, **kwargs):
@@ -116,6 +121,7 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
                 await client.begin_recognize_identity_documents_from_url(self.identity_document_url_jpg)
         assert "Method 'begin_recognize_identity_documents_from_url' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice.py
@@ -17,6 +17,7 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormContentType, FormR
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
@@ -32,6 +33,7 @@ class TestInvoice(FormRecognizerTest):
             client = FormRecognizerClient("http://notreal.azure.com", AzureKeyCredential(formrecognizer_test_api_key))
             poller = client.begin_recognize_invoices(my_file)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -90,6 +92,7 @@ class TestInvoice(FormRecognizerTest):
                 my_file
             )
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -130,6 +133,7 @@ class TestInvoice(FormRecognizerTest):
         self.assertFormPagesTransformCorrect(invoice.pages, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -174,6 +178,7 @@ class TestInvoice(FormRecognizerTest):
 
         self.assertFormPagesTransformCorrect(returned_model.pages, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -198,6 +203,7 @@ class TestInvoice(FormRecognizerTest):
         assert invoice.fields.get("DueDate").value, date(2017, 6 ==  24)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -226,6 +232,7 @@ class TestInvoice(FormRecognizerTest):
         assert remittance_address.value, '2345 Dogwood Lane Birch ==  Kansas 98123'
         assert remittance_address.value_data.page_number ==  1
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -279,6 +286,7 @@ class TestInvoice(FormRecognizerTest):
         assert invoice.fields.get("Items").value[0].value["UnitPrice"].value ==  1.0
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_invoice_continuation_token(self, **kwargs):
@@ -304,6 +312,7 @@ class TestInvoice(FormRecognizerTest):
             client.begin_recognize_invoices(invoice)
         assert "Method 'begin_recognize_invoices' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -325,6 +334,7 @@ class TestInvoice(FormRecognizerTest):
             client.begin_recognize_invoices(invoice, locale="not a locale")
         assert "locale" in e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_async.py
@@ -18,6 +18,7 @@ from azure.ai.formrecognizer import FormContentType, FormRecognizerApiVersion
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import FormRecognizerPreparer
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
@@ -35,6 +36,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
             async with client:
                 poller = await client.begin_recognize_invoices(my_file)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -98,6 +100,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
                     my_file
                 )
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -139,6 +142,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
         self.assertFormPagesTransformCorrect(invoice.pages, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -184,6 +188,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
 
         self.assertFormPagesTransformCorrect(returned_model.pages, read_results, page_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -210,6 +215,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
         assert invoice.fields.get("DueDate").value, date(2017, 6 ==  24)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -240,6 +246,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
         assert remittance_address.value, '2345 Dogwood Lane Birch ==  Kansas 98123'
         assert remittance_address.value_data.page_number ==  1
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -294,6 +301,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
         assert invoice.fields.get("Items").value[0].value["UnitPrice"].value ==  1.0
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     async def test_invoice_continuation_token(self, **kwargs):
@@ -320,6 +328,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
                 await client.begin_recognize_invoices(invoice)
         assert "Method 'begin_recognize_invoices' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -343,6 +352,7 @@ class TestInvoiceAsync(AsyncFormRecognizerTest):
                 await client.begin_recognize_invoices(invoice, locale="not a locale")
         assert "locale" in e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url.py
@@ -15,12 +15,14 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersi
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
 
 class TestInvoiceFromUrl(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
@@ -41,6 +43,7 @@ class TestInvoiceFromUrl(FormRecognizerTest):
         with pytest.raises(HttpResponseError):
             poller = client.begin_recognize_invoices_from_url("https://badurl.jpg")
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -83,6 +86,7 @@ class TestInvoiceFromUrl(FormRecognizerTest):
         self.assertFormPagesTransformCorrect(returned_model.pages, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     def test_invoice_continuation_token(self, **kwargs):
@@ -103,6 +107,7 @@ class TestInvoiceFromUrl(FormRecognizerTest):
             client.begin_recognize_invoices_from_url(self.invoice_url_tiff)
         assert "Method 'begin_recognize_invoices_from_url' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -120,6 +125,7 @@ class TestInvoiceFromUrl(FormRecognizerTest):
             client.begin_recognize_invoices_from_url(self.invoice_url_pdf, locale="not a locale")
         assert "locale" in e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -129,6 +135,7 @@ class TestInvoiceFromUrl(FormRecognizerTest):
         result = poller.result()
         assert result
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_invoice_from_url_async.py
@@ -16,6 +16,7 @@ from azure.ai.formrecognizer.aio import FormRecognizerClient
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import FormRecognizerPreparer
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
@@ -23,6 +24,7 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 
 class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_polling_interval(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):
@@ -45,6 +47,7 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
             async with client:
                 poller = await client.begin_recognize_invoices_from_url("https://badurl.jpg")
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -88,6 +91,7 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
         self.assertFormPagesTransformCorrect(returned_model.pages, read_results, page_results)
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     async def test_invoice_continuation_token(self, **kwargs):
@@ -109,6 +113,7 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
                 await client.begin_recognize_invoices_from_url(self.invoice_url_tiff)
         assert "Method 'begin_recognize_invoices_from_url' is only available for API version V2_1 and up" in str(e.value)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -128,6 +133,7 @@ class TestInvoiceFromUrlAsync(AsyncFormRecognizerTest):
                 await client.begin_recognize_invoices_from_url(self.invoice_url_pdf, locale="not a locale")
         assert "locale" in e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt.py
@@ -13,12 +13,14 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormContentType, FormR
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
 class TestReceiptFromStream(FormRecognizerTest):
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -75,6 +77,7 @@ class TestReceiptFromStream(FormRecognizerTest):
                 content_type="application/json"
             )
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_async.py
@@ -15,6 +15,7 @@ from azure.ai.formrecognizer import FormContentType, FormRecognizerApiVersion
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
@@ -22,6 +23,7 @@ FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormReco
 class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
 
     @pytest.mark.live_test_only
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -75,6 +77,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
                 )
                 result = await poller.result()
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url.py
@@ -14,11 +14,13 @@ from azure.ai.formrecognizer import FormRecognizerClient, FormRecognizerApiVersi
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
 class TestReceiptFromUrl(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy
@@ -56,6 +58,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
         # Check page metadata
         self.assertFormPagesTransformCorrect(receipt.pages, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_frc_receipt_from_url_async.py
@@ -15,11 +15,13 @@ from azure.ai.formrecognizer.aio import FormRecognizerClient
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 FormRecognizerClientPreparer = functools.partial(_GlobalClientPreparer, FormRecognizerClient)
 
 class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async
@@ -57,6 +59,7 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         # Check page metadata
         self.assertFormPagesTransformCorrect(receipt.pages, read_results)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormRecognizerClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model.py
@@ -12,6 +12,7 @@ from azure.ai.formrecognizer import FormTrainingClient, CustomFormModel
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
@@ -19,6 +20,7 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestTraining(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_compose_model_async.py
@@ -13,6 +13,7 @@ from azure.ai.formrecognizer import CustomFormModel
 from preparers import FormRecognizerPreparer
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from asynctestcase import AsyncFormRecognizerTest
+from conftest import skip_flaky_test
 
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
@@ -20,6 +21,7 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestTrainingAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model.py
@@ -13,12 +13,14 @@ from azure.ai.formrecognizer import FormTrainingClient
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
 
 
 class TestCopyModel(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
@@ -41,6 +43,7 @@ class TestCopyModel(FormRecognizerTest):
         assert target["modelId"] != model.model_id
         assert copied_model
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -64,6 +67,7 @@ class TestCopyModel(FormRecognizerTest):
         assert copied_model
         assert copied_model.model_name == "mymodel"
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -104,6 +108,7 @@ class TestCopyModel(FormRecognizerTest):
         assert e.value.error.code == "2024"
         assert e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -124,6 +129,7 @@ class TestCopyModel(FormRecognizerTest):
         assert target["modelId"] == copy.model_id
         assert target["modelId"] != model.model_id
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
@@ -137,6 +143,7 @@ class TestCopyModel(FormRecognizerTest):
         assert target["resourceRegion"] == "eastus"
         assert target["resourceId"] == formrecognizer_resource_id
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -150,6 +157,7 @@ class TestCopyModel(FormRecognizerTest):
         assert target["resourceRegion"] == "eastus"
         assert target["resourceId"] == formrecognizer_resource_id
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_copy_model_async.py
@@ -13,6 +13,7 @@ from azure.ai.formrecognizer.aio import FormTrainingClient
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
@@ -20,6 +21,7 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestCopyModelAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
@@ -42,6 +44,7 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
             assert target["modelId"] != model.model_id
             assert copied_model
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -65,6 +68,7 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
             assert copied_model
             assert copied_model.model_name == "mymodel"
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -105,6 +109,7 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
             assert e.value.error.code == "2024"
             assert e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -125,6 +130,7 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
             assert target["modelId"] == copy.model_id
             assert target["modelId"] != model.model_id
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
@@ -138,6 +144,7 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
             assert target["resourceRegion"] == "eastus"
             assert target["resourceId"] == formrecognizer_resource_id
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -151,6 +158,7 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
             assert target["resourceRegion"] == "eastus"
             assert target["resourceId"] == formrecognizer_resource_id
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt.py
@@ -17,12 +17,14 @@ from azure.ai.formrecognizer import (
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
 
 
 class TestManagement(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -32,6 +34,7 @@ class TestManagement(FormRecognizerTest):
         assert properties.custom_model_limit
         assert properties.custom_model_count
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -69,6 +72,7 @@ class TestManagement(FormRecognizerTest):
         with pytest.raises(ResourceNotFoundError):
             client.get_custom_model(labeled_model_from_train.model_id)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -105,6 +109,7 @@ class TestManagement(FormRecognizerTest):
         with pytest.raises(ResourceNotFoundError):
             client.get_custom_model(unlabeled_model_from_train.model_id)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @recorded_by_proxy
     def test_get_form_recognizer_client_v2(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_mgmt_async.py
@@ -16,6 +16,7 @@ from azure.ai.formrecognizer.aio import FormTrainingClient
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
@@ -23,6 +24,7 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestManagementAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -33,6 +35,7 @@ class TestManagementAsync(AsyncFormRecognizerTest):
             assert properties.custom_model_limit
             assert properties.custom_model_count
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -70,6 +73,7 @@ class TestManagementAsync(AsyncFormRecognizerTest):
             with pytest.raises(ResourceNotFoundError):
                 await client.get_custom_model(labeled_model_from_train.model_id)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -106,6 +110,7 @@ class TestManagementAsync(AsyncFormRecognizerTest):
             with pytest.raises(ResourceNotFoundError):
                 await client.get_custom_model(unlabeled_model_from_train.model_id)
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @recorded_by_proxy_async
     async def test_get_form_recognizer_client(self, formrecognizer_test_endpoint, formrecognizer_test_api_key, **kwargs):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training.py
@@ -13,11 +13,13 @@ from azure.ai.formrecognizer import FormTrainingClient
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
 from preparers import FormRecognizerPreparer
+from conftest import skip_flaky_test
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
 
 class TestTraining(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
@@ -46,6 +48,7 @@ class TestTraining(FormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
@@ -72,6 +75,7 @@ class TestTraining(FormRecognizerTest):
                 assert field.name
 
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
@@ -100,6 +104,7 @@ class TestTraining(FormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy
@@ -146,6 +151,7 @@ class TestTraining(FormRecognizerTest):
         assert e.value.error.code
         assert e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -175,6 +181,7 @@ class TestTraining(FormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -200,6 +207,7 @@ class TestTraining(FormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy
@@ -229,6 +237,7 @@ class TestTraining(FormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_ftc_training_async.py
@@ -13,6 +13,7 @@ from azure.ai.formrecognizer.aio import FormTrainingClient
 from preparers import FormRecognizerPreparer
 from asynctestcase import AsyncFormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 
 FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTrainingClient)
@@ -20,6 +21,7 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 class TestTrainingAsync(AsyncFormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
@@ -48,6 +50,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
@@ -74,6 +77,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
                 assert field.name
 
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
@@ -102,6 +106,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.0"})
     @recorded_by_proxy_async
@@ -148,6 +153,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
             assert e.value.error.code
             assert e.value.error.message
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -177,6 +183,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -202,6 +209,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async
@@ -231,6 +239,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
                 assert field.accuracy is not None
                 assert field.name
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @FormTrainingClientPreparer(client_kwargs={"api_version": "2.1"})
     @recorded_by_proxy_async

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_get_children.py
@@ -11,6 +11,7 @@ from azure.ai.formrecognizer import DocumentAnalysisClient, DocumentLine, Analyz
 from preparers import FormRecognizerPreparer
 from testcase import FormRecognizerTest
 from preparers import GlobalClientPreparer as _GlobalClientPreparer
+from conftest import skip_flaky_test
 
 
 DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, DocumentAnalysisClient)
@@ -18,6 +19,7 @@ DocumentAnalysisClientPreparer = functools.partial(_GlobalClientPreparer, Docume
 
 class TestGetChildren(FormRecognizerTest):
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy
@@ -32,6 +34,7 @@ class TestGetChildren(FormRecognizerTest):
         assert len(elements) == 1
         assert elements[0].content == "Contoso"
 
+    @skip_flaky_test
     @FormRecognizerPreparer()
     @DocumentAnalysisClientPreparer()
     @recorded_by_proxy


### PR DESCRIPTION
Adding the skip flaky test check to FormRecognizerClient and FormTrainingClient tests. 