### PR TITLE
[Storage] Cleanup old test classes after test proxy migration

### DIFF
--- a/sdk/storage/azure-storage-queue/tests/test_queue_service_stats.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_service_stats.py
@@ -39,7 +39,7 @@ class TestQueueServiceStats(StorageRecordedTestCase):
         storage_account_key = kwargs.pop("storage_account_key")
 
         # Arrange
-        qsc = self.create_storage_client(QueueServiceClient, self.account_url(storage_account_name, "queue"), storage_account_key)
+        qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key)
 
         # Act
         stats = qsc.get_service_stats()
@@ -54,7 +54,7 @@ class TestQueueServiceStats(StorageRecordedTestCase):
         storage_account_key = kwargs.pop("storage_account_key")
 
         # Arrange
-        qsc = self.create_storage_client(QueueServiceClient, self.account_url(storage_account_name, "queue"), storage_account_key)
+        qsc = QueueServiceClient(QueueServiceClient, self.account_url(storage_account_name, "queue"), storage_account_key)
 
         # Act
         stats = qsc.get_service_stats()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_service_stats.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_service_stats.py
@@ -54,7 +54,7 @@ class TestQueueServiceStats(StorageRecordedTestCase):
         storage_account_key = kwargs.pop("storage_account_key")
 
         # Arrange
-        qsc = QueueServiceClient(QueueServiceClient, self.account_url(storage_account_name, "queue"), storage_account_key)
+        qsc = QueueServiceClient(self.account_url(storage_account_name, "queue"), storage_account_key)
 
         # Act
         stats = qsc.get_service_stats()

--- a/tools/azure-sdk-tools/devtools_testutils/storage/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/__init__.py
@@ -1,11 +1,11 @@
 from .api_version_policy import ApiVersionAssertPolicy
 from .service_versions import service_version_map, ServiceVersion, is_version_before
-from .testcase import StorageTestCase, StorageRecordedTestCase, LogCaptured
+from .testcase import StorageRecordedTestCase, LogCaptured
 
 __all__ = [
     "ApiVersionAssertPolicy",
     "service_version_map",
-    "StorageTestCase",
+    "StorageRecordedTestCase",
     "ServiceVersion",
     "is_version_before",
     "LogCaptured",

--- a/tools/azure-sdk-tools/devtools_testutils/storage/aio/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/aio/__init__.py
@@ -1,3 +1,3 @@
-from .asynctestcase import AsyncStorageTestCase, AsyncStorageRecordedTestCase
+from .asynctestcase import AsyncStorageRecordedTestCase
 
-__all__ = ["AsyncStorageTestCase", "AsyncStorageRecordedTestCase"]
+__all__ = ["AsyncStorageRecordedTestCase"]

--- a/tools/azure-sdk-tools/devtools_testutils/storage/aio/asynctestcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/aio/asynctestcase.py
@@ -1,82 +1,15 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
 import asyncio
 import functools
 
-from .. import StorageTestCase, StorageRecordedTestCase
+from .. import StorageRecordedTestCase
 from ...fake_credentials_async import AsyncFakeCredential
 
-from azure_devtools.scenario_tests.patches import mock_in_unit_test
 from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
-
-
-def patch_play_responses(unit_test):
-    """Fixes a bug affecting blob tests by applying https://github.com/kevin1024/vcrpy/pull/511 to vcrpy 3.0.0"""
-
-    try:
-        from vcr.stubs.aiohttp_stubs import (
-            _serialize_headers,
-            build_response,
-            Request,
-            URL,
-        )
-    except ImportError:
-        # return a do-nothing patch when importing from vcr fails
-        return lambda _: None
-
-    def fixed_play_responses(cassette, vcr_request):
-        history = []
-        vcr_response = cassette.play_response(vcr_request)
-        response = build_response(vcr_request, vcr_response, history)
-        while 300 <= response.status <= 399:
-            if "location" not in response.headers:
-                break
-            next_url = URL(response.url).with_path(response.headers["location"])
-            vcr_request = Request(
-                "GET",
-                str(next_url),
-                None,
-                _serialize_headers(response.request_info.headers),
-            )
-            vcr_request = cassette.find_requests_with_most_matches(vcr_request)[0][0]
-            history.append(response)
-            vcr_response = cassette.play_response(vcr_request)
-            response = build_response(vcr_request, vcr_response, history)
-        return response
-
-    return mock_in_unit_test(unit_test, "vcr.stubs.aiohttp_stubs.play_responses", fixed_play_responses)
-
-
-class AsyncStorageTestCase(StorageTestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.replay_patches.append(patch_play_responses)
-
-    @staticmethod
-    def await_prepared_test(test_fn):
-        """Synchronous wrapper for async test methods. Used to avoid making changes
-        upstream to AbstractPreparer (which doesn't await the functions it wraps)
-        """
-
-        @functools.wraps(test_fn)
-        def run(test_class_instance, *args, **kwargs):
-            trim_kwargs_from_test_function(test_fn, kwargs)
-            loop = asyncio.get_event_loop()
-            return loop.run_until_complete(test_fn(test_class_instance, **kwargs))
-
-        return run
-
-    def generate_oauth_token(self):
-        if self.is_live:
-            from azure.identity.aio import ClientSecretCredential
-
-            return ClientSecretCredential(
-                self.get_settings_value("TENANT_ID"),
-                self.get_settings_value("CLIENT_ID"),
-                self.get_settings_value("CLIENT_SECRET"),
-            )
-        return self.generate_fake_token()
-
-    def generate_fake_token(self):
-        return AsyncFakeCredential()
 
 
 class AsyncStorageRecordedTestCase(StorageRecordedTestCase):

--- a/tools/azure-sdk-tools/devtools_testutils/storage/testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/storage/testcase.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for
@@ -12,22 +11,13 @@ import logging
 import math
 import os
 import random
-import sys
-import time
 import zlib
 
 import pytest
 
-from devtools_testutils import AzureTestCase, AzureRecordedTestCase
+from devtools_testutils import AzureRecordedTestCase
 
-from .processors import XMSRequestIDBody
-from . import ApiVersionAssertPolicy, service_version_map
 from .. import FakeTokenCredential
-
-try:
-    from cStringIO import StringIO  # Python 2
-except ImportError:
-    from io import StringIO
 
 try:
     from azure.storage.blob import (
@@ -50,7 +40,6 @@ except:
         )
 
 LOGGING_FORMAT = "%(asctime)s %(name)-20s %(levelname)-5s %(message)s"
-
 ENABLE_LOGGING = True
 
 
@@ -65,180 +54,6 @@ def generate_sas_token():
         start=datetime.now() - timedelta(hours=24),
         expiry=datetime.now() + timedelta(days=8),
     )
-
-
-class StorageTestCase(AzureTestCase):
-    def __init__(self, *args, **kwargs):
-        super(StorageTestCase, self).__init__(*args, **kwargs)
-        self.replay_processors.append(XMSRequestIDBody())
-        self.logger = logging.getLogger("azure.storage")
-        self.configure_logging()
-
-    def connection_string(self, account_name, key):
-        return (
-            "DefaultEndpointsProtocol=https;AcCounTName="
-            + account_name
-            + ";AccOuntKey="
-            + str(key)
-            + ";EndpoIntSuffix=core.windows.net"
-        )
-
-    def account_url(self, storage_account, storage_type):
-        """Return an url of storage account.
-
-        :param str storage_account: Storage account name
-        :param str storage_type: The Storage type part of the URL. Should be "blob", or "queue", etc.
-        """
-        return "{}://{}.{}.{}".format(
-            os.environ.get("PROTOCOL", "https"),
-            storage_account,
-            storage_type,
-            os.environ.get("ACCOUNT_URL_SUFFIX", "core.windows.net"),
-        )
-
-    def configure_logging(self):
-        enable_logging = ENABLE_LOGGING
-
-        self.enable_logging() if enable_logging else self.disable_logging()
-
-    def enable_logging(self):
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter(LOGGING_FORMAT))
-        self.logger.handlers = [handler]
-        self.logger.setLevel(logging.DEBUG)
-        self.logger.propagate = True
-        self.logger.disabled = False
-
-    def disable_logging(self):
-        self.logger.propagate = False
-        self.logger.disabled = True
-        self.logger.handlers = []
-
-    def sleep(self, seconds):
-        if self.is_live:
-            time.sleep(seconds)
-
-    def get_random_bytes(self, size):
-        # recordings don't like random stuff. making this more
-        # deterministic.
-        return b"a" * size
-
-    def get_random_text_data(self, size):
-        """Returns random unicode text data exceeding the size threshold for
-        chunking blob upload."""
-        checksum = zlib.adler32(self.qualified_test_name.encode()) & 0xFFFFFFFF
-        rand = random.Random(checksum)
-        text = ""
-        words = ["hello", "world", "python", "啊齄丂狛狜"]
-        while len(text) < size:
-            index = int(rand.random() * (len(words) - 1))
-            text = text + " " + words[index]
-
-        return text
-
-    @staticmethod
-    def _set_test_proxy(service, settings):
-        if settings.USE_PROXY:
-            service.set_proxy(
-                settings.PROXY_HOST,
-                settings.PROXY_PORT,
-                settings.PROXY_USER,
-                settings.PROXY_PASSWORD,
-            )
-
-    def assertNamedItemInContainer(self, container, item_name, msg=None):
-        def _is_string(obj):
-            if sys.version_info >= (3,):
-                return isinstance(obj, str)
-            else:
-                return isinstance(obj, basestring)
-
-        for item in container:
-            if _is_string(item):
-                if item == item_name:
-                    return
-            elif isinstance(item, dict):
-                if item_name == item["name"]:
-                    return
-            elif item.name == item_name:
-                return
-            elif hasattr(item, "snapshot") and item.snapshot == item_name:
-                return
-
-        standardMsg = "{0} not found in {1}".format(repr(item_name), [str(c) for c in container])
-        self.fail(self._formatMessage(msg, standardMsg))
-
-    def assertNamedItemNotInContainer(self, container, item_name, msg=None):
-        for item in container:
-            if item.name == item_name:
-                standardMsg = "{0} unexpectedly found in {1}".format(repr(item_name), repr(container))
-                self.fail(self._formatMessage(msg, standardMsg))
-
-    def assert_upload_progress(self, size, max_chunk_size, progress, unknown_size=False):
-        """Validates that the progress chunks align with our chunking procedure."""
-        index = 0
-        total = None if unknown_size else size
-        small_chunk_size = size % max_chunk_size
-        self.assertEqual(len(progress), math.ceil(size / max_chunk_size))
-        for i in progress:
-            self.assertTrue(i[0] % max_chunk_size == 0 or i[0] % max_chunk_size == small_chunk_size)
-            self.assertEqual(i[1], total)
-
-    def assert_download_progress(self, size, max_chunk_size, max_get_size, progress):
-        """Validates that the progress chunks align with our chunking procedure."""
-        if size <= max_get_size:
-            self.assertEqual(len(progress), 1)
-            self.assertTrue(progress[0][0], size)
-            self.assertTrue(progress[0][1], size)
-        else:
-            small_chunk_size = (size - max_get_size) % max_chunk_size
-            self.assertEqual(len(progress), 1 + math.ceil((size - max_get_size) / max_chunk_size))
-
-            self.assertTrue(progress[0][0], max_get_size)
-            self.assertTrue(progress[0][1], size)
-            for i in progress[1:]:
-                self.assertTrue(i[0] % max_chunk_size == 0 or i[0] % max_chunk_size == small_chunk_size)
-                self.assertEqual(i[1], size)
-
-    def generate_oauth_token(self):
-        if self.is_live:
-            from azure.identity import ClientSecretCredential
-
-            return ClientSecretCredential(
-                self.get_settings_value("TENANT_ID"),
-                self.get_settings_value("CLIENT_ID"),
-                self.get_settings_value("CLIENT_SECRET"),
-            )
-        return self.generate_fake_token()
-
-    def generate_sas_token(self):
-        fake_key = "a" * 30 + "b" * 30
-
-        return "?" + generate_account_sas(
-            account_name="test",  # name of the storage account
-            account_key=fake_key,  # key for the storage account
-            resource_types=ResourceTypes(object=True),
-            permission=AccountSasPermissions(read=True, list=True),
-            start=datetime.now() - timedelta(hours=24),
-            expiry=datetime.now() + timedelta(days=8),
-        )
-
-    def generate_fake_token(self):
-        return FakeTokenCredential()
-
-    def _get_service_version(self, **kwargs):
-        env_version = service_version_map.get(os.environ.get("AZURE_LIVE_TEST_SERVICE_VERSION", "LATEST"))
-        return kwargs.pop("service_version", env_version)
-
-    def create_storage_client(self, client, *args, **kwargs):
-        kwargs["api_version"] = self._get_service_version(**kwargs)
-        kwargs["_additional_pipeline_policies"] = [ApiVersionAssertPolicy(kwargs["api_version"])]
-        return client(*args, **kwargs)
-
-    def create_storage_client_from_conn_str(self, client, *args, **kwargs):
-        kwargs["api_version"] = self._get_service_version(**kwargs)
-        kwargs["_additional_pipeline_policies"] = [ApiVersionAssertPolicy(kwargs["api_version"])]
-        return client.from_connection_string(*args, **kwargs)
 
 
 class StorageRecordedTestCase(AzureRecordedTestCase):
@@ -377,20 +192,6 @@ class StorageRecordedTestCase(AzureRecordedTestCase):
 
     def generate_fake_token(self):
         return FakeTokenCredential()
-
-    def _get_service_version(self, **kwargs):
-        env_version = service_version_map.get(os.environ.get("AZURE_LIVE_TEST_SERVICE_VERSION", "LATEST"))
-        return kwargs.pop("service_version", env_version)
-
-    def create_storage_client(self, client, *args, **kwargs):
-        kwargs["api_version"] = self._get_service_version(**kwargs)
-        kwargs["_additional_pipeline_policies"] = [ApiVersionAssertPolicy(kwargs["api_version"])]
-        return client(*args, **kwargs)
-
-    def create_storage_client_from_conn_str(self, client, *args, **kwargs):
-        kwargs["api_version"] = self._get_service_version(**kwargs)
-        kwargs["_additional_pipeline_policies"] = [ApiVersionAssertPolicy(kwargs["api_version"])]
-        return client.from_connection_string(*args, **kwargs)
 
     def get_datetime_variable(self, variables, name, dt):
         dt_string = variables.setdefault(name, dt.isoformat())


### PR DESCRIPTION
Now that all Storage tests have been migrated to test proxy, we can remove the old VCR test base classes that were replaced with new test proxy versions. Additionally cleaning up some other functions that are no longer used.