### PR TITLE
[EventHubs] check for any non-None values in amqp header/properties

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
@@ -83,7 +83,9 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         :rtype: pyamqp.Message
         """
         message_header = None
-        if annotated_message.header and annotated_message.header._any():    # pylint: disable=protected-access
+        header_vals = annotated_message.header.values() if annotated_message.header else None
+        # If header and non-None header values, create outgoing header.
+        if annotated_message.header and header_vals.count(None) != len(header_vals):
             message_header = Header(
                 delivery_count=annotated_message.header.delivery_count,
                 ttl=annotated_message.header.time_to_live,
@@ -93,7 +95,9 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
             )
 
         message_properties = None
-        if annotated_message.properties and annotated_message.properties._any():    # pylint: disable=protected-access
+        properties_vals = annotated_message.properties.values() if annotated_message.properties else None
+        # If properties and non-None properties values, create outgoing properties.
+        if annotated_message.properties and properties_vals.count(None) != len(properties_vals):
             message_properties = Properties(
                 message_id=annotated_message.properties.message_id,
                 user_id=annotated_message.properties.user_id,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
@@ -83,7 +83,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         :rtype: pyamqp.Message
         """
         message_header = None
-        if annotated_message.header and any(annotated_message.header.values()):
+        if annotated_message.header and annotated_message.header._any():    # pylint: disable=protected-access
             message_header = Header(
                 delivery_count=annotated_message.header.delivery_count,
                 ttl=annotated_message.header.time_to_live,
@@ -93,7 +93,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
             )
 
         message_properties = None
-        if annotated_message.properties and any(annotated_message.properties.values()):
+        if annotated_message.properties and annotated_message.properties._any():    # pylint: disable=protected-access
             message_properties = Properties(
                 message_id=annotated_message.properties.message_id,
                 user_id=annotated_message.properties.user_id,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_uamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_uamqp_transport.py
@@ -124,7 +124,9 @@ if uamqp_installed:
             :rtype: uamqp.Message
             """
             message_header = None
-            if annotated_message.header and annotated_message.header._any():    # pylint: disable=protected-access
+            header_vals = annotated_message.header.values() if annotated_message.header else None
+            # If header and non-None header values, create outgoing header.
+            if annotated_message.header and header_vals.count(None) != len(header_vals):
                 message_header = MessageHeader()
                 message_header.delivery_count = annotated_message.header.delivery_count
                 message_header.time_to_live = annotated_message.header.time_to_live
@@ -133,7 +135,9 @@ if uamqp_installed:
                 message_header.priority = annotated_message.header.priority
 
             message_properties = None
-            if annotated_message.properties and annotated_message.properties._any():    # pylint: disable=protected-access
+            properties_vals = annotated_message.properties.values() if annotated_message.properties else None
+            # If properties and non-None properties values, create outgoing properties.
+            if annotated_message.properties and properties_vals.count(None) != len(properties_vals):
                 message_properties = MessageProperties(
                     message_id=annotated_message.properties.message_id,
                     user_id=annotated_message.properties.user_id,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_uamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_uamqp_transport.py
@@ -124,7 +124,7 @@ if uamqp_installed:
             :rtype: uamqp.Message
             """
             message_header = None
-            if annotated_message.header and any(annotated_message.header.values()):
+            if annotated_message.header and annotated_message.header._any():    # pylint: disable=protected-access
                 message_header = MessageHeader()
                 message_header.delivery_count = annotated_message.header.delivery_count
                 message_header.time_to_live = annotated_message.header.time_to_live
@@ -133,7 +133,7 @@ if uamqp_installed:
                 message_header.priority = annotated_message.header.priority
 
             message_properties = None
-            if annotated_message.properties and any(annotated_message.properties.values()):
+            if annotated_message.properties and annotated_message.properties._any():    # pylint: disable=protected-access
                 message_properties = MessageProperties(
                     message_id=annotated_message.properties.message_id,
                     user_id=annotated_message.properties.user_id,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/amqp/_amqp_message.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/amqp/_amqp_message.py
@@ -346,6 +346,12 @@ class AmqpMessageHeader(DictMixin):
         self.durable = kwargs.get("durable")
         self.priority = kwargs.get("priority")
 
+    def _any(self):
+        # Returns True for values 0, False, "", etc. unlike any()
+        for val in self.values():
+            if val is not None:
+                return True
+        return False
 
 class AmqpMessageProperties(DictMixin):
     # pylint: disable=too-many-instance-attributes
@@ -437,3 +443,10 @@ class AmqpMessageProperties(DictMixin):
         self.group_id = kwargs.get("group_id")
         self.group_sequence = kwargs.get("group_sequence")
         self.reply_to_group_id = kwargs.get("reply_to_group_id")
+
+    def _any(self):
+        # Returns True for values 0, False, "", etc. unlike any()
+        for val in self.values():
+            if val is not None:
+                return True
+        return False

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/amqp/_amqp_message.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/amqp/_amqp_message.py
@@ -346,12 +346,6 @@ class AmqpMessageHeader(DictMixin):
         self.durable = kwargs.get("durable")
         self.priority = kwargs.get("priority")
 
-    def _any(self):
-        # Returns True for values 0, False, "", etc. unlike any()
-        for val in self.values():
-            if val is not None:
-                return True
-        return False
 
 class AmqpMessageProperties(DictMixin):
     # pylint: disable=too-many-instance-attributes
@@ -443,10 +437,3 @@ class AmqpMessageProperties(DictMixin):
         self.group_id = kwargs.get("group_id")
         self.group_sequence = kwargs.get("group_sequence")
         self.reply_to_group_id = kwargs.get("reply_to_group_id")
-
-    def _any(self):
-        # Returns True for values 0, False, "", etc. unlike any()
-        for val in self.values():
-            if val is not None:
-                return True
-        return False

--- a/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
+++ b/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
@@ -173,21 +173,37 @@ def test_amqp_message_str_repr():
     assert str(message) == 'A'
     assert 'AmqpAnnotatedMessage(body=A, body_type=data' in repr(message)
 
-def test_amqp_message_header_properties_any():
-    header = AmqpMessageHeader()
-    header.first_acquirer = False
-    properties = AmqpMessageProperties()
-    properties.creation_time = 0
+def test_outgoing_amqp_message_header_properties(uamqp_transport):
+    if uamqp_transport:
+        amqp_transport = UamqpTransport
+    else:
+        amqp_transport = PyamqpTransport
+    ann_message = AmqpAnnotatedMessage(data_body=b'A')
+    ann_message.header = AmqpMessageHeader()
+    ann_message.properties = AmqpMessageProperties()
+    amqp_message = amqp_transport.to_outgoing_amqp_message(ann_message)
 
-    assert header._any()
-    assert properties._any()
+    assert not amqp_message.header
+    assert not amqp_message.properties
 
-    header = AmqpMessageHeader()
-    properties = AmqpMessageProperties()
-    properties.message_id = ""
+    ann_message = AmqpAnnotatedMessage(data_body=b'A')
+    ann_message.header = AmqpMessageHeader()
+    ann_message.properties = AmqpMessageProperties()
+    ann_message.header.first_acquirer = False
+    ann_message.properties.creation_time = 0
+    amqp_message = amqp_transport.to_outgoing_amqp_message(ann_message)
 
-    assert not header._any()
-    assert properties
+    assert amqp_message.header
+    assert amqp_message.properties
+
+    ann_message = AmqpAnnotatedMessage(data_body=b'A')
+    ann_message.header = AmqpMessageHeader()
+    ann_message.properties = AmqpMessageProperties()
+    ann_message.properties.message_id = ""
+    amqp_message = amqp_transport.to_outgoing_amqp_message(ann_message)
+
+    assert not amqp_message.header
+    assert amqp_message.properties
 
 
 def test_amqp_message_from_message(uamqp_transport):

--- a/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
+++ b/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
@@ -173,6 +173,22 @@ def test_amqp_message_str_repr():
     assert str(message) == 'A'
     assert 'AmqpAnnotatedMessage(body=A, body_type=data' in repr(message)
 
+def test_amqp_message_header_properties_any():
+    header = AmqpMessageHeader()
+    header.first_acquirer = False
+    properties = AmqpMessageProperties()
+    properties.creation_time = 0
+
+    assert header._any()
+    assert properties._any()
+
+    header = AmqpMessageHeader()
+    properties = AmqpMessageProperties()
+    properties.message_id = ""
+
+    assert not header._any()
+    assert properties
+
 
 def test_amqp_message_from_message(uamqp_transport):
     if uamqp_transport:


### PR DESCRIPTION
In [[this line](https://github.com/Azure/azure-sdk-for-python/blob/3711eeb4269214caf70c4f8b034042a9b4b13385/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_uamqp_transport.py#L127)], we use `any()` to check if the AmqpAnnotatedMessage.header has any values set. However, 0/False/"" are falsy values and therefore not detected as values by any().

Adding check of the `len(header/properties.values()` against `values.count(None)` to check that non-None values are detected as values.