### PR TITLE
Livetests don't go through test-proxy by default

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -71,6 +71,8 @@ jobs:
         value: true
       - name: ArmTemplateParameters
         value: '@{}'
+      - name: AZURE_SKIP_LIVE_RECORDING
+        value: true
 
     timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
     continueOnError: false

--- a/sdk/ml/tests.yml
+++ b/sdk/ml/tests.yml
@@ -6,7 +6,6 @@ parameters:
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      TestProxy: true
       ServiceDirectory: ml
       MatrixReplace:
         - TestSamples=.*/true


### PR DESCRIPTION
When running livetests, we shouldn't be going through the proxy. The ML livetests are passing through the proxy before actually running. We can entirely eliminate this by setting the default in `live.tests.yml`.

Furthermore, we can then disable `test-proxy` for ml livetests entirely because we don't actually need it to run during livetests if no traffic goes through it. This should have the knock-on effect of solving the certificate trust issue visible in [this failing livetest](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1943129&view=logs&j=4f81fff1-e645-5c70-43ca-8617659eb31f&t=b0c2c29e-b259-5f45-908e-7935206a485c).

