### PR TITLE
[ml] Bugfix: Fix misconfigured timeout parameter for job.stream

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -168,7 +168,7 @@ def download_text_from_url(
         timeout_params = {}
     else:
         connect_timeout, read_timeout = timeout if isinstance(timeout, tuple) else (timeout, timeout)
-        timeout_params = dict(timeout=read_timeout, connection_timeout=connect_timeout)
+        timeout_params = dict(read_timeout=read_timeout, connection_timeout=connect_timeout)
 
     response = requests_pipeline.get(source_uri, **timeout_params)
     # Match old behavior from execution service's status API.


### PR DESCRIPTION
# Description

This PR fixes an issue where `download_text_from_url`, called as part of `ml_client.jobs.stream`, used the wrong keyword parameter to specify the read timeout for the GET request


_Further details_: 

When sending http requests with `azure.core`, there are several timeout related parameters:

 * `timeout` is handled by `RetryPolicy` and is a time limit for all retry attempts
 * `read_timeout` and `connection_timeout` apply to the http transport, and control the read and connection timeouts for the http requests

`download_text_from_url` erroneously used `timeout` instead of `read_timeout` to specify the read timeout

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
