### PR TITLE
[Pipeline] Enable pipeline input as runsetting value

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
@@ -239,6 +239,8 @@ def get_rest_dict_for_node_attrs(target_obj, clear_empty_value=False):
     """Convert object to dict and convert OrderedDict to dict.
     Allow data binding expression as value, disregarding of the type defined in rest object.
     """
+    from azure.ai.ml.entities._job.pipeline._io import PipelineInput
+
     # pylint: disable=too-many-return-statements
     if target_obj is None:
         return None
@@ -268,6 +270,9 @@ def get_rest_dict_for_node_attrs(target_obj, clear_empty_value=False):
     if isinstance(target_obj, msrest.serialization.Model):
         # can't use result.as_dict() as data binding expression may not fit rest object structure
         return get_rest_dict_for_node_attrs(target_obj.__dict__, clear_empty_value=clear_empty_value)
+
+    if isinstance(target_obj, PipelineInput):
+        return get_rest_dict_for_node_attrs(str(target_obj), clear_empty_value=clear_empty_value)
 
     if not isinstance(target_obj, (str, int, float, bool)):
         raise ValueError("Unexpected type {}".format(type(target_obj)))

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
@@ -239,9 +239,9 @@ def get_rest_dict_for_node_attrs(target_obj, clear_empty_value=False):
     """Convert object to dict and convert OrderedDict to dict.
     Allow data binding expression as value, disregarding of the type defined in rest object.
     """
+    # pylint: disable=too-many-return-statements
     from azure.ai.ml.entities._job.pipeline._io import PipelineInput
 
-    # pylint: disable=too-many-return-statements
     if target_obj is None:
         return None
     if isinstance(target_obj, dict):

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_entity.py
@@ -1467,7 +1467,7 @@ class TestPipelineJobEntity:
         assert "str_param" in rest_obj.properties.inputs
 
     def test_pipeline_input_as_runsettings_value(self, client: MLClient) -> None:
-        input_types_func = load_component(source=r"D:\Project\azure-sdk-for-python\sdk\ml\azure-ai-ml\tests/test_configs/components/input_types_component.yml")
+        input_types_func = load_component(source="./tests/test_configs/components/input_types_component.yml")
 
         @dsl.pipeline(
             default_compute="cpu-cluster",

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_entity.py
@@ -23,6 +23,7 @@ from azure.ai.ml.entities._job.automl.image import (
     ImageInstanceSegmentationJob,
     ImageObjectDetectionJob,
 )
+from azure.ai.ml.entities._job.job_resource_configuration import JobResourceConfiguration
 from azure.ai.ml.entities._job.automl.nlp import TextClassificationJob, TextClassificationMultilabelJob, TextNerJob
 from azure.ai.ml.entities._job.automl.tabular import ClassificationJob, ForecastingJob, RegressionJob
 from azure.ai.ml.entities._job.pipeline._io import PipelineInput, _GroupAttrDict
@@ -1464,3 +1465,27 @@ class TestPipelineJobEntity:
         assert "boolean" in rest_obj.properties.inputs
         assert "number" in rest_obj.properties.inputs
         assert "str_param" in rest_obj.properties.inputs
+
+    def test_pipeline_input_as_runsettings_value(self, client: MLClient) -> None:
+        input_types_func = load_component(source=r"D:\Project\azure-sdk-for-python\sdk\ml\azure-ai-ml\tests/test_configs/components/input_types_component.yml")
+
+        @dsl.pipeline(
+            default_compute="cpu-cluster",
+            description="Set pipeline input to runsettings",
+        )
+        def empty_value_pipeline(integer: int, boolean: bool, number: float,
+                                 str_param: str, shm_size: str):
+            component = input_types_func(component_in_string=str_param,
+                                         component_in_ranged_integer=integer,
+                                         component_in_boolean=boolean,
+                                         component_in_ranged_number=number)
+            component.resources = JobResourceConfiguration(
+                instance_count=integer,
+                shm_size=shm_size,
+            )
+
+        pipeline = empty_value_pipeline(integer=0, boolean=False, number=0,
+                                        str_param="str_param", shm_size="20g")
+        rest_obj = pipeline._to_rest_object()
+        expect_resource = {'instance_count': '${{parent.inputs.integer}}', 'shm_size': '${{parent.inputs.shm_size}}'}
+        assert rest_obj.properties.jobs["component"]["resources"] == expect_resource


### PR DESCRIPTION
# Description
1. Enable pipeline input as runsettings value
2. Remove checksum file when consistency verification failed
If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
