### PR TITLE
[ML][Endpoints] Ensure defaults property is instantiated

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Make registry delete operation return an LROPoller, and change name to begin_delete.
 - Prevent registering an already existing environment that references conda file.
 - Fix ARM id logic for registry environments (ex: Creating a registry component that references a registry environment).
+- Update "defaults" dictionary to match our public documentation.
+
 
 ### Other Changes
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
@@ -54,7 +54,7 @@ class BatchEndpoint(Endpoint):
         auth_mode: str = AAD_TOKEN_YAML,
         description: str = None,
         location: str = None,
-        defaults: Dict[str, str] = None,
+        defaults: Dict[str, str] = {},
         default_deployment_name: str = None,
         scoring_uri: str = None,
         openapi_uri: str = None,


### PR DESCRIPTION
Our document referenced below, states that "defaults" dictionary defaults to {}, however, it is current defaults to None.

Reference: https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.batchendpoint?view=azure-python

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
