### PR TITLE
Add serialization support for pandas and numpy-like objects

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Add support for serialization of numpy and pandas-like objects
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/serialization.py
+++ b/sdk/core/azure-core/azure/core/serialization.py
@@ -111,6 +111,24 @@ class AzureJSONEncoder(JSONEncoder):
     def default(self, o):  # pylint: disable=too-many-return-statements
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        # Serialize pandas DataFrame and Series as dict
+        try:
+            return o.to_dict()
+        except AttributeError:
+            pass
+
+        # Serialize numpy numbers and bool
+        try:
+            return o.item()
+        except AttributeError:
+            pass
+
+        # Serialize numpy arrays
+        try:
+            return o.tolist()
+        except AttributeError:
+            pass
+
         try:
             return _datetime_as_isostr(o)
         except AttributeError:

--- a/sdk/core/azure-core/tests/test_serialization.py
+++ b/sdk/core/azure-core/tests/test_serialization.py
@@ -439,3 +439,44 @@ def test_model_recursion(json_dumps_with_encoder):
         ]
     }
     assert json.loads(json_dumps_with_encoder(expected.to_dict())) == expected_dict
+
+
+def test_pandas_dataframe_like(json_dumps_with_encoder):
+    class DataFrame:
+        def __init__(self, val):
+            self.df = val
+
+        def to_dict(self):
+            return self.df
+
+    exp_dict = {
+        'a': [1, 2, 3]
+    }
+
+    assert json.loads(json_dumps_with_encoder(DataFrame(exp_dict))) == exp_dict
+
+
+def test_numpy_number_like(json_dumps_with_encoder):
+    class NumpyNumber:
+        def __init__(self, val):
+            self.val = val
+
+        def item(self):
+            return self.val
+
+    number = 3
+
+    assert json.loads(json_dumps_with_encoder(NumpyNumber(number))) == number
+
+
+def test_numpy_array_like(json_dumps_with_encoder):
+    class NumpyNDArray:
+        def __init__(self, val):
+            self.list = val
+
+        def tolist(self):
+            return self.list
+
+    val = [1, 2]
+
+    assert json.loads(json_dumps_with_encoder(val)) == val


### PR DESCRIPTION
We introduce logic in the AzureJSONEncoder that allows to serialize objects that implement some particular methods that are present in numpy number, numpy ndarray, pandas dataframes.

The implementation assumes that any object that has those methods will be serialized using them. If you think restricting this only to numpy and pandas object might be better, I can add some introspection logic to target only those.

This PR is loosely related to this issue from the old msrest package: https://github.com/Azure/msrest-for-python/issues/257