### PR TITLE
fix non-pipeline-input with annotation and default value

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
@@ -181,7 +181,8 @@ class PipelineComponentBuilder:
         """
         self.nodes.append(node)
 
-    def build(self, *, user_provided_kwargs=None, non_pipeline_inputs_dict=None, non_pipeline_inputs=None) -> PipelineComponent:
+    def build(self, *, user_provided_kwargs=None,
+              non_pipeline_inputs_dict=None, non_pipeline_inputs=None) -> PipelineComponent:
         """
         Build a pipeline component from current pipeline builder.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
@@ -181,12 +181,13 @@ class PipelineComponentBuilder:
         """
         self.nodes.append(node)
 
-    def build(self, *, user_provided_kwargs=None, non_pipeline_params_dict=None) -> PipelineComponent:
+    def build(self, *, user_provided_kwargs=None, non_pipeline_params_dict=None, non_pipeline_parameters=None) -> PipelineComponent:
         """
         Build a pipeline component from current pipeline builder.
 
         :param user_provided_kwargs: The kwargs user provided to dsl pipeline function. None if not provided.
         :param non_pipeline_params_dict: Non-pipeline parameters to provided value. None if not exist.
+        :param non_pipeline_parameters: List of non-pipeline parameter name. None if not exist.
         """
         if user_provided_kwargs is None:
             user_provided_kwargs = {}
@@ -198,8 +199,9 @@ class PipelineComponentBuilder:
             user_provided_kwargs=user_provided_kwargs,
             # TODO: support result() for pipeline input inside parameter group
             group_default_kwargs=self._get_group_parameter_defaults(),
-            non_pipeline_parameter_dict=non_pipeline_params_dict
+            non_pipeline_parameters=non_pipeline_parameters
         )
+        kwargs.update(non_pipeline_params_dict or {})
         # We use this stack to store the dsl pipeline definition hierarchy
         _definition_builder_stack.push(self)
 
@@ -401,7 +403,7 @@ class PipelineComponentBuilder:
 
 
 def _build_pipeline_parameter(
-        func, *, user_provided_kwargs, group_default_kwargs=None, non_pipeline_parameter_dict=None):
+        func, *, user_provided_kwargs, group_default_kwargs=None, non_pipeline_parameters=None):
     # Pass group defaults into kwargs to support group.item can be used even if no default on function.
     # example:
     # @parameter_group
@@ -413,7 +415,7 @@ def _build_pipeline_parameter(
     #   component_func(input=param.key)  <--- param.key should be val.
 
     # transform kwargs
-    transformed_kwargs = non_pipeline_parameter_dict or {}
+    transformed_kwargs = {}
     if group_default_kwargs:
         transformed_kwargs.update(
             {
@@ -434,7 +436,7 @@ def _build_pipeline_parameter(
     parameters = all_params(signature(func).parameters)
     # transform default values
     for left_args in parameters:
-        if left_args.name not in transformed_kwargs.keys():
+        if left_args.name not in transformed_kwargs.keys() and left_args.name not in non_pipeline_parameters:
             default_value = left_args.default if left_args.default is not Parameter.empty else None
             actual_value = user_provided_kwargs.get(left_args.name)
             transformed_kwargs[left_args.name] = _wrap_pipeline_parameter(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
@@ -165,13 +165,13 @@ def pipeline(
                 provided_positional_args = _validate_args(func, args, kwargs, non_pipeline_inputs)
                 # Convert args to kwargs
                 kwargs.update(provided_positional_args)
-                non_pipeline_params_dict = {k: v for k, v in kwargs.items() if k in non_pipeline_inputs}
+                non_pipeline_inputs_dict = {k: v for k, v in kwargs.items() if k in non_pipeline_inputs}
 
                 # TODO: cache built pipeline component
                 pipeline_component = pipeline_builder.build(
                     user_provided_kwargs=kwargs,
-                    non_pipeline_params_dict=non_pipeline_params_dict,
-                    non_pipeline_parameters=non_pipeline_inputs
+                    non_pipeline_inputs_dict=non_pipeline_inputs_dict,
+                    non_pipeline_inputs=non_pipeline_inputs
                 )
             finally:
                 # use `finally` to ensure pop operation from the stack

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
@@ -170,7 +170,8 @@ def pipeline(
                 # TODO: cache built pipeline component
                 pipeline_component = pipeline_builder.build(
                     user_provided_kwargs=kwargs,
-                    non_pipeline_params_dict=non_pipeline_params_dict
+                    non_pipeline_params_dict=non_pipeline_params_dict,
+                    non_pipeline_parameters=non_pipeline_inputs
                 )
             finally:
                 # use `finally` to ensure pop operation from the stack

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/utils.py
@@ -211,6 +211,7 @@ def _get_param_with_standard_annotation(cls_or_func, is_func=False, skip_params=
     inherited_fields = _get_inherited_fields()
     # From annotations get field with type
     annotations = getattr(cls_or_func, "__annotations__", {})
+    annotations = {k: v for k, v in annotations.items() if k not in skip_params}
     annotations = _update_io_from_mldesigner(annotations)
     annotation_fields = _get_fields(annotations)
     # Update fields use class field with defaults from class dict or signature(func).paramters

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -1,6 +1,7 @@
 import os
 from io import StringIO
 from pathlib import Path
+from typing import Dict
 from unittest import mock
 from unittest.mock import patch
 

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -1930,20 +1930,24 @@ class TestDSLPipeline:
         component_func1 = load_component(source=component_yaml, params_override=[{"name": "component_name_1"}])
         component_func2 = load_component(source=component_yaml, params_override=[{"name": "component_name_2"}])
 
-        @dsl.pipeline(non_pipeline_inputs=["other_params", "is_add_component"])
-        def pipeline_func(job_in_number, job_in_path, other_params, is_add_component):
+        @dsl.pipeline(non_pipeline_inputs=["other_params", "is_add_component",
+                                           "param_with_annotation", "param_with_default"])
+        def pipeline_func(job_in_number, job_in_path, other_params, is_add_component,
+                          param_with_annotation: Dict[str, str], param_with_default: int = 1):
+            assert param_with_default == 1
+            assert param_with_annotation == {"mock": "dict"}
             component_func1(component_in_number=job_in_number, component_in_path=job_in_path)
             component_func2(component_in_number=other_params, component_in_path=job_in_path)
             if is_add_component:
                 component_func2(component_in_number=other_params, component_in_path=job_in_path)
 
-        pipeline = pipeline_func(10, Input(path="/a/path/on/ds"), 15, False)
+        pipeline = pipeline_func(10, Input(path="/a/path/on/ds"), 15, False, {"mock": "dict"})
         assert len(pipeline.jobs) == 2
         assert "other_params" not in pipeline.inputs
         assert isinstance(pipeline.jobs[component_func1.name].inputs["component_in_number"]._data, PipelineInput)
         assert pipeline.jobs[component_func2.name].inputs["component_in_number"]._data == 15
 
-        pipeline = pipeline_func(10, Input(path="/a/path/on/ds"), 15, True)
+        pipeline = pipeline_func(10, Input(path="/a/path/on/ds"), 15, True, {"mock": "dict"})
         assert len(pipeline.jobs) == 3
 
         @dsl.pipeline(non_pipeline_parameters=["other_params", "is_add_component"])


### PR DESCRIPTION
# Description
Fix the bug of non-pipeline-input parameter with annotation or default value.
```
@dsl.pipeline(non_pipeline_inputs=["param_with_annotation", "param_with_default"])
def pipeline_func(param_with_annotation: Dict[str, str], param_with_default: int = 1):
    pass
```

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
