### PR TITLE
[Monitor] Fix live tests

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
@@ -9,7 +9,7 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
     @pytest.mark.live_test_only
     @IngestionPreparer()
     @recorded_by_proxy
-    def test_send_logs(self, variables, azure_monitor_dce, azure_monitor_dcr_id, monitor_client_id, monitor_client_secret, monitor_tenant_id):
+    def test_send_logs(self, azure_monitor_dce, azure_monitor_dcr_id, monitor_client_id, monitor_client_secret, monitor_tenant_id):
         credential = ClientSecretCredential(
         client_id = monitor_client_id,
         client_secret = monitor_client_secret,

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
@@ -11,7 +11,7 @@ from preparer import IngestionPreparer
 class TestLogsIngestionClientAsync(AzureRecordedTestCase):
     @IngestionPreparer()
     @recorded_by_proxy_async
-    async def test_send_logs_async(self, variables, azure_monitor_dce, azure_monitor_dcr_id, monitor_client_id, monitor_client_secret, monitor_tenant_id):
+    async def test_send_logs_async(self, azure_monitor_dce, azure_monitor_dcr_id, monitor_client_id, monitor_client_secret, monitor_tenant_id):
         credential = ClientSecretCredential(
         client_id = monitor_client_id,
         client_secret = monitor_client_secret,

--- a/sdk/monitor/tests.yml
+++ b/sdk/monitor/tests.yml
@@ -16,3 +16,4 @@ stages:
         SECONDARY_WORKSPACE_ID: $(python-query-secondary-workspace-id)
         METRICS_RESOURCE_URI: $(azure-monitor-query-metrics-uri)
         AZURE_TEST_RUN_LIVE: 'true'
+        AZURE_SKIP_LIVE_RECORDING: 'true'


### PR DESCRIPTION
Live tests are failing due to a missing required positional argument error. This fixes that.

Seen error:

```
    async def record_wrap(*args, **kwargs):
        def transform_args(*args, **kwargs):
            copied_positional_args = list(args)
            request = copied_positional_args[1]

            transform_request(request, recording_id)

            return tuple(copied_positional_args), kwargs

        trimmed_kwargs = {k: v for k, v in kwargs.items()}
        trim_kwargs_from_test_function(test_func, trimmed_kwargs)

        if is_live_and_not_recording():
>           return await test_func(*args, **trimmed_kwargs)
E           TypeError: TestLogsIngestionClientAsync.test_send_logs_async() missing 1 required positional argument: 'variables'
```
