### PR TITLE
Patch `is_required_version_on_pypi` to allow `None` specifiers

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -243,9 +243,12 @@ def is_required_version_on_pypi(package_name: str, spec: str) -> bool:
     client = PyPIClient()
     versions = []
     try:
-        versions = [str(v) for v in client.get_ordered_versions(package_name) if str(v) in spec]
+        versions = client.get_ordered_versions(package_name)
+
+        if spec:
+            versions = [str(v) for v in versions if str(v) in spec]
     except:
-        logging.error("Package {} is not found on PyPI", package_name)
+        logging.error("Package {} is not found on PyPI".format(package_name))
     return versions
 
 


### PR DESCRIPTION
To unblock bare `isodate` requirement.