### PR TITLE
[EventHubs] update sync receive client ready flow

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -198,10 +198,12 @@ class EventHubConsumer(
             )
             self._handler = cast("ReceiveClient", self._handler)
             self._handler.open(connection=conn)
-            while not self._handler.client_ready():
-                time.sleep(0.05)
-            self.handler_ready = True
+            self.handler_ready = False
             self.running = True
+        
+        if not self.handler_ready:
+            if self._handler.client_ready():
+                self.handler_ready = True
 
         return self.handler_ready
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -200,9 +200,9 @@ class EventHubConsumer(
             self._handler.open(connection=conn)
             self.handler_ready = False
             self.running = True
-        
+
         if not self.handler_ready:
-            if self._handler.client_ready():
+            if self._handler.client_ready():    # type: ignore
                 self.handler_ready = True
 
         return self.handler_ready

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_reconnect.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_reconnect.py
@@ -153,7 +153,8 @@ def test_receive_connection_idle_timeout_and_reconnect_sync(connstr_senders, uam
     with client:
         consumer = client._create_consumer("$default", "0", "-1", on_event_received)
         with consumer:
-            consumer._open()
+            while not consumer.handler_ready:
+                consumer._open()
             time.sleep(11)
 
             ed = EventData("Event")


### PR DESCRIPTION
When reading from 32 partitions, the sync consumers were taking a long time to connect, b/c the client ready check was happening in a while loop. Each consumer was blocking while checking that the client was ready. Overall, this resulted in very slow connection times for the consumer client.

This is updating the consumers so that the client ready check is no longer blocking.