### PR TITLE
[Monitor] Add Ingestion perf tests

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -9,6 +9,7 @@ omitted_paths:
   - sdk/**/samples/*
   - sdk/identity/azure-identity/tests/*
   - sdk/**/tests/perfstress_tests/*
+  - sdk/**/tests/perf_tests/*
   - sdk/nspkg/*
   - sdk/**/swagger/*
   - sdk/ml/azure-ai-ml/tests/*

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
@@ -35,7 +35,7 @@ These options are available for all perf tests:
 - `--warm-up=5` Number of seconds to spend warming up the connection before measuring begins. Default is 5.
 - `--sync` Whether to run the tests in sync or async. Default is False (async).
 - `--no-cleanup` Whether to keep newly created resources after test run. Default is False (resources will be deleted).
-- `--profile` Whether to run the perftest with cProfile. If enabled (default is False), the output file of the **last completed single iteration** will be written to the current working directory in the format `"cProfile-<TestClassName>-<TestID>-<sync/async>.pstats"`.
+- `--profile` Whether to run the perftest with cProfile. If enabled (default is False), the output file of a single iteration will be written to the current working directory in the format `"cProfile-<TestClassName>-<TestID>-<sync|async>.pstats"`.
 
 ### Ingestion test options
 

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
@@ -1,0 +1,53 @@
+# Monitor Ingestion performance tests
+
+In order to run the performance tests, the `azure-devtools` package must be installed. This is done as part of the `dev_requirements`.
+Start by creating a new virtual environment for your perf tests. This will need to be a Python 3 environment, preferably >=3.7.
+
+### Setup for test resources
+
+These tests will run against a pre-configured Log Analytics workspace. The `test-resources.json` file can be used to provision the needed resources. The following environment variables will need to be set for the tests to access the live resources:
+```
+AZURE_MONITOR_DCR_ID=<The ID of the data collection rule>
+AZURE_MONITOR_DCE=<The data collection endpoint to upload logs to>
+```
+
+### Setup for perf test runs
+
+```cmd
+(env) ~/azure-monitor-ingestion> pip install -r dev_requirements.txt
+(env) ~/azure-monitor-ingestion> pip install -e .
+```
+
+## Test commands
+
+```cmd
+(env) ~/azure-monitor-ingestion> cd tests
+(env) ~/azure-monitor-ingestion/tests> perfstress
+```
+
+### Common perf command line options
+
+These options are available for all perf tests:
+- `--duration=10` Number of seconds to run as many operations (the "run" function) as possible. Default is 10.
+- `--iterations=1` Number of test iterations to run. Default is 1.
+- `--parallel=1` Number of tests to run in parallel. Default is 1.
+- `--warm-up=5` Number of seconds to spend warming up the connection before measuring begins. Default is 5.
+- `--sync` Whether to run the tests in sync or async. Default is False (async).
+- `--no-cleanup` Whether to keep newly created resources after test run. Default is False (resources will be deleted).
+- `--profile` Whether to run the perftest with cProfile. If enabled (default is False), the output file of the **last completed single iteration** will be written to the current working directory in the format `"cProfile-<TestClassName>-<TestID>-<sync/async>.pstats"`.
+
+### Ingestion test options
+
+These options are available for all ingestion perf tests:
+- `-n`, `--num-logs` Number of logs to be uploaded. Defaults to 100.
+
+### Available tests
+
+The tests currently written for the T2 SDK:
+- `UploadLogsPerfTest` Upload a collection of logs to Azure Monitor
+
+## Example command
+
+```cmd
+(env) ~/azure-monitor-ingestion/tests> perfstress UploadLogsPerfTest --num-logs=1000
+```

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
@@ -9,6 +9,7 @@ These tests will run against a pre-configured Log Analytics workspace. The `test
 ```
 AZURE_MONITOR_DCR_ID=<The ID of the data collection rule>
 AZURE_MONITOR_DCE=<The data collection endpoint to upload logs to>
+AZURE_MONITOR_STREAM_NAME=<The data collection stream name>
 ```
 
 ### Setup for perf test runs

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
@@ -22,8 +22,7 @@ AZURE_MONITOR_STREAM_NAME=<The data collection stream name>
 ## Test commands
 
 ```cmd
-(env) ~/azure-monitor-ingestion> cd tests
-(env) ~/azure-monitor-ingestion/tests> perfstress
+(env) ~/azure-monitor-ingestion> perfstress
 ```
 
 ### Common perf command line options

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
@@ -49,5 +49,5 @@ The tests currently written for the T2 SDK:
 ## Example command
 
 ```cmd
-(env) ~/azure-monitor-ingestion/tests> perfstress UploadLogsTest --num-logs=1000
+(env) ~/azure-monitor-ingestion> perfstress UploadLogsTest --num-logs=1000
 ```

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
@@ -45,10 +45,10 @@ These options are available for all ingestion perf tests:
 ### Available tests
 
 The tests currently written for the T2 SDK:
-- `UploadLogsPerfTest` Upload a collection of logs to Azure Monitor
+- `UploadLogsTest` Upload a collection of logs to Azure Monitor
 
 ## Example command
 
 ```cmd
-(env) ~/azure-monitor-ingestion/tests> perfstress UploadLogsPerfTest --num-logs=1000
+(env) ~/azure-monitor-ingestion/tests> perfstress UploadLogsTest --num-logs=1000
 ```

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
@@ -19,6 +19,7 @@ class UploadLogsPerfTest(PerfStressTest):
 
         self.data_collection_rule_id = self.get_from_env("AZURE_MONITOR_DCR_ID")
         self.data_collection_endpoint = self.get_from_env("AZURE_MONITOR_DCE")
+        self.stream_name = self.get_from_env("AZURE_MONITOR_STREAM_NAME")
 
         # Create clients
         self.client = LogsIngestionClient(
@@ -52,13 +53,13 @@ class UploadLogsPerfTest(PerfStressTest):
     def run_sync(self):
         self.client.upload(
             rule_id=self.data_collection_rule_id,
-            stream_name="Custom-MyTableRawData",
+            stream_name=self.stream_name,
             logs=self.logs
         )
 
     async def run_async(self):
         await self.async_client.upload(
             rule_id=self.data_collection_rule_id,
-            stream_name="Custom-MyTableRawData",
+            stream_name=self.stream_name,
             logs=self.logs
         )

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
@@ -1,0 +1,64 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+from datetime import datetime
+
+from azure_devtools.perfstress_tests import PerfStressTest
+from azure.identity import DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
+from azure.monitor.ingestion import LogsIngestionClient
+from azure.monitor.ingestion.aio import LogsIngestionClient as AsyncLogsIngestionClient
+
+
+class UploadLogsPerfTest(PerfStressTest):
+
+    def __init__(self, arguments):
+        super().__init__(arguments)
+
+        self.data_collection_rule_id = self.get_from_env("AZURE_MONITOR_DCR_ID")
+        self.data_collection_endpoint = self.get_from_env("AZURE_MONITOR_DCE")
+
+        # Create clients
+        self.client = LogsIngestionClient(
+            endpoint=self.data_collection_endpoint,
+            credential=DefaultAzureCredential()
+        )
+        self.async_client = AsyncLogsIngestionClient(
+            endpoint=self.data_collection_endpoint,
+            credential=AsyncDefaultAzureCredential()
+        )
+
+        # Create log entries to upload
+        self.logs = []
+        for i in range(self.args.num_logs):
+            self.logs.append({
+                "Time": datetime.now().isoformat(),
+                "Computer": f"Computer {i}",
+                "AdditionalContext": "some additional context"
+            })
+
+    async def close(self):
+        self.client.close()
+        await self.async_client.close()
+        await super().close()
+
+    @staticmethod
+    def add_arguments(parser):
+        super(UploadLogsPerfTest, UploadLogsPerfTest).add_arguments(parser)
+        parser.add_argument("-n", "--num-logs", nargs="?", type=int, help="Number of logs to be uploaded. Defaults to 100", default=100)
+
+    def run_sync(self):
+        self.client.upload(
+            rule_id=self.data_collection_rule_id,
+            stream_name="Custom-MyTableRawData",
+            logs=self.logs
+        )
+
+    async def run_async(self):
+        await self.async_client.upload(
+            rule_id=self.data_collection_rule_id,
+            stream_name="Custom-MyTableRawData",
+            logs=self.logs
+        )

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
@@ -12,7 +12,7 @@ from azure.monitor.ingestion import LogsIngestionClient
 from azure.monitor.ingestion.aio import LogsIngestionClient as AsyncLogsIngestionClient
 
 
-class UploadLogsPerfTest(PerfStressTest):
+class UploadLogsTest(PerfStressTest):
 
     def __init__(self, arguments):
         super().__init__(arguments)
@@ -32,6 +32,7 @@ class UploadLogsPerfTest(PerfStressTest):
         )
 
         # Create log entries to upload
+        # TODO: Parameterize the size of each log entry
         self.logs = []
         for i in range(self.args.num_logs):
             self.logs.append({
@@ -47,7 +48,7 @@ class UploadLogsPerfTest(PerfStressTest):
 
     @staticmethod
     def add_arguments(parser):
-        super(UploadLogsPerfTest, UploadLogsPerfTest).add_arguments(parser)
+        super(UploadLogsTest, UploadLogsTest).add_arguments(parser)
         parser.add_argument("-n", "--num-logs", nargs="?", type=int, help="Number of logs to be uploaded. Defaults to 100", default=100)
 
     def run_sync(self):


### PR DESCRIPTION
A simple upload logs perf test was created using the PerfStress framework. These are based on  existing ingestion perf tests in other language SDKs. Eventually will parameterize the size of each log entry once a common log entry format is determined.

The Monitor Query perf tests were also to updated to use the updated API.
