### PR TITLE
Track azure-sdk usage in statsbeat instrumentations

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add pre-aggregated standard metrics - requests/duration, dependencies/duration
     ([#26753](https://github.com/Azure/azure-sdk-for-python/pull/26753))
+- Add azure-sdk usage to instrumentations statsbeat
+    ([#26753](https://github.com/Azure/azure-sdk-for-python/pull/26753))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add pre-aggregated standard metrics - requests/duration, dependencies/duration
     ([#26753](https://github.com/Azure/azure-sdk-for-python/pull/26753))
 - Add azure-sdk usage to instrumentations statsbeat
-    ([#26753](https://github.com/Azure/azure-sdk-for-python/pull/26753))
+    ([#27756](https://github.com/Azure/azure-sdk-for-python/pull/27756))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
@@ -55,6 +55,10 @@ _STATSBEAT_METRIC_NAME_MAPPINGS = dict(
 
 # Instrumentations
 
+# Special constant for azure-sdk opentelemetry instrumentation
+_AZURE_SDK_OPENTELEMETRY_NAME = "azure-sdk-opentelemetry"
+_AZURE_SDK_NAMESPACE_NAME = "az.namespace"
+
 _BASE = 2
 
 _INSTRUMENTATIONS_LIST = [
@@ -96,7 +100,7 @@ _INSTRUMENTATIONS_LIST = [
     "tornado",
     "urllib",
     "urllib3",
-    "azure-sdk",
+    _AZURE_SDK_OPENTELEMETRY_NAME,
 ]
 
 _INSTRUMENTATIONS_BIT_MAP = {_INSTRUMENTATIONS_LIST[i]: _BASE**i for i in range(len(_INSTRUMENTATIONS_LIST))}

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
@@ -96,6 +96,7 @@ _INSTRUMENTATIONS_LIST = [
     "tornado",
     "urllib",
     "urllib3",
+    "azure-sdk",
 ]
 
 _INSTRUMENTATIONS_BIT_MAP = {_INSTRUMENTATIONS_LIST[i]: _BASE**i for i in range(len(_INSTRUMENTATIONS_LIST))}

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -12,6 +12,8 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import SpanKind
 
 from azure.monitor.opentelemetry.exporter._constants import (
+    _AZURE_SDK_NAMESPACE_NAME,
+    _AZURE_SDK_OPENTELEMETRY_NAME,
     _INSTRUMENTATION_SUPPORTING_METRICS_LIST,
     _SAMPLE_RATE_KEY,
 )
@@ -144,7 +146,7 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
         envelope.tags["ai.operation.name"] = span.name
         if SpanAttributes.NET_PEER_IP in span.attributes:
             envelope.tags["ai.location.ip"] = span.attributes[SpanAttributes.NET_PEER_IP]
-        if "az.namespace" in span.attributes:  # Azure specific resources
+        if _AZURE_SDK_NAMESPACE_NAME in span.attributes:  # Azure specific resources
             # Currently only eventhub and servicebus are supported (kind CONSUMER)
             data.source = _get_azure_sdk_target_source(span.attributes)
             if span.links:
@@ -273,10 +275,10 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
                     port != _get_default_port_db(span.attributes.get(SpanAttributes.DB_SYSTEM)):
                     target = "{}:{}".format(target, port)
         if span.kind is SpanKind.CLIENT:
-            if "az.namespace" in span.attributes:  # Azure specific resources
+            if _AZURE_SDK_NAMESPACE_NAME in span.attributes:  # Azure specific resources
                 # Currently only eventhub and servicebus are supported
                 # https://github.com/Azure/azure-sdk-for-python/issues/9256
-                data.type = span.attributes["az.namespace"]
+                data.type = span.attributes[_AZURE_SDK_NAMESPACE_NAME]
                 data.target = _get_azure_sdk_target_source(span.attributes)
             elif SpanAttributes.HTTP_METHOD in span.attributes:  # HTTP
                 data.type = "HTTP"
@@ -398,8 +400,8 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
                 data.type = "N/A"
         elif span.kind is SpanKind.PRODUCER:  # Messaging
             # Currently only eventhub and servicebus are supported that produce PRODUCER spans
-            if "az.namespace" in span.attributes:
-                data.type = "Queue Message | {}".format(span.attributes["az.namespace"])
+            if _AZURE_SDK_NAMESPACE_NAME in span.attributes:
+                data.type = "Queue Message | {}".format(span.attributes[_AZURE_SDK_NAMESPACE_NAME])
                 data.target = _get_azure_sdk_target_source(span.attributes)
             else:
                 data.type = "Queue Message"
@@ -413,8 +415,8 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
                         target = msg_system
         else:  # SpanKind.INTERNAL
             data.type = "InProc"
-            if "az.namespace" in span.attributes:
-                data.type += " | {}".format(span.attributes["az.namespace"])
+            if _AZURE_SDK_NAMESPACE_NAME in span.attributes:
+                data.type += " | {}".format(span.attributes[_AZURE_SDK_NAMESPACE_NAME])
         # Apply truncation
         # See https://github.com/MohanGsk/ApplicationInsights-Home/tree/master/EndpointSpecs/Schemas/Bond
         if data.name:
@@ -560,8 +562,8 @@ def _is_sql_db(db_system: str) -> bool:
 def _check_instrumentation_span(span: ReadableSpan) -> None:
     # Special use-case for spans generated from azure-sdk services
     # Identified by having az.namespace as a span attribute
-    if "az.namespace" in span.attributes:
-        _utils.add_instrumentation("azure-sdk")
+    if _AZURE_SDK_NAMESPACE_NAME in span.attributes:
+        _utils.add_instrumentation(_AZURE_SDK_OPENTELEMETRY_NAME)
         return
     if span.instrumentation_scope is None:
         return

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -558,6 +558,11 @@ def _is_sql_db(db_system: str) -> bool:
 
 
 def _check_instrumentation_span(span: ReadableSpan) -> None:
+    # Special use-case for spans generated from azure-sdk services
+    # Identified by having az.namespace as a span attribute
+    if "az.namespace" in span.attributes:
+        _utils.add_instrumentation("azure-sdk")
+        return
     if span.instrumentation_scope is None:
         return
     # All instrumentation scope names from OpenTelemetry instrumentations have

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -23,6 +23,10 @@ from azure.monitor.opentelemetry.exporter.export.trace._exporter import (
     _check_instrumentation_span,
     _get_trace_export_result,
 )
+from azure.monitor.opentelemetry.exporter._constants import (
+    _AZURE_SDK_NAMESPACE_NAME,
+    _AZURE_SDK_OPENTELEMETRY_NAME,
+)
 from azure.monitor.opentelemetry.exporter._utils import azure_monitor_context
 
 
@@ -1275,6 +1279,7 @@ class TestAzureTraceExporterUtils(unittest.TestCase):
 
     def test_check_instrumentation_span(self):
         span = mock.Mock()
+        span.attributes = {}
         span.instrumentation_scope.name = "opentelemetry.instrumentation.test"
         with mock.patch(
             "azure.monitor.opentelemetry.exporter._utils.add_instrumentation"
@@ -1284,9 +1289,20 @@ class TestAzureTraceExporterUtils(unittest.TestCase):
 
     def test_check_instrumentation_span_not_instrumentation(self):
         span = mock.Mock()
+        span.attributes = {}
         span.instrumentation_scope.name = "__main__"
         with mock.patch(
             "azure.monitor.opentelemetry.exporter._utils.add_instrumentation"
         ) as add:
             _check_instrumentation_span(span)
             add.assert_not_called()
+
+    def test_check_instrumentation_span_azure_sdk(self):
+        span = mock.Mock()
+        span.attributes = {_AZURE_SDK_NAMESPACE_NAME: "Microsoft.EventHub"}
+        span.instrumentation_scope.name = "__main__"
+        with mock.patch(
+            "azure.monitor.opentelemetry.exporter._utils.add_instrumentation"
+        ) as add:
+            _check_instrumentation_span(span)
+            add.assert_called_once_with(_AZURE_SDK_OPENTELEMETRY_NAME)


### PR DESCRIPTION
The existence of "az.namespace" determines if span originated from an azure-sdk service.