### PR TITLE
Enable updating CMK encryption key through SDK/CLI

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -237,7 +237,7 @@ class MLClient(object):
             **kwargs,
         )
 
-        self._rp_service_client = ServiceClient052022(
+        self._rp_service_client = ServiceClient102022Preview(
             subscription_id=self._operation_scope._subscription_id,
             credential=self._credential,
             base_url=base_url,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/diagnose.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/diagnose.py
@@ -3,11 +3,21 @@
 # ---------------------------------------------------------
 from typing import Any, Dict, List, Optional
 
-from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseRequestProperties as RestDiagnoseRequestProperties
-from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseResponseResult as RestDiagnoseResponseResult
-from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseResponseResultValue as RestDiagnoseResponseResultValue
-from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseResult as RestDiagnoseResult
-from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseWorkspaceParameters as RestDiagnoseWorkspaceParameters
+from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+    DiagnoseRequestProperties as RestDiagnoseRequestProperties
+)
+from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+    DiagnoseResponseResult as RestDiagnoseResponseResult
+)
+from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+    DiagnoseResponseResultValue as RestDiagnoseResponseResultValue
+)
+from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+    DiagnoseResult as RestDiagnoseResult
+)
+from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+    DiagnoseWorkspaceParameters as RestDiagnoseWorkspaceParameters
+)
 
 
 class DiagnoseRequestProperties:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/diagnose.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/diagnose.py
@@ -3,11 +3,11 @@
 # ---------------------------------------------------------
 from typing import Any, Dict, List, Optional
 
-from azure.ai.ml._restclient.v2022_05_01.models import DiagnoseRequestProperties as RestDiagnoseRequestProperties
-from azure.ai.ml._restclient.v2022_05_01.models import DiagnoseResponseResult as RestDiagnoseResponseResult
-from azure.ai.ml._restclient.v2022_05_01.models import DiagnoseResponseResultValue as RestDiagnoseResponseResultValue
-from azure.ai.ml._restclient.v2022_05_01.models import DiagnoseResult as RestDiagnoseResult
-from azure.ai.ml._restclient.v2022_05_01.models import DiagnoseWorkspaceParameters as RestDiagnoseWorkspaceParameters
+from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseRequestProperties as RestDiagnoseRequestProperties
+from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseResponseResult as RestDiagnoseResponseResult
+from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseResponseResultValue as RestDiagnoseResponseResultValue
+from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseResult as RestDiagnoseResult
+from azure.ai.ml._restclient.v2022_10_01_preview.models import DiagnoseWorkspaceParameters as RestDiagnoseWorkspaceParameters
 
 
 class DiagnoseRequestProperties:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/workspace.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/workspace.py
@@ -8,8 +8,8 @@ from os import PathLike
 from pathlib import Path
 from typing import IO, AnyStr, Dict, Union
 
-from azure.ai.ml._restclient.v2022_05_01.models import ManagedServiceIdentity as RestManagedServiceIdentity
-from azure.ai.ml._restclient.v2022_05_01.models import Workspace as RestWorkspace
+from azure.ai.ml._restclient.v2022_10_01_preview.models import ManagedServiceIdentity as RestManagedServiceIdentity
+from azure.ai.ml._restclient.v2022_10_01_preview.models import Workspace as RestWorkspace
 from azure.ai.ml._schema.workspace.workspace import WorkspaceSchema
 from azure.ai.ml._utils.utils import dump_yaml_to_file
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, PARAMS_OVERRIDE_KEY, WorkspaceResourceConstants

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/workspace_keys.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/workspace_keys.py
@@ -4,7 +4,7 @@
 
 from typing import List
 
-from azure.ai.ml._restclient.v2022_05_01.models import ListWorkspaceKeysResult
+from azure.ai.ml._restclient.v2022_10_01_preview.models import ListWorkspaceKeysResult
 
 class ContainerRegistryCredential:
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -318,7 +318,7 @@ class WorkspaceOperations:
                     key_identifier=customer_managed_key_uri,
                 )
             )
-            
+
         resource_group = kwargs.get("resource_group") or workspace.resource_group or self._resource_group_name
 
         # pylint: disable=unused-argument

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -9,8 +9,12 @@ from typing import Dict, Iterable, Tuple
 
 from azure.ai.ml._arm_deployments import ArmDeploymentExecutor
 from azure.ai.ml._arm_deployments.arm_helper import get_template
-from azure.ai.ml._restclient.v2022_05_01 import AzureMachineLearningWorkspaces as ServiceClient052022
-from azure.ai.ml._restclient.v2022_05_01.models import WorkspaceUpdateParameters
+from azure.ai.ml._restclient.v2022_10_01_preview import AzureMachineLearningWorkspaces as ServiceClient102022Preview
+from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+    EncryptionKeyVaultUpdateProperties,
+    EncryptionUpdateProperties,
+    WorkspaceUpdateParameters,
+)
 from azure.ai.ml._scope_dependent_operations import OperationsContainer, OperationScope
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._utils._logger_utils import OpsLogger
@@ -55,7 +59,7 @@ class WorkspaceOperations:
     def __init__(
         self,
         operation_scope: OperationScope,
-        service_client: ServiceClient052022,
+        service_client: ServiceClient102022Preview,
         all_operations: OperationsContainer,
         credentials: TokenCredential = None,
         **kwargs: Dict,
@@ -305,6 +309,16 @@ class WorkspaceOperations:
         update_param.container_registry = container_registry or None
         update_param.application_insights = application_insights or None
 
+        # Only the key uri property of customer_managed_key can be updated.
+        # Check if user is updating CMK key uri, if so, add to update_param
+        if workspace.customer_managed_key is not None and workspace.customer_managed_key.key_uri is not None:
+            customer_managed_key_uri=workspace.customer_managed_key.key_uri
+            update_param.encryption=EncryptionUpdateProperties(
+                key_vault_properties=EncryptionKeyVaultUpdateProperties(
+                    key_identifier=customer_managed_key_uri,
+                )
+            )
+            
         resource_group = kwargs.get("resource_group") or workspace.resource_group or self._resource_group_name
 
         # pylint: disable=unused-argument

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_operations.py
@@ -10,6 +10,10 @@ from azure.ai.ml._scope_dependent_operations import OperationScope
 from azure.ai.ml.constants import ManagedServiceIdentityType
 from azure.ai.ml.entities import CustomerManagedKey, Workspace, \
     IdentityConfiguration, ManagedIdentityConfiguration
+from azure.ai.ml._restclient.v2022_10_01_preview.models import (
+    EncryptionKeyVaultUpdateProperties,
+    EncryptionUpdateProperties,
+)
 from azure.ai.ml.operations import WorkspaceOperations
 from azure.core.polling import LROPoller
 
@@ -130,6 +134,7 @@ class TestWorkspaceOperation:
                 ],
             ),
             primary_user_assigned_identity="resource2",
+            customer_managed_key = CustomerManagedKey(key_uri="new_cmk_uri")
         )
 
         def outgoing_call(rg, name, params, polling, cls):
@@ -145,6 +150,11 @@ class TestWorkspaceOperation:
             assert params.identity.type == ManagedServiceIdentityType.USER_ASSIGNED
             assert len(params.identity.user_assigned_identities) == 2
             assert params.primary_user_assigned_identity == "resource2"
+            assert params.encryption == EncryptionUpdateProperties(
+                key_vault_properties=EncryptionKeyVaultUpdateProperties(
+                    key_identifier="new_cmk_uri",
+                )
+            )            
             assert polling is True
             assert callable(cls)
             return DEFAULT
@@ -166,7 +176,7 @@ class TestWorkspaceOperation:
             assert params.friendly_name == ""  # empty string is supported for friendly name.
             assert params.image_build_compute == ""  # was set to empty string, for user to remove the property value.
             assert params.identity is None
-            assert params.primary_user_assigned_identity is None
+            assert params.primary_user_assigned_identity is None        
             assert (
                 params.public_network_access is None
             )  # was not set for update, no change on service side for this property.

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_operations.py
@@ -176,7 +176,7 @@ class TestWorkspaceOperation:
             assert params.friendly_name == ""  # empty string is supported for friendly name.
             assert params.image_build_compute == ""  # was set to empty string, for user to remove the property value.
             assert params.identity is None
-            assert params.primary_user_assigned_identity is None        
+            assert params.primary_user_assigned_identity is None
             assert (
                 params.public_network_access is None
             )  # was not set for update, no change on service side for this property.


### PR DESCRIPTION
# Description
Enables updating the CMK encryption key for a workspace now that workspace.encryption.keyVaultProperties.keyIdentifier is an updatable property.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
