### PR TITLE
Resolve 3.11 Failures for `storage`

### DIFF
--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -1,8 +1,5 @@
 cryptography<4
 
-# python 3.10 pinned packages
-cffi==1.15.0rc2; python_version >= '3.10'
-
 # requirements leveraged by ci for testing
 pytest==4.6.9; python_version == '2.7'
 pytest==5.4.2; python_version >= '3.5' and python_version <= '3.9'
@@ -30,8 +27,7 @@ packaging==20.4
 Jinja2==2.11.2
 markupsafe==2.0.1; python_version > '2.7'
 markupsafe==1.1.1; python_version == '2.7'
-wrapt==1.12.1; python_version <= '3.10'
-wrapt==1.14.1; python_version >= '3.11'
+wrapt==1.12.1; python_version <= '3.11'
 
 # Locking pylint and required packages
 pylint==1.8.4; python_version < '3.4'

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -27,7 +27,8 @@ packaging==20.4
 Jinja2==2.11.2
 markupsafe==2.0.1; python_version > '2.7'
 markupsafe==1.1.1; python_version == '2.7'
-wrapt==1.12.1; python_version <= '3.11'
+wrapt==1.12.1; python_version <= '3.10'
+wrapt==1.14.1; python_version >= '3.11'
 
 # Locking pylint and required packages
 pylint==1.8.4; python_version < '3.4'

--- a/tools/vcrpy/setup.py
+++ b/tools/vcrpy/setup.py
@@ -24,7 +24,7 @@ class PyTest(TestCommand):
 
 install_requires = [
     "PyYAML",
-    "wrapt<=1.12.1",
+    "wrapt<=1.14.1",
     "six>=1.5",
     'contextlib2; python_version=="2.7"',
     'mock; python_version=="2.7"',


### PR DESCRIPTION
I'm expecting to have to assemble a `yarl` and `multidict` wheel.

Confirming [storage build](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1952847&view=logs&j=84b20eb0-323b-5722-f041-399ea9857d18&t=1024ff5b-59a4-5548-1c1b-bbb298ca1664).