### PR TITLE
Release hotfix monitor 1.0.0b11

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b11 (Unreleased)
+## 1.0.0b11 (2022-12-14)
 
 ### Features Added
 
@@ -12,14 +12,12 @@
 ### Breaking Changes
 
 - Update to OpenTelemetry api/sdk v1.15.0
-    ([#27900](https://github.com/Azure/azure-sdk-for-python/issues/27900))
+    ([#27913](https://github.com/Azure/azure-sdk-for-python/pull/27913))
 
 ### Bugs Fixed
 
 - Pass along sampleRate in SpanEvents from Span
     ([#27629](https://github.com/Azure/azure-sdk-for-python/pull/27629))
-
-### Other Changes
 
 ## 1.0.0b10 (2022-11-10)
 


### PR DESCRIPTION
# Description

This is a hotfix release to fix a breaking issue whereby the new OTel 1.15.0 does not work because of a transferred module. After this release, users will have a version of the exporter designed to work with OTel 1.15.0.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
 - This release requires OTel version >=1.15.0
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
