### PR TITLE
[ML][Pipelines] Not use tmp path in flaky test

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
@@ -367,24 +367,9 @@ class TestComponent(AzureRecordedTestCase):
 
     @pytest.mark.disable_mock_code_hash
     @pytest.mark.skipif(condition=not is_live(), reason="reuse test, target to verify service-side behavior")
-    def test_component_create_twice_same_code_arm_id(
-        self, client: MLClient, randstr: Callable[[str], str], tmp_path: Path
-    ) -> None:
+    def test_component_create_twice_same_code_arm_id(self, client: MLClient, randstr: Callable[[str], str]) -> None:
+        component_path = "./tests/test_configs/components/component_for_reuse_test/component.yml"
         component_name = randstr("component_name")
-        # create new component to prevent the issue when same component code got created at the same time
-        component_path = tmp_path / "component.yml"
-        with open(component_path, "w") as f:
-            f.write(
-                f"""
-$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
-name: {component_name}
-version: 1
-type: command
-name: SampleCommandComponentBasic
-command: echo Hello World
-code: "."
-environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1"""
-            )
         # create a component
         component_resource1 = create_component(client, component_name, path=component_path)
         # create again

--- a/sdk/ml/azure-ai-ml/tests/test_configs/components/component_for_reuse_test/component.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/components/component_for_reuse_test/component.yml
@@ -1,0 +1,8 @@
+$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+name: {component_name}
+version: 1
+type: command
+name: SampleCommandComponentBasic
+command: echo Hello World
+code: "."
+environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1


### PR DESCRIPTION
# Description

Component end-to-end test `test_component_create_twice_same_code_arm_id` consistently breaks in live test with error "azure.ai.ml.exceptions.AssetException: Error creating codes asset : Directory is empty. path or local_path must be a non-empty directory.", which may be caused by tmp path. This test previously use tmp path as we have weekly-built workspace and need to avoid reusing; as we have daily new workspace in live test now, there is no need to use tmp path any more, change it to local file.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
