### PR TITLE
Prevent auto_decompress exception when using EnvironmentCredential

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1024,7 +1024,8 @@
         "myid",
         "jsonify",
         "ints",
-        "inirudebwoy"
+        "inirudebwoy",
+	"mghextreme"
       ]
     },
     {

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix "EnvironmentCredential: 'ClientSession' object has no attribute 'auto_decompress'"
+- Fix "EnvironmentCredential: 'ClientSession' object has no attribute 'auto_decompress'"  (thanks to @mghextreme for the contribution)
 
 ### Other Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix "EnvironmentCredential: 'ClientSession' object has no attribute 'auto_decompress'"
+
 ### Other Changes
 
 - Add "x-ms-error-code" as secure header to log

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix "EnvironmentCredential: 'ClientSession' object has no attribute 'auto_decompress'"  (thanks to @mghextreme for the contribution)
+- Fix 'ClientSession' object has no attribute 'auto_decompress'  (thanks to @mghextreme for the contribution)
 
 ### Other Changes
 

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -198,6 +198,7 @@ class AioHttpTransport(AsyncHttpTransport):
         try:
             auto_decompress = self.session.auto_decompress  # type: ignore
         except AttributeError:
+            # auto_decompress is introduced in aiohttp 3.7. We need this to handle aiohttp 3.6-.
             auto_decompress = False
 
         proxies = config.pop('proxies', None)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -195,7 +195,10 @@ class AioHttpTransport(AsyncHttpTransport):
         :keyword str proxy: will define the proxy to use all the time
         """
         await self.open()
-        auto_decompress = self.session.auto_decompress  # type: ignore
+        try:
+            auto_decompress = self.session.auto_decompress  # type: ignore
+        except AttributeError:
+            auto_decompress = False
 
         proxies = config.pop('proxies', None)
         if proxies and 'proxy' not in config:


### PR DESCRIPTION
# Description

Rolled-back try/except block removed in [this code cleanup](https://github.com/Azure/azure-sdk-for-python/pull/27072/files#diff-3e3d8bcc4360d994e4a73da3a1a870e7d82378311b39712b26aa186441ad7a89).

This is causing errors when connecting using `DefaultAzureCredential` with `AZURE_TENANT_ID`:

```
DefaultAzureCredential failed to retrieve a token from the included credentials.
Attempted credentials: EnvironmentCredential: 'ClientSession' object has no attribute 'auto_decompress'
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
