### PR TITLE
Resolve `depends` failure

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -46,6 +46,7 @@ class ParsedSetup:
         self.namespace = name_space
         self.package_data = package_data
         self.include_package_data = include_package_data
+        self.folder = os.path.dirname(self.setup_filename)
 
     @classmethod
     def from_path(cls, parse_directory_or_file: str):
@@ -200,7 +201,7 @@ def parse_require(req: str) -> Tuple[str, SpecifierSet]:
         return [pkg_name, None]
 
     # regex details ripped from https://peps.python.org/pep-0508/
-    isolated_spec = re.sub(r'^([a-zA-Z0-9\-\_\.]+)(\[[a-zA-Z0-9\-\_\.\,]*\])?', "", str(req_object))
+    isolated_spec = re.sub(r"^([a-zA-Z0-9\-\_\.]+)(\[[a-zA-Z0-9\-\_\.\,]*\])?", "", str(req_object))
     spec = SpecifierSet(isolated_spec)
     return (pkg_name, spec)
 

--- a/tools/azure-sdk-tools/tests/test_parse_functionality.py
+++ b/tools/azure-sdk-tools/tests/test_parse_functionality.py
@@ -113,3 +113,4 @@ setup(
     assert result.namespace == "ci_tools"
     assert "pytyped" in result.package_data
     assert result.include_package_data == True
+    assert result.folder == package_root


### PR DESCRIPTION
@xiangyan99 if you haven't already noticed, you will!

Non-nightly `core` build is failing. It is failing because the `depends` check that resolves just fine for our nightly won't resolve for CI/release builds. This is the case because when building nightly, we will actively update requirements to pull from an alpha version if the real target doesn't exist on pypi. This enables our dev-feed to provide the necessary package.

However, when we are running in `release` mode, like for manual or CI builds, this additional feed is _not_ present. Because that additional dev feed isn't present, there is no way to resolve a dependency on a package that hasn't been released.

I don't want our manual builds to be crippled by this, so I figured I'd file this PR to get our CI/manual builds of `core` green. You will still be _unable_ to release `azure-mgmt-core` without first releasing `azure-core` however. Our dependency release check should catch you.

This PR effectively means that any `tox` environment that uses `create_package_and_install` will automatically get this capability.