### PR TITLE
[Storage] Update `undelete_blob` doc for versioning

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -1164,6 +1164,10 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         Operation will only be successful if used within the specified number of days
         set in the delete retention policy.
 
+        If blob versioning is enabled, the base blob cannot be restored using this
+        method. Instead use :func:`start_copy_from_url` with the URL of the blob version
+        you wish to promote to the current version.
+
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :rtype: None

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -607,6 +607,10 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
         Operation will only be successful if used within the specified number of days
         set in the delete retention policy.
 
+        If blob versioning is enabled, the base blob cannot be restored using this
+        method. Instead use :func:`start_copy_from_url` with the URL of the blob version
+        you wish to promote to the current version.
+
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
         :rtype: None


### PR DESCRIPTION
Resolves #27084 by updating the doc for `undelete_blob` to include a mention that `undelete_blob` cannot restore the base blob when versioning is enabled on the account.