### PR TITLE
update samples check for mypy

### DIFF
--- a/eng/tox/run_mypy.py
+++ b/eng/tox/run_mypy.py
@@ -7,7 +7,7 @@
 
 # This script is used to execute mypy within a tox environment.
 
-from subprocess import check_call
+from subprocess import check_call, CalledProcessError
 import argparse
 import os
 import logging
@@ -42,16 +42,6 @@ if __name__ == "__main__":
         )
         exit(0)
 
-    paths = [
-        os.path.join(args.target_package, "azure"),
-        os.path.join(args.target_package, "samples"),
-    ]
-    if package_name in TYPE_CHECK_SAMPLES_OPT_OUT:
-        logging.info(
-            f"Package {package_name} opts-out of mypy check on samples."
-        )
-        paths = paths[:-1]
-
     commands = [
         sys.executable,
         "-m",
@@ -61,6 +51,45 @@ if __name__ == "__main__":
         "--show-error-codes",
         "--ignore-missing-imports",
     ]
-    commands.extend(paths)
-    check_call(commands)
-    print("See https://aka.ms/python/typing-guide for information.")
+    src_code = [*commands, os.path.join(args.target_package, "azure")]
+    src_code_error = None
+    sample_code_error = None
+    try:
+        logging.info(
+            f"Running mypy commands on src code: {src_code}"
+        )
+        check_call(src_code)
+    except CalledProcessError as src_err:
+        src_code_error = src_err
+
+    if package_name in TYPE_CHECK_SAMPLES_OPT_OUT:
+        logging.info(
+            f"Package {package_name} opts-out of mypy check on samples."
+        )
+    else:
+        sample_code = [
+            *commands,
+            "--check-untyped-defs",
+            "--follow-imports=silent",
+            os.path.join(args.target_package, "samples")
+        ]
+        try:
+            logging.info(
+                f"Running mypy commands on sample code: {sample_code}"
+            )
+            check_call(sample_code)
+        except CalledProcessError as sample_err:
+            sample_code_error = sample_err
+
+    print("See https://aka.ms/python/typing-guide for information.\n\n")
+    if src_code_error and sample_code_error:
+        raise Exception(
+            [
+                src_code_error,
+                sample_code_error,
+            ],
+        )
+    if src_code_error:
+        raise src_code_error
+    if sample_code_error:
+        raise sample_code_error

--- a/eng/tox/run_pyright.py
+++ b/eng/tox/run_pyright.py
@@ -7,7 +7,7 @@
 
 # This script is used to execute pyright within a tox environment.
 
-from subprocess import check_call
+from subprocess import check_call, CalledProcessError
 import argparse
 import os
 import logging
@@ -58,5 +58,8 @@ if __name__ == "__main__":
         "pyright",
     ]
     commands.extend(paths)
-    check_call(commands)
-    print("See https://aka.ms/python/typing-guide for information.")
+    try:
+        check_call(commands)
+    except CalledProcessError as error:
+        print("See https://aka.ms/python/typing-guide for information.\n\n")
+        raise error


### PR DESCRIPTION
A few updates:

- mypy is unique in that **functions that do not contain annotations do not get checked**. Most of our samples are contained in functions without any type annotations like [this](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/translation/azure-ai-translation-document/samples/sample_begin_translation.py#L29). This gives the false impression that samples pass by mypy when in reality they are not being checked _at all_. We can fix this by running mypy with `--check-untyped-defs`, but this isn't something we want to enable on all of our library code (we don't enforce that all code needs type hints, unannotated functions are okay if non-public). To avoid developers missing type checking errors in samples, this PR enables `--check-untyped-defs` for samples _only_. We additionally must tell mypy not to follow imports from the samples or else it reports new errors in non-public code.
- We log the aka.ms link to the typing guide before raising exceptions now