### PR TITLE
[ML][Pipelines] Avoid bool test for pipeline expression in non-pipeline scenarios

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_pipeline_expression.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_pipeline_expression.py
@@ -199,6 +199,14 @@ class PipelineExpressionMixin:
         As overloadable boolean operators PEP (refer to: https://www.python.org/dev/peps/pep-0335/)
         was rejected, logical operations are also not supported.
         """
+        from azure.ai.ml.dsl._pipeline_component_builder import _is_inside_dsl_pipeline_func
+
+        # note: unexpected bool test always be checking if the object is None;
+        # so for non-pipeline scenarios, directly return True to avoid unexpected breaking,
+        # and for pipeline scenarios, will use is not None to replace bool test.
+        if not _is_inside_dsl_pipeline_func():
+            return True
+
         error_message = f"Type {type(self)} is not supported for operation bool()."
         raise UserErrorException(message=error_message, no_personal_data_message=error_message)
 


### PR DESCRIPTION
# Description

Pipeline expression bans bool test on it. To better avoid unexpected breaking in non-pipeline scenarios (i.e. outside a pipeline), add one check for scenario and always return `True` for this.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
