### PR TITLE
Swap to `python -m build` instead of `python setup.py <format>`

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -159,10 +159,10 @@ jobs:
           timeoutInMinutes: 5
 
         - pwsh: |
-            $packages = Get-ChildItem "$(Pipeline.Workspace)/${{ parameters.ArtifactName }}/${{ parameters.Artifact.name }}/*.zip"
+            $packages = Get-ChildItem "$(Pipeline.Workspace)/${{ parameters.ArtifactName }}/${{ parameters.Artifact.name }}/*.tar.gz"
             Write-Host "Artifacts found:"
             $artifacts = $packages | ForEach-Object {
-              if ($_.Name -match "([a-zA-Z\-]+)\-(.*).zip") {
+              if ($_.Name -match "([a-zA-Z\-]+)\-(.*).tar.gz") {
                 Write-Host "$($matches[1]): $($matches[2])"
                 return @{ "name" = $matches[1]; "version" = $matches[2] }
               }

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -110,16 +110,16 @@ stages:
                           set -e
                           twine upload --repository 'pypi' --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.whl
                           echo "Uploaded whl to pypi"
-                          twine upload --repository 'pypi' --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.zip
-                          echo "Uploaded zip to pypi"
+                          twine upload --repository 'pypi' --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tar.gz
+                          echo "Uploaded source distribution to pypi"
                         displayName: 'Publish package to registry: pypi.org'
 
                       - script: |
                           set -e
                           twine upload --repository ${{parameters.DevFeedName}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.whl
                           echo "Uploaded whl to devops feed"
-                          twine upload --repository ${{parameters.DevFeedName}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.zip
-                          echo "Uploaded sdist to devops feed"
+                          twine upload --repository ${{parameters.DevFeedName}} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tar.gz
+                          echo "Uploaded source distribution to devops feed"
                         displayName: 'Publish package to feed: ${{parameters.DevFeedName}}'
 
           - ${{if ne(artifact.skipPublishDocs, 'true')}}:
@@ -265,8 +265,8 @@ stages:
 
               twine upload --repository $(DevFeedName) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*-*a*.whl
               echo "Uploaded whl to devops feed $(DevFeedName)"
-              twine upload --repository $(DevFeedName) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*-*a*.zip
-              echo "Uploaded sdist to devops feed $(DevFeedName)"
+              twine upload --repository $(DevFeedName) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*-*a*.tar.gz
+              echo "Uploaded source distribution to devops feed $(DevFeedName)"
             displayName: 'Publish ${{artifact.name}} alpha package'
 
     - job: PublishDocsToNightlyBranch

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -69,7 +69,7 @@ steps:
 
   - script: |
       twine check $(Build.ArtifactStagingDirectory)/**/*.whl
-      twine check $(Build.ArtifactStagingDirectory)/**/*.zip
+      twine check $(Build.ArtifactStagingDirectory)/**/*.tar.gz
     displayName: 'Verify Readme'
 
   - ${{if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -101,7 +101,13 @@ function Get-python-PackageInfoFromPackageFile ($pkg, $workingDirectory)
   $readmeContent = ""
 
   New-Item -ItemType Directory -Force -Path $workFolder
-  Expand-Archive -Path $pkg -DestinationPath $workFolder
+
+  if ($pkg.EndsWith(".zip")){
+    Expand-Archive -Path $pkg -DestinationPath $workFolder
+  }
+  else {
+    tar -zxvf $pkg -C $workFolder
+  }
 
   $changeLogLoc = @(Get-ChildItem -Path $workFolder -Recurse -Include "CHANGELOG.md")[0]
   if ($changeLogLoc) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -1,7 +1,7 @@
 $Language = "python"
 $LanguageDisplayName = "Python"
 $PackageRepository = "PyPI"
-$packagePattern = "*.zip"
+$packagePattern = "*.tar.gz"
 $MetadataUri = "https://raw.githubusercontent.com/Azure/azure-sdk/main/_data/releases/latest/python-packages.csv"
 $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=container&comp=list&prefix=python%2F&delimiter=%2F"
 $GithubUri = "https://github.com/Azure/azure-sdk-for-python"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -106,7 +106,13 @@ function Get-python-PackageInfoFromPackageFile ($pkg, $workingDirectory)
     Expand-Archive -Path $pkg -DestinationPath $workFolder
   }
   else {
+    Write-Host "tar -zxvf $pkg -C $workFolder"
     tar -zxvf $pkg -C $workFolder
+
+    if ($LASTEXITCODE -ne 0) {
+      Write-Error "tar failed with exit code $LASTEXITCODE."
+      exit $LASTEXITCODE
+    }
   }
 
   $changeLogLoc = @(Get-ChildItem -Path $workFolder -Recurse -Include "CHANGELOG.md")[0]
@@ -150,7 +156,13 @@ function Publish-python-GithubIODocs ($DocLocation, $PublicArtifactLocation)
       New-Item -Path $UnzippedDocumentationPath -ItemType Directory
     }
 
+    Write-Host "tar -zxvf $ZippedDocumentationPath -C $UnzippedDocumentationPath"
     tar -zxvf $ZippedDocumentationPath -C $UnzippedDocumentationPath
+
+    if ($LASTEXITCODE -ne 0) {
+      Write-Error "tar failed with exit code $LASTEXITCODE."
+      exit $LASTEXITCODE
+    }
 
     $Version = $(Get-Content $VersionFileLocation).Trim()
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -102,7 +102,7 @@ function Get-python-PackageInfoFromPackageFile ($pkg, $workingDirectory)
 
   New-Item -ItemType Directory -Force -Path $workFolder
 
-  if ($pkg.EndsWith(".zip")){
+  if ($pkg.Extension -eq ".zip"){
     Expand-Archive -Path $pkg -DestinationPath $workFolder
   }
   else {

--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -85,7 +85,7 @@ def build_and_discover_package(setuppy_path, dist_dir, target_setup, package_typ
         create_package(setuppy_path, dist_dir, enable_wheel=False)
 
     prebuilt_packages = [
-        f for f in os.listdir(args.distribution_directory) if f.endswith(".whl" if package_type == "wheel" else ".zip")
+        f for f in os.listdir(args.distribution_directory) if f.endswith(".whl" if package_type == "wheel" else ".tar.gz")
     ]
 
     if not in_ci():

--- a/eng/tox/run_sphinx_build.py
+++ b/eng/tox/run_sphinx_build.py
@@ -37,7 +37,7 @@ def move_output_and_zip(target_dir, package_dir, package_name):
         os.mkdir(ci_doc_dir)
 
     individual_zip_location = os.path.join(ci_doc_dir, package_name, package_name)
-    shutil.make_archive(individual_zip_location, 'zip', target_dir)
+    shutil.make_archive(individual_zip_location, 'gztar', target_dir)
 
 def sphinx_build(target_dir, output_dir):
     command_array = [

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -39,6 +39,7 @@ pkgs =
     wheel==0.37.0
     packaging==20.4
     urllib3==1.26.12
+    build==0.9.0
 
 
 [testenv]

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -296,7 +296,7 @@ deps =
     {[packaging]pkgs}
 commands =
     {envbindir}/python -m pip install {toxinidir}/../../../tools/azure-sdk-tools --no-deps
-    {envbindir}/python {toxinidir}/setup.py --q sdist --format zip -d {envtmpdir}
+    {envbindir}/python -m build --sdist --outdir {envtmpdir}
     {envbindir}/python {toxinidir}/../../../eng/tox/verify_sdist.py -d {envtmpdir} -t {toxinidir}
 
 

--- a/eng/tox/tox_helper_tasks.py
+++ b/eng/tox/tox_helper_tasks.py
@@ -10,16 +10,14 @@
 import shutil
 import sys
 import logging
-import ast
 import os
-import textwrap
-import io
 import glob
 import zipfile
 import tarfile
 import fnmatch
 import subprocess
 import re
+import pdb
 
 from packaging.specifiers import SpecifierSet
 from pkg_resources import Requirement, parse_version
@@ -58,6 +56,7 @@ def unzip_sdist_to_directory(containing_folder: str) -> str:
         return unzip_file_to_directory(zips[0], containing_folder)
     else:
         tars = glob.glob(os.path.join(containing_folder, "*.tar.gz"))
+        pdb.set_trace()
         return unzip_file_to_directory(tars[0], containing_folder)
 
 
@@ -68,10 +67,13 @@ def unzip_file_to_directory(path_to_zip_file: str, extract_location: str) -> str
             extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
             return os.path.join(extract_location, extracted_dir)
     else:
-        with tarfile.open(path_to_zip_file, "r:gz") as tar_ref:
+        # .tar.gz -> .tar
+        with tarfile.open(path_to_zip_file) as tar_ref:
             tar_ref.extractall(extract_location)
-            extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
-            return os.path.join(extract_location, extracted_dir)
+            extracted_dir = os.path.basename(path_to_zip_file).replace(".tar.gz", "")
+            
+        
+        return os.path.join(extract_location, extracted_dir)
 
 
 def move_and_rename(source_location):

--- a/eng/tox/tox_helper_tasks.py
+++ b/eng/tox/tox_helper_tasks.py
@@ -56,7 +56,6 @@ def unzip_sdist_to_directory(containing_folder: str) -> str:
         return unzip_file_to_directory(zips[0], containing_folder)
     else:
         tars = glob.glob(os.path.join(containing_folder, "*.tar.gz"))
-        pdb.set_trace()
         return unzip_file_to_directory(tars[0], containing_folder)
 
 

--- a/eng/tox/tox_helper_tasks.py
+++ b/eng/tox/tox_helper_tasks.py
@@ -16,6 +16,7 @@ import textwrap
 import io
 import glob
 import zipfile
+import tarfile
 import fnmatch
 import subprocess
 import re
@@ -50,19 +51,27 @@ def get_pip_list_output():
     return collected_output
 
 
-def unzip_sdist_to_directory(containing_folder):
-    # grab the first one
-    path_to_zip_file = glob.glob(os.path.join(containing_folder, "*.zip"))[0]
-    return unzip_file_to_directory(path_to_zip_file, containing_folder)
+def unzip_sdist_to_directory(containing_folder: str) -> str:
+    zips = glob.glob(os.path.join(containing_folder, "*.zip"))
+
+    if zips:
+        return unzip_file_to_directory(zips[0], containing_folder)
+    else:
+        tars = glob.glob(os.path.join(containing_folder, "*.tar.gz"))
+        return unzip_file_to_directory(tars[0], containing_folder)
 
 
-def unzip_file_to_directory(path_to_zip_file, extract_location):
-    # unzip file in given path
-    # dump into given path
-    with zipfile.ZipFile(path_to_zip_file, "r") as zip_ref:
-        zip_ref.extractall(extract_location)
-        extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
-        return os.path.join(extract_location, extracted_dir)
+def unzip_file_to_directory(path_to_zip_file: str, extract_location: str) -> str:
+    if path_to_zip_file.endswith(".zip"):
+        with zipfile.ZipFile(path_to_zip_file, "r") as zip_ref:
+            zip_ref.extractall(extract_location)
+            extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
+            return os.path.join(extract_location, extracted_dir)
+    else:
+        with tarfile.open(path_to_zip_file, "r:gz") as tar_ref:
+            tar_ref.extractall(extract_location)
+            extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
+            return os.path.join(extract_location, extracted_dir)
 
 
 def move_and_rename(source_location):
@@ -85,7 +94,7 @@ def find_sdist(dist_dir, pkg_name, pkg_version):
         logging.error("Package name cannot be empty to find sdist")
         return
 
-    pkg_name_format = "{0}-{1}.zip".format(pkg_name, pkg_version)
+    pkg_name_format = "{0}-{1}.tar.gz".format(pkg_name, pkg_version)
     packages = []
     for root, dirnames, filenames in os.walk(dist_dir):
         for filename in fnmatch.filter(filenames, pkg_name_format):

--- a/eng/tox/verify_sdist.py
+++ b/eng/tox/verify_sdist.py
@@ -42,7 +42,7 @@ def get_root_directories_in_sdist(dist_dir: str, version: str) -> List[str]:
     """
     # find sdist zip file
     # extract sdist and find list of directories in sdist
-    path_to_zip = glob.glob(os.path.join(dist_dir, "*{}*.zip".format(version)))[0]
+    path_to_zip = glob.glob(os.path.join(dist_dir, "*{}*.tar.gz".format(version)))[0]
     extract_location = os.path.join(dist_dir, "unzipped")
     # Cleanup any files in unzipped
     cleanup(extract_location)

--- a/eng/tox/verify_sdist.py
+++ b/eng/tox/verify_sdist.py
@@ -10,7 +10,7 @@ import argparse
 import logging
 import os
 import glob
-import shutil
+import pdb
 from unicodedata import name
 from xmlrpc.client import Boolean
 from tox_helper_tasks import (
@@ -42,6 +42,7 @@ def get_root_directories_in_sdist(dist_dir: str, version: str) -> List[str]:
     """
     # find sdist zip file
     # extract sdist and find list of directories in sdist
+
     path_to_zip = glob.glob(os.path.join(dist_dir, "*{}*.tar.gz".format(version)))[0]
     extract_location = os.path.join(dist_dir, "unzipped")
     # Cleanup any files in unzipped

--- a/eng/tox/verify_whl.py
+++ b/eng/tox/verify_whl.py
@@ -11,6 +11,7 @@ import logging
 import os
 import glob
 import shutil
+import pdb
 from tox_helper_tasks import (
     unzip_sdist_to_directory,
     move_and_rename,
@@ -36,13 +37,14 @@ def extract_whl(dist_dir, version):
     path_to_whl = glob.glob(os.path.join(dist_dir, "*{}*.whl".format(version)))[0]
 
     # Cleanup any existing stale files if any and rename whl file to tar.gz
-    zip_file = path_to_whl.replace(".whl", ".tar.gz")
+    zip_file = path_to_whl.replace(".whl", ".zip")
     cleanup(zip_file)
     os.rename(path_to_whl, zip_file)
 
     # Extrat renamed gz file to unzipped folder
     extract_location = os.path.join(dist_dir, "unzipped")
     cleanup(extract_location)
+
     unzip_file_to_directory(zip_file, extract_location)
     return extract_location
 

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -150,6 +150,6 @@ def create_package(
         setup_directory_or_file = os.path.dirname(setup_directory_or_file)
 
     if enable_wheel:
-        run_logged([sys.executable, "setup.py", "bdist_wheel", "-d", dist], prefix="create_wheel", cwd=setup_directory_or_file)
+        run_logged([sys.executable, "-m", "build", "--wheel", "--outdir", dist], prefix="create_wheel", cwd=setup_directory_or_file)
     if enable_sdist:
-        run_logged([sys.executable, "setup.py", "sdist", "--format", "zip", "-d", dist], prefix="create_sdist", cwd=setup_directory_or_file)
+        run_logged([sys.executable, "-m", "build", "--sdist", "--outdir", dist], prefix="create_sdist", cwd=setup_directory_or_file)

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -10,6 +10,8 @@ from ci_tools.variables import discover_repo_root, get_artifact_directory
 from ci_tools.versioning.version_shared import set_version_py, set_dev_classifier
 from ci_tools.versioning.version_set_dev import get_dev_version, format_build_id
 from ci_tools.logging import initialize_logger, run_logged
+import build
+
 
 def build() -> None:
     parser = argparse.ArgumentParser(

--- a/tools/azure-sdk-tools/ci_tools/logging/__init__.py
+++ b/tools/azure-sdk-tools/ci_tools/logging/__init__.py
@@ -48,9 +48,9 @@ def get_log_file(prefix: str = "") -> str:
 
 def run_logged(*args, prefix="", **kwargs):
     logfile = get_log_file(prefix)
+    logfile_error = get_log_file(f"{prefix}_error")
 
-    with open(logfile, "w") as log_output:
-        run(*args, **kwargs, stdout=log_output)
-
+    with open(logfile, "w") as log_output, open(logfile_error, "w") as error_output:
+        run(*args, **kwargs, stdout=log_output, stderr=error_output)
 
 __all__ = ["initialize_logger", "run_logged"]

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -7,6 +7,7 @@ from setuptools import setup, find_packages
 DEPENDENCIES = [
     # Packaging
     "packaging",
+    "build",
     "wheel",
     "Jinja2",
     "MarkupSafe==2.0.1",


### PR DESCRIPTION
[As warned in our CI](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1991227&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=c6642a37-b24b-5443-7452-ff95456b7c94&l=16), we really needed to modernize how we produce our wheels/sdists.

Unfortunately, it looks like I'm going to need to add a post-step that unzips the tar.gz and rezips it if we want to continue publishing our `sdist`s as `zip`. Unfortunately, unlike `python setup.py`, it doesn't look like `build` honors `--format=sdist`.

EDIT: found the official docs referencing the new requirement: https://packaging.python.org/en/latest/key_projects/#build, for anyone concerned about introducing a random `build` package 👍 

- [x] Check all tox environments
- [x] This PR somehow destroys all the logging cleanup that I had finished with `python setup.py`. Need to resolve this before merging. `python -m build` is loud.
- [x] Ensure that integration and pypi publishing still works
- [x] Ensure that github.io and docs.ms productions still work
 