### PR TITLE
[Azure Monitor] [OTEL Exporter] Fix azure monitor redirect error logging

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -202,12 +202,16 @@ class BaseExporter:
                     if self._should_collect_stats():
                         _update_requests_map(_REQ_THROTTLE_NAME[1], value=response_error.status_code)
                     result = ExportResult.FAILED_NOT_RETRYABLE
-                elif _is_redirect_code(response_error.status_code) and response_error.response and response_error.response.headers:
+                elif _is_redirect_code(response_error.status_code):
                     self._consecutive_redirects = self._consecutive_redirects + 1
                     if self._consecutive_redirects < self.client._config.redirect_policy.max_redirects:  # pylint: disable=W0212
-                        location = response_error.response.headers.get("location")
-                        url = urlparse(location)
-                        if url.scheme and url.netloc:
+                        if response_error.response and response_error.response.headers:
+                            redirect_has_headers = True
+                            location = response_error.response.headers.get("location")
+                            url = urlparse(location)
+                        else:
+                            redirect_has_headers = False
+                        if redirect_has_headers and url.scheme and url.netloc:
                             # Change the host to the new redirected host
                             self.client._config.host = "{}://{}".format(url.scheme, url.netloc)  # pylint: disable=W0212
                             # Attempt to export again


### PR DESCRIPTION
# Description
Currently, the Azure Monitor OpenTelemetry Exporter always logs error messages on redirect responses.
This commit changes it so the error is only logged when the `location` header could not be parsed or is not a valid URL.

It also sets the result to a non retryable export result.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
