### PR TITLE
[Monitor][Query] Propagate details in LogsQueryError

### DIFF
--- a/sdk/monitor/azure-monitor-query/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-query/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Error details are now propagated inside the `LogsQueryError` object. ([#25137](https://github.com/Azure/azure-sdk-for-python/issues/25137))
+
 ### Other Changes
 
 * Python 3.6 is no longer supported. Please use Python version 3.7 or later. For more details, see [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy).

--- a/sdk/monitor/azure-monitor-query/README.md
+++ b/sdk/monitor/azure-monitor-query/README.md
@@ -139,7 +139,7 @@ try:
     if response.status == LogsQueryStatus.PARTIAL:
         error = response.partial_error
         data = response.partial_data
-        print(error.message)
+        print(error)
     elif response.status == LogsQueryStatus.SUCCESS:
         data = response.tables
     for table in data:
@@ -170,6 +170,7 @@ LogsQueryPartialResult
 |---partial_error (a `LogsQueryError` object)
     |---code
     |---message
+    |---details
     |---status
 |---partial_data (list of `LogsTable` objects)
     |---name
@@ -241,7 +242,7 @@ for res in results:
         print(res.message)
     elif res.status == LogsQueryStatus.PARTIAL:
         ## this will be a LogsQueryPartialResult
-        print(res.partial_error.message)
+        print(res.partial_error)
         for table in res.partial_data:
             df = pd.DataFrame(table.rows, columns=table.columns)
             print(df)

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_exceptions.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_exceptions.py
@@ -17,6 +17,8 @@ class LogsQueryError(object):
     :vartype code: str
     :ivar message: A human readable error message.
     :vartype message: str
+    :ivar details: A list of additional details about the error.
+    :vartype details: list[JSON]
     :ivar status: status for error item when iterating over list of
         results. Always "Failure" for an instance of a LogsQueryError.
     :vartype status: ~azure.monitor.query.LogsQueryStatus
@@ -25,7 +27,11 @@ class LogsQueryError(object):
     def __init__(self, **kwargs: Any) -> None:
         self.code = kwargs.get("code", None)
         self.message = kwargs.get("message", None)
+        self.details = kwargs.get("details", None)
         self.status = LogsQueryStatus.FAILURE
+
+    def __str__(self):
+        return str(self.__dict__)
 
     @classmethod
     def _from_generated(cls, generated):
@@ -38,4 +44,5 @@ class LogsQueryError(object):
         return cls(
             code=generated.get("code"),
             message=message,
+            details=generated.get("details"),
         )

--- a/sdk/monitor/azure-monitor-query/samples/async_samples/sample_log_query_async.py
+++ b/sdk/monitor/azure-monitor-query/samples/async_samples/sample_log_query_async.py
@@ -37,7 +37,7 @@ async def logs_query():
         if response.status == LogsQueryStatus.PARTIAL:
             error = response.partial_error
             data = response.partial_data
-            print(error.message)
+            print(error)
         elif response.status == LogsQueryStatus.SUCCESS:
             data = response.tables
         for table in data:

--- a/sdk/monitor/azure-monitor-query/samples/async_samples/sample_metric_definitions_async.py
+++ b/sdk/monitor/azure-monitor-query/samples/async_samples/sample_metric_definitions_async.py
@@ -21,7 +21,7 @@ from azure.identity.aio import DefaultAzureCredential
 
 class ListDefinitions():
     async def list_definitions(self):
-        credential  = DefaultAzureCredential()
+        credential = DefaultAzureCredential()
 
         client = MetricsQueryClient(credential)
 

--- a/sdk/monitor/azure-monitor-query/samples/async_samples/sample_metric_namespaces_async.py
+++ b/sdk/monitor/azure-monitor-query/samples/async_samples/sample_metric_namespaces_async.py
@@ -8,7 +8,7 @@ USAGE:
     python sample_metric_namespaces_async.py
     Set the environment variables with your own values before running the sample:
     1) METRICS_RESOURCE_URI - The resource URI of the resource for which the metrics are being queried.
-    
+
     This example uses DefaultAzureCredential, which requests a token from Azure Active Directory.
     For more information on DefaultAzureCredential, see https://docs.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential.
 
@@ -21,7 +21,7 @@ from azure.identity.aio import DefaultAzureCredential
 
 class ListNameSpaces():
     async def list_namespaces(self):
-        credential  = DefaultAzureCredential()
+        credential = DefaultAzureCredential()
 
         client = MetricsQueryClient(credential)
 

--- a/sdk/monitor/azure-monitor-query/samples/async_samples/sample_metrics_query_async.py
+++ b/sdk/monitor/azure-monitor-query/samples/async_samples/sample_metrics_query_async.py
@@ -24,7 +24,7 @@ from azure.monitor.query import MetricAggregationType
 from azure.identity.aio import DefaultAzureCredential
 
 async def query_metrics():
-    credential  = DefaultAzureCredential()
+    credential = DefaultAzureCredential()
 
     client = MetricsQueryClient(credential)
 
@@ -43,6 +43,6 @@ async def query_metrics():
         for time_series_element in metric.timeseries:
             for metric_value in time_series_element.data:
                 print(metric_value.timestamp)
-    
+
 if __name__ == '__main__':
     asyncio.run(query_metrics())

--- a/sdk/monitor/azure-monitor-query/samples/sample_batch_query.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_batch_query.py
@@ -22,7 +22,7 @@ import pandas as pd
 from azure.monitor.query import LogsQueryClient, LogsBatchQuery, LogsQueryStatus
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = LogsQueryClient(credential)
 
@@ -52,10 +52,10 @@ results = client.query_batch(requests)
 for res in results:
     if res.status == LogsQueryStatus.FAILURE:
         # this will be a LogsQueryError
-        print(res.message)
+        print(res)
     elif res.status == LogsQueryStatus.PARTIAL:
         ## this will be a LogsQueryPartialResult
-        print(res.partial_error.message)
+        print(res.partial_error)
         for table in res.partial_data:
             df = pd.DataFrame(table.rows, columns=table.columns)
             print(df)

--- a/sdk/monitor/azure-monitor-query/samples/sample_log_query_multiple_workspaces.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_log_query_multiple_workspaces.py
@@ -24,7 +24,7 @@ from azure.monitor.query import LogsQueryClient
 from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = LogsQueryClient(credential)
 

--- a/sdk/monitor/azure-monitor-query/samples/sample_logs_query_key_value_form.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_logs_query_key_value_form.py
@@ -24,7 +24,7 @@ from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = LogsQueryClient(credential)
 
@@ -35,7 +35,7 @@ try:
     if response.status == LogsQueryStatus.PARTIAL:
         error = response.partial_error
         data = response.partial_data
-        print(error.message)
+        print(error)
     elif response.status == LogsQueryStatus.SUCCESS:
         data = response.tables
     for table in data:

--- a/sdk/monitor/azure-monitor-query/samples/sample_logs_single_query.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_logs_single_query.py
@@ -36,7 +36,7 @@ try:
     if response.status == LogsQueryStatus.PARTIAL:
         error = response.partial_error
         data = response.partial_data
-        print(error.message)
+        print(error)
     elif response.status == LogsQueryStatus.SUCCESS:
         data = response.tables
     for table in data:

--- a/sdk/monitor/azure-monitor-query/samples/sample_logs_single_query_partial_result.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_logs_single_query_partial_result.py
@@ -23,7 +23,7 @@ from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = LogsQueryClient(credential)
 
@@ -32,7 +32,7 @@ query= """let Weight = 92233720368547758;
             | summarize percentilesw(x, Weight * 100, 50)"""
 
 
-# this block of code is exactly the same whether the expected result is a success, a failure or a 
+# this block of code is exactly the same whether the expected result is a success, a failure or a
 # partial success
 try:
     response = client.query_workspace(os.environ['LOGS_WORKSPACE_ID'], query, timespan=timedelta(days=1))
@@ -40,9 +40,10 @@ try:
         # handle error here
         error = response.partial_error
         data = response.partial_data
-        print(error.message)
+        print(error)
     elif response.status == LogsQueryStatus.SUCCESS:
         data = response.tables
+
     for table in data:
         df = pd.DataFrame(data=table.rows, columns=table.columns)
         print(df)

--- a/sdk/monitor/azure-monitor-query/samples/sample_metric_definitions.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_metric_definitions.py
@@ -8,7 +8,7 @@ USAGE:
     python sample_metric_definitions.py
     Set the environment variables with your own values before running the sample:
     1) METRICS_RESOURCE_URI - The resource URI of the resource for which the metrics are being queried.
-    
+
     This example uses DefaultAzureCredential, which requests a token from Azure Active Directory.
     For more information on DefaultAzureCredential, see https://docs.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential.
 
@@ -18,7 +18,7 @@ import os
 from azure.monitor.query import MetricsQueryClient
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = MetricsQueryClient(credential)
 

--- a/sdk/monitor/azure-monitor-query/samples/sample_metric_namespaces.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_metric_namespaces.py
@@ -8,7 +8,7 @@ USAGE:
     python sample_metric_namespaces.py
     Set the environment variables with your own values before running the sample:
     1) METRICS_RESOURCE_URI - The resource URI of the resource for which the metrics are being queried.
-    
+
     This example uses DefaultAzureCredential, which requests a token from Azure Active Directory.
     For more information on DefaultAzureCredential, see https://docs.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential.
 
@@ -18,7 +18,7 @@ import os
 from azure.monitor.query import MetricsQueryClient
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = MetricsQueryClient(credential)
 

--- a/sdk/monitor/azure-monitor-query/samples/sample_metrics_query.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_metrics_query.py
@@ -26,7 +26,7 @@ from azure.identity import DefaultAzureCredential
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # [START metrics_client_auth_with_token_cred]
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = MetricsQueryClient(credential)
 # [END metrics_client_auth_with_token_cred]

--- a/sdk/monitor/azure-monitor-query/samples/sample_server_timeout.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_server_timeout.py
@@ -22,7 +22,7 @@ from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = LogsQueryClient(credential)
 
@@ -38,7 +38,7 @@ try:
     if response.status == LogsQueryStatus.PARTIAL:
         error = response.partial_error
         data = response.partial_data
-        print(error.message)
+        print(error)
     elif response.status == LogsQueryStatus.SUCCESS:
         data = response.tables
     for table in data:

--- a/sdk/monitor/azure-monitor-query/samples/sample_single_log_query_without_pandas.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_single_log_query_without_pandas.py
@@ -11,7 +11,7 @@ USAGE:
     1) LOGS_WORKSPACE_ID - The first (primary) workspace ID.
 
 This example uses DefaultAzureCredential, which requests a token from Azure Active Directory.
-For more information on DefaultAzureCredential, see https://docs.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential.   
+For more information on DefaultAzureCredential, see https://docs.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential.
 """
 import os
 from datetime import timedelta
@@ -19,7 +19,7 @@ from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 
-credential  = DefaultAzureCredential()
+credential = DefaultAzureCredential()
 
 client = LogsQueryClient(credential)
 
@@ -31,7 +31,7 @@ try:
         # handle error here
         error = response.partial_error
         data = response.partial_data
-        print(error.message)
+        print(error)
     elif response.status == LogsQueryStatus.SUCCESS:
         data = response.tables
     for table in data:

--- a/sdk/monitor/azure-monitor-query/tests/test_exceptions.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_exceptions.py
@@ -29,6 +29,7 @@ class TestQueryExceptions(AzureRecordedTestCase):
         assert response.__class__ == LogsQueryPartialResult
         assert response.partial_error is not None
         assert response.partial_data is not None
+        assert response.partial_error.details is not None
         assert response.partial_error.code == 'PartialError'
         assert response.partial_error.__class__ == LogsQueryError
 


### PR DESCRIPTION
In order to provide more information about an error to the user, the error details should also be propagated. This adds a new instance variable 'details' to the LogsQueryError.

A `__str__` method is also added to make it easier for users to print the full error information.

Closes: #25137

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
