### PR TITLE
Add pytest command flags

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -41,7 +41,7 @@ def get_release_policy(attestation_uri, **kwargs):
 def get_test_parameters(only_hsm=False, only_vault=False, api_versions=None):
     """generates a list of parameter pairs for test case parameterization, where [x, y] = [api_version, is_hsm]"""
     combinations = []
-    versions = api_versions or ApiVersion
+    versions = api_versions or pytest.api_version
     hsm_supported_versions = {ApiVersion.V7_2, ApiVersion.V7_3, ApiVersion.V7_4_PREVIEW_1}
 
     for api_version in versions:

--- a/sdk/keyvault/azure-keyvault-keys/tests/conftest.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/conftest.py
@@ -11,8 +11,20 @@ import pytest
 from devtools_testutils import (add_general_regex_sanitizer,
                                 add_oauth_response_sanitizer, is_live,
                                 test_proxy)
+from azure.keyvault.keys._shared.client_base import DEFAULT_VERSION, ApiVersion
 
 os.environ['PYTHONHASHSEED'] = '0'
+ALL_API_VERSIONS = "--all-api-versions"
+
+def pytest_addoption(parser):
+    parser.addoption(ALL_API_VERSIONS, action="store_true", default=False,
+                     help="Test all api version in live mode. Not applicable in playback mode.")
+
+def pytest_configure(config):
+    if is_live() and not config.getoption(ALL_API_VERSIONS):
+        pytest.api_version = [DEFAULT_VERSION]
+    else:
+        pytest.api_version = ApiVersion
 
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):


### PR DESCRIPTION
# Description
Resolves https://github.com/Azure/azure-sdk-for-python/issues/22855 with @ponopono0322 

If we're running live tests and `--all-api-versions` isn't provided, only use the default version. 
Otherwise, use all API versions.

This issue was previously posted in https://github.com/Azure/azure-sdk-for-python/pull/26157.
There was a commit mistake, so I reopened the PR.

Thank you for helping us with your kind and nice suggestions. @mccoyp 



# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
