### PR TITLE
Add docs for out-of-repo recording management

### DIFF
--- a/doc/dev/recording_migration_guide.md
+++ b/doc/dev/recording_migration_guide.md
@@ -1,0 +1,130 @@
+# Guide for migrating test recordings out of the `azure-sdk-for-python` repository
+
+The Azure SDK test proxy enables tests to run recorded tests, even when these test recordings are outside the
+`azure-sdk-for-python` repository. Migrating to this out-of-repo recording setup requires an initial recording move,
+and after this the flow to update recordings will be slightly different. This guide describes the first stage of this
+process and links to updated recording instructions.
+
+More technical documentation of the test proxy's out-of-repo recording support can be found [here][detailed_docs] in
+the `azure-sdk-tools` repository.
+
+## Table of contents
+- [Current recording setup](#current-recording-setup)
+- [New recording setup](#new-recording-setup)
+- [Initial recording migration](#initial-recording-migration)
+  - [Migration script prerequisites](#migration-script-prerequisites)
+  - [Execute the migration script](#execute-the-migration-script)
+- [Run tests with out-of-repo recordings](#run-tests-with-out-of-repo-recordings)
+
+## Current recording setup
+
+Currently, test recordings live in the `azure-sdk-for-python` repository (or "language repo"), under a given package's
+`/tests/recordings` directory. The test proxy loads recordings from this local directory -- this can be done entirely
+offline.
+
+However, the main drawback of storing recordings in the language repo is bloat; a huge percentage of all language repo
+files are actually test recordings. Recording file updates are also included in pull requests, which can make them more
+tedious to review and difficult to load.
+
+## New recording setup
+
+With the test proxy, we can instead store recordings in a completely different git repository (called
+[`azure-sdk-assets`][azure_sdk_assets], or the "assets repo"). The test proxy creates a sparse clone of only the
+recordings for the package being tested, stores them locally in a git-excluded language repo directory, and runs
+playback tests in the same way as before.
+
+The out-of-repo recording system requires a connection to fetch recordings but frees up considerable space in the
+language repo. Additionally, pull requests that update recordings now update a single pointer to new recordings instead
+of full recording files.
+
+The pointer to test recordings is stored in a new `assets.json` file that will be created for each package during the
+initial migration.
+
+## Initial recording migration
+
+A [PowerShell script][transition_script] in the `azure-sdk-tools` repository will assist in pushing recordings to the
+assets repo, removing recordings from the language repo, and creating an `assets.json` file for the package you're
+migrating.
+
+This script -- [`generate-assets-json.ps1`][generate_assets_json] -- should be run once per package, and can be used
+either directly from an `azure-sdk-tools` repo clone or with a local download of the script. To download the script to
+your current working directory, use the following PowerShell command:
+```PowerShell
+Invoke-WebRequest -OutFile "generate-assets-json.ps1" https://raw.githubusercontent.com/Azure/azure-sdk-tools/main/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
+```
+
+### Migration script prerequisites
+
+- The targeted library is already migrated to use the test proxy.
+- Git version > 2.25.0 is to on the machine and in the path. Git is used by the script and test proxy.
+- [PowerShell Core][powershell] >= 7.0 is installed.
+- [Docker][docker] or [Podman][podman] is installed.
+- Global [git config settings][git_setup] are configured for `user.name` and `user.email`.
+  - These settings can be overridden with environment variables `GIT_COMMIT_EMAIL` and `GIT_COMMIT_OWNER`, respectively.
+- The environment variable `GIT_TOKEN` is set to a valid [personal access token][git_token] for your user.
+  - This token is necessary for authenticating git requests made in a Docker/Podman container.
+- Membership in the `azure-sdk-write` GitHub group.
+
+### Execute the migration script
+
+In a PowerShell window:
+
+1. Set your working directory to the root of the package you're migrating (`sdk/{service}/{package}`) -- for example:
+```PowerShell
+cd C:\azure-sdk-for-python\sdk\keyvault\azure-keyvault-keys
+```
+2. Run the following command:
+```PowerShell
+<path-to-script>/generate-assets-json.ps1 -TestProxyExe "docker" -InitialPush
+```
+
+If you run `git status` from within the language repo, you should see:
+- Deleted files for each test recording in the package
+- A new `assets.json` file under the root of your package
+
+The `assets.json` file will have the form:
+```json
+{
+  "AssetsRepo": "Azure/azure-sdk-assets",
+  "AssetsRepoPrefixPath": "python",
+  "TagPrefix": "python/{service}/{package}",
+  "Tag": "python/{service}/{package}_<10-character-commit-SHA>"
+}
+```
+
+The `Tag` field matches the name of a tag that's been created in the assets repo and contains the uploaded recordings.
+Before creating a PR to cement the recording move, it's a good idea to check out that tag in the assets repo and make
+sure the recordings that you expect to see are there.
+
+## Run tests with out-of-repo recordings
+
+After moving recordings to the asset repo, live and playback testing will be the same as it was in the past. The test
+proxy automatically pulls down the correct set of recordings based on the `Tag` in your package's `assets.json` file.
+
+The process for updating test recordings is slightly different than it was with in-repo recordings, and differs in two
+primary ways:
+
+1. When tests are run in recording mode, recording changes won't be visible in the language repo and will instead be
+tracked in a separate directory.
+2. When updated recordings are pushed to the assets repo, the `Tag` field in your package's `assets.json` file will be
+updated to point to these new recordings. This `assets.json` change is what you'll include in a pull request to update
+recordings in the language repo.
+
+For more details, refer to the documentation in [tests.md][recording_updates].
+
+
+[azure_sdk_assets]: https://github.com/Azure/azure-sdk-assets
+
+[detailed_docs]: https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/documentation/asset-sync/README.md
+[docker]: https://docs.docker.com/engine/install/
+
+[generate_assets_json]: https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
+[git_setup]: https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup
+[git_token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+
+[podman]: https://podman.io/getting-started/installation.html
+[powershell]: https://learn.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-latest
+
+[recording_updates]: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md#run-tests-with-out-of-repo-recordings
+
+[transition_script]: https://github.com/Azure/azure-sdk-tools/tree/main/tools/test-proxy/scripts/transition-scripts

--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -23,6 +23,7 @@ testing infrastructure, and demonstrates how to write and run tests for a servic
         - [Write your tests](#write-your-tests)
         - [Configure live or playback testing mode](#configure-live-or-playback-testing-mode)
         - [Run and record tests](#run-and-record-tests)
+        - [Run tests with out-of-repo recordings](#run-tests-with-out-of-repo-recordings)
         - [Sanitize secrets](#sanitize-secrets)
             - [Special case: SAS tokens](#special-case-sas-tokens)
     - [Functional vs. unit tests](#functional-vs-unit-tests)
@@ -365,6 +366,48 @@ recording in this folder will be a `.json` file that captures the HTTP traffic t
 matching the file's name. If you set the `AZURE_TEST_RUN_LIVE` environment variable to "false" and re-run tests, they
 should pass again -- this time, in playback mode (i.e. without making actual HTTP requests).
 
+### Run tests with out-of-repo recordings
+
+If the package being tested stores its recordings outside the `azure-sdk-for-python` repository -- i.e. the
+[recording migration guide][recording_move] has been followed and the package contains an `assets.json` file -- there
+won't be a `recordings` folder in the `tests` directory. Instead, the package's `assets.json` file will point to a tag
+in the `azure-sdk-assets` repository that contains the recordings. This is the preferred recording configuration.
+
+Running live or playback tests is the same in this configuration as it was in the previous section. The only changes are
+to the process of updating recordings.
+
+#### Update test recordings
+
+Test recordings will be updated if tests are run while `AZURE_TEST_RUN_LIVE` is set to "true" and
+`AZURE_SKIP_LIVE_RECORDING` is unset or "false". Since the recordings themselves are no longer in the
+`azure-sdk-for-python` repo, though, these updates will be reflected in a git-excluded `.assets` folder at the root of
+the repo.
+
+The `.assets` folder contains one or more directories with random names, which each are a git directory containing
+recordings. If you `cd` into the folder containing your package's recordings, you can use `git status` to view the
+recording updates you've made.
+
+To find the directory containing your package's recordings, open the `.breadcrumb` file in the `.assets` folder. This
+file lists a package name on each line, followed by the recording directory name; for example:
+```
+sdk/{service}/{package}/assets.json;2Km2Z8755;python/{service}/{package}_<10-character-commit-SHA>
+```
+The recording directory in this case is `2Km2Z8755`, the string between the two semicolons.
+
+After verifying that your recording updates look correct, you can use the `manage_recordings.py` script from
+`azure-sdk-for-python/scripts` to push these recordings to the `azure-sdk-assets` repo. For example, from the root of
+the `azure-sdk-for-python` repo:
+```
+python scripts/manage_recordings.py push sdk/{service}/{package}/assets.json
+```
+
+**NOTE:** The `manage_recordings.py` script is still under development at the time of writing. To push updated
+recordings in the meantime, refer to https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/documentation/asset-sync/README.md#pushing-new-recordings.
+
+After pushing your recordings, the `assets.json` file for your package will be updated to point to a new `Tag` that
+contains the updates. Include this `assets.json` update in any pull request to update the recordings pointer in the
+upstream repo.
+
 ### Sanitize secrets
 
 The `.json` files created from running tests in live mode can include authorization details, account names, shared
@@ -676,6 +719,8 @@ Tests that use the Shared Access Signature (SAS) to authenticate a client should
 [pytest_invocation]: https://pytest.org/latest/how-to/usage.html
 [pytest_logging]: https://docs.pytest.org/en/stable/logging.html
 [python-dotenv_readme]:https://github.com/theskumar/python-dotenv
+
+[recording_move]: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/recording_migration_guide.md
 
 [test_proxy_startup]: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/test_proxy_migration_guide.md#start-the-proxy-server
 [test_resources]: https://github.com/Azure/azure-sdk-for-python/tree/main/eng/common/TestResources#readme


### PR DESCRIPTION
# Description

Adds a specific guide for moving recordings to the `azure-sdk-assets` repo when using Docker (per Python's preference). Also adds a section to our `tests.md` documentation to describe the process of updating these recordings.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- _N/A_ **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- _N/A_ Pull request includes test coverage for the included changes.
