### PR TITLE
[Identity] Adjust flaky timeout test

### DIFF
--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import datetime
+from unittest.mock import ANY, Mock, patch
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
@@ -19,11 +20,6 @@ from helpers import (
     Request,
     validating_transport,
 )
-
-try:
-    from unittest.mock import Mock, patch
-except ImportError:  # python < 3.3
-    from mock import Mock, patch  # type: ignore
 
 
 def test_tenant_id_validation():
@@ -272,23 +268,17 @@ def test_tenant_id():
 
 
 def test_timeout():
-    transport = validating_transport(
-        requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
-        responses=[
-            # expected requests: discover tenant, start device code flow, poll for completion
-            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
-            mock_response(json_payload={"device_code": "_", "user_code": "_", "verification_uri": "_"}),
-            mock_response(json_payload={"error": "authorization_pending"}),
-        ],
-    )
+    flow = {"expires_in": 1800, "message": "foo"}
+    with patch.object(DeviceCodeCredential, "_get_app") as get_app:
+        msal_app = get_app()
+        msal_app.initiate_device_flow.return_value = flow
+        msal_app.acquire_token_by_device_flow.return_value = {"error": "authorization_pending"}
 
-    credential = DeviceCodeCredential(
-        client_id="_", prompt_callback=Mock(), transport=transport, timeout=0.01, instance_discovery=False,
-    )
-
-    with pytest.raises(ClientAuthenticationError) as ex:
-        credential.get_token("scope")
-    assert "timed out" in ex.value.message.lower()
+        credential = DeviceCodeCredential(client_id="_", timeout=1, instance_discovery=False)
+        with pytest.raises(ClientAuthenticationError) as ex:
+            credential.get_token("scope")
+        assert "timed out" in ex.value.message.lower()
+        msal_app.acquire_token_by_device_flow.assert_called_once_with(flow, exit_condition=ANY, claims_challenge=None)
 
 
 def test_client_capabilities():


### PR DESCRIPTION
The current `test_timeout` test for DeviceCodeCredential sometimes fails in the CI presumably because of variable processing times causing the timeout not to be hit before another error occurs. This specific test's sporadic failures have been plaguing our identity pipeline runs for a while now with the following error:

```
assert "timed out" in ex.value.message.lower()
E       AssertionError: assert 'timed out' in 'authentication failed: unexpected request: post https://a/b'
E        +  where 'authentication failed: unexpected request: post https://a/b' = <built-in method lower of str object at 0x10c9126c0>()
E        +    where <built-in method lower of str object at 0x10c9126c0> = 'Authentication failed: unexpected request: POST https://a/b'.lower
E        +      where 'Authentication failed: unexpected request: POST https://a/b' = ClientAuthenticationError('Authentication failed: unexpected request: POST https://a/b').message
E        +        where ClientAuthenticationError('Authentication failed: unexpected request: POST https://a/b') = <ExceptionInfo ClientAuthenticationError('Authentication failed: unexpected request: POST https://a/b') tblen=4>.value
```

This PR adjusts the test to be more reliable, and we simply test that the correct code path is called when a timeout is specified.

