### PR TITLE
git: ignore pre-commit configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ sdk/cosmos/azure-cosmos/test/test_config.py
 
 # local SSL certificate folder
 .certificate
+
+# ignore pre-commit config to avoid adding hooks in this repo as
+# package specific hooks will bring delay and in some cases errors to all developers
+.pre-commit-config.yaml


### PR DESCRIPTION
# Description

Add pre-commit configuration file to .gitignore.

We don't want to enable git hooks in root level as package specific hooks may bring delay and in some cases error to all developers.

By adding the configuration file to .gitignore, package developers may enable pre-commit locally if needed without impact the repo.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
