### PR TITLE
Updated communication siprouting tests to use randomised domains.

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_add_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_add_trunk.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:37 GMT
+      - Wed, 09 Nov 2022 10:46:00 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs3.18f83c776c25435b90ff7e5b6345e648.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:36 GMT
+      - Wed, 09 Nov 2022 10:45:58 GMT
       ms-cv:
-      - U7nV6phSLUuBlPzdqktkKg.0
+      - SDn4p+MUXkm6GFnWZ29aoQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 297ms
+      - 278ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:38 GMT
+      - Wed, 09 Nov 2022 10:46:01 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs3.18f83c776c25435b90ff7e5b6345e648.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:37 GMT
+      - Wed, 09 Nov 2022 10:45:59 GMT
       ms-cv:
-      - yy/oHFR/s0SNJSV9H3MB+A.0
+      - WMWP1uNH5ECkpLZtBDQSnA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,14 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 233ms
+      - 90ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123},
+      "sbs3.18f83c776c25435b90ff7e5b6345e648.com": null}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +95,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '209'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:38 GMT
+      - Wed, 09 Nov 2022 10:46:01 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:37 GMT
+      - Wed, 09 Nov 2022 10:45:59 GMT
       ms-cv:
-      - wGVCBVFi4k+74cdXc/K+jg.0
+      - MGLy1enutUCnOXG+M+XMFQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,13 +125,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 607ms
+      - 465ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs3.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      2222}}}'
     headers:
       Accept:
       - application/json
@@ -132,27 +140,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:39 GMT
+      - Wed, 09 Nov 2022 10:46:01 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:38 GMT
+      - Wed, 09 Nov 2022 10:46:00 GMT
       ms-cv:
-      - ocyEfv4oEk6IDTY4neLreA.0
+      - g0V6SaIR20+0xk8vVHi2gg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -160,49 +170,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 802ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:00:40 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:00:39 GMT
-      ms-cv:
-      - WAZkBMF4bESPGxfakFooaA.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 856ms
+      - 255ms
     status:
       code: 200
       message: OK
@@ -216,23 +184,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:41 GMT
+      - Wed, 09 Nov 2022 10:46:02 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:40 GMT
+      - Wed, 09 Nov 2022 10:46:00 GMT
       ms-cv:
-      - 7yqT1dZ5SU2BfunFQ5R03A.0
+      - 7V6oaiIFpUaaPQSRFkPZUA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -240,7 +210,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 162ms
+      - 83ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_add_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_add_trunk_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:41 GMT
+      - Wed, 09 Nov 2022 10:46:02 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:40 GMT
+      - Wed, 09 Nov 2022 10:46:01 GMT
       ms-cv:
-      - fC4LVcYgsE+Qi3AeUQbOQA.0
+      - 3uWgjNs4fU2/GG1K89Cp2g.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 331ms
+      - 310ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:42 GMT
+      - Wed, 09 Nov 2022 10:46:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:41 GMT
+      - Wed, 09 Nov 2022 10:46:02 GMT
       ms-cv:
-      - gzWSgsnNuUqt5KV0VCKe4Q.0
+      - Vmsn2GakBkmMJoT9UoOnfw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,13 +79,14 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 251ms
+      - 94ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null,
-      "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123},
+      "sbs3.0d6643317d3b45bb8435d73cc67e025a.com": null}}'
     headers:
       Accept:
       - application/json
@@ -90,27 +95,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '108'
+      - '209'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:42 GMT
+      - Wed, 09 Nov 2022 10:46:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:41 GMT
+      - Wed, 09 Nov 2022 10:46:02 GMT
       ms-cv:
-      - nmk6XHTGhkKZyMwfTH0QyQ.0
+      - DYpzyUCCkEmmwCfgN0RG7g.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -118,13 +125,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 501ms
+      - 689ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs3.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      2222}}}'
     headers:
       Accept:
       - application/json
@@ -133,27 +140,25 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:00:43 GMT
-      x-ms-return-client-request-id:
-      - 'true'
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:42 GMT
+      - Wed, 09 Nov 2022 10:46:04 GMT
       ms-cv:
-      - 54BFwJeXeUi4GDgwrQQivw.0
+      - 5XEL93lA/UeOJ+11Rry94w.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -161,45 +166,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 924ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:00:45 GMT
-      ms-cv:
-      - z2GyN1S5P0SbxJ41vdaZ7w.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 1673ms
+      - 733ms
     status:
       code: 200
       message: OK
@@ -213,19 +180,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:46 GMT
+      - Wed, 09 Nov 2022 10:46:04 GMT
       ms-cv:
-      - xqx3gRgUg02gk4Q8ujf/ng.0
+      - TrWRAiYqsEa6yLYE/A4c0A.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -233,7 +202,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 741ms
+      - 212ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_delete_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_delete_trunk.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:48 GMT
+      - Wed, 09 Nov 2022 10:46:06 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:47 GMT
+      - Wed, 09 Nov 2022 10:46:04 GMT
       ms-cv:
-      - t/kQ2LLC+UqLrehdBhj91g.0
+      - wsmZ67ZN3kmVXdbX+T01xQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 261ms
+      - 379ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:49 GMT
+      - Wed, 09 Nov 2022 10:46:06 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123},"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:48 GMT
+      - Wed, 09 Nov 2022 10:46:04 GMT
       ms-cv:
-      - SvGrtlt9lkK4rdWwu85rsQ.0
+      - Fa4OIx9bTEWi+pDFOWQVWg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,13 +79,14 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 169ms
+      - 94ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null,
-      "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123},
+      "sbs3.0d6643317d3b45bb8435d73cc67e025a.com": null}}'
     headers:
       Accept:
       - application/json
@@ -90,27 +95,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '108'
+      - '209'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:49 GMT
+      - Wed, 09 Nov 2022 10:46:07 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:49 GMT
+      - Wed, 09 Nov 2022 10:46:05 GMT
       ms-cv:
-      - o0ekirlpx0eY99lvDS956g.0
+      - KG3Wsl20VkqFYkHD4KbFGQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -118,13 +125,12 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 582ms
+      - 185ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.0d6643317d3b45bb8435d73cc67e025a.com": null}}'
     headers:
       Accept:
       - application/json
@@ -133,27 +139,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '63'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:50 GMT
+      - Wed, 09 Nov 2022 10:46:07 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:50 GMT
+      - Wed, 09 Nov 2022 10:46:05 GMT
       ms-cv:
-      - FBiPqJqgR0uvICs87Mgcrg.0
+      - 3G6vEA+1okCHrT3qbrTNGw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -161,49 +169,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 733ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": null}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:00:51 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:00:50 GMT
-      ms-cv:
-      - dJnLzyfXQk6ppj8d5j5Gtg.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 317ms
+      - 114ms
     status:
       code: 200
       message: OK
@@ -217,23 +183,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:51 GMT
+      - Wed, 09 Nov 2022 10:46:07 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:50 GMT
+      - Wed, 09 Nov 2022 10:46:05 GMT
       ms-cv:
-      - k3yBMQVhR0W4cqpgR7GUBw.0
+      - wJXO8BXtP0+Lw9HUtMJScA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -241,7 +209,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 136ms
+      - 87ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_delete_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_delete_trunk_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:52 GMT
+      - Wed, 09 Nov 2022 10:46:07 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:52 GMT
+      - Wed, 09 Nov 2022 10:46:07 GMT
       ms-cv:
-      - fCVs7Qi/U02aHHdNAgXGpg.0
+      - U2qPkRdytUSAGneVZMj6QA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 327ms
+      - 508ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:53 GMT
+      - Wed, 09 Nov 2022 10:46:08 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:52 GMT
+      - Wed, 09 Nov 2022 10:46:07 GMT
       ms-cv:
-      - dLaLN3I4FEqEQakkxmAk8g.0
+      - 6nL52jSQF0KkagWMGFkIRw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 258ms
+      - 74ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '44'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:53 GMT
+      - Wed, 09 Nov 2022 10:46:09 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:53 GMT
+      - Wed, 09 Nov 2022 10:46:08 GMT
       ms-cv:
-      - awi15oSbKkSeagOrfK7FCg.0
+      - SFGbYE7t2kytv7oXb/B80w.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,13 +124,12 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 345ms
+      - 400ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.0d6643317d3b45bb8435d73cc67e025a.com": null}}'
     headers:
       Accept:
       - application/json
@@ -132,27 +138,25 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '63'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:00:54 GMT
-      x-ms-return-client-request-id:
-      - 'true'
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:54 GMT
+      - Wed, 09 Nov 2022 10:46:09 GMT
       ms-cv:
-      - hMN/XL4uQEiIG5zs6qAGGQ.0
+      - XGwS1fsGh0er0CZ9h4Jzwg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -160,45 +164,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 796ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": null}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:00:55 GMT
-      ms-cv:
-      - NF/T4tDDRkOv/nmEq6+p7A.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 418ms
+      - 518ms
     status:
       code: 200
       message: OK
@@ -212,19 +178,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:56 GMT
+      - Wed, 09 Nov 2022 10:46:10 GMT
       ms-cv:
-      - mOVJ6heCr0WHQmLOBuPsJQ.0
+      - ebhRFNXt70ymhn9rM2a09g.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -232,7 +200,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 213ms
+      - 220ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_routes.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_routes.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:57 GMT
+      - Wed, 09 Nov 2022 10:46:11 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:57 GMT
+      - Wed, 09 Nov 2022 10:46:10 GMT
       ms-cv:
-      - 4+R//0q1rkGyyBTCiGgJxw.0
+      - /acSBWBp10yObvqU5dW1PA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 247ms
+      - 372ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:58 GMT
+      - Wed, 09 Nov 2022 10:46:12 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:57 GMT
+      - Wed, 09 Nov 2022 10:46:10 GMT
       ms-cv:
-      - j+jjTlVujEatGxOzpFLcgg.0
+      - ShRu7FgoDEW8+/PpALDqoQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 185ms
+      - 83ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '44'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:00:58 GMT
+      - Wed, 09 Nov 2022 10:46:12 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:58 GMT
+      - Wed, 09 Nov 2022 10:46:11 GMT
       ms-cv:
-      - gpCYLjEBJki9qLgq0z2Jrg.0
+      - UfHM/ew2+Eu4sxiXHDVWvQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,56 +124,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 346ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:00:59 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:00:59 GMT
-      ms-cv:
-      - 9zornMI6Ukif4NXrcT8UDQ.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 820ms
+      - 680ms
     status:
       code: 200
       message: OK
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
       Accept:
       - application/json
@@ -175,28 +139,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:00 GMT
+      - Wed, 09 Nov 2022 10:46:13 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:59 GMT
+      - Wed, 09 Nov 2022 10:46:11 GMT
       ms-cv:
-      - HhsgYYule0qEdgLRPxX24w.0
+      - SltY8pF6WU26AUJ3GHFF+A.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -204,7 +170,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 229ms
+      - 175ms
     status:
       code: 200
       message: OK
@@ -218,24 +184,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:00 GMT
+      - Wed, 09 Nov 2022 10:46:13 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:00:59 GMT
+      - Wed, 09 Nov 2022 10:46:11 GMT
       ms-cv:
-      - 461609NZ20GeOHv9ZVYcIw.0
+      - YSankDH9EU2vE3/meN643A.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -243,7 +211,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 244ms
+      - 87ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_routes_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_routes_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:00 GMT
+      - Wed, 09 Nov 2022 10:46:14 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:00 GMT
+      - Wed, 09 Nov 2022 10:46:12 GMT
       ms-cv:
-      - 8Sy5DWPpYUSHwMOZG787DA.0
+      - V5M+Fp2bpEavL4v8Oc24rg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 236ms
+      - 273ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:02 GMT
+      - Wed, 09 Nov 2022 10:46:14 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:00 GMT
+      - Wed, 09 Nov 2022 10:46:13 GMT
       ms-cv:
-      - CtpUbcpTv0mGQoqHm+9Qcg.0
+      - 0Q5cMh2WiUeskOwH4g3vkA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 134ms
+      - 89ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:02 GMT
+      - Wed, 09 Nov 2022 10:46:15 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:01 GMT
+      - Wed, 09 Nov 2022 10:46:14 GMT
       ms-cv:
-      - fDjZ9kvD80KiTU95oi2vYw.0
+      - QrRP3ucPJkiCTNFwHVC8ZQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,56 +124,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 334ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:02 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:02 GMT
-      ms-cv:
-      - eXbstW3/aE+dfGs6Z5ebRw.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 676ms
+      - 407ms
     status:
       code: 200
       message: OK
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
       Accept:
       - application/json
@@ -175,24 +139,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:03 GMT
+      - Wed, 09 Nov 2022 10:46:15 GMT
       ms-cv:
-      - cLF/2go/K0es1Oo4SiIBmg.0
+      - Uyy+69VYLkeViHnnB3KBbA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -200,7 +166,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 239ms
+      - 455ms
     status:
       code: 200
       message: OK
@@ -214,20 +180,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:04 GMT
+      - Wed, 09 Nov 2022 10:46:15 GMT
       ms-cv:
-      - ZvtEQTBDOEihKDx+1k90IA.0
+      - r2vI7v7G8ka6ag6ODLqxng.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -235,7 +203,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 219ms
+      - 235ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunk.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:05 GMT
+      - Wed, 09 Nov 2022 11:15:33 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.6b7a4d47f64d4c70903d728e2a8c2675.com":{"sipSignalingPort":1122},"sbs2.6b7a4d47f64d4c70903d728e2a8c2675.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:04 GMT
+      - Wed, 09 Nov 2022 11:15:31 GMT
       ms-cv:
-      - XMr9L76nOkOthEmRXnMj2Q.0
+      - w2C34BWQFUGvy9I6lllZNA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 300ms
+      - 208ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:06 GMT
+      - Wed, 09 Nov 2022 11:15:33 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.6b7a4d47f64d4c70903d728e2a8c2675.com":{"sipSignalingPort":1122},"sbs2.6b7a4d47f64d4c70903d728e2a8c2675.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:04 GMT
+      - Wed, 09 Nov 2022 11:15:32 GMT
       ms-cv:
-      - uPLtIO7hC0Chz6ikWDjo4Q.0
+      - 5ub19+MGt0OIhHbkXbYuUA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,15 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 252ms
+      - 115ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort":
+      1122}, "sbs2.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort": 1123},
+      "sbs1.6b7a4d47f64d4c70903d728e2a8c2675.com": null, "sbs2.6b7a4d47f64d4c70903d728e2a8c2675.com":
+      null}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +96,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '260'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:06 GMT
+      - Wed, 09 Nov 2022 11:15:34 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:05 GMT
+      - Wed, 09 Nov 2022 11:15:33 GMT
       ms-cv:
-      - YDq+Jmazj0eAcB7WK1izZg.0
+      - r0xDy0FNdEOQwD6aOYuG1w.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,50 +126,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 411ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:07 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:08 GMT
-      ms-cv:
-      - H6QwzYiD3keptTwxLGlzWQ.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 790ms
+      - 1026ms
     status:
       code: 200
       message: OK
@@ -174,23 +140,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:08 GMT
+      - Wed, 09 Nov 2022 11:15:35 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:08 GMT
+      - Wed, 09 Nov 2022 11:15:33 GMT
       ms-cv:
-      - Dh8FbRdqOkOYFqFSsBorFw.0
+      - 0O2L2wsURkKWAoE40yHR8A.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -198,7 +166,47 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 225ms
+      - 129ms
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
+      x-ms-date:
+      - Wed, 09 Nov 2022 11:15:35 GMT
+      x-ms-return-client-request-id:
+      - 'true'
+    method: GET
+    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
+  response:
+    body:
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
+    headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Nov 2022 11:15:33 GMT
+      ms-cv:
+      - 3GoZkekDU0+j0l59a/Eq9g.0
+      strict-transport-security:
+      - max-age=2592000
+      transfer-encoding:
+      - chunked
+      x-cache:
+      - CONFIG_NOCACHE
+      x-processing-time:
+      - 93ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunk_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:09 GMT
+      - Wed, 09 Nov 2022 11:15:35 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:08 GMT
+      - Wed, 09 Nov 2022 11:15:34 GMT
       ms-cv:
-      - rmW1g9yIfkKDrK4bQLvxQw.0
+      - d7R98NdfGUi9Z80PTMHSEQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 339ms
+      - 229ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:10 GMT
+      - Wed, 09 Nov 2022 11:15:36 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:09 GMT
+      - Wed, 09 Nov 2022 11:15:34 GMT
       ms-cv:
-      - 4HZVmbr6fEOXk4+s+Tww1g.0
+      - W9P7x9aXP0upgWLEvTfA1Q.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 253ms
+      - 86ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort":
+      1122}, "sbs2.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:11 GMT
+      - Wed, 09 Nov 2022 11:15:36 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:09 GMT
+      - Wed, 09 Nov 2022 11:15:35 GMT
       ms-cv:
-      - 8Al9DThBEUa5JFIjuS941w.0
+      - RtpSumjpa0WWhX3TA3OPXA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,50 +124,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 387ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:11 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:10 GMT
-      ms-cv:
-      - fLd9o2baBUCx0gzyQtLZ+A.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 615ms
+      - 162ms
     status:
       code: 200
       message: OK
@@ -174,19 +138,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
+      x-ms-date:
+      - Wed, 09 Nov 2022 11:15:36 GMT
+      x-ms-return-client-request-id:
+      - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:12 GMT
+      - Wed, 09 Nov 2022 11:15:35 GMT
       ms-cv:
-      - 5hgplNTEqkawK1xCt0IabQ.0
+      - 580cmWjpsEua8zRuJ0vFwQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -194,7 +164,43 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 226ms
+      - 76ms
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
+  response:
+    body:
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
+    headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Nov 2022 11:15:35 GMT
+      ms-cv:
+      - pMJmtNupmUO93kRKfmGwSg.0
+      strict-transport-security:
+      - max-age=2592000
+      transfer-encoding:
+      - chunked
+      x-cache:
+      - CONFIG_NOCACHE
+      x-processing-time:
+      - 296ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunks.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunks.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:13 GMT
+      - Wed, 09 Nov 2022 10:46:21 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:13 GMT
+      - Wed, 09 Nov 2022 10:46:20 GMT
       ms-cv:
-      - 1ak1rfSH3EOJfQ56uIaGxQ.0
+      - N67IkToAREy/Ad2GJUvYhA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 266ms
+      - 232ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:14 GMT
+      - Wed, 09 Nov 2022 10:46:22 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:13 GMT
+      - Wed, 09 Nov 2022 10:46:21 GMT
       ms-cv:
-      - 1ZKvQ5T+GEyb52icwsE/eA.0
+      - Si/NdztXyku9HMzj8tINtw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 139ms
+      - 76ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:14 GMT
+      - Wed, 09 Nov 2022 10:46:22 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:13 GMT
+      - Wed, 09 Nov 2022 10:46:21 GMT
       ms-cv:
-      - VtRZRT2PekmilA53v5qCBw.0
+      - mRcXkr+PtkeqdSx/c6iouA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,50 +124,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 316ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:14 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:14 GMT
-      ms-cv:
-      - 3YrWCDKJdkOdptYnvOJZog.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 706ms
+      - 327ms
     status:
       code: 200
       message: OK
@@ -174,23 +138,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:15 GMT
+      - Wed, 09 Nov 2022 10:46:23 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:14 GMT
+      - Wed, 09 Nov 2022 10:46:21 GMT
       ms-cv:
-      - CLmW5wS/vUOly8YDcpPVeQ.0
+      - LzxqROfGzkGgfDeamB93Ig.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -198,7 +164,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 156ms
+      - 87ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunks_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_get_trunks_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:16 GMT
+      - Wed, 09 Nov 2022 10:46:23 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:15 GMT
+      - Wed, 09 Nov 2022 10:46:21 GMT
       ms-cv:
-      - 5tVD9Ma/dU6tWC0E66DGGA.0
+      - 0CouSn19EUO37X+kvAekhg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 235ms
+      - 99ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:16 GMT
+      - Wed, 09 Nov 2022 10:46:23 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:16 GMT
+      - Wed, 09 Nov 2022 10:46:21 GMT
       ms-cv:
-      - cgol26ErYEuyRnDuKQFCtw.0
+      - Z4eYInMtXkG3PW/wv5g3uQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 174ms
+      - 84ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:17 GMT
+      - Wed, 09 Nov 2022 10:46:23 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:16 GMT
+      - Wed, 09 Nov 2022 10:46:22 GMT
       ms-cv:
-      - 81zuKezH9EG1R+qihA7Wzw.0
+      - nRj55rT+U0SEsVdiFD/TEQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,50 +124,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 295ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:17 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:17 GMT
-      ms-cv:
-      - CLfprdS52UiLF+B2jg3Lag.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 629ms
+      - 180ms
     status:
       code: 200
       message: OK
@@ -174,19 +138,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:18 GMT
+      - Wed, 09 Nov 2022 10:46:22 GMT
       ms-cv:
-      - 4VGwmzAB5UO5A1aVpnYycg.0
+      - YL7am4QWdkOr43LTULI1WQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -194,7 +160,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 124ms
+      - 255ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_routes.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_routes.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:19 GMT
+      - Wed, 09 Nov 2022 10:46:25 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:18 GMT
+      - Wed, 09 Nov 2022 10:46:23 GMT
       ms-cv:
-      - bqIaeym27UOC0pgCL0sU/A.0
+      - nRlZG9ZbEE+Ll3RlE5gX8w.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 258ms
+      - 117ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:20 GMT
+      - Wed, 09 Nov 2022 10:46:25 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:19 GMT
+      - Wed, 09 Nov 2022 10:46:23 GMT
       ms-cv:
-      - PhBhUtBACEKxZn3wLaR9sw.0
+      - 8fMFBOlCOkqbFihY0V725g.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 151ms
+      - 96ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:20 GMT
+      - Wed, 09 Nov 2022 10:46:25 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:19 GMT
+      - Wed, 09 Nov 2022 10:46:24 GMT
       ms-cv:
-      - QtfWNTovJ0GNtn4Rpi0CeQ.0
+      - +x1BIuwpPE2VMH+9zweInw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,56 +124,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 359ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:21 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:20 GMT
-      ms-cv:
-      - bRIitbNMcUWW5/zHgL3TTQ.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 640ms
+      - 194ms
     status:
       code: 200
       message: OK
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
       Accept:
       - application/json
@@ -175,28 +139,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:22 GMT
+      - Wed, 09 Nov 2022 10:46:26 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:21 GMT
+      - Wed, 09 Nov 2022 10:46:24 GMT
       ms-cv:
-      - gXreYa0IyEKg4520u7Y+ww.0
+      - EI5N9OmWvkSNW1ycTgN8GA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -204,13 +170,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 281ms
+      - 230ms
     status:
       code: 200
       message: OK
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+999''", "name":
-      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.sipconfigtest.com"]}]}'
+      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
       Accept:
       - application/json
@@ -219,28 +185,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '167'
+      - '186'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:22 GMT
+      - Wed, 09 Nov 2022 10:46:26 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:21 GMT
+      - Wed, 09 Nov 2022 10:46:25 GMT
       ms-cv:
-      - E/MAvQcnxEihPedXNSS6eg.0
+      - rP2VEfzcqkW6vqWp6HvF8Q.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -248,7 +216,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 281ms
+      - 102ms
     status:
       code: 200
       message: OK
@@ -262,24 +230,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:22 GMT
+      - Wed, 09 Nov 2022 10:46:27 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:21 GMT
+      - Wed, 09 Nov 2022 10:46:25 GMT
       ms-cv:
-      - D9rR21rBj0q6VrKkUi2xiQ.0
+      - KPMVbe2h7Emxk4vedhscwA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -287,7 +257,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 137ms
+      - 105ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_routes_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_routes_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:23 GMT
+      - Wed, 09 Nov 2022 10:46:27 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:24 GMT
+      - Wed, 09 Nov 2022 10:46:26 GMT
       ms-cv:
-      - u7DxMj8200eopMwuIyzA/A.0
+      - BKEKqRwwMUW8DYRtTc+fuA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 960ms
+      - 112ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:25 GMT
+      - Wed, 09 Nov 2022 10:46:27 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:24 GMT
+      - Wed, 09 Nov 2022 10:46:26 GMT
       ms-cv:
-      - p8c2sKbjhEi8XCPkvKderQ.0
+      - 4WiuZbsszUeY5AflwI5s1g.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 125ms
+      - 83ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:25 GMT
+      - Wed, 09 Nov 2022 10:46:27 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:24 GMT
+      - Wed, 09 Nov 2022 10:46:26 GMT
       ms-cv:
-      - Mw5oCsL3d0ufJ3TZY4mwHA.0
+      - /2pYipgRhUyvyrfAHgBm+A.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,56 +124,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 354ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:25 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:25 GMT
-      ms-cv:
-      - E+ilUIm3YUqQIYVyDx2FFQ.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 688ms
+      - 159ms
     status:
       code: 200
       message: OK
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
       Accept:
       - application/json
@@ -175,24 +139,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:26 GMT
+      - Wed, 09 Nov 2022 10:46:26 GMT
       ms-cv:
-      - zXvgpj+y40qxoSy9xBWxhg.0
+      - mzrHYyOG0USVBEwbXPqDDw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -200,13 +166,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 508ms
+      - 95ms
     status:
       code: 200
       message: OK
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+999''", "name":
-      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.sipconfigtest.com"]}]}'
+      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
       Accept:
       - application/json
@@ -215,24 +181,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '167'
+      - '186'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:26 GMT
+      - Wed, 09 Nov 2022 10:46:27 GMT
       ms-cv:
-      - eoIdssDIb0mGJu3GSjFqeQ.0
+      - jvdwaYKScE68j8VAduym2Q.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -240,7 +208,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 234ms
+      - 97ms
     status:
       code: 200
       message: OK
@@ -254,20 +222,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.0d6643317d3b45bb8435d73cc67e025a.com"]}]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:27 GMT
+      - Wed, 09 Nov 2022 10:46:27 GMT
       ms-cv:
-      - p7VfrTRCOUaVdFijO1O3zA.0
+      - CnN/Hf8xtU2IRDCcnJwlRg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -275,7 +245,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 126ms
+      - 76ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunk.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:28 GMT
+      - Wed, 09 Nov 2022 11:15:38 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:28 GMT
+      - Wed, 09 Nov 2022 11:15:37 GMT
       ms-cv:
-      - ispDysMj+Ui35yfo3+J5gA.0
+      - 9rqjiCaICkmSi5h3kLE3TQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 289ms
+      - 200ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:29 GMT
+      - Wed, 09 Nov 2022 11:15:38 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:28 GMT
+      - Wed, 09 Nov 2022 11:15:37 GMT
       ms-cv:
-      - NngSNCyovk69bcO1p5xDlw.0
+      - 3dYARRt2pESjEyMZb6JEnA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 141ms
+      - 76ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort":
+      1122}, "sbs2.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:30 GMT
+      - Wed, 09 Nov 2022 11:15:39 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:29 GMT
+      - Wed, 09 Nov 2022 11:15:37 GMT
       ms-cv:
-      - /HGeqBNnzUKWOFjos4BTqQ.0
+      - HXM2omxFoU+xmm7yYF/jtg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,13 +124,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 377ms
+      - 171ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort":
+      7777}}}'
     headers:
       Accept:
       - application/json
@@ -132,27 +139,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:30 GMT
+      - Wed, 09 Nov 2022 11:15:39 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:30 GMT
+      - Wed, 09 Nov 2022 11:15:38 GMT
       ms-cv:
-      - w/pKr0H0SEWvSvEJnMhedw.0
+      - D6qlebiTKkanRpBdJr/NVw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -160,49 +169,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 636ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": {"sipSignalingPort": 7777}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:31 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:31 GMT
-      ms-cv:
-      - AxArr8cWRkWx1ciVzZrgXg.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 580ms
+      - 407ms
     status:
       code: 200
       message: OK
@@ -216,23 +183,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:32 GMT
+      - Wed, 09 Nov 2022 11:15:40 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:31 GMT
+      - Wed, 09 Nov 2022 11:15:38 GMT
       ms-cv:
-      - ma6TZn+aU0C5SQsqX0PeOw.0
+      - G6UGmMidWkKUv/3THr8RjA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -240,7 +209,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 197ms
+      - 161ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunk_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:32 GMT
+      - Wed, 09 Nov 2022 11:15:40 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:32 GMT
+      - Wed, 09 Nov 2022 11:15:39 GMT
       ms-cv:
-      - ST45WmDs90qd2czf9u9Htg.0
+      - Xy2ewBHU7EGGcOGi0y4xkQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 316ms
+      - 154ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:33 GMT
+      - Wed, 09 Nov 2022 11:15:40 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:33 GMT
+      - Wed, 09 Nov 2022 11:15:39 GMT
       ms-cv:
-      - cw/8t1KWrkKfb+fy742JVw.0
+      - zjMG/boGv0aEspB1XDje9g.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,12 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 121ms
+      - 93ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort":
+      1122}, "sbs2.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -89,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 12:01:34 GMT
+      - Wed, 09 Nov 2022 11:15:41 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:33 GMT
+      - Wed, 09 Nov 2022 11:15:40 GMT
       ms-cv:
-      - qJb+AtWot0yegD0LVivk4g.0
+      - SCUeJ4Gz50ad0YPIF7iuWw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -117,13 +124,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 378ms
+      - 349ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com": {"sipSignalingPort":
+      7777}}}'
     headers:
       Accept:
       - application/json
@@ -132,27 +139,25 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 12:01:34 GMT
-      x-ms-return-client-request-id:
-      - 'true'
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:34 GMT
+      - Wed, 09 Nov 2022 11:15:41 GMT
       ms-cv:
-      - YuD6NqKQc0+FAw2gxK2Pzg.0
+      - DOTildzX7kefSjAtlo8jrg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -160,45 +165,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 674ms
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": {"sipSignalingPort": 7777}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
-    headers:
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 23 May 2022 12:01:35 GMT
-      ms-cv:
-      - V6usiS+Eu0yUL7PgTcPIng.0
-      strict-transport-security:
-      - max-age=2592000
-      transfer-encoding:
-      - chunked
-      x-cache:
-      - CONFIG_NOCACHE
-      x-processing-time:
-      - 498ms
+      - 782ms
     status:
       code: 200
       message: OK
@@ -212,19 +179,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 23 May 2022 12:01:35 GMT
+      - Wed, 09 Nov 2022 11:15:41 GMT
       ms-cv:
-      - r1EVfOCqAEey4EnscF81KA.0
+      - EBNmdPF+M0GXibpxHRGNpw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -232,7 +201,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 184ms
+      - 247ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunks.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunks.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:45 GMT
+      - Wed, 09 Nov 2022 10:46:32 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:46 GMT
+      - Wed, 09 Nov 2022 10:46:31 GMT
       ms-cv:
-      - T4BRgksRPECCxhnj/ppbow.0
+      - MyJfwLaL7EW6SrupXDZoYQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 917ms
+      - 342ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:46 GMT
+      - Wed, 09 Nov 2022 10:46:33 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:46 GMT
+      - Wed, 09 Nov 2022 10:46:31 GMT
       ms-cv:
-      - ROLMC4p2skOGcWneNOe2xw.0
+      - ouPL3AUD7UqQlxSTyM4CgQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,13 +79,13 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 213ms
+      - 71ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}, "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
@@ -90,27 +94,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '152'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:47 GMT
+      - Wed, 09 Nov 2022 10:46:33 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:47 GMT
+      - Wed, 09 Nov 2022 10:46:32 GMT
       ms-cv:
-      - IuWINSpJx06f0tUYLZPmvg.0
+      - VgpvQIyWi0KyJpZFKvNzYA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -118,7 +124,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1035ms
+      - 164ms
     status:
       code: 200
       message: OK
@@ -132,23 +138,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:48 GMT
+      - Wed, 09 Nov 2022 10:46:34 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:48 GMT
+      - Wed, 09 Nov 2022 10:46:32 GMT
       ms-cv:
-      - H3T6H4aUHk6uGANHGTmEWA.0
+      - R71HDUaYvk+Z+fbpwgookA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -156,13 +164,14 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 245ms
+      - 75ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}, "sbs1.sipconfigtest.com":
-      null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs3.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      2222}, "sbs1.0d6643317d3b45bb8435d73cc67e025a.com": null, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com":
+      null}}'
     headers:
       Accept:
       - application/json
@@ -171,27 +180,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '130'
+      - '187'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:48 GMT
+      - Wed, 09 Nov 2022 10:46:34 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:49 GMT
+      - Wed, 09 Nov 2022 10:46:33 GMT
       ms-cv:
-      - Jz28/zJUTkmanyjQjWAcoA.0
+      - DIpz8DnSbEuGk+9s6Ae6sw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -199,7 +210,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1315ms
+      - 722ms
     status:
       code: 200
       message: OK
@@ -213,23 +224,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:50 GMT
+      - Wed, 09 Nov 2022 10:46:35 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:50 GMT
+      - Wed, 09 Nov 2022 10:46:33 GMT
       ms-cv:
-      - 22mzNHTc00+rK02w9bIWuw.0
+      - 6ESXa26tr0aj82q9ss7i2A.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -237,7 +250,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 373ms
+      - 76ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunks_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.test_set_trunks_from_managed_identity.yaml
@@ -13,23 +13,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:51 GMT
+      - Wed, 09 Nov 2022 10:46:35 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:51 GMT
+      - Wed, 09 Nov 2022 10:46:34 GMT
       ms-cv:
-      - c2pUt7Mpo0OPoclNhkyR4A.0
+      - X3NogcpQY0CpUK1hwJTt1w.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -37,7 +39,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 547ms
+      - 169ms
     status:
       code: 200
       message: OK
@@ -51,23 +53,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:52 GMT
+      - Wed, 09 Nov 2022 10:46:35 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:52 GMT
+      - Wed, 09 Nov 2022 10:46:34 GMT
       ms-cv:
-      - KB58yN/OqEWN0SOLSP0sPw.0
+      - 21PPrDK1ckmrJ/yNonfOhg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -75,13 +79,14 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 270ms
+      - 92ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}, "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      1122}, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort": 1123},
+      "sbs3.0d6643317d3b45bb8435d73cc67e025a.com": null}}'
     headers:
       Accept:
       - application/json
@@ -90,27 +95,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '152'
+      - '209'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:39:52 GMT
+      - Wed, 09 Nov 2022 10:46:36 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:54 GMT
+      - Wed, 09 Nov 2022 10:46:35 GMT
       ms-cv:
-      - 5m8KcBxVyUG9UVmPgxTimA.0
+      - rQj2J+wnw0GkQUP0HbeeRw.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -118,7 +125,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1858ms
+      - 416ms
     status:
       code: 200
       message: OK
@@ -132,19 +139,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1122},"sbs2.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:56 GMT
+      - Wed, 09 Nov 2022 10:46:35 GMT
       ms-cv:
-      - eOqgZNziJEOr7R5IaWXD+g.0
+      - NXYXGjTsmkKnk7EN8IvBVQ.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -152,13 +161,14 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 328ms
+      - 90ms
     status:
       code: 200
       message: OK
 - request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}, "sbs1.sipconfigtest.com":
-      null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs3.0d6643317d3b45bb8435d73cc67e025a.com": {"sipSignalingPort":
+      2222}, "sbs1.0d6643317d3b45bb8435d73cc67e025a.com": null, "sbs2.0d6643317d3b45bb8435d73cc67e025a.com":
+      null}}'
     headers:
       Accept:
       - application/json
@@ -167,23 +177,25 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '130'
+      - '187'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:57 GMT
+      - Wed, 09 Nov 2022 10:46:36 GMT
       ms-cv:
-      - LzZC5xePc0264g2vR1T4zQ.0
+      - mUGYNVZHREmpuhgEHT5QpA.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -191,7 +203,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 1099ms
+      - 635ms
     status:
       code: 200
       message: OK
@@ -205,19 +217,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.0d6643317d3b45bb8435d73cc67e025a.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions:
+      - 2021-05-01-preview, 2022-09-01-preview
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 09 Jun 2022 08:39:57 GMT
+      - Wed, 09 Nov 2022 10:46:36 GMT
       ms-cv:
-      - YfP9BqdjnUCxinfLuLF6Kg.0
+      - adBGJGP/yE+yWug49hwiUg.0
       strict-transport-security:
       - max-age=2592000
       transfer-encoding:
@@ -225,7 +239,7 @@ interactions:
       x-cache:
       - CONFIG_NOCACHE
       x-processing-time:
-      - 261ms
+      - 88ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_add_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_add_trunk.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:42 GMT
+      - Wed, 09 Nov 2022 12:01:47 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:42 GMT
-      ms-cv: 7sx2yqZDrkOOM33MVUsJTg.0
+      date: Wed, 09 Nov 2022 12:01:46 GMT
+      ms-cv: Spmg6LQ+dUi/EQgXz7Pvbw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 451ms
+      x-processing-time: 307ms
     status:
       code: 200
       message: OK
@@ -37,121 +38,95 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:43 GMT
+      - Wed, 09 Nov 2022 12:01:48 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":1122},"sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:42 GMT
-      ms-cv: smXs4FC9FE+Uj8XxWV9I8Q.0
+      date: Wed, 09 Nov 2022 12:01:47 GMT
+      ms-cv: wKpKLQqP2kyciYKEM/ANlQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 262ms
+      x-processing-time: 183ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123},
+      "sbs1.f3d48969d5814d4b856dd02418c9ae4f.com": null, "sbs2.f3d48969d5814d4b856dd02418c9ae4f.com":
+      null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '260'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:43 GMT
+      - Wed, 09 Nov 2022 12:01:48 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:43 GMT
-      ms-cv: zFW+oiEpZEq+p5G7oq+xuw.0
+      date: Wed, 09 Nov 2022 12:01:48 GMT
+      ms-cv: iLdin3tP+U6XFHQpk1j0FQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 699ms
+      x-processing-time: 938ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs3.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      2222}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:44 GMT
+      - Wed, 09 Nov 2022 12:01:49 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:45 GMT
-      ms-cv: fIBZ6R0dr0KC9NPhUnaOwA.0
+      date: Wed, 09 Nov 2022 12:01:49 GMT
+      ms-cv: Y8tyT06UG0iSo9ww4fYLMg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 1140ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:40:45 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:46 GMT
-      ms-cv: ADaGvSErtk2HXW+MeCnkWw.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 1047ms
+      x-processing-time: 553ms
     status:
       code: 200
       message: OK
@@ -162,24 +137,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:47 GMT
+      - Wed, 09 Nov 2022 12:01:50 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:46 GMT
-      ms-cv: VB3hCx4W4Uq3hyr8VL2zzg.0
+      date: Wed, 09 Nov 2022 12:01:49 GMT
+      ms-cv: jzuMUImMAEqjqY8i8nL8Ww.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 212ms
+      x-processing-time: 81ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_add_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_add_trunk_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:47 GMT
+      - Wed, 09 Nov 2022 12:01:50 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:47 GMT
-      ms-cv: rZmEte2MWE2PhwnzSsNIBQ.0
+      date: Wed, 09 Nov 2022 12:01:49 GMT
+      ms-cv: eUFY2Ki20EGx6VjaInaU4w.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 426ms
+      x-processing-time: 241ms
     status:
       code: 200
       message: OK
@@ -37,118 +38,90 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:48 GMT
+      - Wed, 09 Nov 2022 12:01:51 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:47 GMT
-      ms-cv: Z0ZYpNVNHEiZF1OgqrGe2w.0
+      date: Wed, 09 Nov 2022 12:01:49 GMT
+      ms-cv: UhZrpcCSzUKHNFk2P+rgNQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 372ms
+      x-processing-time: 85ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null,
-      "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123},
+      "sbs3.00035101e6744cde8e2dd763e44696ee.com": null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '108'
+      - '209'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:48 GMT
+      - Wed, 09 Nov 2022 12:01:51 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:48 GMT
-      ms-cv: yt2kI2FhUUaHCQVoCMCkfA.0
+      date: Wed, 09 Nov 2022 12:01:50 GMT
+      ms-cv: fJnLl+jt50yKU+QB8BVuFA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 627ms
+      x-processing-time: 189ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs3.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      2222}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:40:49 GMT
-      x-ms-return-client-request-id:
-      - 'true'
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:50 GMT
-      ms-cv: sWzxpTQWpky++j2w6N2hhA.0
+      date: Wed, 09 Nov 2022 12:01:51 GMT
+      ms-cv: yUMiDzUeWEus8ifsy2FDOA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 1641ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:52 GMT
-      ms-cv: 2dtkpUCl8kO5Nqv8fleLag.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 1440ms
+      x-processing-time: 590ms
     status:
       code: 200
       message: OK
@@ -159,20 +132,21 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:53 GMT
-      ms-cv: IyJACuJOaEqMwCldzrjhDA.0
+      date: Wed, 09 Nov 2022 12:01:51 GMT
+      ms-cv: a1Z3DgntBkyvgolFxGXi4A.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 220ms
+      x-processing-time: 292ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_delete_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_delete_trunk.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:54 GMT
+      - Wed, 09 Nov 2022 12:01:54 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:54 GMT
-      ms-cv: aNCLtJTwu0mNEdta/Nidfw.0
+      date: Wed, 09 Nov 2022 12:01:53 GMT
+      ms-cv: 2cvbC4DLW0m/oc1Knniq9A.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 340ms
+      x-processing-time: 262ms
     status:
       code: 200
       message: OK
@@ -37,122 +38,93 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:55 GMT
+      - Wed, 09 Nov 2022 12:01:54 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123},"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123},"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:55 GMT
-      ms-cv: Qo+nYMjPzkaDV+urpQjZbw.0
+      date: Wed, 09 Nov 2022 12:01:53 GMT
+      ms-cv: j3SAd6oFRUekSqbC4EXsAw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 193ms
+      x-processing-time: 92ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null,
-      "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123},
+      "sbs3.00035101e6744cde8e2dd763e44696ee.com": null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '108'
+      - '209'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:56 GMT
+      - Wed, 09 Nov 2022 12:01:55 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:55 GMT
-      ms-cv: 1mV3Sf9ZRUW73RrqzcU3nQ.0
+      date: Wed, 09 Nov 2022 12:01:53 GMT
+      ms-cv: MG8YPjFEP023ppVMa5WWjw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 461ms
+      x-processing-time: 474ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.00035101e6744cde8e2dd763e44696ee.com": null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '120'
+      - '63'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:56 GMT
+      - Wed, 09 Nov 2022 12:01:55 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:56 GMT
-      ms-cv: k1cvggReSEOmPb5Mltf/mA.0
+      date: Wed, 09 Nov 2022 12:01:54 GMT
+      ms-cv: pMivt/aLEU2OLUbGJczj+g.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 789ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": null}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:40:57 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:57 GMT
-      ms-cv: +N2uxm0C6EiKvtrgKNHjZA.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 436ms
+      x-processing-time: 300ms
     status:
       code: 200
       message: OK
@@ -163,24 +135,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:58 GMT
+      - Wed, 09 Nov 2022 12:01:56 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:57 GMT
-      ms-cv: gjmgQ2G4DE+2rImAejkT2A.0
+      date: Wed, 09 Nov 2022 12:01:54 GMT
+      ms-cv: YWeyU5PpxUuY7Hv83gQMGQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 287ms
+      x-processing-time: 87ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_delete_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_delete_trunk_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:58 GMT
+      - Wed, 09 Nov 2022 12:01:56 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:58 GMT
-      ms-cv: 4z5niFhQMEmKRNQIAqzaZA.0
+      date: Wed, 09 Nov 2022 12:01:55 GMT
+      ms-cv: RhmJndHC5km7yW5aADTmow.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 345ms
+      x-processing-time: 292ms
     status:
       code: 200
       message: OK
@@ -37,117 +38,88 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:59 GMT
+      - Wed, 09 Nov 2022 12:01:57 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:59 GMT
-      ms-cv: 6SHxlnvi6EurzL4lzo5QaA.0
+      date: Wed, 09 Nov 2022 12:01:55 GMT
+      ms-cv: dZZMScHgj0CErd9J2nveuw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 261ms
+      x-processing-time: 302ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '44'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:40:59 GMT
+      - Wed, 09 Nov 2022 12:01:57 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:40:59 GMT
-      ms-cv: fZM6sNqXE0uG2D1MrdttRg.0
+      date: Wed, 09 Nov 2022 12:01:56 GMT
+      ms-cv: qhN4rCnigUqx/J808T9z4g.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 523ms
+      x-processing-time: 673ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.00035101e6744cde8e2dd763e44696ee.com": null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '120'
+      - '63'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:00 GMT
-      x-ms-return-client-request-id:
-      - 'true'
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:00 GMT
-      ms-cv: NZHZVo2FqUqujnIjSw3rTQ.0
+      date: Wed, 09 Nov 2022 12:01:58 GMT
+      ms-cv: B3ukQnzyq0uT2DbM3SQaTQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 720ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": null}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:01 GMT
-      ms-cv: ih2rU+YfZE6EGz7ZyGsUDA.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 480ms
+      x-processing-time: 920ms
     status:
       code: 200
       message: OK
@@ -158,20 +130,21 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:02 GMT
-      ms-cv: G197N3/0cE2/4/2/35E3Og.0
+      date: Wed, 09 Nov 2022 12:01:58 GMT
+      ms-cv: 0ofbKadmj0KoaecP1mVVMQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 330ms
+      x-processing-time: 256ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_routes.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_routes.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:03 GMT
+      - Wed, 09 Nov 2022 12:02:00 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:03 GMT
-      ms-cv: aBmtuPXkikSCebqojpbw4w.0
+      date: Wed, 09 Nov 2022 12:01:59 GMT
+      ms-cv: 1jn/NodEPkOZNpMnoKde7g.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 372ms
+      x-processing-time: 272ms
     status:
       code: 200
       message: OK
@@ -37,123 +38,94 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:03 GMT
+      - Wed, 09 Nov 2022 12:02:00 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:03 GMT
-      ms-cv: xMXz1+8tz0KpO4DMrBa+cQ.0
+      date: Wed, 09 Nov 2022 12:01:59 GMT
+      ms-cv: vujsDVY7S0+eM/vbF6MpRQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 262ms
+      x-processing-time: 87ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '44'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:04 GMT
+      - Wed, 09 Nov 2022 12:02:01 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:04 GMT
-      ms-cv: xthAFIIZVUGiM/44mebsog.0
+      date: Wed, 09 Nov 2022 12:02:00 GMT
+      ms-cv: AJjOftOxBEujyj+coaYihw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 448ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:04 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:05 GMT
-      ms-cv: AXueh08tiEWxVJ5wFKo6UA.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 982ms
+      x-processing-time: 479ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:05 GMT
+      - Wed, 09 Nov 2022 12:02:01 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:05 GMT
-      ms-cv: lcRB/lYApUWkmGjOv8eA9A.0
+      date: Wed, 09 Nov 2022 12:02:00 GMT
+      ms-cv: qg+XQnBMQU6jlcUXdnnr4Q.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 298ms
+      x-processing-time: 229ms
     status:
       code: 200
       message: OK
@@ -164,25 +136,26 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:06 GMT
+      - Wed, 09 Nov 2022 12:02:02 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:05 GMT
-      ms-cv: O3e2GNxLik+etpDcuzRcYQ.0
+      date: Wed, 09 Nov 2022 12:02:00 GMT
+      ms-cv: YVAHQTzMo0yTshzVq+b3uA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 282ms
+      x-processing-time: 96ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_routes_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_routes_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:06 GMT
+      - Wed, 09 Nov 2022 12:02:02 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:06 GMT
-      ms-cv: NqCl8cPBdU68wXu8femS/w.0
+      date: Wed, 09 Nov 2022 12:02:01 GMT
+      ms-cv: SafeGUtEA06bIL2BhQfeKA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 330ms
+      x-processing-time: 263ms
     status:
       code: 200
       message: OK
@@ -37,123 +38,90 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:07 GMT
+      - Wed, 09 Nov 2022 12:02:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:06 GMT
-      ms-cv: F9WtIQzC5kmzwScGuu3nEw.0
+      date: Wed, 09 Nov 2022 12:02:01 GMT
+      ms-cv: x20WEJbwv0yDtZQ4XTRgsQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 288ms
+      x-processing-time: 83ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:08 GMT
+      - Wed, 09 Nov 2022 12:02:03 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:07 GMT
-      ms-cv: QHKFD+wPYE+0J4Iv3TTfPg.0
+      date: Wed, 09 Nov 2022 12:02:02 GMT
+      ms-cv: zEYXy1EqREOW1SMKlsVz+g.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 461ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:08 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:08 GMT
-      ms-cv: 3BB4TaRLuEiFRBKFay+XkA.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 836ms
+      x-processing-time: 373ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:09 GMT
-      x-ms-return-client-request-id:
-      - 'true'
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:08 GMT
-      ms-cv: +/6RN3pXzUyhRuOwjqX5Eg.0
+      date: Wed, 09 Nov 2022 12:02:03 GMT
+      ms-cv: cyXgB7OVmEuXAGEPdDQX4w.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 396ms
+      x-processing-time: 824ms
     status:
       code: 200
       message: OK
@@ -164,21 +132,22 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:09 GMT
-      ms-cv: rRi7QEtsfk61KkCLm5JvTQ.0
+      date: Wed, 09 Nov 2022 12:02:03 GMT
+      ms-cv: iN4SYJbXgUCWyghaDIDW5A.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 371ms
+      x-processing-time: 323ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunk.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:11 GMT
+      - Wed, 09 Nov 2022 12:02:05 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:10 GMT
-      ms-cv: RxMkkYe09kOdUjhtg5Ie1A.0
+      date: Wed, 09 Nov 2022 12:02:04 GMT
+      ms-cv: aJKHJy501kmzRKHjLTYY9Q.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 378ms
+      x-processing-time: 304ms
     status:
       code: 200
       message: OK
@@ -37,89 +38,59 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:12 GMT
+      - Wed, 09 Nov 2022 12:02:06 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:11 GMT
-      ms-cv: ypgrPJlD+EK6UMiAI9TaAg.0
+      date: Wed, 09 Nov 2022 12:02:04 GMT
+      ms-cv: su9pBN9TO0WI0682K/nQnQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 180ms
+      x-processing-time: 69ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:12 GMT
+      - Wed, 09 Nov 2022 12:02:06 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:11 GMT
-      ms-cv: jxr6gqEIyEueyR5LjGYZQg.0
+      date: Wed, 09 Nov 2022 12:02:04 GMT
+      ms-cv: bITh4DlVZkq6L2ghXfwygA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 383ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:12 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:12 GMT
-      ms-cv: ScPo21KWG0i4yTyVKk8Eow.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 1035ms
+      x-processing-time: 150ms
     status:
       code: 200
       message: OK
@@ -130,24 +101,54 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:14 GMT
+      - Wed, 09 Nov 2022 12:02:07 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:13 GMT
-      ms-cv: dAn2upDPK0uATB9n75zSpg.0
+      date: Wed, 09 Nov 2022 12:02:05 GMT
+      ms-cv: 6VUh0/NWG0aQLLdP81iCww.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 162ms
+      x-processing-time: 72ms
+    status:
+      code: 200
+      message: OK
+    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
+- request:
+    body: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
+      x-ms-date:
+      - Wed, 09 Nov 2022 12:02:07 GMT
+      x-ms-return-client-request-id:
+      - 'true'
+    method: GET
+    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
+  response:
+    body:
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
+    headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
+      content-type: application/json; charset=utf-8
+      date: Wed, 09 Nov 2022 12:02:05 GMT
+      ms-cv: y1k2sK9K6k27dQJHoEXv/Q.0
+      strict-transport-security: max-age=2592000
+      transfer-encoding: chunked
+      x-cache: CONFIG_NOCACHE
+      x-processing-time: 71ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunk_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:14 GMT
+      - Wed, 09 Nov 2022 12:02:07 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:13 GMT
-      ms-cv: wGJFymw7WUehKdvldGrMJg.0
+      date: Wed, 09 Nov 2022 12:02:06 GMT
+      ms-cv: KqeVNPlZZkeGaO6tz+NzrA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 361ms
+      x-processing-time: 106ms
     status:
       code: 200
       message: OK
@@ -37,89 +38,59 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:15 GMT
+      - Wed, 09 Nov 2022 12:02:08 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:14 GMT
-      ms-cv: GL3UQFhuMEuWI4OKRCe5vQ.0
+      date: Wed, 09 Nov 2022 12:02:06 GMT
+      ms-cv: WPK0L85LUkKdVkstCy3hpg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 255ms
+      x-processing-time: 89ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:15 GMT
+      - Wed, 09 Nov 2022 12:02:08 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:14 GMT
-      ms-cv: hkVbbKhjwUG5hWIvFEB0aQ.0
+      date: Wed, 09 Nov 2022 12:02:06 GMT
+      ms-cv: g64gW3FGwUK74IIQD0WGQQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 423ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:16 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:15 GMT
-      ms-cv: cYB+sOW6H0CP1GCGDlTG+Q.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 986ms
+      x-processing-time: 169ms
     status:
       code: 200
       message: OK
@@ -130,20 +101,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:17 GMT
-      ms-cv: +9g2vvu35UWaO9nKXAEOlA.0
+      date: Wed, 09 Nov 2022 12:02:07 GMT
+      ms-cv: vtPDSvHh0kiadsIweUK5Yw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 176ms
+      x-processing-time: 95ms
+    status:
+      code: 200
+      message: OK
+    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
+  response:
+    body:
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
+    headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
+      content-type: application/json; charset=utf-8
+      date: Wed, 09 Nov 2022 12:02:07 GMT
+      ms-cv: QLWL7AVUO0OH1p5tdDFE4g.0
+      strict-transport-security: max-age=2592000
+      transfer-encoding: chunked
+      x-cache: CONFIG_NOCACHE
+      x-processing-time: 85ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunks.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunks.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:18 GMT
+      - Wed, 09 Nov 2022 12:02:09 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:17 GMT
-      ms-cv: 5dLeLfV6N0+qp68ERFlw2Q.0
+      date: Wed, 09 Nov 2022 12:02:08 GMT
+      ms-cv: W2PTCJKFx0CX4y6ew5yRYA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 277ms
+      x-processing-time: 209ms
     status:
       code: 200
       message: OK
@@ -37,89 +38,59 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:19 GMT
+      - Wed, 09 Nov 2022 12:02:10 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:17 GMT
-      ms-cv: YZFpybMfw0arS8W8GDeQeQ.0
+      date: Wed, 09 Nov 2022 12:02:08 GMT
+      ms-cv: 96CGVs0+s0Kb/EDrsDfP0w.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 206ms
+      x-processing-time: 85ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:19 GMT
+      - Wed, 09 Nov 2022 12:02:10 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:18 GMT
-      ms-cv: HRqC9h2tBE+9EpvhkGLbEA.0
+      date: Wed, 09 Nov 2022 12:02:09 GMT
+      ms-cv: 25frRP/ybUKs0XtnjQ1BjQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 377ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:19 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:19 GMT
-      ms-cv: QobxS5cZkk68/pCiSoRSUQ.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 963ms
+      x-processing-time: 280ms
     status:
       code: 200
       message: OK
@@ -130,24 +101,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:20 GMT
+      - Wed, 09 Nov 2022 12:02:10 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:19 GMT
-      ms-cv: TEPgXVyVdkGTQOmrWQrenQ.0
+      date: Wed, 09 Nov 2022 12:02:09 GMT
+      ms-cv: +QpIDdhl40G6i+OxlbJbFg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 224ms
+      x-processing-time: 82ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunks_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_get_trunks_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:21 GMT
+      - Wed, 09 Nov 2022 12:02:11 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:21 GMT
-      ms-cv: uuT+de6TMkOPGWZoSF3aMg.0
+      date: Wed, 09 Nov 2022 12:02:09 GMT
+      ms-cv: u6HF/jaRPkiIa4ZMWqstPw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 343ms
+      x-processing-time: 154ms
     status:
       code: 200
       message: OK
@@ -37,89 +38,59 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:22 GMT
+      - Wed, 09 Nov 2022 12:02:11 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:21 GMT
-      ms-cv: nBkBq6PRRUSsi6TK3HTEnQ.0
+      date: Wed, 09 Nov 2022 12:02:10 GMT
+      ms-cv: zZm4lwe73kqxQ6ZsAe9btg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 345ms
+      x-processing-time: 96ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:22 GMT
+      - Wed, 09 Nov 2022 12:02:11 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:22 GMT
-      ms-cv: ZFB7PJVRn0ayNM0wmzufUw.0
+      date: Wed, 09 Nov 2022 12:02:10 GMT
+      ms-cv: FTJ9mCZH2UiRn+tG9ov+xg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 382ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:23 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:23 GMT
-      ms-cv: wH7wjwovJUO7tO0I0c2+Sg.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 961ms
+      x-processing-time: 272ms
     status:
       code: 200
       message: OK
@@ -130,20 +101,21 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:23 GMT
-      ms-cv: kn+uFDLjhUCnd811y/9DzA.0
+      date: Wed, 09 Nov 2022 12:02:10 GMT
+      ms-cv: m+09XNVBtEaTHCXrNZ67Jg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 298ms
+      x-processing-time: 212ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_routes.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_routes.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:24 GMT
+      - Wed, 09 Nov 2022 12:02:12 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:23 GMT
-      ms-cv: IoKRLyuMKU2X9vw2++a5Uw.0
+      date: Wed, 09 Nov 2022 12:02:10 GMT
+      ms-cv: FzLSgOBtu0ySPR0l4Q6JbQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 310ms
+      x-processing-time: 114ms
     status:
       code: 200
       message: OK
@@ -37,157 +38,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:25 GMT
+      - Wed, 09 Nov 2022 12:02:12 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:24 GMT
-      ms-cv: g137mBts/UmhMXBYTmrOIA.0
+      date: Wed, 09 Nov 2022 12:02:11 GMT
+      ms-cv: UGKXaMns+0C2E1rKzlbIRA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 180ms
+      x-processing-time: 89ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:25 GMT
+      - Wed, 09 Nov 2022 12:02:13 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:24 GMT
-      ms-cv: 7+gt6pi5aEO4++3QmzLzmw.0
+      date: Wed, 09 Nov 2022 12:02:11 GMT
+      ms-cv: CpG+dP0LkUmnLIEQDInoZQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 403ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:26 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:25 GMT
-      ms-cv: EWi0MxIHf06HujoZ+wU/6w.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 875ms
+      x-processing-time: 166ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:27 GMT
+      - Wed, 09 Nov 2022 12:02:13 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:26 GMT
-      ms-cv: IUrNuBzLYkyx+FiUa8F2+g.0
+      date: Wed, 09 Nov 2022 12:02:11 GMT
+      ms-cv: UOkAMuHHbkySZiuG8iuKSA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 304ms
+      x-processing-time: 194ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+999''", "name":
-      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.sipconfigtest.com"]}]}'
+      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '167'
+      - '186'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:27 GMT
+      - Wed, 09 Nov 2022 12:02:13 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:26 GMT
-      ms-cv: jTF0GTdW3USv/1vp54rOjA.0
+      date: Wed, 09 Nov 2022 12:02:11 GMT
+      ms-cv: fyWsKQzAtUqSMWSmhOvxdw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 296ms
+      x-processing-time: 125ms
     status:
       code: 200
       message: OK
@@ -198,25 +171,26 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:27 GMT
+      - Wed, 09 Nov 2022 12:02:14 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:26 GMT
-      ms-cv: qX7GZD0d6ke3KVm8v9F3GA.0
+      date: Wed, 09 Nov 2022 12:02:12 GMT
+      ms-cv: v1r6Z9GlDk2QW9n/IG1m3g.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 293ms
+      x-processing-time: 87ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_routes_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_routes_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:28 GMT
+      - Wed, 09 Nov 2022 12:02:14 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:28 GMT
-      ms-cv: uZVAUEDU0EOgI+LRXxuCOg.0
+      date: Wed, 09 Nov 2022 12:02:12 GMT
+      ms-cv: edHOE83V10yiRYYuhFYX7g.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 263ms
+      x-processing-time: 190ms
     status:
       code: 200
       message: OK
@@ -37,149 +38,121 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:29 GMT
+      - Wed, 09 Nov 2022 12:02:14 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:28 GMT
-      ms-cv: iZyQw4u7eU+WHNN7TlWGlA.0
+      date: Wed, 09 Nov 2022 12:02:12 GMT
+      ms-cv: /X5yqCV56Em8tic19G7Apw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 215ms
+      x-processing-time: 91ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:29 GMT
+      - Wed, 09 Nov 2022 12:02:14 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:28 GMT
-      ms-cv: XzCDESMYM0SLUW+tHzNLnw.0
+      date: Wed, 09 Nov 2022 12:02:13 GMT
+      ms-cv: /NwzWYglAEeWdW4G47ompw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 407ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:30 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:29 GMT
-      ms-cv: J3cuD0RU7EGOiHOOyt30ug.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 935ms
+      x-processing-time: 370ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+123''", "name":
-      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.sipconfigtest.com"]}]}'
+      "First rule", "numberPattern": "\\+123[0-9]+", "trunks": ["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '161'
+      - '180'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+123''","name":"First rule","numberPattern":"\\+123[0-9]+","trunks":["sbs1.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:30 GMT
-      ms-cv: bCU+uDwkckSqF+8kZjTn7g.0
+      date: Wed, 09 Nov 2022 12:02:14 GMT
+      ms-cv: l1D+QrDx4Eiui8wCiLvPOg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 415ms
+      x-processing-time: 315ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
     body: '{"routes": [{"description": "Handle numbers starting with ''+999''", "name":
-      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.sipconfigtest.com"]}]}'
+      "Alternative rule", "numberPattern": "\\+999[0-9]+", "trunks": ["sbs2.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '167'
+      - '186'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:31 GMT
-      ms-cv: l3KNbnHqoUCwq+kL2j+hOQ.0
+      date: Wed, 09 Nov 2022 12:02:14 GMT
+      ms-cv: xSGb95GaiEOmM+lSfRdzXg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 361ms
+      x-processing-time: 211ms
     status:
       code: 200
       message: OK
@@ -190,21 +163,22 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
-        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.sipconfigtest.com"]}]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[{"description":"Handle
+        numbers starting with ''+999''","name":"Alternative rule","numberPattern":"\\+999[0-9]+","trunks":["sbs2.00035101e6744cde8e2dd763e44696ee.com"]}]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:31 GMT
-      ms-cv: fCU3l3JTI0iztQnZHESRBg.0
+      date: Wed, 09 Nov 2022 12:02:15 GMT
+      ms-cv: RDROey4dl0CUA6P2GI/cpg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 323ms
+      x-processing-time: 97ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunk.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunk.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:33 GMT
+      - Wed, 09 Nov 2022 12:02:17 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:32 GMT
-      ms-cv: jvxsnY/ZVE2qhqGluIjJrA.0
+      date: Wed, 09 Nov 2022 12:02:16 GMT
+      ms-cv: NltY63u00U+hoM9p66U6dQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 313ms
+      x-processing-time: 167ms
     status:
       code: 200
       message: OK
@@ -37,121 +38,93 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:33 GMT
+      - Wed, 09 Nov 2022 12:02:17 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:32 GMT
-      ms-cv: biiy3dwpVkCjYyrTTpHtpg.0
+      date: Wed, 09 Nov 2022 12:02:16 GMT
+      ms-cv: AbEcFXK7/k2BY7AfdCmJpA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 254ms
+      x-processing-time: 86ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:34 GMT
+      - Wed, 09 Nov 2022 12:02:17 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:33 GMT
-      ms-cv: SS5PNuXixU+NxaK8F5IW9Q.0
+      date: Wed, 09 Nov 2022 12:02:16 GMT
+      ms-cv: Vd6JVRhscEueOzo35WbyjA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 346ms
+      x-processing-time: 250ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      7777}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:34 GMT
+      - Wed, 09 Nov 2022 12:02:18 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:34 GMT
-      ms-cv: puoqX43rPkaxBvbzPAa+/w.0
+      date: Wed, 09 Nov 2022 12:02:17 GMT
+      ms-cv: OZecEWj/wUG0pzQyzDe8Rw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 813ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": {"sipSignalingPort": 7777}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:35 GMT
-      x-ms-return-client-request-id:
-      - 'true'
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:34 GMT
-      ms-cv: JDI+1NyHsk+dHx4EjhdlgA.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 568ms
+      x-processing-time: 284ms
     status:
       code: 200
       message: OK
@@ -162,24 +135,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:36 GMT
+      - Wed, 09 Nov 2022 12:02:18 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:35 GMT
-      ms-cv: /5DPURkkgUSdPVCss8B67Q.0
+      date: Wed, 09 Nov 2022 12:02:17 GMT
+      ms-cv: beOymINOvESa8/IRlXXDyw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 306ms
+      x-processing-time: 88ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunk_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunk_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:36 GMT
+      - Wed, 09 Nov 2022 12:02:18 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:35 GMT
-      ms-cv: X4HwEgBEGUKqVDMO86zYnw.0
+      date: Wed, 09 Nov 2022 12:02:17 GMT
+      ms-cv: pNhCWbfRAU+zU3n8eWHZAQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 378ms
+      x-processing-time: 187ms
     status:
       code: 200
       message: OK
@@ -37,117 +38,89 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:37 GMT
+      - Wed, 09 Nov 2022 12:02:19 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:37 GMT
-      ms-cv: 0WoreQhsP0Say2m0ZzwQ9g.0
+      date: Wed, 09 Nov 2022 12:02:17 GMT
+      ms-cv: y4LsOJrFCkWjaPt2T9d1vw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 224ms
+      x-processing-time: 101ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '76'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Mon, 23 May 2022 17:41:37 GMT
+      - Wed, 09 Nov 2022 12:02:19 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:37 GMT
-      ms-cv: UHZUwQc3OUCfZkQK05X9YQ.0
+      date: Wed, 09 Nov 2022 12:02:18 GMT
+      ms-cv: g5W6PShq1EOu9pWpAXY1ag.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 483ms
+      x-processing-time: 319ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}}}'
+    body: '{"trunks": {"sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      7777}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '120'
+      - '85'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-      x-ms-date:
-      - Mon, 23 May 2022 17:41:38 GMT
-      x-ms-return-client-request-id:
-      - 'true'
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:38 GMT
-      ms-cv: 27Y4uRBg70CH+YSbeZUwHw.0
+      date: Wed, 09 Nov 2022 12:02:18 GMT
+      ms-cv: sJoKmIOEVEGjwADo432fAg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 854ms
-    status:
-      code: 200
-      message: OK
-    url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-- request:
-    body: '{"trunks": {"sbs2.sipconfigtest.com": {"sipSignalingPort": 7777}}}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/merge-patch+json
-      User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
-    method: PATCH
-    uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
-  response:
-    body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
-    headers:
-      content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:39 GMT
-      ms-cv: 6+h5Zo47cUSZuJr0OhjX8Q.0
-      strict-transport-security: max-age=2592000
-      transfer-encoding: chunked
-      x-cache: CONFIG_NOCACHE
-      x-processing-time: 719ms
+      x-processing-time: 358ms
     status:
       code: 200
       message: OK
@@ -158,20 +131,21 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":7777}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Mon, 23 May 2022 17:41:39 GMT
-      ms-cv: vo9r5GGUlEWWqJqP/9O2Dw.0
+      date: Wed, 09 Nov 2022 12:02:18 GMT
+      ms-cv: OehcSvquiES7ZfsEhRValg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 222ms
+      x-processing-time: 233ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunks.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunks.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:10 GMT
+      - Wed, 09 Nov 2022 12:02:21 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:10 GMT
-      ms-cv: 40DhLCcvP0WTTDFY44NfGA.0
+      date: Wed, 09 Nov 2022 12:02:19 GMT
+      ms-cv: qt9LZV66tEu8Jpz0VVGctg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 372ms
+      x-processing-time: 106ms
     status:
       code: 200
       message: OK
@@ -37,57 +38,59 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:10 GMT
+      - Wed, 09 Nov 2022 12:02:21 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":7777}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:11 GMT
-      ms-cv: kzsm/yKy+ESBMvxrnipOJw.0
+      date: Wed, 09 Nov 2022 12:02:19 GMT
+      ms-cv: 8qptcya6mEGzeYctCRkGFw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 154ms
+      x-processing-time: 81ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}, "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123}}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '152'
+      - '158'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:11 GMT
+      - Wed, 09 Nov 2022 12:02:21 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:12 GMT
-      ms-cv: K2EKoH/EB0mJMud7G8rSqg.0
+      date: Wed, 09 Nov 2022 12:02:19 GMT
+      ms-cv: TIirbTuReUyzxEtIwqlbVA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 1296ms
+      x-processing-time: 210ms
     status:
       code: 200
       message: OK
@@ -98,57 +101,60 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:12 GMT
+      - Wed, 09 Nov 2022 12:02:21 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:12 GMT
-      ms-cv: gVba07k8r0uoQJ8PRccHaQ.0
+      date: Wed, 09 Nov 2022 12:02:19 GMT
+      ms-cv: YglFo6X4TkG7gSo4WjLVSw.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 174ms
+      x-processing-time: 85ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}, "sbs1.sipconfigtest.com":
-      null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs3.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      2222}, "sbs1.00035101e6744cde8e2dd763e44696ee.com": null, "sbs2.00035101e6744cde8e2dd763e44696ee.com":
+      null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '130'
+      - '187'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:12 GMT
+      - Wed, 09 Nov 2022 12:02:22 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:13 GMT
-      ms-cv: Xj7GFpakmka4O5moqmA2og.0
+      date: Wed, 09 Nov 2022 12:02:20 GMT
+      ms-cv: iFtY0/vz+0yTznnQR9crJQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 850ms
+      x-processing-time: 430ms
     status:
       code: 200
       message: OK
@@ -159,24 +165,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:13 GMT
+      - Wed, 09 Nov 2022 12:02:22 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:14 GMT
-      ms-cv: +UGpRBRHHEaHklk8HX1AVQ.0
+      date: Wed, 09 Nov 2022 12:02:20 GMT
+      ms-cv: GuOqWSXmakeWhc7l1C3aHg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 159ms
+      x-processing-time: 81ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunks_from_managed_identity.yaml
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.test_set_trunks_from_managed_identity.yaml
@@ -9,24 +9,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:14 GMT
+      - Wed, 09 Nov 2022 12:02:22 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:14 GMT
-      ms-cv: iDmo4wmVO06eA6E5m93LoA.0
+      date: Wed, 09 Nov 2022 12:02:21 GMT
+      ms-cv: BQCxPnKrQUC1V0b6ootG1A.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 223ms
+      x-processing-time: 121ms
     status:
       code: 200
       message: OK
@@ -37,57 +38,60 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:15 GMT
+      - Wed, 09 Nov 2022 12:02:23 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:14 GMT
-      ms-cv: GMwQXKillkOEhNqoDm82oQ.0
+      date: Wed, 09 Nov 2022 12:02:21 GMT
+      ms-cv: rT6kVipPakWES6cX/taKOg.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 164ms
+      x-processing-time: 93ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs1.sipconfigtest.com": {"sipSignalingPort": 1122}, "sbs2.sipconfigtest.com":
-      {"sipSignalingPort": 1123}, "sbs3.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs1.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      1122}, "sbs2.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort": 1123},
+      "sbs3.00035101e6744cde8e2dd763e44696ee.com": null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '152'
+      - '209'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Thu, 09 Jun 2022 08:35:15 GMT
+      - Wed, 09 Nov 2022 12:02:23 GMT
       x-ms-return-client-request-id:
       - 'true'
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:15 GMT
-      ms-cv: R6kvkTPtGke3VPqIPEY3DA.0
+      date: Wed, 09 Nov 2022 12:02:22 GMT
+      ms-cv: 9Q+b57fMWUecvrM1BO8tLA.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 963ms
+      x-processing-time: 263ms
     status:
       code: 200
       message: OK
@@ -98,49 +102,52 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs1.sipconfigtest.com":{"sipSignalingPort":1122},"sbs2.sipconfigtest.com":{"sipSignalingPort":1123}},"routes":[]}'
+      string: '{"trunks":{"sbs1.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1122},"sbs2.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":1123}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:17 GMT
-      ms-cv: aqYtZOYluEu11ml/cWOt6Q.0
+      date: Wed, 09 Nov 2022 12:02:22 GMT
+      ms-cv: YK/gwML8lUi8N8gE4RK62A.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 318ms
+      x-processing-time: 218ms
     status:
       code: 200
       message: OK
     url: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
 - request:
-    body: '{"trunks": {"sbs3.sipconfigtest.com": {"sipSignalingPort": 2222}, "sbs1.sipconfigtest.com":
-      null, "sbs2.sipconfigtest.com": null}}'
+    body: '{"trunks": {"sbs3.00035101e6744cde8e2dd763e44696ee.com": {"sipSignalingPort":
+      2222}, "sbs1.00035101e6744cde8e2dd763e44696ee.com": null, "sbs2.00035101e6744cde8e2dd763e44696ee.com":
+      null}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '130'
+      - '187'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: PATCH
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:18 GMT
-      ms-cv: xREcXDs9uk+mL2LqqG3LGg.0
+      date: Wed, 09 Nov 2022 12:02:22 GMT
+      ms-cv: km7gwZgImk6E+aGd/o/U1A.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 1266ms
+      x-processing-time: 230ms
     status:
       code: 200
       message: OK
@@ -151,20 +158,21 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+      - azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview
   response:
     body:
-      string: '{"trunks":{"sbs3.sipconfigtest.com":{"sipSignalingPort":2222}},"routes":[]}'
+      string: '{"trunks":{"sbs3.00035101e6744cde8e2dd763e44696ee.com":{"sipSignalingPort":2222}},"routes":[]}'
     headers:
+      api-supported-versions: 2021-05-01-preview, 2022-09-01-preview
       content-type: application/json; charset=utf-8
-      date: Thu, 09 Jun 2022 08:35:18 GMT
-      ms-cv: y9AQR8XOiEyTZgvyobowvg.0
+      date: Wed, 09 Nov 2022 12:02:23 GMT
+      ms-cv: MTmtHLRX7EyQznjxcfM1NQ.0
       strict-transport-security: max-age=2592000
       transfer-encoding: chunked
       x-cache: CONFIG_NOCACHE
-      x-processing-time: 272ms
+      x-processing-time: 77ms
     status:
       code: 200
       message: OK

--- a/sdk/communication/azure-communication-phonenumbers/test/sip_routing_helper.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/sip_routing_helper.py
@@ -1,0 +1,41 @@
+# ------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+import uuid
+
+def get_randomised_domain():
+    return "." + uuid.uuid4().hex + ".com"
+
+def get_trunk_with_actual_domain(trunk_fqdn, actual_trunk_fqdn):
+    actual_domain = actual_trunk_fqdn.split(".",1)[1]
+    return trunk_fqdn[0:5] + actual_domain
+
+def trunks_are_equal(response_trunks, request_trunks):
+    assert len(response_trunks) == len(request_trunks), "Length of trunk list doesn't match."
+
+    for k in range(len(request_trunks)):
+        assert _compare_fqdns_domain_agnostic(response_trunks[k].fqdn, request_trunks[k].fqdn), "Trunk FQDNs don't match."
+        assert (
+            response_trunks[k].sip_signaling_port==request_trunks[k].sip_signaling_port
+        ), "SIP signaling ports don't match."
+
+def routes_are_equal(response_routes, request_routes):
+    assert len(response_routes) == len(request_routes)
+
+    for k in range(len(request_routes)):
+        assert request_routes[k].name == response_routes[k].name, "Names don't match."
+        assert request_routes[k].description == response_routes[k].description, "Descriptions don't match."
+        assert (
+            request_routes[k].number_pattern == response_routes[k].number_pattern
+        ), "Number patterns don't match."
+        assert len(request_routes[k].trunks) == len(response_routes[k].trunks), "Trunk lists length doesn't match."
+        for m in range(len(request_routes[k].trunks)):
+            assert _compare_fqdns_domain_agnostic(request_routes[k].trunks[m], response_routes[k].trunks[m]) , "Trunk lists don't match."
+
+def _compare_fqdns_domain_agnostic(trunk1_fqdn, trunk2_fqdn):
+    trunk1_fqdn_no_domain = trunk1_fqdn.split(".",)[0]
+    trunk2_fqdn_no_domain = trunk2_fqdn.split(".",)[0]
+    return trunk1_fqdn_no_domain == trunk2_fqdn_no_domain

--- a/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e.py
@@ -7,14 +7,18 @@
 from _shared.testcase import CommunicationTestCase
 from _shared.helper import URIReplacerProcessor
 from _shared.utils import create_token_credential, get_http_logging_policy
+from sip_routing_helper import get_randomised_domain, get_trunk_with_actual_domain, trunks_are_equal, routes_are_equal
 
 from azure.communication.phonenumbers.siprouting import SipRoutingClient, SipTrunk, SipTrunkRoute
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 
 class TestSipRoutingClientE2E(CommunicationTestCase):
-    TRUNKS = [SipTrunk(fqdn="sbs1.sipconfigtest.com", sip_signaling_port=1122), SipTrunk(fqdn="sbs2.sipconfigtest.com", sip_signaling_port=1123)]
-    ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\\+123[0-9]+", trunks=["sbs1.sipconfigtest.com"])]
-
+    # Tests have to use randomised domain, because of domain name collision check on BE. It returns errror, if trunk domain is already used with any other ACS resource.
+    randomisedDomain = get_randomised_domain()
+    additionalTrunkFqdn = "sbs3" + randomisedDomain
+    TRUNKS = [SipTrunk(fqdn="sbs1" + randomisedDomain, sip_signaling_port=1122), SipTrunk(fqdn="sbs2" + randomisedDomain, sip_signaling_port=1123)]
+    ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\\+123[0-9]+", trunks=["sbs1" + randomisedDomain])]
+    
     def __init__(self, method_name):
         super(TestSipRoutingClientE2E, self).__init__(method_name)
         
@@ -32,98 +36,102 @@ class TestSipRoutingClientE2E(CommunicationTestCase):
         client = self._get_sip_client_managed_identity()
         trunks = client.get_trunks()
         assert trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(trunks,self.TRUNKS)
+        trunks_are_equal(trunks,self.TRUNKS)
 
     def test_get_trunks(self):
         trunks = self._sip_routing_client.get_trunks()
         assert trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(trunks,self.TRUNKS)
+        trunks_are_equal(trunks,self.TRUNKS)
 
     def test_get_trunks_from_managed_identity(self):
         client = self._get_sip_client_managed_identity()
         trunks = client.get_trunks()
         assert trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(trunks,self.TRUNKS)
+        trunks_are_equal(trunks,self.TRUNKS)
 
     def test_get_routes(self):
         self._sip_routing_client.set_routes(self.ROUTES)
         routes = self._sip_routing_client.get_routes()
         assert routes is not None, "No routes were returned."
-        self._routes_are_equal(routes,self.ROUTES)
+        routes_are_equal(routes,self.ROUTES)
 
     def test_get_routes_from_managed_identity(self):
         client = self._get_sip_client_managed_identity()
         client.set_routes(self.ROUTES)
         routes = client.get_routes()
         assert routes is not None, "No routes were returned."
-        self._routes_are_equal(routes,self.ROUTES)
+        routes_are_equal(routes,self.ROUTES)
 
     def test_set_trunks(self):
-        new_trunks = [SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)]
+        new_trunks = [SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)]
         self._sip_routing_client.set_trunks(new_trunks)
         result_trunks = self._sip_routing_client.get_trunks()
         assert result_trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(result_trunks,new_trunks)
+        trunks_are_equal(result_trunks,new_trunks)
 
     def test_set_trunks_from_managed_identity(self):
-        new_trunks = [SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)]
+        new_trunks = [SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)]
         client = self._get_sip_client_managed_identity()
         client.set_trunks(new_trunks)
         result_trunks = client.get_trunks()
         assert result_trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(result_trunks,new_trunks)
+        trunks_are_equal(result_trunks,new_trunks)
 
     def test_set_routes(self):
-        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=["sbs2.sipconfigtest.com"])]
+        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=[self.TRUNKS[1].fqdn])]
         self._sip_routing_client.set_routes(self.ROUTES)
         self._sip_routing_client.set_routes(new_routes)
         result_routes = self._sip_routing_client.get_routes()
         assert result_routes is not None, "No routes were returned."
-        self._routes_are_equal(result_routes,new_routes)
+        routes_are_equal(result_routes,new_routes)
 
     def test_set_routes_from_managed_identity(self):
-        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=["sbs2.sipconfigtest.com"])]
+        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=[self.TRUNKS[1].fqdn])]
         client = self._get_sip_client_managed_identity()
         client.set_routes(self.ROUTES)
         client.set_routes(new_routes)
         result_routes = client.get_routes()
         assert result_routes is not None, "No routes were returned."
-        self._routes_are_equal(result_routes,new_routes)
+        routes_are_equal(result_routes,new_routes)
 
     def test_delete_trunk(self):
         trunk_to_delete = self.TRUNKS[1].fqdn
         self._sip_routing_client.delete_trunk(trunk_to_delete)
         new_trunks = self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0]])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0]])
 
     def test_delete_trunk_from_managed_identity(self):
         trunk_to_delete = self.TRUNKS[1].fqdn
         client = self._get_sip_client_managed_identity()
         client.delete_trunk(trunk_to_delete)
         new_trunks = client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0]])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0]])
 
     def test_add_trunk(self):
-        new_trunk = SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)
+        new_trunk = SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)
         self._sip_routing_client.set_trunk(new_trunk)
         new_trunks = self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
 
     def test_add_trunk_from_managed_identity(self):
-        new_trunk = SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)
+        new_trunk = SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)
         client = self._get_sip_client_managed_identity()
         client.set_trunk(new_trunk)
         new_trunks = client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
 
     def test_get_trunk(self):
-        trunk = self._sip_routing_client.get_trunk(self.TRUNKS[0].fqdn)
+        actual_trunks = self._sip_routing_client.get_trunks()
+        trunk_actual_domain = get_trunk_with_actual_domain(self.TRUNKS[0].fqdn, actual_trunks[0].fqdn)
+        trunk = self._sip_routing_client.get_trunk(trunk_actual_domain)
         assert trunk is not None, "No trunk was returned."
         trunk == self.TRUNKS[0]
 
     def test_get_trunk_from_managed_identity(self):
         client = self._get_sip_client_managed_identity()
-        trunk = client.get_trunk(self.TRUNKS[0].fqdn)
+        actual_trunks = client.get_trunks()
+        trunk_actual_domain = get_trunk_with_actual_domain(self.TRUNKS[0].fqdn, actual_trunks[0].fqdn)
+        trunk = client.get_trunk(trunk_actual_domain)
         assert trunk is not None, "No trunk was returned."
         trunk == self.TRUNKS[0]
 
@@ -131,36 +139,16 @@ class TestSipRoutingClientE2E(CommunicationTestCase):
         modified_trunk = SipTrunk(fqdn=self.TRUNKS[1].fqdn,sip_signaling_port=7777)
         self._sip_routing_client.set_trunk(modified_trunk)
         new_trunks = self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
     
     def test_set_trunk_from_managed_identity(self):
         modified_trunk = SipTrunk(fqdn=self.TRUNKS[1].fqdn,sip_signaling_port=7777)
         client = self._get_sip_client_managed_identity()
         client.set_trunk(modified_trunk)
         new_trunks = client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
 
     def _get_sip_client_managed_identity(self):
         endpoint, accesskey = parse_connection_str(self.connection_str)
         credential = create_token_credential()
         return SipRoutingClient(endpoint, credential)
-
-    def _trunks_are_equal(self, response_trunks, request_trunks):
-        assert len(response_trunks) == len(request_trunks), "Trunks have different length."
-
-        for k in range(len(request_trunks)):
-            assert response_trunks[k].fqdn==request_trunks[k].fqdn, "Trunk FQDNs don't match."
-            assert (
-                response_trunks[k].sip_signaling_port==request_trunks[k].sip_signaling_port
-            ), "SIP signaling ports don't match."
-
-    def _routes_are_equal(self, response_routes, request_routes):
-        assert len(response_routes) == len(request_routes)
-
-        for k in range(len(request_routes)):
-            assert request_routes[k].name == response_routes[k].name, "Names don't match."
-            assert request_routes[k].description == response_routes[k].description, "Descriptions don't match."
-            assert (
-                request_routes[k].number_pattern == response_routes[k].number_pattern
-            ), "Number patterns don't match."
-            assert request_routes[k].trunks == response_routes[k].trunks, "Trunk lists don't match."

--- a/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
@@ -4,11 +4,10 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import asyncio
-
 from _shared.asynctestcase import AsyncCommunicationTestCase
 from _shared.helper import URIReplacerProcessor
 from _shared.utils import async_create_token_credential, get_http_logging_policy
+from sip_routing_helper import get_randomised_domain, get_trunk_with_actual_domain, trunks_are_equal, routes_are_equal
 
 from azure.communication.phonenumbers.siprouting.aio import SipRoutingClient
 from azure.communication.phonenumbers.siprouting._generated.models import SipTrunkRoute
@@ -16,185 +15,185 @@ from azure.communication.phonenumbers.siprouting._models import SipTrunk
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 
 class TestSipRoutingClientE2EAsync(AsyncCommunicationTestCase):
-    TRUNKS = [SipTrunk(fqdn="sbs1.sipconfigtest.com", sip_signaling_port=1122), SipTrunk(fqdn="sbs2.sipconfigtest.com", sip_signaling_port=1123)]
-    ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\\+123[0-9]+", trunks=["sbs1.sipconfigtest.com"])]
+    # Tests have to use randomised domain, because of domain name collision check on BE. It returns errror, if trunk domain is already used with any other ACS resource.
+    randomisedDomain = get_randomised_domain()
+    additionalTrunkFqdn = "sbs3" + randomisedDomain
+    TRUNKS = [SipTrunk(fqdn="sbs1" + randomisedDomain, sip_signaling_port=1122), SipTrunk(fqdn="sbs2" + randomisedDomain, sip_signaling_port=1123)]
+    ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\\+123[0-9]+", trunks=["sbs1" + randomisedDomain])]
 
     def __init__(self, method_name):
         super(TestSipRoutingClientE2EAsync, self).__init__(method_name)
         
     def setUp(self):
         super(TestSipRoutingClientE2EAsync, self).setUp()
-
         self._sip_routing_client = SipRoutingClient.from_connection_string(
             self.connection_str, http_logging_policy=get_http_logging_policy()
         )
         self.recording_processors.extend([URIReplacerProcessor()])
-        loop = asyncio.get_event_loop()
-        coroutine = self._sip_routing_client.set_routes([])
-        loop.run_until_complete(coroutine)
-        loop = asyncio.get_event_loop()
-        coroutine = self._sip_routing_client.set_trunks(self.TRUNKS)
-        loop.run_until_complete(coroutine)
+
+    async def _prepare_test(self):
+        await self._sip_routing_client.set_routes([])
+        await self._sip_routing_client.set_trunks(self.TRUNKS)
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_get_trunks(self):
+        await self._prepare_test()
         async with self._sip_routing_client:
             trunks = await self._sip_routing_client.get_trunks()
         assert trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(trunks,self.TRUNKS), "Trunks are not equal."
+        trunks_are_equal(trunks,self.TRUNKS), "Trunks are not equal."
     
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_get_trunks_from_managed_identity(self):
+        await self._prepare_test()
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             trunks = await self._sip_routing_client.get_trunks()
         assert trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(trunks,self.TRUNKS), "Trunks are not equal."
+        trunks_are_equal(trunks,self.TRUNKS), "Trunks are not equal."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_get_routes(self):
+        await self._prepare_test()
         async with self._sip_routing_client:
             await self._sip_routing_client.set_routes(self.ROUTES)
             routes = await self._sip_routing_client.get_routes()
         assert routes is not None, "No routes were returned."
-        self._routes_are_equal(routes,self.ROUTES), "Routes are not equal."
+        routes_are_equal(routes,self.ROUTES), "Routes are not equal."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_get_routes_from_managed_identity(self):
+        await self._prepare_test()
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             await self._sip_routing_client.set_routes(self.ROUTES)
             routes = await self._sip_routing_client.get_routes()
         assert routes is not None, "No routes were returned."
-        self._routes_are_equal(routes,self.ROUTES), "Routes are not equal."
+        routes_are_equal(routes,self.ROUTES), "Routes are not equal."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_set_trunks(self):
-        new_trunks = [SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)]
+        await self._prepare_test()
+        new_trunks = [SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)]
         async with self._sip_routing_client:
             await self._sip_routing_client.set_trunks(new_trunks)
             result_trunks = await self._sip_routing_client.get_trunks()
         assert result_trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(result_trunks,new_trunks), "Trunks are not equal."
+        trunks_are_equal(result_trunks,new_trunks), "Trunks are not equal."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_set_trunks_from_managed_identity(self):
-        new_trunks = [SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)]
+        await self._prepare_test()
+        new_trunks = [SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)]
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             await self._sip_routing_client.set_trunks(new_trunks)
             result_trunks = await self._sip_routing_client.get_trunks()
         assert result_trunks is not None, "No trunks were returned."
-        self._trunks_are_equal(result_trunks,new_trunks), "Trunks are not equal."
+        trunks_are_equal(result_trunks,new_trunks), "Trunks are not equal."
     
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_set_routes(self):
-        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=["sbs2.sipconfigtest.com"])]
+        await self._prepare_test()
+        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=[self.TRUNKS[1].fqdn])]
         async with self._sip_routing_client:
             await self._sip_routing_client.set_routes(self.ROUTES)
             await self._sip_routing_client.set_routes(new_routes)
             result_routes = await self._sip_routing_client.get_routes()
         assert result_routes is not None, "No routes were returned."
-        self._routes_are_equal(result_routes,new_routes), "Routes are not equal."
+        routes_are_equal(result_routes,new_routes), "Routes are not equal."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_set_routes_from_managed_identity(self):
-        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=["sbs2.sipconfigtest.com"])]
+        await self._prepare_test()
+        new_routes = [SipTrunkRoute(name="Alternative rule", description="Handle numbers starting with '+999'", number_pattern="\\+999[0-9]+", trunks=[self.TRUNKS[1].fqdn])]
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             await self._sip_routing_client.set_routes(self.ROUTES)
             await self._sip_routing_client.set_routes(new_routes)
             result_routes = await self._sip_routing_client.get_routes()
         assert result_routes is not None, "No routes were returned."
-        self._routes_are_equal(result_routes,new_routes), "Routes are not equal."
+        routes_are_equal(result_routes,new_routes), "Routes are not equal."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_delete_trunk(self):
+        await self._prepare_test()
         trunk_to_delete = self.TRUNKS[1].fqdn
         async with self._sip_routing_client:
             await self._sip_routing_client.delete_trunk(trunk_to_delete)
             new_trunks = await self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0]]), "Trunk was not deleted."
+        trunks_are_equal(new_trunks,[self.TRUNKS[0]]), "Trunk was not deleted."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_delete_trunk_from_managed_identity(self):
+        await self._prepare_test()
         trunk_to_delete = self.TRUNKS[1].fqdn
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             await self._sip_routing_client.delete_trunk(trunk_to_delete)
             new_trunks = await self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0]]), "Trunk was not deleted."
+        trunks_are_equal(new_trunks,[self.TRUNKS[0]]), "Trunk was not deleted."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_add_trunk(self):
-        new_trunk = SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)
+        await self._prepare_test()
+        new_trunk = SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)
         async with self._sip_routing_client:
             await self._sip_routing_client.set_trunk(new_trunk)
             new_trunks = await self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
     
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_add_trunk_from_managed_identity(self):
-        new_trunk = SipTrunk(fqdn="sbs3.sipconfigtest.com", sip_signaling_port=2222)
+        await self._prepare_test()
+        new_trunk = SipTrunk(fqdn=self.additionalTrunkFqdn, sip_signaling_port=2222)
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             await self._sip_routing_client.set_trunk(new_trunk)
             new_trunks = await self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
-    
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],self.TRUNKS[1],new_trunk])
+
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_get_trunk(self):
+        await self._prepare_test()
         async with self._sip_routing_client:
-            trunk = await self._sip_routing_client.get_trunk(self.TRUNKS[0].fqdn)
+            actual_trunks = await self._sip_routing_client.get_trunks()
+            trunk_actual_domain = get_trunk_with_actual_domain(self.TRUNKS[0].fqdn, actual_trunks[0].fqdn)
+            trunk = await self._sip_routing_client.get_trunk(trunk_actual_domain)
         assert trunk is not None, "No trunk was returned."
-        self._trunks_are_equal([trunk],[self.TRUNKS[0]]), "Returned trunk does not match the required trunk."
+        trunks_are_equal([trunk],[self.TRUNKS[0]]), "Returned trunk does not match the required trunk."
 
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_get_trunk_from_managed_identity(self):
+        await self._prepare_test()
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
-            trunk = await self._sip_routing_client.get_trunk(self.TRUNKS[0].fqdn)
+            actual_trunks = await self._sip_routing_client.get_trunks()
+            trunk_actual_domain = get_trunk_with_actual_domain(self.TRUNKS[0].fqdn, actual_trunks[0].fqdn)
+            trunk = await self._sip_routing_client.get_trunk(trunk_actual_domain)
         assert trunk is not None, "No trunk was returned."
-        self._trunks_are_equal([trunk],[self.TRUNKS[0]]), "Returned trunk does not match the required trunk."
-
+        trunks_are_equal([trunk],[self.TRUNKS[0]]), "Returned trunk does not match the required trunk."
+        
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_set_trunk(self):
+        await self._prepare_test()
         modified_trunk = SipTrunk(fqdn=self.TRUNKS[1].fqdn,sip_signaling_port=7777)
         async with self._sip_routing_client:
             await self._sip_routing_client.set_trunk(modified_trunk)
             new_trunks = await self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
     
     @AsyncCommunicationTestCase.await_prepared_test
     async def test_set_trunk_from_managed_identity(self):
+        await self._prepare_test()
         modified_trunk = SipTrunk(fqdn=self.TRUNKS[1].fqdn,sip_signaling_port=7777)
         self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             await self._sip_routing_client.set_trunk(modified_trunk)
             new_trunks = await self._sip_routing_client.get_trunks()
-        self._trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
+        trunks_are_equal(new_trunks,[self.TRUNKS[0],modified_trunk])
 
     def _get_sip_client_managed_identity(self):
         endpoint, accesskey = parse_connection_str(self.connection_str)
         credential = async_create_token_credential()
         return SipRoutingClient(endpoint, credential, http_logging_policy=get_http_logging_policy())
-
-    def _trunks_are_equal(self, response_trunks, request_trunks):
-        assert len(response_trunks) == len(request_trunks)
-
-        for k in range(len(request_trunks)):
-            assert response_trunks[k].fqdn==request_trunks[k].fqdn, "Trunk FQDNs don't match."
-            assert (
-                response_trunks[k].sip_signaling_port==request_trunks[k].sip_signaling_port
-            ), "SIP signaling ports don't match."
-
-    def _routes_are_equal(self, response_routes, request_routes):
-        assert len(response_routes) == len(request_routes)
-
-        for k in range(len(request_routes)):
-            assert request_routes[k].name == response_routes[k].name, "Names don't match."
-            assert request_routes[k].description == response_routes[k].description, "Descriptions don't match."
-            assert (
-                request_routes[k].number_pattern == response_routes[k].number_pattern
-            ), "Number patterns don't match."
-            assert request_routes[k].trunks == response_routes[k].trunks, "Trunk lists don't match."


### PR DESCRIPTION
# Description

This PR aims to fix failing live tests for communication-phone-numbers-siprouting on one of the pipelines.
The problem is with the test data, because tests use hardcoded domain names and with those we're seeing "Domain name collision" error, meaning the domain is already used on another resource.
The validation rules on BE don't allow to register fqdns with same domain on multiple ACS resources, thus returning error.

To counter this issue, our tests have been modified to use each time a randomly generated domain name (UUID in hex format).

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
