### PR TITLE
[ML][Pipelines] Fix validation bug for init/finalize

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -15,6 +15,7 @@ from azure.ai.ml._restclient.v2022_05_01.models import ComponentContainerData, C
 from azure.ai.ml.constants._common import (
     AZUREML_PRIVATE_FEATURES_ENV_VAR,
     AZUREML_RESOURCE_PROVIDER,
+    InputOutputModes,
     NAMED_RESOURCE_ID_FORMAT,
     VERSIONED_RESOURCE_ID_FORMAT,
     AssetTypes,
@@ -26,7 +27,7 @@ from azure.ai.ml.entities import (
     JobResourceConfiguration,
     PipelineJob,
 )
-from azure.ai.ml.entities._builders import Command
+from azure.ai.ml.entities._builders import Command, Spark
 from azure.ai.ml.entities._job.pipeline._io import PipelineInput
 from azure.ai.ml.entities._job.pipeline._load_component import _generate_component_function
 from azure.ai.ml.exceptions import UserErrorException, ValidationException, ParamValueNotExistsError
@@ -2023,3 +2024,110 @@ class TestDSLPipeline:
         with pytest.raises(UserErrorException) as e:
             pipeline_func_consume_invalid_component()
         assert str(e.value) == "Exactly one output is expected for condition node, 0 outputs found."
+
+    def test_dsl_pipeline_with_spark_hobo(self) -> None:
+        add_greeting_column_func = load_component(
+            "./tests/test_configs/dsl_pipeline/spark_job_in_pipeline/add_greeting_column_component.yml"
+        )
+        count_by_row_func = load_component(
+            "./tests/test_configs/dsl_pipeline/spark_job_in_pipeline/count_by_row_component.yml"
+        )
+
+        @dsl.pipeline(description="submit a pipeline with spark job")
+        def spark_pipeline_from_yaml(iris_data):
+            add_greeting_column = add_greeting_column_func(file_input=iris_data)
+            add_greeting_column.resources = {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"}
+            count_by_row = count_by_row_func(file_input=iris_data)
+            count_by_row.resources = {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"}
+            count_by_row.identity = {"type": "managed"}
+
+            return {"output": count_by_row.outputs.output}
+
+        dsl_pipeline: PipelineJob = spark_pipeline_from_yaml(
+            iris_data=Input(
+                path="https://azuremlexamples.blob.core.windows.net/datasets/iris.csv",
+                type=AssetTypes.URI_FILE,
+                mode=InputOutputModes.DIRECT,
+            ),
+        )
+        dsl_pipeline.outputs.output.mode = "Direct"
+
+        spark_node = dsl_pipeline.jobs["add_greeting_column"]
+        job_data_path_input = spark_node.inputs["file_input"]._meta
+        assert job_data_path_input
+        # spark_node.component._id = "azureml:test_component:1"
+        spark_node_dict = spark_node._to_dict()
+
+        spark_node_rest_obj = spark_node._to_rest_object()
+        regenerated_spark_node = Spark._from_rest_object(spark_node_rest_obj)
+
+        spark_node_dict_from_rest = regenerated_spark_node._to_dict()
+        omit_fields = []
+        assert pydash.omit(spark_node_dict, *omit_fields) == pydash.omit(spark_node_dict_from_rest, *omit_fields)
+        omit_fields = [
+            "jobs.add_greeting_column.componentId",
+            "jobs.count_by_row.componentId",
+            "jobs.add_greeting_column.properties",
+            "jobs.count_by_row.properties",
+        ]
+        actual_job = pydash.omit(dsl_pipeline._to_rest_object().properties.as_dict(), *omit_fields)
+        assert actual_job == {
+            "description": "submit a pipeline with spark job",
+            "properties": {},
+            "tags": {},
+            "display_name": "spark_pipeline_from_yaml",
+            "is_archived": False,
+            "job_type": "Pipeline",
+            "inputs": {
+                "iris_data": {
+                    "mode": "Direct",
+                    "uri": "https://azuremlexamples.blob.core.windows.net/datasets/iris.csv",
+                    "job_input_type": "uri_file",
+                }
+            },
+            "jobs": {
+                "add_greeting_column": {
+                    "type": "spark",
+                    "resources": {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"},
+                    "entry": {"file": "add_greeting_column.py", "spark_job_entry_type": "SparkJobPythonEntry"},
+                    "py_files": ["utils.zip"],
+                    "files": ["my_files.txt"],
+                    "identity": {"identity_type": "UserIdentity"},
+                    "conf": {
+                        "spark.driver.cores": 2,
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": 1,
+                        "spark.executor.memory": "1g",
+                        "spark.executor.instances": 1,
+                    },
+                    "args": "--file_input ${{inputs.file_input}}",
+                    "name": "add_greeting_column",
+                    "inputs": {
+                        "file_input": {"job_input_type": "literal", "value": "${{parent.inputs.iris_data}}"},
+                    },
+                    "_source": "YAML.COMPONENT",
+                },
+                "count_by_row": {
+                    "_source": "YAML.COMPONENT",
+                    "args": "--file_input ${{inputs.file_input}} " "--output ${{outputs.output}}",
+                    "conf": {
+                        "spark.driver.cores": 2,
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": 1,
+                        "spark.executor.instances": 1,
+                        "spark.executor.memory": "1g",
+                    },
+                    "entry": {"file": "count_by_row.py", "spark_job_entry_type": "SparkJobPythonEntry"},
+                    "files": ["my_files.txt"],
+                    "identity": {"identity_type": "Managed"},
+                    "inputs": {"file_input": {"job_input_type": "literal", "value": "${{parent.inputs.iris_data}}"}},
+                    "jars": ["scalaproj.jar"],
+                    "name": "count_by_row",
+                    "outputs": {"output": {"type": "literal", "value": "${{parent.outputs.output}}"}},
+                    "resources": {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"},
+                    "type": "spark",
+                },
+            },
+            "outputs": {"output": {"job_output_type": "uri_folder", "mode": "Direct"}},
+            "settings": {"_source": "DSL"},
+        }

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_init_finalize_job.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_init_finalize_job.py
@@ -1,15 +1,9 @@
 from functools import partial
 from pathlib import Path
 
-import pydash
 import pytest
-from azure.ai.ml import Input, dsl, load_component, load_job
-from azure.ai.ml.constants._common import (
-    AssetTypes,
-    InputOutputModes,
-)
+from azure.ai.ml import dsl, load_component, load_job
 from azure.ai.ml.entities import PipelineJob
-from azure.ai.ml.entities._builders import Spark
 
 from .._util import _DSL_TIMEOUT_SECOND
 
@@ -182,110 +176,3 @@ class TestInitFinalizeJob:
         assert valid_pipeline._validate().passed
         assert valid_pipeline.settings.on_init == "init_job"
         assert valid_pipeline.settings.on_finalize == "finalize_job"
-
-    def test_dsl_pipeline_with_spark_hobo(self) -> None:
-        add_greeting_column_func = load_component(
-            "./tests/test_configs/dsl_pipeline/spark_job_in_pipeline/add_greeting_column_component.yml"
-        )
-        count_by_row_func = load_component(
-            "./tests/test_configs/dsl_pipeline/spark_job_in_pipeline/count_by_row_component.yml"
-        )
-
-        @dsl.pipeline(description="submit a pipeline with spark job")
-        def spark_pipeline_from_yaml(iris_data):
-            add_greeting_column = add_greeting_column_func(file_input=iris_data)
-            add_greeting_column.resources = {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"}
-            count_by_row = count_by_row_func(file_input=iris_data)
-            count_by_row.resources = {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"}
-            count_by_row.identity = {"type": "managed"}
-
-            return {"output": count_by_row.outputs.output}
-
-        dsl_pipeline: PipelineJob = spark_pipeline_from_yaml(
-            iris_data=Input(
-                path="https://azuremlexamples.blob.core.windows.net/datasets/iris.csv",
-                type=AssetTypes.URI_FILE,
-                mode=InputOutputModes.DIRECT,
-            ),
-        )
-        dsl_pipeline.outputs.output.mode = "Direct"
-
-        spark_node = dsl_pipeline.jobs["add_greeting_column"]
-        job_data_path_input = spark_node.inputs["file_input"]._meta
-        assert job_data_path_input
-        # spark_node.component._id = "azureml:test_component:1"
-        spark_node_dict = spark_node._to_dict()
-
-        spark_node_rest_obj = spark_node._to_rest_object()
-        regenerated_spark_node = Spark._from_rest_object(spark_node_rest_obj)
-
-        spark_node_dict_from_rest = regenerated_spark_node._to_dict()
-        omit_fields = []
-        assert pydash.omit(spark_node_dict, *omit_fields) == pydash.omit(spark_node_dict_from_rest, *omit_fields)
-        omit_fields = [
-            "jobs.add_greeting_column.componentId",
-            "jobs.count_by_row.componentId",
-            "jobs.add_greeting_column.properties",
-            "jobs.count_by_row.properties",
-        ]
-        actual_job = pydash.omit(dsl_pipeline._to_rest_object().properties.as_dict(), *omit_fields)
-        assert actual_job == {
-            "description": "submit a pipeline with spark job",
-            "properties": {},
-            "tags": {},
-            "display_name": "spark_pipeline_from_yaml",
-            "is_archived": False,
-            "job_type": "Pipeline",
-            "inputs": {
-                "iris_data": {
-                    "mode": "Direct",
-                    "uri": "https://azuremlexamples.blob.core.windows.net/datasets/iris.csv",
-                    "job_input_type": "uri_file",
-                }
-            },
-            "jobs": {
-                "add_greeting_column": {
-                    "type": "spark",
-                    "resources": {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"},
-                    "entry": {"file": "add_greeting_column.py", "spark_job_entry_type": "SparkJobPythonEntry"},
-                    "py_files": ["utils.zip"],
-                    "files": ["my_files.txt"],
-                    "identity": {"identity_type": "UserIdentity"},
-                    "conf": {
-                        "spark.driver.cores": 2,
-                        "spark.driver.memory": "1g",
-                        "spark.executor.cores": 1,
-                        "spark.executor.memory": "1g",
-                        "spark.executor.instances": 1,
-                    },
-                    "args": "--file_input ${{inputs.file_input}}",
-                    "name": "add_greeting_column",
-                    "inputs": {
-                        "file_input": {"job_input_type": "literal", "value": "${{parent.inputs.iris_data}}"},
-                    },
-                    "_source": "YAML.COMPONENT",
-                },
-                "count_by_row": {
-                    "_source": "YAML.COMPONENT",
-                    "args": "--file_input ${{inputs.file_input}} " "--output ${{outputs.output}}",
-                    "conf": {
-                        "spark.driver.cores": 2,
-                        "spark.driver.memory": "1g",
-                        "spark.executor.cores": 1,
-                        "spark.executor.instances": 1,
-                        "spark.executor.memory": "1g",
-                    },
-                    "entry": {"file": "count_by_row.py", "spark_job_entry_type": "SparkJobPythonEntry"},
-                    "files": ["my_files.txt"],
-                    "identity": {"identity_type": "Managed"},
-                    "inputs": {"file_input": {"job_input_type": "literal", "value": "${{parent.inputs.iris_data}}"}},
-                    "jars": ["scalaproj.jar"],
-                    "name": "count_by_row",
-                    "outputs": {"output": {"type": "literal", "value": "${{parent.outputs.output}}"}},
-                    "resources": {"instance_type": "Standard_E8S_V3", "runtime_version": "3.1.0"},
-                    "type": "spark",
-                },
-            },
-            "outputs": {"output": {"job_output_type": "uri_folder", "mode": "Direct"}},
-            "settings": {"_source": "DSL"},
-        }

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_entity.py
@@ -1321,14 +1321,6 @@ class TestPipelineJobEntity:
             },
         }
 
-    def test_pipeline_with_init_finalize(self) -> None:
-        pipeline_job = load_job("./tests/test_configs/pipeline_jobs/pipeline_job_init_finalize.yaml")
-        assert pipeline_job.settings.on_init == "a"
-        assert pipeline_job.settings.on_finalize == "c"
-        pipeline_job_dict = pipeline_job._to_rest_object().as_dict()
-        assert pipeline_job_dict["properties"]["settings"]["on_init"] == "a"
-        assert pipeline_job_dict["properties"]["settings"]["on_finalize"] == "c"
-
     def test_non_string_pipeline_node_input(self):
         test_path = "./tests/test_configs/pipeline_jobs/rest_non_string_input_pipeline.json"
         with open(test_path, "r") as f:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_job_init_finalize_invalid.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_job_init_finalize_invalid.yaml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       world_output:
   c:
-    command: echo hello ${{inputs.hello_string}}
+    command: echo ${{inputs.world_input}}/world.txt
     environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu@latest
     inputs:
-      hello_string: ${{parent.inputs.hello_string_top_level_input}}
+      world_input: ${{parent.jobs.b.outputs.world_output}}


### PR DESCRIPTION
# Description

When load pipeline job from YAML, even if one node consumes output from other node, the `_data` will be string and this may lead to validation for init/finalize ignore some cases. This PR targets to fix this bug.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
