### PR TITLE
[pyamqp] value error revert 

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -420,6 +420,9 @@ class _AbstractTransport(object):  # pylint: disable=too-many-instance-attribute
                 _LOGGER.debug(
                     "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
                 )
+                raise ValueError(
+                    "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
+                )
 
             # >I is an unsigned int, but the argument to sock.recv is signed,
             # so we know the size can be at most 2 * SIGNED_INT_MAX

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -421,7 +421,7 @@ class _AbstractTransport(object):  # pylint: disable=too-many-instance-attribute
                     "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
                 )
                 raise ValueError(
-                    "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
+                    f"Received invalid frame type: {frame_type}, expected: {verify_frame_type}"
                 )
 
             # >I is an unsigned int, but the argument to sock.recv is signed,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -421,7 +421,7 @@ class _AbstractTransport(object):  # pylint: disable=too-many-instance-attribute
                     "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
                 )
                 raise ValueError(
-                    f"Received invalid frame type: {frame_type}, expected: {verify_frame_type}"
+                        f"Received invalid frame type: {frame_type}, expected: {verify_frame_type}"
                 )
 
             # >I is an unsigned int, but the argument to sock.recv is signed,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -107,7 +107,7 @@ class AsyncTransportMixin:
                         "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
                     )
                     raise ValueError(
-                        "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
+                        f"Received invalid frame type: {frame_type}, expected: {verify_frame_type}"
                     )
 
                 # >I is an unsigned int, but the argument to sock.recv is signed,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -106,6 +106,10 @@ class AsyncTransportMixin:
                     _LOGGER.debug(
                         "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
                     )
+                    raise ValueError(
+                        "Received invalid frame type: %r, expected: %r", frame_type, verify_frame_type
+                    )
+
                 # >I is an unsigned int, but the argument to sock.recv is signed,
                 # so we know the size can be at most 2 * SIGNED_INT_MAX
                 payload_size = size - len(frame_header)


### PR DESCRIPTION
introduced a bug by making an error a log instead -- reverting after catching it in perftest pipeline and local runs