### PR TITLE
[ML] Marked Compute Schedules as Mutable on October Preview API

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (Unreleased)
+## 1.2.0 (2022-12-05)
 
 ### Features Added
 - Added OS Patching Parameters to Compute Instance.
@@ -8,7 +8,8 @@
 ### Bugs Fixed
 - Fixed Sweep node not excluding optional input with value `None` in REST object. 
 - Fixed bool test for output in download operation.
-- Fixed Compute Instance schedule not being created  
+- Fixed Compute Instance schedule not being created
+- Removed erroneous experimental warning from Compute Schedules
 
 ## 1.1.2 (2022-11-21)
 

--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-## 1.3.0 (Unreleased)
-
-### Bugs Fixed
-- Removed erroneous experimental warning from Compute Schedules.
-- 
-
 ## 1.2.0 (Unreleased)
 
 ### Features Added
@@ -14,6 +8,7 @@
 ### Bugs Fixed
 - Fixed Sweep node not excluding optional input with value `None` in REST object. 
 - Fixed bool test for output in download operation.
+- Fixed Compute Instance schedule not being created  
 
 ## 1.1.2 (2022-11-21)
 

--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release History
 
-## 1.2.0 (2022-12-05)
+## 1.3.0 (Unreleased)
+
+### Bugs Fixed
+- Removed erroneous experimental warning from Compute Schedules.
+- 
+
+## 1.2.0 (Unreleased)
 
 ### Features Added
 - Added OS Patching Parameters to Compute Instance.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/v2022_10_01_preview/models/_models_py3.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_restclient/v2022_10_01_preview/models/_models_py3.py
@@ -6485,7 +6485,6 @@ class ComputeInstanceProperties(msrest.serialization.Model):
         'errors': {'readonly': True},
         'state': {'readonly': True},
         'last_operation': {'readonly': True},
-        'schedules': {'readonly': True},
         'containers': {'readonly': True},
         'data_disks': {'readonly': True},
         'data_mounts': {'readonly': True},

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_schedule.py
@@ -102,7 +102,6 @@ class ComputeStartStopSchedule(RestTranslatableMixin):
         return schedule
 
 
-@experimental
 class ComputeSchedules(RestTranslatableMixin):
     """Compute schedules.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_schedule.py
@@ -9,7 +9,6 @@ from azure.ai.ml._restclient.v2022_10_01_preview.models import ComputeSchedules 
 from azure.ai.ml._restclient.v2022_10_01_preview.models import ComputeStartStopSchedule as RestComputeStartStopSchedule
 from azure.ai.ml._restclient.v2022_10_01_preview.models import ScheduleStatus as ScheduleState
 from azure.ai.ml._restclient.v2022_10_01_preview.models import TriggerType
-from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml.entities._mixins import RestTranslatableMixin
 
 from .._schedule.trigger import CronTrigger, RecurrenceTrigger

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute_instance.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute_instance.py
@@ -354,7 +354,6 @@ class ComputeInstance(Compute):
         os_image_metadata = None
         if prop.properties and prop.properties.os_image_metadata:
             metadata = prop.properties.os_image_metadata
-            print(metadata)
             os_image_metadata = ImageMetadata(
                 is_latest_os_image_version=metadata.is_latest_os_image_version
                 if metadata.is_latest_os_image_version is not None


### PR DESCRIPTION
# Description

Fixes several bugs for Compute Instances: 
 - Removes readonly property from Compute Schedules on the 10-01-2022-preview API.
 - Removes an extra print statement from Compute Instances.
 - Removes experimental tag from Compute Schedules.

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
