### PR TITLE
[Perf framework] Mitigate race condition

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_random_stream.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_random_stream.py
@@ -11,8 +11,8 @@ _BYTE_BUFFER = [_DEFAULT_LENGTH, os.urandom(_DEFAULT_LENGTH)]
 
 def get_random_bytes(buffer_length):
     if buffer_length > _BYTE_BUFFER[0]:
-        _BYTE_BUFFER[0] = buffer_length
         _BYTE_BUFFER[1] = os.urandom(buffer_length)
+        _BYTE_BUFFER[0] = buffer_length
     return _BYTE_BUFFER[1][:buffer_length]
 
 


### PR DESCRIPTION
Related to #27941
This update means that other threads will not read from the buffer before it has been updated to reflect the accurate length. It has inefficiencies as it means that multiple threads might update update the buffer at once due to it not being locked, however the buffer is only random bytes, and this should only happen once during the warmup.

The alternative would be to only check the buffer length (and subsequently update the buffer) within a thread lock - however this means the lock would need to be acquired on every read which makes the overall read performance slower.