### PR TITLE
Fix handling of nested symlink in get_directory_size()

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
@@ -412,7 +412,7 @@ def get_directory_size(root: os.PathLike) -> Tuple[int, Dict[str, int]]:
                 path_size = os.path.getsize(full_path)
             else:
                 path_size = os.path.getsize(
-                    os.readlink(convert_windows_path_to_unix(full_path))
+                    os.path.realpath(convert_windows_path_to_unix(full_path))
                 )  # ensure we're counting the size of the linked file
             size_list[full_path] = path_size
             total_size += path_size


### PR DESCRIPTION
# Description

fix: https://github.com/Azure/azure-sdk-for-python/issues/27980

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
