### PR TITLE
Making attachments paths in email samples absolute

### DIFF
--- a/sdk/communication/azure-communication-email/samples/send_email_with_attachments_sample.py
+++ b/sdk/communication/azure-communication-email/samples/send_email_with_attachments_sample.py
@@ -38,7 +38,11 @@ class EmailWithAttachmentSample(object):
         email_client = EmailClient.from_connection_string(self.connection_string)
 
         # creating the email message
-        with open("./attachment.txt", "rb") as file:
+        attachment_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "attachment.txt")
+
+        with open(attachment_path, "rb") as file:
             file_bytes = file.read()
 
         file_bytes_b64 = base64.b64encode(file_bytes)

--- a/sdk/communication/azure-communication-email/samples/send_email_with_attachments_sample_async.py
+++ b/sdk/communication/azure-communication-email/samples/send_email_with_attachments_sample_async.py
@@ -39,7 +39,11 @@ class EmailWithAttachmentSampleAsync(object):
         email_client = EmailClient.from_connection_string(self.connection_string)
 
         # creating the email message
-        with open("./attachment.txt", "rb") as file:
+        attachment_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "attachment.txt")
+
+        with open(attachment_path, "rb") as file:
             file_bytes = file.read()
 
         file_bytes_b64 = base64.b64encode(file_bytes)


### PR DESCRIPTION
# Description

There was an error running the samples in the communication email live test pipeline. This was because the samples were being run from the root directory rather than the `samples` directory. These samples were modified to use an absolute path for the attachments being read to avoid this issue.
