### PR TITLE
Adding email live tests resources to test-resources.json

### DIFF
--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -2,83 +2,134 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "baseName": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().name]",
-            "metadata": {
-                "description": "The base resource name."
-            }
-        },
-        "endpointPrefix": {
-            "defaultValue": "communication",
-            "type": "string"
-        },
-        "testApplicationOid": {
-            "type": "string",
-            "metadata": {
-                "description": "The client OID to grant access to test resources."
-            }
-        },
-        "tenantId": {
-            "type": "string",
-            "metadata": {
-                "description": "The tenant id to which the application and resources belong."
-            }
-        },
-        "testApplicationId": {
-            "type": "string",
-            "metadata": {
-                "description": "The application client id used to run tests."
-            }
-        },
-        "testApplicationSecret": {
-            "type": "string",
-            "metadata": {
-                "description": "The application client secret used to run tests."
-            }
+      "baseName": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().name]",
+        "metadata": {
+          "description": "The base resource name."
         }
+      },
+      "endpointPrefix": {
+        "defaultValue": "communication",
+        "type": "string"
+      },
+      "testApplicationOid": {
+        "type": "string",
+        "metadata": {
+          "description": "The client OID to grant access to test resources."
+        }
+      },
+      "tenantId": {
+        "type": "string",
+        "metadata": {
+          "description": "The tenant id to which the application and resources belong."
+        }
+      },
+      "testApplicationId": {
+        "type": "string",
+        "metadata": {
+          "description": "The application client id used to run tests."
+        }
+      },
+      "testApplicationSecret": {
+        "type": "string",
+        "metadata": {
+          "description": "The application client secret used to run tests."
+        }
+      }
     },
     "variables": {
-        "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
-        "contributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c"
+      "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
+      "emailServiceName": "[format('{0}-{1}', variables('uniqueSubDomainName'), 'email-service')]",
+      "contributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c"
     },
     "resources": [
-        {
-            "type": "Microsoft.Communication/CommunicationServices",
-            "apiVersion": "2020-08-20-preview",
-            "name": "[variables('uniqueSubDomainName')]",
-            "location": "global",
-            "properties": {
-                "dataLocation": "UnitedStates"
-            }
+      {
+        "type": "Microsoft.Communication/CommunicationServices",
+        "apiVersion": "2021-10-01-preview",
+        "name": "[variables('uniqueSubDomainName')]",
+        "location": "global",
+        "properties": {
+          "dataLocation": "UnitedStates",
+          "linkedDomains": [
+            "[resourceId('Microsoft.Communication/EmailServices/Domains', variables('emailServiceName'), 'AzureManagedDomain')]"
+          ]
         },
-        {
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2019-04-01-preview",
-            "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('contributorRoleId'))]",
-            "properties": {
-                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
-                "principalId": "[parameters('testApplicationOid')]",
-                "scope": "[resourceGroup().id]"
-            }
+        "dependsOn": [
+          "AzureManagedDomain"
+        ]
+      },
+      {
+        "type": "Microsoft.Authorization/roleAssignments",
+        "apiVersion": "2019-04-01-preview",
+        "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('contributorRoleId'))]",
+        "properties": {
+          "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
+          "principalId": "[parameters('testApplicationOid')]",
+          "scope": "[resourceGroup().id]"
         }
+      },
+      {
+        "type": "Microsoft.Communication/EmailServices",
+        "apiVersion": "2021-10-01-preview",
+        "name": "[variables('emailServiceName')]",
+        "location": "global",
+        "properties": {
+          "dataLocation": "UnitedStates"
+        },
+        "resources": [
+          {
+            "type": "Domains",
+            "apiVersion": "2021-10-01-preview",
+            "name": "AzureManagedDomain",
+            "location": "global",
+            "dependsOn": [
+              "[variables('emailServiceName')]"
+            ],
+            "properties": {
+              "domainManagement": "AzureManaged"
+            }
+          }
+        ]
+      }
     ],
     "outputs": {
-        "AZURE_TENANT_ID": {
-            "type": "string",
-            "value": "[parameters('tenantId')]"
-        },
-        "AZURE_CLIENT_ID": {
-            "type": "string",
-            "value": "[parameters('testApplicationId')]"
-        },
-        "AZURE_CLIENT_SECRET": {
-            "type": "string",
-            "value": "[parameters('testApplicationSecret')]"
-        },
-        "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
-            "type": "string",
-            "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
-        }
+      "AZURE_TENANT_ID": {
+        "type": "string",
+        "value": "[parameters('tenantId')]"
+      },
+      "AZURE_CLIENT_ID": {
+        "type": "string",
+        "value": "[parameters('testApplicationId')]"
+      },
+      "AZURE_CLIENT_SECRET": {
+        "type": "string",
+        "value": "[parameters('testApplicationSecret')]"
+      },
+      "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
+        "type": "string",
+        "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
+      },
+      "RESOURCE_GROUP_NAME": {
+        "type": "string",
+        "value": "[resourceGroup().Name]"
+      },
+      "COMMUNICATION_CONNECTION_STRING_EMAIL": {
+        "type": "string",
+        "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
+      },
+      "SENDER_ADDRESS": {
+        "type": "string",
+        "value": "[format('{0}@{1}', 'DoNotReply', reference(resourceId('Microsoft.Communication/EmailServices/Domains', variables('emailServiceName'), 'AzureManagedDomain')).mailFromSenderDomain)]"
+      },
+      "RECIPIENT_ADDRESS": {
+        "type": "string",
+        "value": "acseaastesting@gmail.com"
+      },
+      "SECOND_RECIPIENT_ADDRESS": {
+        "type": "string",
+        "value": "acseaastesting@gmail.com"
+      }
     }
-}
+  }
+  


### PR DESCRIPTION
The email live tests were previously using pre-provisioned resources. The secrets for these resources were stored in a key vault and accessed by the pipeline.

We are now creating these test resources at the pipeline runtime using an arm template.