### PR TITLE
[ML] Extend error messages for environment, model, online/batch endpoints and deployments

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
@@ -22,7 +22,7 @@ from azure.ai.ml.entities._assets import Environment, Model
 from azure.ai.ml.entities._deployment.deployment_settings import BatchRetrySettings
 from azure.ai.ml.entities._job.resource_configuration import ResourceConfiguration
 from azure.ai.ml.entities._util import load_from_dict
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
 from .code_configuration import CodeConfiguration
 from .deployment import Deployment
@@ -142,6 +142,7 @@ class BatchDeployment(Deployment):
                 target=ErrorTarget.BATCH_DEPLOYMENT,
                 no_personal_data_message=msg,
                 error_category=ErrorCategory.USER_ERROR,
+                error_type=ValidationErrorType.INVALID_VALUE,
             )
 
         if not self.resources and instance_count:
@@ -288,4 +289,5 @@ class BatchDeployment(Deployment):
                 target=ErrorTarget.BATCH_DEPLOYMENT,
                 no_personal_data_message=msg,
                 error_category=ErrorCategory.USER_ERROR,
+                error_type=ValidationErrorType.INVALID_VALUE,
             )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/code_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/code_configuration.py
@@ -7,7 +7,7 @@ import logging
 from azure.ai.ml._restclient.v2021_10_01.models import CodeConfiguration as RestCodeConfiguration
 from azure.ai.ml.entities._assets import Code
 from azure.ai.ml.entities._mixins import DictMixin
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
 module_logger = logging.getLogger(__name__)
 
@@ -44,6 +44,7 @@ class CodeConfiguration(DictMixin):
                 target=ErrorTarget.CODE,
                 no_personal_data_message=msg,
                 error_category=ErrorCategory.USER_ERROR,
+                error_type=ValidationErrorType.MISSING_FIELD,
             )
 
     @staticmethod

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
@@ -15,7 +15,7 @@ from azure.ai.ml._utils.utils import dump_yaml_to_file
 from azure.ai.ml.entities._job.resource_configuration import ResourceConfiguration
 from azure.ai.ml.entities._mixins import RestTranslatableMixin
 from azure.ai.ml.entities._resource import Resource
-from azure.ai.ml.exceptions import DeploymentException, ErrorCategory, ErrorTarget, ValidationException
+from azure.ai.ml.exceptions import DeploymentException, ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
 from .code_configuration import CodeConfiguration
 
@@ -76,6 +76,7 @@ class Deployment(Resource, RestTranslatableMixin):
                 target=ErrorTarget.DEPLOYMENT,
                 no_personal_data_message=msg,
                 error_category=ErrorCategory.USER_ERROR,
+                error_type=ValidationErrorType.INVALID_VALUE,
             )
 
         super().__init__(name, description, tags, properties, **kwargs)
@@ -163,6 +164,7 @@ class Deployment(Resource, RestTranslatableMixin):
                     target=ErrorTarget.DEPLOYMENT,
                     no_personal_data_message=msg.format("[name1]", "[name2]"),
                     error_category=ErrorCategory.USER_ERROR,
+                    error_type=ValidationErrorType.INVALID_VALUE,
                 )
             if other.tags:
                 self.tags = {**self.tags, **other.tags}

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
@@ -15,7 +15,13 @@ from azure.ai.ml._utils.utils import dump_yaml_to_file
 from azure.ai.ml.entities._job.resource_configuration import ResourceConfiguration
 from azure.ai.ml.entities._mixins import RestTranslatableMixin
 from azure.ai.ml.entities._resource import Resource
-from azure.ai.ml.exceptions import DeploymentException, ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
+from azure.ai.ml.exceptions import (
+    DeploymentException,
+    ErrorCategory,
+    ErrorTarget,
+    ValidationErrorType,
+    ValidationException,
+)
 
 from .code_configuration import CodeConfiguration
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
@@ -40,7 +40,7 @@ from azure.ai.ml.entities._deployment.scale_settings import (
 )
 from azure.ai.ml.entities._endpoint._endpoint_helpers import validate_endpoint_or_deployment_name
 from azure.ai.ml.entities._util import load_from_dict
-from azure.ai.ml.exceptions import DeploymentException, ErrorCategory, ErrorTarget, ValidationException
+from azure.ai.ml.exceptions import DeploymentException, ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
 from ..._vendor.azure_resources.flatten_json import flatten, unflatten
 from .deployment import Deployment
@@ -234,6 +234,7 @@ class OnlineDeployment(Deployment):
                     target=ErrorTarget.ONLINE_DEPLOYMENT,
                     no_personal_data_message=msg.format("[name1]", "[name2]"),
                     error_category=ErrorCategory.USER_ERROR,
+                    error_type=ValidationErrorType.INVALID_VALUE,
                 )
             super()._merge_with(other)
             self.app_insights_enabled = other.app_insights_enabled or self.app_insights_enabled
@@ -706,4 +707,5 @@ class ManagedOnlineDeployment(OnlineDeployment):
                     target=ErrorTarget.ONLINE_DEPLOYMENT,
                     no_personal_data_message=msg,
                     error_category=ErrorCategory.USER_ERROR,
+                    error_type=ValidationErrorType.INVALID_VALUE,
                 )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
@@ -40,7 +40,13 @@ from azure.ai.ml.entities._deployment.scale_settings import (
 )
 from azure.ai.ml.entities._endpoint._endpoint_helpers import validate_endpoint_or_deployment_name
 from azure.ai.ml.entities._util import load_from_dict
-from azure.ai.ml.exceptions import DeploymentException, ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
+from azure.ai.ml.exceptions import (
+    DeploymentException,
+    ErrorCategory,
+    ErrorTarget,
+    ValidationErrorType,
+    ValidationException,
+)
 
 from ..._vendor.azure_resources.flatten_json import flatten, unflatten
 from .deployment import Deployment

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/endpoint.py
@@ -8,7 +8,7 @@ from os import PathLike
 from typing import IO, Any, AnyStr, Dict, Optional, Union
 
 from azure.ai.ml.entities._resource import Resource
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
 module_logger = logging.getLogger(__name__)
 
@@ -102,6 +102,7 @@ class Endpoint(Resource):  # pylint: disable=too-many-instance-attributes
                     target=ErrorTarget.ENDPOINT,
                     no_personal_data_message=msg.format("[name1]", "[name2]"),
                     error_category=ErrorCategory.USER_ERROR,
+                    error_type=ValidationErrorType.INVALID_VALUE,
                 )
             self.description = other.description or self.description
             if other.tags:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
@@ -27,7 +27,7 @@ from azure.ai.ml.constants._common import (
 from azure.ai.ml.constants._endpoint import EndpointYamlFields
 from azure.ai.ml.entities._mixins import RestTranslatableMixin
 from azure.ai.ml.entities._util import is_compute_in_override, load_from_dict
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 from azure.ai.ml.entities._credentials import IdentityConfiguration
 from azure.ai.ml._restclient.v2022_02_01_preview.models import (
     EndpointAuthKeys as RestEndpointAuthKeys,
@@ -348,6 +348,7 @@ class KubernetesOnlineEndpoint(OnlineEndpoint):
                     target=ErrorTarget.ONLINE_ENDPOINT,
                     no_personal_data_message=msg.format("[name1]", "[name2]"),
                     error_category=ErrorCategory.USER_ERROR,
+                    error_type=ValidationErrorType.INVALID_VALUE,
                 )
             super()._merge_with(other)
             self.compute = other.compute or self.compute

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -134,7 +134,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
         :type name: str
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
-        :return: a deployment entity
+        :return: A deployment entity
         :rtype: ~azure.ai.ml.entities.BatchDeployment
         """
 
@@ -213,7 +213,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
         :type name: str
         :raise: Exception if endpoint_type is not BATCH_ENDPOINT_TYPE
         :return: List of jobs
-        :rtype: ~azure.core.paging.ItemPaged[BatchJob]
+        :rtype: ~azure.core.paging.ItemPaged[~azure.ai.ml.entities.BatchJob]
         """
 
         workspace_operations = self._all_operations.all_operations[AzureMLResourceType.WORKSPACE]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
@@ -10,8 +10,11 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict
 
+from marshmallow.exceptions import ValidationError as SchemaValidationError
+
 from azure.ai.ml._artifacts._artifact_utilities import _upload_and_generate_remote_uri
 from azure.ai.ml._azure_environments import _get_aml_resource_id_from_metadata, _resource_to_scopes
+from azure.ai.ml._exception_helper import log_and_raise_error
 from azure.ai.ml._restclient.v2020_09_01_dataplanepreview.models import BatchJobResource
 from azure.ai.ml._restclient.v2022_05_01 import AzureMachineLearningWorkspaces as ServiceClient052022
 from azure.ai.ml._schema._deployment.batch.batch_job import BatchJobSchema
@@ -42,7 +45,7 @@ from azure.ai.ml.constants._common import (
 from azure.ai.ml.constants._endpoint import EndpointInvokeFields, EndpointYamlFields
 from azure.ai.ml.entities import BatchEndpoint, BatchJob
 from azure.ai.ml.entities._inputs_outputs import Input
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, MlException, ValidationException
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, MlException, ValidationErrorType, ValidationException
 from azure.core.credentials import TokenCredential
 from azure.core.exceptions import HttpResponseError
 from azure.core.paging import ItemPaged
@@ -114,9 +117,10 @@ class BatchEndpointOperations(_ScopeDependentOperations):
     ) -> BatchEndpoint:
         """Get a Endpoint resource.
 
-        :param str name: Name of the endpoint.
+        :param name: Name of the endpoint.
+        :type name: str
         :return: Endpoint object retrieved from the service.
-        :rtype: BatchEndpoint
+        :rtype: ~azure.ai.ml.entities.BatchEndpoint
         """
         # first get the endpoint
         endpoint = self._batch_operation.get(
@@ -167,7 +171,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
         :param endpoint: The endpoint entity.
         :type endpoint: ~azure.ai.ml.entities.BatchEndpoint
         :return: A poller to track the operation status.
-        :rtype:  ~azure.core.polling.LROPoller[~azure.ai.ml.entities.BatchEndpoint]
+        :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.BatchEndpoint]
         """
 
         try:
@@ -185,6 +189,8 @@ class BatchEndpointOperations(_ScopeDependentOperations):
             return poller
 
         except Exception as ex:
+            if isinstance(ex, (ValidationException, SchemaValidationError)):
+                log_and_raise_error(ex)
             raise ex
 
     @distributed_trace
@@ -201,9 +207,9 @@ class BatchEndpointOperations(_ScopeDependentOperations):
 
         :param endpoint_name: The endpoint name.
         :type endpoint_name: str
-        :param deployment_name: The name of a specific deployment to invoke. This is optional.
+        :param deployment_name: (Optional) The name of a specific deployment to invoke. This is optional.
             By default requests are routed to any of the deployments according to the traffic rules.
-        :type deployment_name: Optional[str]
+        :type deployment_name: str
         :param inputs: (Optional) A dictionary of existing data asset, public uri file or folder
             to use with the deployment
         :type inputs: Dict[str, Input]
@@ -216,7 +222,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
             Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.EmptyDirectoryError: Raised if local path provided points to an empty directory.
         :return: The invoked batch deployment job.
-        :rtype: BatchJob
+        :rtype: ~azure.ai.ml.entities.BatchJob
         """
         params_override = kwargs.get("params_override", None) or []
         input = kwargs.get("input", None) # pylint: disable=redefined-builtin
@@ -248,6 +254,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
                 target=ErrorTarget.BATCH_ENDPOINT,
                 no_personal_data_message=msg,
                 error_category=ErrorCategory.USER_ERROR,
+                error_type=ValidationErrorType.INVALID_VALUE,
             )
 
         # Batch job doesn't have a python class, loading a rest object using params override
@@ -302,7 +309,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
         :param endpoint_name: The endpoint name
         :type endpoint_name: str
         :return: List of jobs
-        :rtype: ItemPaged[BatchJob]
+        :rtype: ~azure.core.paging.ItemPaged[~azure.ai.ml.entities.BatchJob]
         """
 
         workspace_operations = self._all_operations.all_operations[AzureMLResourceType.WORKSPACE]
@@ -340,6 +347,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
                     no_personal_data_message=msg.format("[deployment_name]"),
                     target=ErrorTarget.DEPLOYMENT,
                     error_category=ErrorCategory.USER_ERROR,
+                    error_type=ValidationErrorType.RESOURCE_NOT_FOUND,
                 )
         else:
             msg = "No deployment exists for this endpoint"
@@ -348,6 +356,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
                 no_personal_data_message=msg,
                 error_category=ErrorCategory.USER_ERROR,
                 target=ErrorTarget.DEPLOYMENT,
+                error_type=ValidationErrorType.RESOURCE_NOT_FOUND,
             )
 
     def _resolve_input(self, entry: Input, base_path: str) -> None:
@@ -366,6 +375,7 @@ class BatchEndpointOperations(_ScopeDependentOperations):
                         message="Invalid input path",
                         target=ErrorTarget.BATCH_ENDPOINT,
                         no_personal_data_message="Invalid input path",
+                        error_type=ValidationErrorType.INVALID_VALUE,
                     )
             elif os.path.isabs(entry.path):  # absolute local path, upload, transform to remote url
                 if entry.type == AssetTypes.URI_FOLDER and not os.path.isdir(entry.path):
@@ -373,12 +383,14 @@ class BatchEndpointOperations(_ScopeDependentOperations):
                         message="There is no folder on target path: {}".format(entry.path),
                         target=ErrorTarget.BATCH_ENDPOINT,
                         no_personal_data_message="There is no folder on target path",
+                        error_type=ValidationErrorType.FILE_OR_FOLDER_NOT_FOUND,
                     )
                 if entry.type == AssetTypes.URI_FILE and not os.path.isfile(entry.path):
                     raise ValidationException(
                         message="There is no file on target path: {}".format(entry.path),
                         target=ErrorTarget.BATCH_ENDPOINT,
                         no_personal_data_message="There is no file on target path",
+                        error_type=ValidationErrorType.FILE_OR_FOLDER_NOT_FOUND,
                     )
                 # absolute local path
                 entry.path = _upload_and_generate_remote_uri(
@@ -419,4 +431,5 @@ class BatchEndpointOperations(_ScopeDependentOperations):
                 no_personal_data_message="Supported input path value are: path on the datastore, "
                 "public URI, a registered data asset, or a local folder path.",
                 error=e,
+                error_type=ValidationErrorType.INVALID_VALUE,
             )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
@@ -72,7 +72,7 @@ class EnvironmentOperations(_ScopeDependentOperations):
         """Returns created or updated environment asset.
 
         :param environment: Environment object
-        :type environment: Environment
+        :type environment: ~azure.ai.ml.entities._assets.Environment
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Environment cannot be successfully validated.
             Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.EmptyDirectoryError: Raised if local path provided points to an empty directory.


### PR DESCRIPTION
# Description

Changes to extend error messages for get/show operations for environment, model, online/batch endpoints and deployments.

For `ValidationException` we need to specify `error_type` value

If we have something like:
`except Exception as err` we need to `log_and_raise_error` if err is of type `ValidationException` or `SchemaValidationError`

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
