### PR TITLE
[ML][Pipelines] Fix flaky tests in live mode

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
@@ -1,4 +1,5 @@
 import re
+import tempfile
 import uuid
 from itertools import tee
 from pathlib import Path
@@ -374,13 +375,15 @@ class TestComponent(AzureRecordedTestCase):
     @pytest.mark.disable_mock_code_hash
     @pytest.mark.skipif(condition=not is_live(), reason="reuse test, target to verify service-side behavior")
     def test_component_create_twice_same_code_arm_id(
-        self, client: MLClient, randstr: Callable[[str], str], tmp_path: Path
+        self, client: MLClient, randstr: Callable[[str], str]
     ) -> None:
-        component_name = randstr("component_name")
-        # create new component to prevent the issue when same component code got created at the same time
-        component_path = tmp_path / "component.yml"
-        component_path.write_text(
-            f"""
+        with tempfile.TemporaryDirectory() as tmp_path:
+            tmp_path = Path(tmp_path)
+            component_name = randstr("component_name")
+            # create new component to prevent the issue when same component code got created at the same time
+            component_path = tmp_path / "component.yml"
+            component_path.write_text(
+                f"""
 $schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
 name: {component_name}
 version: 1
@@ -389,13 +392,13 @@ name: SampleCommandComponentBasic
 command: echo Hello World
 code: "."
 environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1"""
-        )
-        # create a component
-        component_resource1 = create_component(client, component_name, path=component_path)
-        # create again
-        component_resource2 = create_component(client, component_name, path=component_path)
-        # the code arm id should be the same
-        assert component_resource1.code == component_resource2.code
+            )
+            # create a component
+            component_resource1 = create_component(client, component_name, path=component_path)
+            # create again
+            component_resource2 = create_component(client, component_name, path=component_path)
+            # the code arm id should be the same
+            assert component_resource1.code == component_resource2.code
 
     @pytest.mark.skipif(condition=not is_live(), reason="non-deterministic upload fails in playback on CI")
     def test_component_update_code(self, client: MLClient, randstr: Callable[[str], str], tmp_path: Path) -> None:

--- a/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
@@ -625,7 +625,7 @@ environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1"""
 
         for version in versions:
             create_component(client, name, params_override=[{"version": version}])
-            sleep_if_live(1)
+            sleep_if_live(5)
             assert client.components.get(name, label="latest").version == version
 
     @pytest.mark.skip(reason="Test fails because MFE index service consistency bug")


### PR DESCRIPTION
# Description

This PR targets to fix two flaky tests in live mode:

- `test_command_component_get_latest_label`: original sleeps for only 1 second, which shall be not enough; sleep more to ensure server finishes update.
- `test_component_create_twice_same_code_arm_id`: this test use `pytest` fixture `tmp_path`, as different Python version will use same temp folder, this may affect other tests on same platform when using same agent; update this using `tempfile.TemporaryDirectory` to replace `tmp_path` fixture.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
