### PR TITLE
[ML][Pipelines] Add private preview flag for unexposed fields in schema

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/settings.py
@@ -8,6 +8,7 @@ from marshmallow import INCLUDE, Schema, fields, post_dump, post_load
 
 from azure.ai.ml._schema.core.fields import ArmStr
 from azure.ai.ml._schema.pipeline.pipeline_component import NodeNameStr
+from azure.ai.ml._utils.utils import is_private_preview_enabled
 from azure.ai.ml.constants._common import AzureMLResourceType
 
 
@@ -19,8 +20,11 @@ class PipelineJobSettingsSchema(Schema):
     default_compute = ArmStr(azureml_type=AzureMLResourceType.COMPUTE)
     continue_on_step_failure = fields.Bool()
     force_rerun = fields.Bool()
-    on_init = NodeNameStr()
-    on_finalize = NodeNameStr()
+
+    # move init/finalize under private preview flag to hide them in spec
+    if is_private_preview_enabled():
+        on_init = NodeNameStr()
+        on_finalize = NodeNameStr()
 
     @post_load
     def make(self, data, **kwargs) -> "PipelineJobSettings":


### PR DESCRIPTION
# Description

Add private preview flag for `on_init` and `on_finalize` in pipeline settings' schema to hide them in YAML spec.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
