### PR TITLE
Resolve Failing Storage Build

### DIFF
--- a/sdk/storage/azure-mgmt-storagesync/dev_requirements.txt
+++ b/sdk/storage/azure-mgmt-storagesync/dev_requirements.txt
@@ -2,3 +2,4 @@
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools
 -e ../../core/azure-mgmt-core
+-e ../../core/azure-core


### PR DESCRIPTION
azure-mgmt-storagesync -> azure-mgmt-core -> azure-core.

Required version of azure-mgmt-core needs newest version of azure-core, but at this point of the build process we don't want to force access to the dev feed. Add relative dep on version of azure-core that is actually necessary.

@jalauzon-msft 