### PR TITLE
Release 1.0.0b11 Hotfix. Reverting [#27913]. Pinning to < Otel 1.15 instead

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b11 (Unreleased)
+## 1.0.0b11 (2022-12-15)
 
 ### Features Added
 
@@ -9,17 +9,12 @@
 - Add azure-sdk usage to instrumentations statsbeat
     ([#27756](https://github.com/Azure/azure-sdk-for-python/pull/27756))
 
-### Breaking Changes
-
-- Update to OpenTelemetry api/sdk v1.15.0
-    ([#27900](https://github.com/Azure/azure-sdk-for-python/issues/27900))
-
 ### Bugs Fixed
 
+- Pinning OpenTelemetry SDK and API to between 1.12 and 1.14 to avoid bug from change in module path. Reverting [#27913]
+    ([#27958](https://github.com/Azure/azure-sdk-for-python/pull/27958))
 - Pass along sampleRate in SpanEvents from Span
     ([#27629](https://github.com/Azure/azure-sdk-for-python/pull/27629))
-
-### Other Changes
 
 ## 1.0.0b10 (2022-11-10)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Sequence, Any
 
-from opentelemetry._logs.severity import SeverityNumber
+from opentelemetry.sdk._logs.severity import SeverityNumber
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.sdk._logs import LogData
 from opentelemetry.sdk._logs.export import LogExporter, LogExportResult

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -84,8 +84,8 @@ setup(
         "azure-core<2.0.0,>=1.23.0",
         "fixedint==0.1.6",
         "msrest>=0.6.10",
-        "opentelemetry-api<2.0.0,>=1.15.0",
-        "opentelemetry-sdk<2.0.0,>=1.15.0",
+        "opentelemetry-api<1.15.0,>=1.12.0",
+        "opentelemetry-sdk<1.15.0,>=1.12.0",
     ],
     entry_points={
         "opentelemetry_traces_exporter": [

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
@@ -12,7 +12,7 @@ from opentelemetry.sdk import _logs
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk._logs.export import LogExportResult
-from opentelemetry._logs.severity import SeverityNumber
+from opentelemetry.sdk._logs.severity import SeverityNumber
 
 from azure.monitor.opentelemetry.exporter.export._base import ExportResult
 from azure.monitor.opentelemetry.exporter.export.logs._exporter import (

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -306,9 +306,9 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-monitor-opentelemetry-exporter fixedint==0.1.6
 #override azure-monitor-opentelemetry-exporter msrest>=0.6.10
 #override azure-mgmt-healthbot azure-mgmt-core>=1.3.2,<2.0.0
-#override azure-monitor-opentelemetry-exporter opentelemetry-api<2.0.0,>=1.15.0
+#override azure-monitor-opentelemetry-exporter opentelemetry-api<1.15.0,>=1.12.0
 #override azure-mgmt-cosmosdb typing-extensions>=4.3.0; python_version<'3.8.0'
-#override azure-monitor-opentelemetry-exporter opentelemetry-sdk<2.0.0,>=1.15.0
+#override azure-monitor-opentelemetry-exporter opentelemetry-sdk<1.15.0,>=1.12.0
 #override azure-mgmt-support msrest>=0.7.1
 #override azure-core-tracing-opentelemetry opentelemetry-api<2.0.0,>=1.0.0
 #override azure-identity six>=1.12.0


### PR DESCRIPTION
# Description

OTel 1.15 has a memory allocation issue related to Werkzeug. Until that is fixed, we should not update to 1.15. Instead, pinning the exporter to <1.15 in the meantime. Fixes #27900.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
