### PR TITLE
Fix test to expect  the correct HTTP status

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/CHANGELOG.md
+++ b/sdk/communication/azure-communication-phonenumbers/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## 1.1.0b3 (Unreleased)
 - Users can now manage SIP configuration for Direct routing.
 
+### Bug Fixes
+- The test "test_update_phone_number_capabilities_with_invalid_phone_number" for the phone number SDK now expects the correct HTTP status code (403).
+
 ### Features Added
 - Added new SIP routing client for handling Direct routing numbers.
 - Added the ability specify the API version by an optional `api_version` keyword parameter.

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
@@ -257,5 +257,5 @@ class TestPhoneNumbersClient(PhoneNumbersTestCase):
                 polling=True
             )
 
-        assert str(ex.value.status_code) == "404"  # type: ignore
+        assert str(ex.value.status_code) == "403"  # type: ignore
         assert ex.value.message is not None  # type: ignore

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
@@ -273,6 +273,6 @@ class TestPhoneNumbersClientAsync(PhoneNumbersTestCase):
                     PhoneNumberCapabilityType.INBOUND,
                     polling=True
                 )
-
-        assert str(ex.value.status_code) == "404"  # type: ignore
+        
+        assert str(ex.value.status_code) == "403"  # type: ignore
         assert ex.value.message is not None  # type: ignore


### PR DESCRIPTION
# Description
The test "test_update_phone_number_capabilities_with_invalid_phone_number" for the phone number SDK was expecting the wrong status code, it should be expecting a 403.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
