### PR TITLE
Fix #26857: separate stdout from stderr in AzureCliCredential (#26953)

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- `AzureCliCredential` now works even when `az` prints warnings to stderr. ([#26857](https://github.com/Azure/azure-sdk-for-python/issues/26857))
 - Fixed issue where user-supplied `TokenCachePersistenceOptions` weren't propagated when using `SharedTokenCacheCredential` ([#26982](https://github.com/Azure/azure-sdk-for-python/issues/26982))
 
 ### Other Changes

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -143,7 +143,7 @@ def _run_command(command):
         working_directory = get_safe_working_dir()
 
         kwargs = {
-            "stderr": subprocess.STDOUT,
+            "stderr": subprocess.PIPE,
             "cwd": working_directory,
             "universal_newlines": True,
             "env": dict(os.environ, AZURE_CORE_NO_COLOR="true"),
@@ -154,14 +154,14 @@ def _run_command(command):
         return subprocess.check_output(args, **kwargs)
     except subprocess.CalledProcessError as ex:
         # non-zero return from shell
-        if ex.returncode == 127 or ex.output.startswith("'az' is not recognized"):
+        if ex.returncode == 127 or ex.stderr.startswith("'az' is not recognized"):
             raise CredentialUnavailableError(message=CLI_NOT_FOUND)
-        if "az login" in ex.output or "az account set" in ex.output:
+        if "az login" in ex.stderr or "az account set" in ex.stderr:
             raise CredentialUnavailableError(message=NOT_LOGGED_IN)
 
         # return code is from the CLI -> propagate its output
-        if ex.output:
-            message = sanitize_output(ex.output)
+        if ex.stderr:
+            message = sanitize_output(ex.stderr)
         else:
             message = "Failed to invoke Azure CLI"
         raise ClientAuthenticationError(message=message)

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -31,8 +31,8 @@ TEST_ERROR_OUTPUTS = (
 )
 
 
-def raise_called_process_error(return_code, output, cmd="..."):
-    error = subprocess.CalledProcessError(return_code, cmd=cmd, output=output)
+def raise_called_process_error(return_code, output="", cmd="...", stderr=""):
+    error = subprocess.CalledProcessError(return_code, cmd=cmd, output=output, stderr=stderr)
     return mock.Mock(side_effect=error)
 
 
@@ -76,8 +76,8 @@ def test_get_token():
 def test_cli_not_installed_linux():
     """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
 
-    output = "/bin/sh: 1: az: not found"
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(127, output)):
+    stderr = "/bin/sh: 1: az: not found"
+    with mock.patch(CHECK_OUTPUT, raise_called_process_error(127, stderr=stderr)):
         with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
             AzureCliCredential().get_token("scope")
 
@@ -85,8 +85,8 @@ def test_cli_not_installed_linux():
 def test_cli_not_installed_windows():
     """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
 
-    output = "'az' is not recognized as an internal or external command, operable program or batch file."
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, output)):
+    stderr = "'az' is not recognized as an internal or external command, operable program or batch file."
+    with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, stderr=stderr)):
         with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
             AzureCliCredential().get_token("scope")
 
@@ -102,8 +102,8 @@ def test_cannot_execute_shell():
 def test_not_logged_in():
     """When the CLI isn't logged in, the credential should raise CredentialUnavailableError"""
 
-    output = "ERROR: Please run 'az login' to setup account."
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, output)):
+    stderr = "ERROR: Please run 'az login' to setup account."
+    with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, stderr=stderr)):
         with pytest.raises(CredentialUnavailableError, match=NOT_LOGGED_IN):
             AzureCliCredential().get_token("scope")
 
@@ -111,9 +111,9 @@ def test_not_logged_in():
 def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 
-    output = "something went wrong"
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(42, output)):
-        with pytest.raises(ClientAuthenticationError, match=output):
+    stderr = "something went wrong"
+    with mock.patch(CHECK_OUTPUT, raise_called_process_error(42, stderr=stderr)):
+        with pytest.raises(ClientAuthenticationError, match=stderr):
             AzureCliCredential().get_token("scope")
 
 
@@ -181,7 +181,7 @@ def test_multitenant_authentication_class():
 
         token = AzureCliCredential(tenant_id=second_tenant).get_token("scope")
         assert token.token == second_token
-        
+
 def test_multitenant_authentication():
     default_tenant = "first-tenant"
     first_token = "***"

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -101,8 +101,8 @@ async def test_get_token():
 async def test_cli_not_installed_linux():
     """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
 
-    output = "/bin/sh: 1: az: not found"
-    with mock.patch(SUBPROCESS_EXEC, mock_exec(output, return_code=127)):
+    stderr = "/bin/sh: 1: az: not found"
+    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=127)):
         with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
             credential = AzureCliCredential()
             await credential.get_token("scope")
@@ -111,8 +111,8 @@ async def test_cli_not_installed_linux():
 async def test_cli_not_installed_windows():
     """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
 
-    output = "'az' is not recognized as an internal or external command, operable program or batch file."
-    with mock.patch(SUBPROCESS_EXEC, mock_exec(output, return_code=1)):
+    stderr = "'az' is not recognized as an internal or external command, operable program or batch file."
+    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=1)):
         with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
             credential = AzureCliCredential()
             await credential.get_token("scope")
@@ -130,8 +130,8 @@ async def test_cannot_execute_shell():
 async def test_not_logged_in():
     """When the CLI isn't logged in, the credential should raise CredentialUnavailableError"""
 
-    output = "ERROR: Please run 'az login' to setup account."
-    with mock.patch(SUBPROCESS_EXEC, mock_exec(output, return_code=1)):
+    stderr = "ERROR: Please run 'az login' to setup account."
+    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=1)):
         with pytest.raises(CredentialUnavailableError, match=NOT_LOGGED_IN):
             credential = AzureCliCredential()
             await credential.get_token("scope")
@@ -140,9 +140,9 @@ async def test_not_logged_in():
 async def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 
-    output = "something went wrong"
-    with mock.patch(SUBPROCESS_EXEC, mock_exec(output, return_code=42)):
-        with pytest.raises(ClientAuthenticationError, match=output):
+    stderr = "something went wrong"
+    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=42)):
+        with pytest.raises(ClientAuthenticationError, match=stderr):
             credential = AzureCliCredential()
             await credential.get_token("scope")
 


### PR DESCRIPTION
* Fix #26857: separate stdout from stderr in AzureCliCredential

* Fix unit tests for AzureCliCredential

* Fix #26857 for aio.AzureCliCredential

* azure_cli.py: Fix types in _run_command

* Fix test_cli_credential_async.py

* Update sdk/identity/azure-identity/CHANGELOG.md

Co-authored-by: Paul Van Eck <paulvaneck@microsoft.com>

Co-authored-by: Tingmao Wang <tingmaowang@microsoft.com>
Co-authored-by: Paul Van Eck <paulvaneck@microsoft.com>
Co-authored-by: Xiang Yan <xiangsjtu@gmail.com>

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
