### PR TITLE
Fixed bug in sip routing. SDK shouldnt send empty patch.

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/siprouting/_sip_routing_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/siprouting/_sip_routing_client.py
@@ -206,9 +206,10 @@ class SipRoutingClient(object):
             if x.fqdn not in [o.fqdn for o in trunks]:
                 config.trunks[x.fqdn] = None
 
-        self._rest_service.patch_sip_configuration(
-            body=config, **kwargs
-        )
+        if len(config.trunks) > 0:
+            self._rest_service.patch_sip_configuration(
+                body=config, **kwargs
+            )
 
     @distributed_trace
     def set_routes(

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/siprouting/aio/_sip_routing_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/siprouting/aio/_sip_routing_client_async.py
@@ -210,9 +210,10 @@ class SipRoutingClient(object):
             if x.fqdn not in [o.fqdn for o in trunks]:
                 config.trunks[x.fqdn] = None
 
-        await self._rest_service.patch_sip_configuration(
-            body=config, **kwargs
-        )
+        if len(config.trunks) > 0:
+            await self._rest_service.patch_sip_configuration(
+                body=config, **kwargs
+            )
 
     @distributed_trace_async
     async def set_routes(

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.pyTestSipRoutingClientE2Etest_set_trunks_empty_list.json
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e.pyTestSipRoutingClientE2Etest_set_trunks_empty_list.json
@@ -1,0 +1,65 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)",
+        "x-ms-content-sha256": "sanitized",
+        "x-ms-date": "sanitized",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "sanitized",
+        "MS-CV": "sanitized",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "sanitized",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "182ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)",
+        "x-ms-content-sha256": "sanitized",
+        "x-ms-date": "sanitized",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "sanitized",
+        "MS-CV": "sanitized",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "sanitized",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "279ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.pyTestSipRoutingClientE2EAsynctest_set_trunks_empty_list.json
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.pyTestSipRoutingClientE2EAsynctest_set_trunks_empty_list.json
@@ -1,45 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://login.microsoftonline.com/sanitized/oauth2/v2.0/token",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "*/*",
-        "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "131",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "User-Agent": "azsdk-python-identity/1.9.0 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
-      },
-      "RequestBody": "client_id=sanitized\u0026client_secret=sanitized\u0026grant_type=client_credentials\u0026scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-store, no-cache",
-        "Content-Length": "90",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "sanitized",
-        "Expires": "-1",
-        "P3P": "sanitized",
-        "Pragma": "no-cache",
-        "Set-Cookie": "sanitized",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-ests-server": "sanitized",
-        "X-XSS-Protection": "0"
-      },
-      "ResponseBody": {
-        "token_type": "Bearer",
-        "expires_in": 3599,
-        "ext_expires_in": 3599,
-        "access_token": "Sanitized"
-      }
-    },
-    {
       "RequestUri": "https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)",
+        "x-ms-content-sha256": "sanitized",
+        "x-ms-date": "sanitized",
+        "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -52,7 +23,7 @@
         "Transfer-Encoding": "chunked",
         "X-Azure-Ref": "sanitized",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "1647ms"
+        "X-Processing-Time": "270ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -65,7 +36,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)",
+        "x-ms-content-sha256": "sanitized",
+        "x-ms-date": "sanitized",
+        "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -78,7 +53,7 @@
         "Transfer-Encoding": "chunked",
         "X-Azure-Ref": "sanitized",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "194ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {},

--- a/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.pyTestSipRoutingClientE2EAsynctest_set_trunks_empty_list.json
+++ b/sdk/communication/azure-communication-phonenumbers/test/recordings/test_sip_routing_client_e2e_async.pyTestSipRoutingClientE2EAsynctest_set_trunks_empty_list.json
@@ -1,0 +1,90 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://login.microsoftonline.com/sanitized/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "131",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": "azsdk-python-identity/1.9.0 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+      },
+      "RequestBody": "client_id=sanitized\u0026client_secret=sanitized\u0026grant_type=client_credentials\u0026scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "sanitized",
+        "Expires": "-1",
+        "P3P": "sanitized",
+        "Pragma": "no-cache",
+        "Set-Cookie": "sanitized",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "sanitized",
+        "X-XSS-Protection": "0"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized"
+      }
+    },
+    {
+      "RequestUri": "https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "sanitized",
+        "MS-CV": "sanitized",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "sanitized",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "1647ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://sanitized.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-communication-phonenumbers/1.1.0b3 Python/3.10.0 (Windows-10-10.0.22621-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "sanitized",
+        "MS-CV": "sanitized",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "sanitized",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "194ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
+from azure.core.exceptions import HttpResponseError
 from phone_numbers_testcase import PhoneNumbersTestCase
 from _shared.utils import create_token_credential, get_http_logging_policy
 from sip_routing_helper import get_user_domain, assert_trunks_are_equal, assert_routes_are_equal
@@ -78,6 +78,16 @@ class TestSipRoutingClientE2E(PhoneNumbersTestCase):
         result_trunks = client.get_trunks()
         assert result_trunks is not None, "No trunks were returned."
         assert_trunks_are_equal(result_trunks,[self.additional_trunk])
+
+    @recorded_by_proxy
+    def test_set_trunks_empty_list(self, **kwargs):
+        """Verification of bug fix. SDK shouldn't send empty PATCH, otherwise it will receive exception.
+        This situation occurs, when sending empty trunks list to already empty trunk configuration."""
+        try: 
+            self._sip_routing_client.set_trunks([])
+            self._sip_routing_client.set_trunks([])
+        except HttpResponseError as exception:
+             assert False, "Trying to set empty trunks list returned Http error: " + str(exception.status_code) + ", message: " + exception.message
 
     @recorded_by_proxy
     def test_set_routes(self, **kwargs):

--- a/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
 import pytest
+from azure.core.exceptions import HttpResponseError
 from phone_numbers_testcase import PhoneNumbersTestCase
 from devtools_testutils.aio import recorded_by_proxy_async
 from _shared.utils import async_create_token_credential, get_http_logging_policy
@@ -88,6 +88,18 @@ class TestSipRoutingClientE2EAsync(PhoneNumbersTestCase):
             result_trunks = await self._sip_routing_client.get_trunks()
         assert result_trunks is not None, "No trunks were returned."
         assert_trunks_are_equal(result_trunks,[self.additional_trunk]), "Trunks are not equal."
+
+    @recorded_by_proxy_async
+    async def test_set_trunks_empty_list(self):
+        """Verification of bug fix. SDK shouldn't send empty PATCH, otherwise it will receive exception.
+        This situation occurs, when sending empty trunks list to already empty trunk configuration."""
+        self._sip_routing_client = self._get_sip_client_managed_identity()
+        async with self._sip_routing_client:
+            try: 
+                await self._sip_routing_client.set_trunks([])
+                await self._sip_routing_client.set_trunks([])
+            except HttpResponseError as exception:
+                assert False, "Trying to set empty trunks list returned Http error: " + str(exception.status_code) + ", message: " + exception.message
     
     @recorded_by_proxy_async
     async def test_set_routes(self):

--- a/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
@@ -93,7 +93,6 @@ class TestSipRoutingClientE2EAsync(PhoneNumbersTestCase):
     async def test_set_trunks_empty_list(self):
         """Verification of bug fix. SDK shouldn't send empty PATCH, otherwise it will receive exception.
         This situation occurs, when sending empty trunks list to already empty trunk configuration."""
-        self._sip_routing_client = self._get_sip_client_managed_identity()
         async with self._sip_routing_client:
             try: 
                 await self._sip_routing_client.set_trunks([])


### PR DESCRIPTION
# Description

Recently, we found bug in sending PATCH for sip configuration. When the trunks dictionary on the backend is already empty and user tries to call set_trunks with empty list, the API returns 422, unproccessable entity, because the PATCH request has empty body. This happens, because for trunks dictionary, we're using merge patch.

To fix this, check was added, to send the PATCH only if there are any trunks, that changed.

Scenarios for set_routes don't have this problem, as routes list is always completely replaced and not merge patched.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
