### PR TITLE
Fixes around MLTable metadata schema validation

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
@@ -237,7 +237,7 @@ class DataOperations(_ScopeDependentOperations):
             if is_url(asset_path):
                 try:
                     metadata_contents = read_remote_mltable_metadata_contents(
-                        path=asset_path,
+                        base_uri=asset_path,
                         datastore_operations=self._datastore_operation,
                         requests_pipeline=self._requests_pipeline,
                     )
@@ -246,8 +246,7 @@ class DataOperations(_ScopeDependentOperations):
                     # skip validation for remote MLTable when the contents cannot be read
                     logger.info(
                         "Unable to access MLTable metadata at path %s",
-                        asset_path,
-                        exc_info=1,
+                        asset_path
                     )
                     return
             else:
@@ -273,15 +272,16 @@ class DataOperations(_ScopeDependentOperations):
             _assert_local_path_matches_asset_type(abs_path, asset_type)
 
     def _try_get_mltable_metadata_jsonschema(
-        self, mltable_schema_url: str = MLTABLE_METADATA_SCHEMA_URL_FALLBACK
+        self, mltable_schema_url: str
     ) -> Union[Dict, None]:
+        if mltable_schema_url is None:
+            mltable_schema_url = MLTABLE_METADATA_SCHEMA_URL_FALLBACK
         try:
             return download_mltable_metadata_schema(mltable_schema_url, self._requests_pipeline)
         except Exception:  # pylint: disable=broad-except
             logger.info(
                 'Failed to download MLTable metadata jsonschema from "%s", skipping validation',
-                mltable_schema_url,
-                exc_info=1,
+                mltable_schema_url
             )
             return None
 

--- a/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_operations.py
@@ -214,7 +214,7 @@ class TestDataOperations:
         mock_data_operations.create_or_update(data)
 
         _mock_read_remote_mltable_metadata_contents.assert_called_once_with(
-            path=data_path,
+            base_uri=data_path,
             datastore_operations=mock_datastore_operation,
             requests_pipeline=mock_data_operations._requests_pipeline,
         )

--- a/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_utils.py
@@ -60,7 +60,7 @@ class TestDataUtils:
         ):
             contents = read_remote_mltable_metadata_contents(
                 datastore_operations=mock_datastore_operations,
-                path="https://fake.localhost/file.yaml",
+                base_uri="https://fake.localhost/file.yaml",
                 requests_pipeline=mock_requests_pipeline,
             )
             assert contents["paths"] == [OrderedDict([("file", "./tmp_file.csv")])]
@@ -69,16 +69,16 @@ class TestDataUtils:
         with pytest.raises(Exception) as ex:
             contents = read_remote_mltable_metadata_contents(
                 datastore_operations=mock_datastore_operations,
-                path="https://fake.localhost/file.yaml",
+                base_uri="https://fake.localhost/file.yaml",
                 requests_pipeline=mock_requests_pipeline,
             )
-        assert "Invalid URL" in str(ex)
+        assert "Failed to establish a new connection" in str(ex)
 
         # remote azureml accessible
         with patch("azure.ai.ml._utils._data_utils.TemporaryDirectory", return_value=mltable_folder):
             contents = read_remote_mltable_metadata_contents(
                 datastore_operations=mock_datastore_operations,
-                path="azureml://datastores/mydatastore/paths/images/dogs",
+                base_uri="azureml://datastores/mydatastore/paths/images/dogs",
                 requests_pipeline=mock_requests_pipeline,
             )
             assert contents["paths"] == [OrderedDict([("file", "./tmp_file.csv")])]
@@ -87,7 +87,7 @@ class TestDataUtils:
         with pytest.raises(Exception) as ex:
             contents = read_remote_mltable_metadata_contents(
                 datastore_operations=mock_datastore_operations,
-                path="azureml://datastores/mydatastore/paths/images/dogs",
+                base_uri="azureml://datastores/mydatastore/paths/images/dogs",
                 requests_pipeline=mock_requests_pipeline,
             )
         assert "No such file or directory" in str(ex)


### PR DESCRIPTION
# Description

Changes:
downloading of MLTable file is fixed for datastores internal uril starting with azureml://
exc_info=1 is removed from logger.info() so that the stack trace is not logged.
MLTable metadata schema file is now loaded from the fallback url. (to note: None is treated as a valid argument)

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
