### PR TITLE
[Storage] Adjust test case for `test_rename_from_a_shorter_directory_to_longer_directory`

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_directory.pyTestDirectorytest_rename_from_a_shorter_directory_to_longer_directory.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_directory.pyTestDirectorytest_rename_from_a_shorter_directory_to_longer_directory.json
@@ -1,23 +1,24 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagename.blob.core.windows.net/filesystem58243cd1?restype=container\u0026timeout=5",
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystemc76a3856?restype=container\u0026timeout=5",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-dfs/12.9.2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Sat, 12 Nov 2022 00:41:20 GMT",
+        "x-ms-date": "Sat, 12 Nov 2022 00:40:18 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 12 Nov 2022 00:41:20 GMT",
-        "ETag": "\u00220x8DAC4469E6C91F5\u0022",
-        "Last-Modified": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "Date": "Sat, 12 Nov 2022 00:40:18 GMT",
+        "ETag": "\u00220x8DAC44679519619\u0022",
+        "Last-Modified": "Sat, 12 Nov 2022 00:40:18 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -27,23 +28,24 @@
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem58243cd1/directory58243cd1?resource=directory",
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemc76a3856/directoryc76a3856?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-dfs/12.9.2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "x-ms-date": "Sat, 12 Nov 2022 00:40:18 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 12 Nov 2022 00:41:21 GMT",
-        "ETag": "\u00220x8DAC4469EDFFF74\u0022",
-        "Last-Modified": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "Date": "Sat, 12 Nov 2022 00:40:19 GMT",
+        "ETag": "\u00220x8DAC44679AC0306\u0022",
+        "Last-Modified": "Sat, 12 Nov 2022 00:40:19 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -54,23 +56,24 @@
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem58243cd1/newname?resource=directory",
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemc76a3856/newname?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-dfs/12.9.2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "x-ms-date": "Sat, 12 Nov 2022 00:40:19 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 12 Nov 2022 00:41:21 GMT",
-        "ETag": "\u00220x8DAC4469EF5A24A\u0022",
-        "Last-Modified": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "Date": "Sat, 12 Nov 2022 00:40:19 GMT",
+        "ETag": "\u00220x8DAC44679BCFEC2\u0022",
+        "Last-Modified": "Sat, 12 Nov 2022 00:40:19 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -81,23 +84,24 @@
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem58243cd1/newname%2Fnewsub?resource=directory",
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemc76a3856/newname%2Fnewsub?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-dfs/12.9.2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "x-ms-date": "Sat, 12 Nov 2022 00:40:19 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 12 Nov 2022 00:41:21 GMT",
-        "ETag": "\u00220x8DAC4469F05B3B5\u0022",
-        "Last-Modified": "Sat, 12 Nov 2022 00:41:22 GMT",
+        "Date": "Sat, 12 Nov 2022 00:40:19 GMT",
+        "ETag": "\u00220x8DAC44679D3A672\u0022",
+        "Last-Modified": "Sat, 12 Nov 2022 00:40:19 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -108,15 +112,16 @@
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem58243cd1/newname%2Fnewsub?mode=legacy",
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemc76a3856/newname%2Fnewsub?mode=legacy",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-dfs/12.9.2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Sat, 12 Nov 2022 00:41:22 GMT",
-        "x-ms-rename-source": "/filesystem58243cd1/directory58243cd1",
+        "x-ms-date": "Sat, 12 Nov 2022 00:40:19 GMT",
+        "x-ms-rename-source": "/filesystemc76a3856/directoryc76a3856",
         "x-ms-source-lease-id": "",
         "x-ms-version": "2021-08-06"
       },
@@ -124,9 +129,9 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 12 Nov 2022 00:41:21 GMT",
-        "ETag": "\u00220x8DAC4469EDFFF74\u0022",
-        "Last-Modified": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "Date": "Sat, 12 Nov 2022 00:40:19 GMT",
+        "ETag": "\u00220x8DAC44679AC0306\u0022",
+        "Last-Modified": "Sat, 12 Nov 2022 00:40:19 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -136,13 +141,14 @@
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagename.blob.core.windows.net/filesystem58243cd1/newname/newsub",
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystemc76a3856/newname/newsub",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "User-Agent": "azsdk-python-storage-dfs/12.9.2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Sat, 12 Nov 2022 00:41:22 GMT",
+        "x-ms-date": "Sat, 12 Nov 2022 00:40:19 GMT",
         "x-ms-version": "2021-08-06"
       },
       "RequestBody": null,
@@ -151,9 +157,9 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Sat, 12 Nov 2022 00:41:22 GMT",
-        "ETag": "\u00220x8DAC4469EDFFF74\u0022",
-        "Last-Modified": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "Date": "Sat, 12 Nov 2022 00:40:19 GMT",
+        "ETag": "\u00220x8DAC44679AC0306\u0022",
+        "Last-Modified": "Sat, 12 Nov 2022 00:40:19 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -161,7 +167,7 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-creation-time": "Sat, 12 Nov 2022 00:41:21 GMT",
+        "x-ms-creation-time": "Sat, 12 Nov 2022 00:40:19 GMT",
         "x-ms-group": "$superuser",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
@@ -1142,15 +1142,15 @@ class TestDirectory(StorageRecordedTestCase):
         assert properties is not None
         assert properties.get('content_settings') is None
 
-    @pytest.mark.skip(reason="Investigate why renaming from shorter path to longer path does not work")
     @DataLakePreparer()
+    @recorded_by_proxy
     def test_rename_from_a_shorter_directory_to_longer_directory(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
         datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
 
         self._setUp(datalake_storage_account_name, datalake_storage_account_key)
         directory_name = self._get_directory_reference()
-        self._create_directory_and_get_directory_client(directory_name="old")
+        self._create_directory_and_get_directory_client(directory_name=directory_name)
 
         new_name = "newname"
         new_directory_client = self._create_directory_and_get_directory_client(directory_name=new_name)

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
@@ -1307,7 +1307,7 @@ class TestDirectory(StorageRecordedTestCase):
 
         assert non_existing_dir_name == res.path_name
 
-    @pytest.mark.skip(reason="Investigate why renaming to non-empty directory doesn't work")
+    @pytest.mark.skip(reason="Investigate why renaming non-empty directory doesn't work")
     @DataLakePreparer()
     def test_rename_directory_to_non_empty_directory(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
@@ -1307,7 +1307,7 @@ class TestDirectory(StorageRecordedTestCase):
 
         assert non_existing_dir_name == res.path_name
 
-    @pytest.mark.skip(reason="Investigate why renaming non-empty directory doesn't work")
+    @pytest.mark.skip(reason="Investigate why renaming to non-empty directory doesn't work")
     @DataLakePreparer()
     def test_rename_directory_to_non_empty_directory(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory_async.py
@@ -1073,7 +1073,6 @@ class TestDirectoryAsync(AsyncStorageRecordedTestCase):
         assert properties is not None
         assert properties.get('content_settings') is None
 
-    @pytest.mark.skip(reason="Investigate why renaming from shorter path to longer path does not work")
     @DataLakePreparer()
     @recorded_by_proxy_async
     async def test_rename_from_a_shorter_directory_to_longer_directory(self, **kwargs):
@@ -1082,7 +1081,7 @@ class TestDirectoryAsync(AsyncStorageRecordedTestCase):
 
         await self._setUp(datalake_storage_account_name, datalake_storage_account_key)
         directory_name = self._get_directory_reference()
-        await self._create_directory_and_get_directory_client(directory_name="old")
+        await self._create_directory_and_get_directory_client(directory_name=directory_name)
 
         new_name = "newname"
         new_directory_client = await self._create_directory_and_get_directory_client(directory_name=new_name)


### PR DESCRIPTION
This PR adjusts this testcase which has been marked as skipped since it's migration to track2. 
The issue here is that the original test case had a `directory_name` variable that contained the source destination's directory name, but then didn't use the variable when creating the source destination's directory. It would then later pass the variable to the rename API, but this directory didn't exist due to using a different name when creating the source destination's directory ("old")