### PR TITLE
[TA] only run tests where features supported

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -1986,6 +1986,7 @@ class TestAnalyze(TextAnalyticsTest):
                         assert context.length is not None
                     assert summary.text
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
@@ -2061,6 +2062,7 @@ class TestAnalyze(TextAnalyticsTest):
                 else:
                     assert doc.detected_language.iso6391_name == "es"
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -2106,6 +2106,7 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                         assert context.length is not None
                     assert summary.text
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
@@ -2183,6 +2184,7 @@ class TestAnalyzeAsync(TextAnalyticsTest):
                     else:
                         assert doc.detected_language.iso6391_name == "es"
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -12,7 +12,7 @@ import itertools
 import datetime
 from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
-from testcase import TextAnalyticsTest, TextAnalyticsPreparer
+from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils import recorded_by_proxy
 from azure.ai.textanalytics import (
@@ -151,6 +151,7 @@ class TestHealth(TextAnalyticsTest):
             assert not resp.statistics
         assert num_error == 1
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud raise InternalServerError: https://dev.azure.com/msazure/Cognitive%20Services/_workitems/edit/15860714')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -12,7 +12,7 @@ import itertools
 import datetime
 from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.core.credentials import AzureKeyCredential
-from testcase import TextAnalyticsPreparer
+from testcase import TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils.aio import recorded_by_proxy_async
 from testcase import TextAnalyticsTest
@@ -169,6 +169,7 @@ class TestHealth(TextAnalyticsTest):
             assert not resp.statistics
         assert num_error == 1
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud raise InternalServerError: https://dev.azure.com/msazure/Cognitive%20Services/_workitems/edit/15860714')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"api_version": "v3.1"})
     @recorded_by_proxy_async

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_dynamic_classification.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_dynamic_classification.py
@@ -6,7 +6,7 @@
 import pytest
 import platform
 import functools
-from testcase import TextAnalyticsTest, TextAnalyticsPreparer
+from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils import recorded_by_proxy
 from azure.ai.textanalytics import (
@@ -21,6 +21,7 @@ TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, Te
 
 class TestDynamicClassification(TextAnalyticsTest):
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy
@@ -41,6 +42,7 @@ class TestDynamicClassification(TextAnalyticsTest):
                 assert classification.category
                 assert classification.confidence_score is not None
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_dynamic_classification_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_dynamic_classification_async.py
@@ -6,7 +6,7 @@
 import pytest
 import platform
 import functools
-from testcase import TextAnalyticsTest, TextAnalyticsPreparer
+from testcase import TextAnalyticsTest, TextAnalyticsPreparer, is_public_cloud
 from testcase import TextAnalyticsClientPreparer as _TextAnalyticsClientPreparer
 from devtools_testutils.aio import recorded_by_proxy_async
 from azure.ai.textanalytics.aio import TextAnalyticsClient
@@ -21,6 +21,7 @@ TextAnalyticsClientPreparer = functools.partial(_TextAnalyticsClientPreparer, Te
 
 class TestDynamicClassification(TextAnalyticsTest):
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async
@@ -42,6 +43,7 @@ class TestDynamicClassification(TextAnalyticsTest):
                     assert classification.category
                     assert classification.confidence_score is not None
 
+    @pytest.mark.skipif(not is_public_cloud(), reason='Usgov and China Cloud are not supported')
     @TextAnalyticsPreparer()
     @TextAnalyticsClientPreparer()
     @recorded_by_proxy_async


### PR DESCRIPTION
Looked at the wrong pipeline and assumed we were good. Missed a few more tests where these features are not supported yet in non-public cloud.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1987829&view=results