### PR TITLE
[PyAMQP] AioHttp Client session closed 

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -495,6 +495,8 @@ class WebSocketTransportAsync(
             raise ValueError(
                 "Please install aiohttp library to use websocket transport."
             )
+        except OSError:
+            await self.session.close()
 
     async def _read(self, n, buffer=None, **kwargs):  # pylint: disable=unused-argument
         """Read exactly n bytes from the peer."""
@@ -518,6 +520,8 @@ class WebSocketTransportAsync(
             return view
         except asyncio.TimeoutError:
             raise TimeoutError()
+        except OSError:
+            await self.session.close()
 
     async def close(self):
         """Do any preliminary work in shutting down the connection."""
@@ -531,4 +535,7 @@ class WebSocketTransportAsync(
         See http://tools.ietf.org/html/rfc5234
         http://tools.ietf.org/html/rfc6455#section-5.2
         """
-        await self.ws.send_bytes(s)
+        try:
+            await self.ws.send_bytes(s)
+        except OSError:
+            await self.session.close()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -495,7 +495,7 @@ class WebSocketTransportAsync(
             raise ValueError(
                 "Please install aiohttp library to use websocket transport."
             )
-        except OSError:
+        except ConnectionResetError:
             await self.session.close()
 
     async def _read(self, n, buffer=None, **kwargs):  # pylint: disable=unused-argument
@@ -520,7 +520,7 @@ class WebSocketTransportAsync(
             return view
         except asyncio.TimeoutError:
             raise TimeoutError()
-        except OSError:
+        except ConnectionResetError:
             await self.session.close()
 
     async def close(self):
@@ -537,5 +537,5 @@ class WebSocketTransportAsync(
         """
         try:
             await self.ws.send_bytes(s)
-        except OSError:
+        except ConnectionResetError:
             await self.session.close()


### PR DESCRIPTION
AioHttp websockets when the connection gets disconnected without their knowledge throw a "Cannot write to closing transport" on read/write operations. We were not handling this so our aiohttp ClientSession() was not being closed (aiohttp.client_exceptions.ClientOSError).

To prevent us having import aiohttp I used except OSError instead of the aiohttp clientOSError