### PR TITLE
[pipeline] autorest upgrade to `6.2.7`

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.9.2",
-      "use": ["@autorest/python@6.2.1", "@autorest/modelerfour@4.24.3"],
+      "use": ["@autorest/python@6.2.7", "@autorest/modelerfour@4.24.3"],
       "python": "",
       "sdkrel:python-sdks-folder": "./sdk/.",
       "version-tolerant": false,

--- a/swagger_to_sdk_config_dpg.json
+++ b/swagger_to_sdk_config_dpg.json
@@ -2,7 +2,7 @@
   "meta": {
     "autorest_options": {
       "version": "3.9.2",
-      "use": ["@autorest/python@6.1.11", "@autorest/modelerfour@4.24.3"]
+      "use": ["@autorest/python@6.2.7", "@autorest/modelerfour@4.24.3"]
     },
     "advanced_options": {
       "create_sdk_pull_requests": true,


### PR DESCRIPTION
Fix pipeline failure for `automation`: https://github.com/Azure/azure-rest-api-specs/pull/21128