### PR TITLE
[ML][Pipelines] Add component validate test for early available output

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_validate.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_validate.py
@@ -70,6 +70,16 @@ class TestComponentValidate:
             with pytest.raises(ValidationException, match="is not a valid parameter name"):
                 component()
 
+    @pytest.mark.usefixtures("enable_private_preview_schema_features")
+    def test_component_early_available_output_not_set_is_control(self):
+        yaml_file = str(components_dir / "invalid/helloworld_component_early_available_output_not_set_is_control.yml")
+        component = load_component(yaml_file)
+        validation_result = component._validate()
+        assert not validation_result.passed
+        assert "outputs.component_out_string" in validation_result.error_messages
+        expected_error_message = "Early available output 'component_out_string' requires is_control as True, got None."
+        assert validation_result.error_messages["outputs.component_out_string"] == expected_error_message
+
     @pytest.mark.parametrize(
         "expected_location,asset_object",
         [

--- a/sdk/ml/azure-ai-ml/tests/test_configs/components/invalid/helloworld_component_early_available_output_not_set_is_control.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/components/invalid/helloworld_component_early_available_output_not_set_is_control.yml
@@ -1,0 +1,15 @@
+$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+type: command
+
+name: microsoftsamples_command_component_basic
+
+outputs:
+  # early_available output not set is_control
+  component_out_string:
+    type: string
+    early_available: true
+
+command: >-
+  echo Hello World
+
+environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1


### PR DESCRIPTION
# Description

Add component validate test to validate early available output not set `is_control`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
