### PR TITLE
[Pyamqp EH]

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -713,7 +713,6 @@ class WebSocketTransport(_AbstractTransport):
         try:
             while n:
                 data = self.ws.recv()
-
                 if len(data) <= n:
                     view[length : length + len(data)] = data
                     n -= len(data)
@@ -722,8 +721,8 @@ class WebSocketTransport(_AbstractTransport):
                     self._read_buffer = BytesIO(data[n:])
                     n = 0
             return view
-        except WebSocketTimeoutException:
-            raise TimeoutError()
+        except WebSocketTimeoutException as wte:
+            raise ConnectionError('recv timed out (%s)' % wte)
 
     def _shutdown_transport(self):
         # TODO Sync and Async close functions named differently
@@ -736,4 +735,13 @@ class WebSocketTransport(_AbstractTransport):
         See http://tools.ietf.org/html/rfc5234
         http://tools.ietf.org/html/rfc6455#section-5.2
         """
-        self.ws.send_binary(s)
+        from websocket import WebSocketConnectionClosedException, WebSocketTimeoutException
+        try:
+            self.ws.send_binary(s)
+        except WebSocketTimeoutException as e:
+            raise ConnectionError('send timed out (%s)' % e)
+        except SSLError as e:
+            raise ConnectionError('send disconnected by SSL (%s)' % e)
+        except WebSocketConnectionClosedException as e:
+            raise ConnectionError('send disconnected (%s)' % e)
+            

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -495,6 +495,8 @@ class WebSocketTransportAsync(
             raise ValueError(
                 "Please install aiohttp library to use websocket transport."
             )
+        except OSError:
+            await self.session.close()
 
     async def _read(self, n, buffer=None, **kwargs):  # pylint: disable=unused-argument
         """Read exactly n bytes from the peer."""
@@ -518,6 +520,8 @@ class WebSocketTransportAsync(
             return view
         except asyncio.TimeoutError:
             raise TimeoutError()
+        except OSError:
+            await self.session.close()
 
     async def close(self):
         """Do any preliminary work in shutting down the connection."""
@@ -531,4 +535,7 @@ class WebSocketTransportAsync(
         See http://tools.ietf.org/html/rfc5234
         http://tools.ietf.org/html/rfc6455#section-5.2
         """
-        await self.ws.send_bytes(s)
+        try:
+            await self.ws.send_bytes(s)
+        except OSError:
+            await self.session.close()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -82,6 +82,7 @@ class AsyncTransportMixin:
             asyncio.IncompleteReadError,
             asyncio.TimeoutError,
         ):
+            print("receive frame caught tht timeout error")
             return None, None
 
     async def read(self, verify_frame_type=0):
@@ -123,6 +124,7 @@ class AsyncTransportMixin:
                         await self._read(payload_size, buffer=payload)
                     )
             except (TimeoutError, socket.timeout, asyncio.IncompleteReadError):
+                print("async transport read caught the timeout error")
                 read_frame_buffer.write(self._read_buffer.getvalue())
                 self._read_buffer = read_frame_buffer
                 self._read_buffer.seek(0)
@@ -488,6 +490,7 @@ class WebSocketTransportAsync(
                 proxy=http_proxy_host,
                 proxy_auth=http_proxy_auth,
                 ssl=self.sslopts,
+                heartbeat=10,
             )
             self.connected = True
 


### PR DESCRIPTION
AioHttp websockets when the connection gets disconnected without their knowledge throw a "Cannot write to closing transport" on read/write operations. We were not handling this so our aiohttp ClientSession() was not being closed (aiohttp.client_exceptions.ClientOSError).  

To prevent us having import aiohttp I used except OSError instead of the aiohttp clientOSError