### PR TITLE
[Batch component deployment]Assign default_compute value

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
-from marshmallow import fields, post_load, validates_schema
+from marshmallow import fields, post_load
 
 from azure.ai.ml._schema._deployment.deployment import DeploymentSchema
 from azure.ai.ml._schema._deployment.batch.job_definition_schema import JobDefinitionSchema
@@ -23,7 +23,7 @@ module_logger = logging.getLogger(__name__)
 
 
 class BatchDeploymentSchema(DeploymentSchema):
-    compute = ComputeField()
+    compute = ComputeField(required=True)
     error_threshold = fields.Int(
         metadata={
             "description": """Error threshold, if the error count for the entire input goes above this value,\r\n
@@ -65,15 +65,3 @@ class BatchDeploymentSchema(DeploymentSchema):
         from azure.ai.ml.entities import BatchDeployment
 
         return BatchDeployment(base_path=self.context[BASE_PATH_CONTEXT_KEY], **data)
-
-    @validates_schema
-    def validate(self, data: Any, **kwargs):
-        if data.get("type") == BatchDeploymentType.MODEL and not data.get("compute"):
-            msg = "Compute name is required"
-            raise ValidationException(
-                message=msg,
-                no_personal_data_message=msg,
-                error_category=ErrorCategory.USER_ERROR,
-                target=ErrorTarget.JOB,
-                error_type=ValidationErrorType.MISSING_FIELD,
-            )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
@@ -6,7 +6,6 @@
 
 import logging
 from typing import Any
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
@@ -6,8 +6,9 @@
 
 import logging
 from typing import Any
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
-from marshmallow import fields, post_load
+from marshmallow import fields, post_load, validates_schema
 
 from azure.ai.ml._schema._deployment.deployment import DeploymentSchema
 from azure.ai.ml._schema._deployment.batch.job_definition_schema import JobDefinitionSchema
@@ -22,7 +23,7 @@ module_logger = logging.getLogger(__name__)
 
 
 class BatchDeploymentSchema(DeploymentSchema):
-    compute = ComputeField(required=True)
+    compute = ComputeField()
     error_threshold = fields.Int(
         metadata={
             "description": """Error threshold, if the error count for the entire input goes above this value,\r\n
@@ -64,3 +65,15 @@ class BatchDeploymentSchema(DeploymentSchema):
         from azure.ai.ml.entities import BatchDeployment
 
         return BatchDeployment(base_path=self.context[BASE_PATH_CONTEXT_KEY], **data)
+
+    @validates_schema
+    def validate(self, data: Any, **kwargs):
+        if data.get("type") == BatchDeploymentType.MODEL and not data.get("compute"):
+            msg = "Compute name is required"
+            raise ValidationException(
+                message=msg,
+                no_personal_data_message=msg,
+                error_category=ErrorCategory.USER_ERROR,
+                target=ErrorTarget.JOB,
+                error_type=ValidationErrorType.MISSING_FIELD,
+            )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
@@ -19,6 +19,7 @@ from azure.ai.ml._utils._arm_id_utils import _parse_endpoint_name_from_deploymen
 from azure.ai.ml._utils.utils import is_private_preview_enabled, camel_to_snake
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, PARAMS_OVERRIDE_KEY
 from azure.ai.ml.constants._deployment import BatchDeploymentOutputAction
+from azure.ai.ml.constants._job.pipeline import PipelineConstants
 from azure.ai.ml.entities._assets import Environment, Model
 from azure.ai.ml.entities._deployment.deployment_settings import BatchRetrySettings
 from azure.ai.ml.entities._job.resource_configuration import ResourceConfiguration
@@ -218,6 +219,9 @@ class BatchDeployment(Deployment): # pylint: disable=too-many-instance-attribute
         )
 
         if is_private_preview_enabled() and self.job_definition:
+            if not self.job_definition.settings and self.compute:
+                self.job_definition.settings = {}
+            self.job_definition.settings[PipelineConstants.DEFAULT_COMPUTE] = self.compute
             non_flat_data = {}
             non_flat_data["ComponentDeployment"] = self.job_definition._to_dict()
             flat_data = flatten(non_flat_data, ".")

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
@@ -219,7 +219,7 @@ class BatchDeployment(Deployment): # pylint: disable=too-many-instance-attribute
         )
 
         if is_private_preview_enabled() and self.job_definition:
-            if not self.job_definition.settings and self.compute:
+            if not self.job_definition.settings:
                 self.job_definition.settings = {}
             self.job_definition.settings[PipelineConstants.DEFAULT_COMPUTE] = self.compute
             non_flat_data = {}


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

As part of the PrP we need to populate "ComponentDeployment.default_compute" with the `compute` value is being defined in the YAML file.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
