### PR TITLE
Remove UpdateSubnetPolicy task from workspace deployment template

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_base.json
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_base.json
@@ -406,10 +406,6 @@
                 }
             ]
         },
-        "subnetPolicyForPE": {
-            "privateEndpointNetworkPolicies": "Disabled",
-            "privateLinkServiceNetworkPolicies": "Enabled"
-        },
         "privateEndpointSettings": {
             "name": "[concat(parameters('workspaceName'), '-PrivateEndpoint')]",
             "properties": {
@@ -461,31 +457,6 @@
                         "service": "Microsoft.ContainerRegistry"
                     }
                 ]
-            }
-        },
-        {
-            "condition": "[and(equals(parameters('subnetOption'), 'existing'), not(equals(parameters('privateEndpointType'), 'none')))]",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2019-10-01",
-            "name": "[concat('UpdateSubnetPolicy-', uniqueString(parameters('vnetName'), parameters('subnetName')))]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]"
-            ],
-            "resourceGroup": "[parameters('vnetResourceGroupName')]",
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "resources": [
-                        {
-                            "type": "Microsoft.Network/virtualNetworks/subnets",
-                            "apiVersion": "2019-09-01",
-                            "name": "[concat(parameters('vnetName'), '/', parameters('subnetName'))]",
-                            "properties": "[if(and(equals(parameters('subnetOption'), 'existing'), not(equals(parameters('privateEndpointType'), 'none'))), union(reference(variables('subnet'), '2019-09-01'), variables('subnetPolicyForPE')), json('null'))]"
-                        }
-                    ]
-                }
             }
         },
         {


### PR DESCRIPTION
# Description
Remove UpdateSubnetPolicy step from workspace creation deployment tasks so that Network Contributor role is not needed by user creating the workspace with PE and existing subnet. This change has already been done for our other workspace templates used internally and by the Azure Portal. The two policies that were being updated, privateEndpointNetworkPolicies and privateLinkServiceNetworkPolicies, are both being set to the default values that subnets have upon creation, so removing this task will not create any issues unless the user-provided subnet had these properties modified after creation.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
