### PR TITLE
[Monitor][Ingestion] Remove msrest dependency

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+  - Removed `msrest` dependency.
+  - Added requirement for `isodate>=0.6.0` (`isodate` was required by `msrest`)
 
 ## 1.0.0b1 (2022-07-15)
 

--- a/sdk/monitor/azure-monitor-ingestion/setup.py
+++ b/sdk/monitor/azure-monitor-ingestion/setup.py
@@ -82,7 +82,7 @@ setup(
     ]),
     include_package_data=True,
     install_requires=[
-        'msrest>=0.6.19',
         'azure-core<2.0.0,>=1.24.0',
+        'isodate>=0.6.0',
     ]
 )


### PR DESCRIPTION
The `msrest` package is no longer required and also updated the changelog to note the removal of Python 3.6 support.
