### PR TITLE
[Storage] Improve error code for `PublicAccessNotPermitted`

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -54,6 +54,7 @@ class StorageErrorCode(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     OPERATION_TIMED_OUT = "OperationTimedOut"
     OUT_OF_RANGE_INPUT = "OutOfRangeInput"
     OUT_OF_RANGE_QUERY_PARAMETER_VALUE = "OutOfRangeQueryParameterValue"
+    PUBLIC_ACCESS_NOT_PERMITTED = "PublicAccessNotPermitted"
     REQUEST_BODY_TOO_LARGE = "RequestBodyTooLarge"
     RESOURCE_TYPE_MISMATCH = "ResourceTypeMismatch"
     REQUEST_URL_FAILED_TO_PARSE = "RequestUrlFailedToParse"

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -122,6 +122,10 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
         # If we extracted from a Json or XML response
         if error_dict:
             error_code = error_dict.get('code')
+            # Special case for public access error code to be surfaced properly
+            if error_code == StorageErrorCode.PUBLIC_ACCESS_NOT_PERMITTED:
+                serialized = False
+
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}
     except DecodeError:
@@ -135,7 +139,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
                               StorageErrorCode.blob_overwritten]:
                 raise_error = ResourceModifiedError
             if error_code in [StorageErrorCode.invalid_authentication_info,
-                              StorageErrorCode.authentication_failed]:
+                              StorageErrorCode.authentication_failed,
+                              StorageErrorCode.public_access_not_permitted]:
                 raise_error = ClientAuthenticationError
             if error_code in [StorageErrorCode.resource_not_found,
                               StorageErrorCode.cannot_verify_copy_source,

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_public_access_error_code.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_public_access_error_code.json
@@ -1,0 +1,89 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer821e2d3d?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.14.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
+        "x-ms-date": "Mon, 24 Oct 2022 23:39:28 GMT",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 24 Oct 2022 23:39:28 GMT",
+        "ETag": "\u00220x8DAB618FE679C14\u0022",
+        "Last-Modified": "Mon, 24 Oct 2022 23:39:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainersource821e2d3d?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.14.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
+        "x-ms-date": "Mon, 24 Oct 2022 23:39:28 GMT",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 24 Oct 2022 23:39:28 GMT",
+        "ETag": "\u00220x8DAB618FE77EE5C\u0022",
+        "Last-Modified": "Mon, 24 Oct 2022 23:39:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer821e2d3d/test",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "8",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "User-Agent": "azsdk-python-storage-blob/12.14.1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Mon, 24 Oct 2022 23:39:28 GMT",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": "MTIzNDU2Nzg=",
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "248",
+        "Content-Type": "application/xml",
+        "Date": "Mon, 24 Oct 2022 23:39:28 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "x-ms-error-code": "PublicAccessNotPermitted"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EPublicAccessNotPermitted\u003C/Code\u003E\u003CMessage\u003EPublic access is not permitted on this storage account.\n",
+        "RequestId:23687549-801e-009e-3301-e8e5ff000000\n",
+        "Time:2022-10-24T23:39:29.2179134Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -3249,4 +3249,22 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         assert blob_client.exists()
         assert blob_client.get_blob_properties().size == 0
 
+    @BlobPreparer()
+    @recorded_by_proxy
+    def test_public_access_error_code(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+
+        blob_data = b'12345678'
+        blob_name = self.get_resource_name("utcontainer")
+
+
+        # Act
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"))
+        blob = bsc.get_blob_client(container=blob_name, blob='test')
+        with pytest.raises(ClientAuthenticationError):
+            blob.upload_blob(blob_data)
+
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/models.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/models.py
@@ -55,6 +55,7 @@ class StorageErrorCode(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     OPERATION_TIMED_OUT = "OperationTimedOut"
     OUT_OF_RANGE_INPUT = "OutOfRangeInput"
     OUT_OF_RANGE_QUERY_PARAMETER_VALUE = "OutOfRangeQueryParameterValue"
+    PUBLIC_ACCESS_NOT_PERMITTED = "PublicAccessNotPermitted"
     REQUEST_BODY_TOO_LARGE = "RequestBodyTooLarge"
     RESOURCE_TYPE_MISMATCH = "ResourceTypeMismatch"
     REQUEST_URL_FAILED_TO_PARSE = "RequestUrlFailedToParse"

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -119,6 +119,9 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
         # If we extracted from a Json or XML response
         if error_dict:
             error_code = error_dict.get('code')
+            # Special case for public access error code to be surfaced properly
+            if error_code == StorageErrorCode.PUBLIC_ACCESS_NOT_PERMITTED:
+                serialized = False
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}
     except DecodeError:
@@ -132,7 +135,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
                               StorageErrorCode.blob_overwritten]:
                 raise_error = ResourceModifiedError
             if error_code in [StorageErrorCode.invalid_authentication_info,
-                              StorageErrorCode.authentication_failed]:
+                              StorageErrorCode.authentication_failed,
+                              StorageErrorCode.public_access_not_permitted]:
                 raise_error = ClientAuthenticationError
             if error_code in [StorageErrorCode.resource_not_found,
                               StorageErrorCode.cannot_verify_copy_source,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/models.py
@@ -54,6 +54,7 @@ class StorageErrorCode(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     OPERATION_TIMED_OUT = "OperationTimedOut"
     OUT_OF_RANGE_INPUT = "OutOfRangeInput"
     OUT_OF_RANGE_QUERY_PARAMETER_VALUE = "OutOfRangeQueryParameterValue"
+    PUBLIC_ACCESS_NOT_PERMITTED = "PublicAccessNotPermitted"
     REQUEST_BODY_TOO_LARGE = "RequestBodyTooLarge"
     RESOURCE_TYPE_MISMATCH = "ResourceTypeMismatch"
     REQUEST_URL_FAILED_TO_PARSE = "RequestUrlFailedToParse"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
@@ -119,6 +119,9 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
         # If we extracted from a Json or XML response
         if error_dict:
             error_code = error_dict.get('code')
+            # Special case for public access error code to be surfaced properly
+            if error_code == StorageErrorCode.PUBLIC_ACCESS_NOT_PERMITTED:
+                serialized = False
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}
     except DecodeError:
@@ -132,7 +135,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
                               StorageErrorCode.blob_overwritten]:
                 raise_error = ResourceModifiedError
             if error_code in [StorageErrorCode.invalid_authentication_info,
-                              StorageErrorCode.authentication_failed]:
+                              StorageErrorCode.authentication_failed,
+                              StorageErrorCode.public_access_not_permitted]:
                 raise_error = ClientAuthenticationError
             if error_code in [StorageErrorCode.resource_not_found,
                               StorageErrorCode.cannot_verify_copy_source,

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
@@ -55,6 +55,7 @@ class StorageErrorCode(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     OPERATION_TIMED_OUT = "OperationTimedOut"
     OUT_OF_RANGE_INPUT = "OutOfRangeInput"
     OUT_OF_RANGE_QUERY_PARAMETER_VALUE = "OutOfRangeQueryParameterValue"
+    PUBLIC_ACCESS_NOT_PERMITTED = "PublicAccessNotPermitted"
     REQUEST_BODY_TOO_LARGE = "RequestBodyTooLarge"
     RESOURCE_TYPE_MISMATCH = "ResourceTypeMismatch"
     REQUEST_URL_FAILED_TO_PARSE = "RequestUrlFailedToParse"

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
@@ -121,6 +121,9 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
         # If we extracted from a Json or XML response
         if error_dict:
             error_code = error_dict.get('code')
+            # Special case for public access error code to be surfaced properly
+            if error_code == StorageErrorCode.PUBLIC_ACCESS_NOT_PERMITTED:
+                serialized = False
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}
     except DecodeError:
@@ -134,7 +137,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
                               StorageErrorCode.blob_overwritten]:
                 raise_error = ResourceModifiedError
             if error_code in [StorageErrorCode.invalid_authentication_info,
-                              StorageErrorCode.authentication_failed]:
+                              StorageErrorCode.authentication_failed,
+                              StorageErrorCode.public_access_not_permitted]:
                 raise_error = ClientAuthenticationError
             if error_code in [StorageErrorCode.resource_not_found,
                               StorageErrorCode.cannot_verify_copy_source,


### PR DESCRIPTION
This PR is for a change to how `PublicAccessNotPermitted` is raised. Currently, from generated it is a `ResourceExistsError`, and so it will surface that (and `PublicAccessNotPermitted` is only known from the XML deserialization).

This PR checks for this special case, and if encountered forces it to be serialized as if it was not serialized from generated, thus allowing it to surface the correct error (auth error). An alternative approach is to make an adjustment at the `_generated` layer.

Resolves #26919