### PR TITLE
[Storage] Refactor tests in `test_avro_async.py`

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/avro/test_avro_async.py
+++ b/sdk/storage/azure-storage-blob/tests/avro/test_avro_async.py
@@ -84,9 +84,8 @@ class AvroReaderTestsAsync(unittest.TestCase):
             correct,
             len(CODECS_TO_VALIDATE) * len(SCHEMAS_TO_VALIDATE))
 
-    def test_reader(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self._test_reader())
+    async def test_reader(self):
+        await self._test_reader()
 
     @pytest.mark.asyncio
     async def _test_change_feed(self):
@@ -102,12 +101,11 @@ class AvroReaderTestsAsync(unittest.TestCase):
                 expected_record = CHANGE_FEED_RECORD
                 self.assertEqual(expected_record, data[0])
 
-    def test_change_feed(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self._test_change_feed())
+    async def test_change_feed(self):
+        await self._test_change_feed()
 
     @pytest.mark.asyncio
-    async def _test_with_hearder_reader(self):
+    async def _test_with_header_reader(self):
         # Note: only when the data stream doesn't have header, we need header stream to help
         file_path = os.path.join(AvroReaderTestsAsync._samples_dir_root, 'changeFeed.avro')
         # this data stream has header
@@ -138,9 +136,8 @@ class AvroReaderTestsAsync(unittest.TestCase):
         self.assertEqual(CHANGE_FEED_RECORD, records[0])
         self.assertIsNot(partial_data_stream.object_position, 0)
 
-    def test_with_hearder_reader(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self._test_with_hearder_reader())
+    async def test_with_header_reader(self):
+        await self._test_with_header_reader()
 
 class _HeaderStream(object):
     def __init__(self):

--- a/sdk/storage/azure-storage-blob/tests/avro/test_avro_async.py
+++ b/sdk/storage/azure-storage-blob/tests/avro/test_avro_async.py
@@ -65,7 +65,7 @@ class AvroReaderTestsAsync(unittest.TestCase):
         cls._samples_dir_root = os.path.join(os.path.dirname(test_file_path), 'samples')
 
     @pytest.mark.asyncio
-    async def _test_reader(self):
+    async def test_reader(self):
         correct = 0
         nitems = 10
         for iexample, (writer_schema, datum) in enumerate(SCHEMAS_TO_VALIDATE):
@@ -80,15 +80,10 @@ class AvroReaderTestsAsync(unittest.TestCase):
                             round_trip_data.append(x)
                         if ([datum] * nitems) == round_trip_data:
                             correct += 1
-        self.assertEqual(
-            correct,
-            len(CODECS_TO_VALIDATE) * len(SCHEMAS_TO_VALIDATE))
-
-    async def test_reader(self):
-        await self._test_reader()
+        self.assertEqual(correct, len(CODECS_TO_VALIDATE) * len(SCHEMAS_TO_VALIDATE))
 
     @pytest.mark.asyncio
-    async def _test_change_feed(self):
+    async def test_change_feed(self):
         file_path = os.path.join(AvroReaderTestsAsync._samples_dir_root, 'changeFeed.avro')
         with open(file_path, 'rb') as reader:
             datum_reader = AsyncDatumReader()
@@ -101,11 +96,8 @@ class AvroReaderTestsAsync(unittest.TestCase):
                 expected_record = CHANGE_FEED_RECORD
                 self.assertEqual(expected_record, data[0])
 
-    async def test_change_feed(self):
-        await self._test_change_feed()
-
     @pytest.mark.asyncio
-    async def _test_with_header_reader(self):
+    async def test_with_header_reader(self):
         # Note: only when the data stream doesn't have header, we need header stream to help
         file_path = os.path.join(AvroReaderTestsAsync._samples_dir_root, 'changeFeed.avro')
         # this data stream has header
@@ -135,9 +127,6 @@ class AvroReaderTestsAsync(unittest.TestCase):
             records.append(record)
         self.assertEqual(CHANGE_FEED_RECORD, records[0])
         self.assertIsNot(partial_data_stream.object_position, 0)
-
-    async def test_with_header_reader(self):
-        await self._test_with_header_reader()
 
 class _HeaderStream(object):
     def __init__(self):


### PR DESCRIPTION
This is the start of the work to help clear up some failures in the pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1972571&view=ms.vss-test-web.build-test-results-tab

This fixes the tests in the tests/avro path

Additionally, this fixes a typo (`test_with_hearder_reader` --> `test_with_header_reader`)