### PR TITLE
[DT] update python version for INT tests

### DIFF
--- a/sdk/translation/tests.yml
+++ b/sdk/translation/tests.yml
@@ -16,14 +16,8 @@ stages:
           # We run tests in Dogfood for the service team. This cloud config is just used to validate the service deployment
           # so we don't need to run on every version of Python.
           SubscriptionConfiguration: $(sub-config-translation-int-test-resources)
-          # TODO fix this to specify which version to run rather than filtering out versions.
           MatrixFilters:
-            - PythonVersion=^(?!pypy3).*
-            - PythonVersion=^(?!3.6).*
-            - PythonVersion=^(?!3.7).*
-            - PythonVersion=^(?!3.8).*
-            - PythonVersion=^(?!3.9).*
-            - PythonVersion=^(?!3.10).*
+            - PythonVersion=3.11.*
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/translation/tests.yml
+++ b/sdk/translation/tests.yml
@@ -23,6 +23,7 @@ stages:
             - PythonVersion=^(?!3.7).*
             - PythonVersion=^(?!3.8).*
             - PythonVersion=^(?!3.9).*
+            - PythonVersion=^(?!3.10).*
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)


### PR DESCRIPTION
These tests just validate service behavior. We don't need to run with more than one version of Python (latest is fine).