### PR TITLE
[Bot Rules] Update service contacts for Text Analytics

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1740,7 +1740,7 @@
               "Cognitive - Text Analytics"
             ],
             "mentionees": [
-              "assafi"
+              "mikaelsitruk"
             ]
           },
           {


### PR DESCRIPTION
# Summary

The focus of these changes is to update the bot rules with the Text Analytics service contact from #27104.