### PR TITLE
[ML][Pipelines] Always cancel submitted pipeline jobs

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -325,7 +325,7 @@ def pipelines_registry_client(e2e_ws_scope: OperationScope, auth: ClientSecretCr
     return MLClient(
         credential=auth,
         logging_enable=getenv(E2E_TEST_LOGGING_ENABLED),
-        registry_name="sdk-canary",
+        registry_name="sdk-test",
     )
 
 

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/e2etests/test_pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/e2etests/test_pipeline_job.py
@@ -1360,20 +1360,12 @@ class TestPipelineJob(AzureRecordedTestCase):
         )
 
 
-
-@pytest.mark.usefixtures(
-    "recorded_test",
-    "mock_code_hash",
-    "enable_pipeline_private_preview_features",
-    "mock_asset_name",
-    "mock_component_hash",
-    "enable_environment_id_arm_expansion",
-)
-@pytest.mark.timeout(timeout=_PIPELINE_JOB_LONG_RUNNING_TIMEOUT_SECOND, method=_PYTEST_TIMEOUT_METHOD)
+@pytest.mark.usefixtures("enable_pipeline_private_preview_features")
 @pytest.mark.e2etest
 @pytest.mark.pipeline_test
 @pytest.mark.skipif(condition=not is_live(), reason="no need to run in playback mode")
-class TestPipelineJobLongRunning(AzureRecordedTestCase):
+@pytest.mark.timeout(timeout=_PIPELINE_JOB_LONG_RUNNING_TIMEOUT_SECOND, method=_PYTEST_TIMEOUT_METHOD)
+class TestPipelineJobLongRunning:
     """Long-running tests that require pipeline job completed."""
     def test_pipeline_job_get_child_run(self, client: MLClient, randstr: Callable[[str], str]):
         pipeline_job = load_job(
@@ -1381,6 +1373,7 @@ class TestPipelineJobLongRunning(AzureRecordedTestCase):
             params_override=[{"name": randstr("name")}],
         )
         job = client.jobs.create_or_update(pipeline_job)
+        print("pipeline job name:", job.name)
         wait_until_done(client, job)
         child_job = next(
             job
@@ -1400,6 +1393,7 @@ class TestPipelineJobLongRunning(AzureRecordedTestCase):
                 params_override=[{"name": randstr("job_name")}],
             )
         )
+        print("pipeline job name:", job.name)
         wait_until_done(client, job)
         client.jobs.download(name=job.name, download_path=tmp_path)
         artifact_dir = tmp_path / "artifacts"
@@ -1415,6 +1409,7 @@ class TestPipelineJobLongRunning(AzureRecordedTestCase):
                 params_override=[{"name": randstr("job_name")}],
             )
         )
+        print("pipeline job name:", job.name)
         wait_until_done(client, job)
         child_job = next(
             job
@@ -1434,7 +1429,6 @@ class TestPipelineJobLongRunning(AzureRecordedTestCase):
         assert output_dir.exists()
         assert next(output_dir.iterdir(), None), "No artifacts were downloaded"
 
-    @pytest.mark.disable_mock_code_hash
     def test_reused_pipeline_child_job_download(
         self,
         client: MLClient,
@@ -1445,7 +1439,7 @@ class TestPipelineJobLongRunning(AzureRecordedTestCase):
 
         # ensure previous job exists for reuse
         job_name = randstr("job_name")
-        print(f"previous job name: {job_name}")
+        print("previous job name:", job_name)
         previous_job = client.jobs.create_or_update(
             load_job(source=pipeline_spec_path, params_override=[{"name": job_name}])
         )
@@ -1453,7 +1447,7 @@ class TestPipelineJobLongRunning(AzureRecordedTestCase):
 
         # submit a new job that will reuse previous job
         new_job_name = randstr("new_job_name")
-        print(f"new job name: {new_job_name}")
+        print("new job name:", new_job_name)
         new_job = client.jobs.create_or_update(
             load_job(pipeline_spec_path, params_override=[{"name": new_job_name}]),
         )

--- a/sdk/ml/azure-ai-ml/tests/test_utilities/utils.py
+++ b/sdk/ml/azure-ai-ml/tests/test_utilities/utils.py
@@ -292,7 +292,7 @@ def assert_job_cancel(
     created_job = client.jobs.create_or_update(job, experiment_name=experiment_name)
     if check_before_cancelled is not None:
         assert check_before_cancelled(created_job)
-        cancel_job(client, created_job)
+    cancel_job(client, created_job)
     return created_job
 
 


### PR DESCRIPTION
# Description

- Cancel submitted pipeline jobs to release compute resources.
- Try changing Pipelines registry, to solve auth issue during live test.
- For test class `TestPipelineJobLongRunning`, remove test proxy related fixtures as it will only run in live mode and no need for test proxy things.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
