### PR TITLE
[Storage] Use `tempfile` for datalake package

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import tempfile
 import unittest
 from datetime import datetime, timedelta
 from math import ceil
@@ -42,6 +41,7 @@ from settings.testcase import DataLakePreparer
 
 TEST_DIRECTORY_PREFIX = 'directory'
 TEST_FILE_PREFIX = 'file'
+FILE_PATH = 'file_output.temp.dat'
 
 # ------------------------------------------------------------------------------
 
@@ -749,17 +749,15 @@ class TestFile(StorageRecordedTestCase):
         file_client.append_data(data, 0, len(data))
         file_client.flush_data(len(data))
 
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
         # download the data into a file and make sure it is the same as uploaded data
-        with open(temp_file.name, 'wb') as stream:
+        with open(FILE_PATH, 'wb') as stream:
             download = file_client.download_file()
             download.readinto(stream)
 
         # Assert
-        with open(temp_file.name, 'rb') as stream:
+        with open(FILE_PATH, 'rb') as stream:
             actual = stream.read()
             assert data == actual
-        temp_file.close()
 
     @DataLakePreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -749,17 +749,16 @@ class TestFile(StorageRecordedTestCase):
         file_client.append_data(data, 0, len(data))
         file_client.flush_data(len(data))
 
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
         # download the data into a file and make sure it is the same as uploaded data
-        with open(temp_file.name, 'wb') as stream:
+        with tempfile.TemporaryFile() as temp_file:
             download = file_client.download_file()
-            download.readinto(stream)
+            download.readinto(temp_file)
 
-        # Assert
-        with open(temp_file.name, 'rb') as stream:
-            actual = stream.read()
+            temp_file.seek(0)
+
+            # Assert
+            actual = temp_file.read()
             assert data == actual
-        temp_file.close()
 
     @DataLakePreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import tempfile
 import unittest
 from datetime import datetime, timedelta
 from math import ceil
@@ -41,7 +42,6 @@ from settings.testcase import DataLakePreparer
 
 TEST_DIRECTORY_PREFIX = 'directory'
 TEST_FILE_PREFIX = 'file'
-FILE_PATH = 'file_output.temp.dat'
 
 # ------------------------------------------------------------------------------
 
@@ -749,15 +749,17 @@ class TestFile(StorageRecordedTestCase):
         file_client.append_data(data, 0, len(data))
         file_client.flush_data(len(data))
 
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
         # download the data into a file and make sure it is the same as uploaded data
-        with open(FILE_PATH, 'wb') as stream:
+        with open(temp_file.name, 'wb') as stream:
             download = file_client.download_file()
             download.readinto(stream)
 
         # Assert
-        with open(FILE_PATH, 'rb') as stream:
+        with open(temp_file.name, 'rb') as stream:
             actual = stream.read()
             assert data == actual
+        temp_file.close()
 
     @DataLakePreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import asyncio
+import tempfile
 import unittest
 from datetime import datetime, timedelta
 from math import ceil
@@ -36,7 +37,6 @@ from settings.testcase import DataLakePreparer
 
 TEST_DIRECTORY_PREFIX = 'directory'
 TEST_FILE_PREFIX = 'file'
-FILE_PATH = 'file_output.temp.dat'
 
 # ------------------------------------------------------------------------------
 
@@ -694,15 +694,17 @@ class TestFileAsync(AsyncStorageRecordedTestCase):
         await file_client.append_data(data, 0, len(data))
         await file_client.flush_data(len(data))
 
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
         # download the data into a file and make sure it is the same as uploaded data
-        with open(FILE_PATH, 'wb') as stream:
+        with open(temp_file.name, 'wb') as stream:
             download = await file_client.download_file()
             await download.readinto(stream)
 
         # Assert
-        with open(FILE_PATH, 'rb') as stream:
+        with open(temp_file.name, 'rb') as stream:
             actual = stream.read()
             assert data == actual
+        temp_file.close()
 
     @DataLakePreparer()
     @recorded_by_proxy_async

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 import asyncio
-import tempfile
 import unittest
 from datetime import datetime, timedelta
 from math import ceil
@@ -37,6 +36,7 @@ from settings.testcase import DataLakePreparer
 
 TEST_DIRECTORY_PREFIX = 'directory'
 TEST_FILE_PREFIX = 'file'
+FILE_PATH = 'file_output.temp.dat'
 
 # ------------------------------------------------------------------------------
 
@@ -694,17 +694,15 @@ class TestFileAsync(AsyncStorageRecordedTestCase):
         await file_client.append_data(data, 0, len(data))
         await file_client.flush_data(len(data))
 
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
         # download the data into a file and make sure it is the same as uploaded data
-        with open(temp_file.name, 'wb') as stream:
+        with open(FILE_PATH, 'wb') as stream:
             download = await file_client.download_file()
             await download.readinto(stream)
 
         # Assert
-        with open(temp_file.name, 'rb') as stream:
+        with open(FILE_PATH, 'rb') as stream:
             actual = stream.read()
             assert data == actual
-        temp_file.close()
 
     @DataLakePreparer()
     @recorded_by_proxy_async

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
@@ -694,17 +694,16 @@ class TestFileAsync(AsyncStorageRecordedTestCase):
         await file_client.append_data(data, 0, len(data))
         await file_client.flush_data(len(data))
 
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
         # download the data into a file and make sure it is the same as uploaded data
-        with open(temp_file.name, 'wb') as stream:
+        with tempfile.TemporaryFile() as temp_file:
             download = await file_client.download_file()
-            await download.readinto(stream)
+            await download.readinto(temp_file)
 
-        # Assert
-        with open(temp_file.name, 'rb') as stream:
-            actual = stream.read()
+            temp_file.seek(0)
+
+            # Assert
+            actual = temp_file.read()
             assert data == actual
-        temp_file.close()
 
     @DataLakePreparer()
     @recorded_by_proxy_async


### PR DESCRIPTION
This PR starts the work for using `tempfile` across all packages for file IO operations in an effort to reduce the failures in CI related to file IO operations.

