### PR TITLE
Enforce Package name approval for preview release

### DIFF
--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -117,6 +117,13 @@ function ProcessPackage($PackageName)
                 }
                 elseif ($version.IsPrerelease)
                 {
+                    # Check if package name is approved. Preview version cannot be released without package name approval
+                    if ($respCode -eq '202' -and $pkgInfo.ReleaseStatus -and $pkgInfo.ReleaseStatus -ne "Unreleased")
+                    {
+                        Write-Host "Package $($PackageName) is not yet approved on APIView for preview release. Package approval for beta relase must be completed by an API approver if it was never released as a stable version."
+                        Write-Host "You can check http://aka.ms/azsdk/engsys/apireview/faq for more details on package name approval."
+                        exit 1
+                    }
                     # Ignore API review status for prerelease version
                     Write-Host "Package version is not GA. Ignoring API view approval status"
                 }

--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -120,8 +120,8 @@ function ProcessPackage($PackageName)
                     # Check if package name is approved. Preview version cannot be released without package name approval
                     if ($respCode -eq '202' -and $pkgInfo.ReleaseStatus -and $pkgInfo.ReleaseStatus -ne "Unreleased")
                     {
-                        Write-Host "Package $($PackageName) is not yet approved on APIView for preview release. Package approval for beta relase must be completed by an API approver if it was never released as a stable version."
-                        Write-Host "You can check http://aka.ms/azsdk/engsys/apireview/faq for more details on package name approval."
+                        Write-Error "Package '$PackageName' is not yet approved on APIView for preview release. Package approval for beta relase must be completed by an API approver if it was never released as a stable version."
+                        Write-Error "You can check http://aka.ms/azsdk/engsys/apireview/faq for more details on package name approval."
                         exit 1
                     }
                     # Ignore API review status for prerelease version


### PR DESCRIPTION
APIView returns 202 is package is not approved for preview release. Package must be approved (basic approval like package name) in APIView to release a package as preview if it was never approved or released as GA before. 