### PR TITLE
[Storage] Pin `azure-mgmt-storage` dev requirement to fix ci

### DIFF
--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -3,5 +3,5 @@
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
 azure-identity
--e ../../storage/azure-mgmt-storage
+azure-mgmt-storage==20.1.0
 aiohttp>=3.0

--- a/sdk/storage/azure-storage-queue/dev_requirements.txt
+++ b/sdk/storage/azure-storage-queue/dev_requirements.txt
@@ -2,7 +2,7 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 -e ../../resources/azure-mgmt-resource
--e ../azure-mgmt-storage
 ../../core/azure-core
 azure-identity
+azure-mgmt-storage==20.1.0
 aiohttp>=3.0


### PR DESCRIPTION
Storage ci broke because the recent release of `azure-mgmt-storage` added a dep on a `typing-extensions` version that is higher than the required req for Storage packages. Since we only use this package for test, pinning it to a previous version to fix this break and avoid future breaks.