### PR TITLE
Moving all artifact publishing to end of test job

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -81,15 +81,11 @@ steps:
 
   - ${{ parameters.AfterTestSteps }}
 
-  - pwsh: |
-      if (Test-Path -Path '.\_coverage\') {
-        Get-ChildItem .\_coverage\ -Recurse |
-        Foreach-Object {
-          Get-Content $_
-        }
-      }
-    displayName: 'Show .coverage files'
-    condition: and(succeeded(), ${{ parameters.RunCoverage }})
+  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.SourcesDirectory)/_coverage'
+      ArtifactName: '$(System.StageName)_$(Agent.JobName)_coverage'
+      CustomCondition: '${{ parameters.RunCoverage }}'
 
   - pwsh: |
       python -m pip install coverage==4.5.4
@@ -118,12 +114,6 @@ steps:
       ArtifactPath: '$(Build.SourcesDirectory)/_tox_logs'
       ArtifactName: '$(System.StageName)_$(Agent.JobName)_tox_logs'
       CustomCondition: failed()
-
-  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
-    parameters:
-      ArtifactPath: '$(Build.SourcesDirectory)/_coverage'
-      ArtifactName: '$(System.StageName)_$(Agent.JobName)_coverage'
-      CustomCondition: '${{ parameters.RunCoverage }}'
 
   - task: PublishTestResults@2
     condition: always()

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -113,21 +113,17 @@ steps:
       ArtifactPath: '$(Build.SourcesDirectory)/.logs'
       ArtifactName: '$(System.StageName)_$(Agent.JobName)_logs'
 
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Tox Logs
-    condition: failed()
-    continueOnError: true
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/_tox_logs'
-      artifactType: 'pipeline'
+  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.SourcesDirectory)/_tox_logs'
+      ArtifactName: '$(System.StageName)_$(Agent.JobName)_tox_logs'
+      CustomCondition: $[eq(variables['Agent.JobStatus'], 'Failed')]
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish raw .coverage files'
-    continueOnError: true
-    condition: and(succeeded(), ${{ parameters.RunCoverage }})
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/_coverage'
-      artifactType: 'pipeline'
+  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.SourcesDirectory)/_coverage'
+      ArtifactName: '$(System.StageName)_$(Agent.JobName)_coverage'
+      CustomCondition: $[and(succeeded(), parameters['RunCoverage'])]
 
   - task: PublishTestResults@2
     condition: always()

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -123,7 +123,7 @@ steps:
     parameters:
       ArtifactPath: '$(Build.SourcesDirectory)/_coverage'
       ArtifactName: '$(System.StageName)_$(Agent.JobName)_coverage'
-      CustomCondition: parameters['RunCoverage']
+      CustomCondition: '${{ parameters.RunCoverage }}'
 
   - task: PublishTestResults@2
     condition: always()

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -117,13 +117,13 @@ steps:
     parameters:
       ArtifactPath: '$(Build.SourcesDirectory)/_tox_logs'
       ArtifactName: '$(System.StageName)_$(Agent.JobName)_tox_logs'
-      CustomCondition: $[eq(variables['Agent.JobStatus'], 'Failed')]
+      CustomCondition: failed()
 
   - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
     parameters:
       ArtifactPath: '$(Build.SourcesDirectory)/_coverage'
       ArtifactName: '$(System.StageName)_$(Agent.JobName)_coverage'
-      CustomCondition: $[and(succeeded(), parameters['RunCoverage'])]
+      CustomCondition: parameters['RunCoverage']
 
   - task: PublishTestResults@2
     condition: always()

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -79,6 +79,35 @@ steps:
       displayName: Dump Test-Proxy Logs
       condition: succeededOrFailed()
 
+  - ${{ parameters.AfterTestSteps }}
+
+  - pwsh: |
+      if (Test-Path -Path '.\_coverage\') {
+        Get-ChildItem .\_coverage\ -Recurse |
+        Foreach-Object {
+          Get-Content $_
+        }
+      }
+    displayName: 'Show .coverage files'
+    condition: and(succeeded(), ${{ parameters.RunCoverage }})
+
+  - pwsh: |
+      python -m pip install coverage==4.5.4
+      python scripts/devops_tasks/create_coverage.py
+    displayName: Create Coverage Report
+    condition: and(succeeded(), ${{ parameters.RunCoverage }})
+
+  - task: PythonScript@0
+    displayName: 'Test Samples'
+    condition: and(succeeded(), eq(variables['TestSamples'], 'true'))
+    inputs:
+      scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
+      arguments: >-
+        "$(TargetingString)"
+        --service="${{ parameters.ServiceDirectory }}"
+        --toxenv="samples"
+    env: ${{ parameters.EnvVars }}
+
   - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
     parameters:
       ArtifactPath: '$(Build.SourcesDirectory)/.logs'
@@ -92,18 +121,6 @@ steps:
       targetPath: '$(Build.SourcesDirectory)/_tox_logs'
       artifactType: 'pipeline'
 
-  - ${{ parameters.AfterTestSteps }}
-
-  - pwsh: |
-      if (Test-Path -Path '.\_coverage\') {
-        Get-ChildItem .\_coverage\ -Recurse |
-        Foreach-Object {
-          Get-Content $_
-        }
-      }
-    displayName: 'Show .coverage files'
-    condition: and(succeeded(), ${{ parameters.RunCoverage }})
-
   - task: PublishPipelineArtifact@1
     displayName: 'Publish raw .coverage files'
     continueOnError: true
@@ -112,29 +129,12 @@ steps:
       targetPath: '$(Build.SourcesDirectory)/_coverage'
       artifactType: 'pipeline'
 
-  - pwsh: |
-      python -m pip install coverage==4.5.4
-      python scripts/devops_tasks/create_coverage.py
-    displayName: Create Coverage Report
-    condition: and(succeeded(), ${{ parameters.RunCoverage }})
-
   - task: PublishTestResults@2
     condition: always()
     inputs:
       testResultsFiles: '**/*test*.xml'
       testRunTitle: '${{ parameters.ServiceDirectory }} ${{ parameters.CloudName }} $(Agent.JobName)'
       failTaskOnFailedTests: true
-
-  - task: PythonScript@0
-    displayName: 'Test Samples'
-    condition: and(succeeded(), eq(variables['TestSamples'], 'true'))
-    inputs:
-      scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
-      arguments: >-
-        "$(TargetingString)"
-        --service="${{ parameters.ServiceDirectory }}"
-        --toxenv="samples"
-    env: ${{ parameters.EnvVars }}
 
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish Code Coverage to DevOps'


### PR DESCRIPTION
@kristapratico raised a good point.

If tests succeed, but SAMPLES fail, then on retry the artifact upload of the samples report will fail. 

This is due to the fact that once an artifact is uploaded, it cannot be overwritten. Let's move all the artifact upload to the end so that we can't end up in that same situation.