### PR TITLE
Use asyncio.run() instead of loop in preparer

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
@@ -155,8 +155,7 @@ You must specify use_cache=True in the preparer decorator""".format(
                     fn(test_class_instance, **trimmed_kwargs)
                 else:
                     if asyncio.iscoroutinefunction(fn):
-                        loop = asyncio.get_event_loop()
-                        loop.run_until_complete(fn(test_class_instance, **trimmed_kwargs))
+                        asyncio.run(fn(test_class_instance, **trimmed_kwargs))
                     else:
                         fn(test_class_instance, **trimmed_kwargs)
             finally:


### PR DESCRIPTION
Get rid of the deprecation warning while using loop.