### PR TITLE
[Draft] Adding optional decimal kwarg to `serialize_iso()` 

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
@@ -1114,9 +1114,11 @@ class Serializer(object):
         """Serialize Datetime object into ISO-8601 formatted string.
 
         :param Datetime attr: Object to be serialized.
+        :keyword str decimals: Number of decimal places to truncate to.
         :rtype: str
         :raises: SerializationError if format invalid.
         """
+        decimals = kwargs.pop('decimals', 6)
         if isinstance(attr, str):
             attr = isodate.parse_datetime(attr)
         try:
@@ -1126,7 +1128,7 @@ class Serializer(object):
             if utc.tm_year > 9999 or utc.tm_year < 1:
                 raise OverflowError("Hit max or min date")
 
-            microseconds = str(attr.microsecond).rjust(6, "0").rstrip("0").ljust(3, "0")
+            microseconds = str(attr.microsecond).rjust(decimals, "0").rstrip("0").ljust(3, "0")
             if microseconds:
                 microseconds = "." + microseconds
             date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
@@ -1118,7 +1118,7 @@ class Serializer(object):
         :rtype: str
         :raises: SerializationError if format invalid.
         """
-        decimals = kwargs.pop('decimals', 6)
+        decimals = kwargs.pop('decimals', 3)
         if isinstance(attr, str):
             attr = isodate.parse_datetime(attr)
         try:
@@ -1128,7 +1128,7 @@ class Serializer(object):
             if utc.tm_year > 9999 or utc.tm_year < 1:
                 raise OverflowError("Hit max or min date")
 
-            microseconds = str(attr.microsecond).rjust(decimals, "0").rstrip("0").ljust(3, "0")
+            microseconds = str(attr.microsecond).rjust(6, "0").rstrip("0").ljust(decimals, "0")
             if microseconds:
                 microseconds = "." + microseconds
             date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
@@ -1114,7 +1114,7 @@ class Serializer(object):
         """Serialize Datetime object into ISO-8601 formatted string.
 
         :param Datetime attr: Object to be serialized.
-        :keyword str decimals: Number of decimal places to truncate to.
+        :keyword int decimals: Number of decimal places to truncate to.
         :rtype: str
         :raises: SerializationError if format invalid.
         """

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 from datetime import datetime, timedelta
+from ._generated._serialization import serialize_iso
 
 _ERROR_TOO_MANY_FILE_PERMISSIONS = 'file_permission and file_permission_key should not be set at the same time'
 _FILE_PERMISSION_TOO_LONG = 'Size of file_permission is too large. file_permission should be <=8KB, else' \
@@ -41,4 +42,4 @@ def _parse_datetime_from_str(string_datetime):
 def _datetime_to_str(datetime_obj):
     if not datetime_obj:
         return None
-    return datetime_obj if isinstance(datetime_obj, str) else datetime_obj.isoformat() + '0Z'
+    return datetime_obj if isinstance(datetime_obj, str) else serialize_iso(datetime_obj, 7)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 
 from datetime import datetime, timedelta
-from ._generated._serialization import serialize_iso
+from ._generated._serialization import Serializer
 
 _ERROR_TOO_MANY_FILE_PERMISSIONS = 'file_permission and file_permission_key should not be set at the same time'
 _FILE_PERMISSION_TOO_LONG = 'Size of file_permission is too large. file_permission should be <=8KB, else' \
@@ -42,4 +42,4 @@ def _parse_datetime_from_str(string_datetime):
 def _datetime_to_str(datetime_obj):
     if not datetime_obj:
         return None
-    return datetime_obj if isinstance(datetime_obj, str) else serialize_iso(datetime_obj, 7)
+    return datetime_obj if isinstance(datetime_obj, str) else Serializer.serialize_iso(datetime_obj, decimals=7)


### PR DESCRIPTION
This draft PR is to test whether adding a optional `decimal` kwarg to `serialize_iso()` has no intended side effects and can be a plausible fix (which will ultimately be a swagger code change).