### PR TITLE
update python API parser to 0.3.5

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -1,2 +1,2 @@
-api-stub-generator==0.3.3
+api-stub-generator==0.3.5
 pylint-guidelines-checker==0.0.7


### PR DESCRIPTION
Update python API parser to 0.3.5