### PR TITLE
[TA] remove pinning specific model_version in tests

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities.pyTestRecognizeEntitiestest_all_successful_passing_dict.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities.pyTestRecognizeEntitiestest_all_successful_passing_dict.json
@@ -7,9 +7,9 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "495",
+        "Content-Length": "465",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b1 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b2 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -33,21 +33,21 @@
           ]
         },
         "parameters": {
-          "modelVersion": "2020-02-01",
           "stringIndexType": "UnicodeCodePoint"
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f392e61e-33b1-4861-ad5d-25dee2123745",
-        "Content-Length": "1113",
+        "apim-request-id": "8dfdda75-5cbe-4620-8748-22bc971321d5",
+        "Content-Length": "1646",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Mon, 17 Oct 2022 19:03:25 GMT",
+        "Date": "Mon, 21 Nov 2022 19:23:38 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "255"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -78,14 +78,14 @@
                   "category": "Person",
                   "offset": 25,
                   "length": 10,
-                  "confidenceScore": 0.67
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "Paul Allen",
                   "category": "Person",
                   "offset": 40,
                   "length": 10,
-                  "confidenceScore": 0.81
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "April 4, 1975",
@@ -106,6 +106,27 @@
               },
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 26,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 39,
+                  "length": 10,
+                  "confidenceScore": 0.99
+                },
+                {
                   "text": "4 de abril de 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
@@ -124,19 +145,40 @@
               },
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
                   "text": "4. April 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
                   "offset": 19,
                   "length": 13,
                   "confidenceScore": 0.8
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 37,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 52,
+                  "length": 10,
+                  "confidenceScore": 1.0
                 }
               ],
               "warnings": []
             }
           ],
           "errors": [],
-          "modelVersion": "2020-02-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities.pyTestRecognizeEntitiestest_all_successful_passing_text_document_input.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities.pyTestRecognizeEntitiestest_all_successful_passing_text_document_input.json
@@ -7,9 +7,9 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "Content-Length": "495",
+        "Content-Length": "465",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b1 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b2 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -33,21 +33,21 @@
           ]
         },
         "parameters": {
-          "modelVersion": "2020-02-01",
           "stringIndexType": "UnicodeCodePoint"
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca8dedb9-9aef-4869-a763-0894ca861462",
-        "Content-Length": "831",
+        "apim-request-id": "b9e984ce-bf34-4e6d-a7fe-a92193fd0b35",
+        "Content-Length": "1364",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Mon, 17 Oct 2022 19:03:25 GMT",
+        "Date": "Mon, 21 Nov 2022 19:23:55 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "101"
+        "x-envoy-upstream-service-time": "37",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -68,14 +68,14 @@
                   "category": "Person",
                   "offset": 25,
                   "length": 10,
-                  "confidenceScore": 0.67
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "Paul Allen",
                   "category": "Person",
                   "offset": 40,
                   "length": 10,
-                  "confidenceScore": 0.81
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "April 4, 1975",
@@ -92,6 +92,27 @@
               "id": "2",
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 26,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 39,
+                  "length": 10,
+                  "confidenceScore": 0.99
+                },
+                {
                   "text": "4 de abril de 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
@@ -106,19 +127,40 @@
               "id": "3",
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
                   "text": "4. April 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
                   "offset": 19,
                   "length": 13,
                   "confidenceScore": 0.8
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 37,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 52,
+                  "length": 10,
+                  "confidenceScore": 1.0
                 }
               ],
               "warnings": []
             }
           ],
           "errors": [],
-          "modelVersion": "2020-02-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities_async.pyTestRecognizeEntitiestest_all_successful_passing_dict.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities_async.pyTestRecognizeEntitiestest_all_successful_passing_dict.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "495",
+        "Content-Length": "465",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b1 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b2 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -32,21 +32,21 @@
           ]
         },
         "parameters": {
-          "modelVersion": "2020-02-01",
           "stringIndexType": "UnicodeCodePoint"
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "28fecaf5-831e-4b7c-9d74-1e6954a63f72",
-        "Content-Length": "1113",
+        "apim-request-id": "aaa90acd-bf36-4b1d-bf58-24c2d8cdb9b7",
+        "Content-Length": "1646",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Mon, 17 Oct 2022 19:03:41 GMT",
+        "Date": "Mon, 21 Nov 2022 19:24:53 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "97"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -77,14 +77,14 @@
                   "category": "Person",
                   "offset": 25,
                   "length": 10,
-                  "confidenceScore": 0.67
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "Paul Allen",
                   "category": "Person",
                   "offset": 40,
                   "length": 10,
-                  "confidenceScore": 0.81
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "April 4, 1975",
@@ -105,6 +105,27 @@
               },
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 26,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 39,
+                  "length": 10,
+                  "confidenceScore": 0.99
+                },
+                {
                   "text": "4 de abril de 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
@@ -123,19 +144,40 @@
               },
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
                   "text": "4. April 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
                   "offset": 19,
                   "length": 13,
                   "confidenceScore": 0.8
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 37,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 52,
+                  "length": 10,
+                  "confidenceScore": 1.0
                 }
               ],
               "warnings": []
             }
           ],
           "errors": [],
-          "modelVersion": "2020-02-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities_async.pyTestRecognizeEntitiestest_all_successful_passing_text_document_input.json
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities_async.pyTestRecognizeEntitiestest_all_successful_passing_text_document_input.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "495",
+        "Content-Length": "465",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b1 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+        "User-Agent": "azsdk-python-ai-textanalytics/5.3.0b2 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -32,21 +32,21 @@
           ]
         },
         "parameters": {
-          "modelVersion": "2020-02-01",
           "stringIndexType": "UnicodeCodePoint"
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "13a452a3-c0dc-4227-b39d-5c5cb3a64356",
-        "Content-Length": "831",
+        "apim-request-id": "24666b80-4ae8-43d3-9a40-7ce5a595d522",
+        "Content-Length": "1364",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Mon, 17 Oct 2022 19:03:42 GMT",
+        "Date": "Mon, 21 Nov 2022 19:24:28 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "76"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -67,14 +67,14 @@
                   "category": "Person",
                   "offset": 25,
                   "length": 10,
-                  "confidenceScore": 0.67
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "Paul Allen",
                   "category": "Person",
                   "offset": 40,
                   "length": 10,
-                  "confidenceScore": 0.81
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "April 4, 1975",
@@ -91,6 +91,27 @@
               "id": "2",
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 26,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 39,
+                  "length": 10,
+                  "confidenceScore": 0.99
+                },
+                {
                   "text": "4 de abril de 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
@@ -105,19 +126,40 @@
               "id": "3",
               "entities": [
                 {
+                  "text": "Microsoft",
+                  "category": "Organization",
+                  "offset": 0,
+                  "length": 9,
+                  "confidenceScore": 1.0
+                },
+                {
                   "text": "4. April 1975",
                   "category": "DateTime",
                   "subcategory": "Date",
                   "offset": 19,
                   "length": 13,
                   "confidenceScore": 0.8
+                },
+                {
+                  "text": "Bill Gates",
+                  "category": "Person",
+                  "offset": 37,
+                  "length": 10,
+                  "confidenceScore": 1.0
+                },
+                {
+                  "text": "Paul Allen",
+                  "category": "Person",
+                  "offset": 52,
+                  "length": 10,
+                  "confidenceScore": 1.0
                 }
               ],
               "warnings": []
             }
           ],
           "errors": [],
-          "modelVersion": "2020-02-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare.py
@@ -173,7 +173,6 @@ class TestHealth(TextAnalyticsTest):
         response = client.begin_analyze_healthcare_entities(
             docs,
             show_stats=True,
-            model_version="2021-01-11",
             polling_interval=self._interval(),
             raw_response_hook = callback,
         ).result()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_healthcare_async.py
@@ -192,7 +192,6 @@ class TestHealth(TextAnalyticsTest):
             response = await (await client.begin_analyze_healthcare_entities(
                 docs,
                 show_stats=True,
-                model_version="2021-01-11",
                 polling_interval=self._interval(),
                 raw_response_hook=callback,
             )).result()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
@@ -39,9 +39,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975."},
                 {"id": "3", "language": "de", "text": "Microsoft wurde am 4. April 1975 von Bill Gates und Paul Allen gegründet."}]
 
-        response = client.recognize_entities(docs, model_version="2020-02-01", show_stats=True)
+        response = client.recognize_entities(docs, show_stats=True)
         for doc in response:
-            # assert len(doc.entities) == 4 commenting out because of service error
             assert doc.id is not None
             assert doc.statistics is not None
             for entity in doc.entities:
@@ -60,9 +59,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
             TextDocumentInput(id="3", text="Microsoft wurde am 4. April 1975 von Bill Gates und Paul Allen gegründet.", language="de")
         ]
 
-        response = client.recognize_entities(docs, model_version="2020-02-01")
+        response = client.recognize_entities(docs)
         for doc in response:
-            # assert len(doc.entities) == 4 commenting out because of service error
             for entity in doc.entities:
                 assert entity.text is not None
                 assert entity.category is not None

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
@@ -43,9 +43,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975."},
                 {"id": "3", "language": "de", "text": "Microsoft wurde am 4. April 1975 von Bill Gates und Paul Allen gegründet."}]
 
-        response = await client.recognize_entities(docs, model_version="2020-02-01", show_stats=True)
+        response = await client.recognize_entities(docs, show_stats=True)
         for doc in response:
-            # assert len(doc.entities) == 4 commenting out because of service error
             assert doc.id is not None
             assert doc.statistics is not None
             for entity in doc.entities:
@@ -64,9 +63,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
             TextDocumentInput(id="3", text="Microsoft wurde am 4. April 1975 von Bill Gates und Paul Allen gegründet.", language="de")
         ]
 
-        response = await client.recognize_entities(docs, model_version="2020-02-01")
+        response = await client.recognize_entities(docs)
         for doc in response:
-            # assert len(doc.entities) == 4 commenting out because of service error
             for entity in doc.entities:
                 assert entity.text is not None
                 assert entity.category is not None


### PR DESCRIPTION
The service floats the model_version to "latest" if not specified. By pinning the model_version to older versions, we create flaky tests since these versions eventually are deprecated/expire.