### PR TITLE
[Storage] Add back support for importing `HandleItem`

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/__init__.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/__init__.py
@@ -35,9 +35,7 @@ from ._models import (
     ContentSettings,
     NTFSAttributes)
 from ._generated.models import (
-    ShareAccessTier
-)
-from ._generated.models import (
+    ShareAccessTier,
     ShareRootSquash
 )
 
@@ -78,3 +76,9 @@ __all__ = [
     'generate_share_sas',
     'generate_file_sas'
 ]
+
+
+def __getattr__(name):
+    if name == 'HandleItem':
+        from ._generated.models import HandleItem
+        return HandleItem

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/__init__.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/__init__.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import warnings
 
 from ._version import VERSION
 from ._file_client import ShareFileClient
@@ -79,7 +80,18 @@ __all__ = [
 
 
 def __getattr__(name):
+    """
+    This function is added to deal with HandleItem which is a generated model that
+    was mistakenly added to the module exports. It has been removed import and __all__
+    to prevent it from showing in intellisense/docs but we handle it here to prevent
+    breaking any existing code which may have imported it.
+    """
     if name == 'HandleItem':
         from ._generated.models import HandleItem
+        warnings.warn(
+            "HandleItem is deprecated and should not be used. Use Handle instead.",
+            DeprecationWarning
+        )
         return HandleItem
+
     raise AttributeError(f"module 'azure.storage.fileshare' has no attribute {name}")

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/__init__.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/__init__.py
@@ -82,3 +82,4 @@ def __getattr__(name):
     if name == 'HandleItem':
         from ._generated.models import HandleItem
         return HandleItem
+    raise AttributeError(f"module 'azure.storage.fileshare' has no attribute {name}")


### PR DESCRIPTION
A previous change removed the generated `HandleItem` from export but to be safe this change adds back support for importing the class but without it showing up in intellisense. This was done by adding it to a `__getattr__` in the main file-share `__init__` file.