### PR TITLE
fixing default compute pascal casing issue

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
@@ -337,6 +337,7 @@ class BatchDeployment(Deployment): # pylint: disable=too-many-instance-attribute
         key_arr = key_str.split(".")
         pascal_array = []
         for key in key_arr:
+            # pylint: disable=line-too-long
             if key not in [PipelineConstants.CONTINUE_ON_STEP_FAILURE, PipelineConstants.DEFAULT_COMPUTE, PipelineConstants.DEFAULT_DATASTORE]:
                 pascal_array.append(snake_to_pascal(key))
             else:
@@ -348,6 +349,7 @@ class BatchDeployment(Deployment): # pylint: disable=too-many-instance-attribute
         key_arr = key_str.split(".")
         snake_array = []
         for key in key_arr:
+            # pylint: disable=line-too-long
             if key not in [PipelineConstants.CONTINUE_ON_STEP_FAILURE, PipelineConstants.DEFAULT_COMPUTE, PipelineConstants.DEFAULT_DATASTORE]:
                 snake_array.append(camel_to_snake(key))
             else:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
@@ -337,7 +337,10 @@ class BatchDeployment(Deployment): # pylint: disable=too-many-instance-attribute
         key_arr = key_str.split(".")
         pascal_array = []
         for key in key_arr:
-            pascal_array.append(snake_to_pascal(key))
+            if key not in [PipelineConstants.CONTINUE_ON_STEP_FAILURE, PipelineConstants.DEFAULT_COMPUTE, PipelineConstants.DEFAULT_DATASTORE]:
+                pascal_array.append(snake_to_pascal(key))
+            else:
+                pascal_array.append(key)
         return '.'.join(pascal_array)
 
     @classmethod
@@ -345,7 +348,7 @@ class BatchDeployment(Deployment): # pylint: disable=too-many-instance-attribute
         key_arr = key_str.split(".")
         snake_array = []
         for key in key_arr:
-            if key != "continue_on_step_failure":
+            if key not in [PipelineConstants.CONTINUE_ON_STEP_FAILURE, PipelineConstants.DEFAULT_COMPUTE, PipelineConstants.DEFAULT_DATASTORE]:
                 snake_array.append(camel_to_snake(key))
             else:
                 snake_array.append(key)


### PR DESCRIPTION
# Description

Default compute value getting passed down from deployment compute was getting passed in as pascal case. Implemented logic to make sure it go into the rest payload as snake case.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
