### PR TITLE
[Identity] Fix 'az' existence check in CliCred

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where `AzureCliCredential` would return the wrong error message when the Azure CLI was not installed on non-English consoles. ([#27965](https://github.com/Azure/azure-sdk-for-python/issues/27965))
+
 ### Other Changes
 
 ## 1.12.0 (2022-11-08)
@@ -23,11 +25,11 @@
 
 ### Breaking Changes
 
-- Excluded `VisualStudioCodeCredential` from `DefaultAzureCredential` token chain by default as SDK 
-  authentication via Visual Studio Code is broken due to 
-  issue [#23249](https://github.com/Azure/azure-sdk-for-python/issues/23249). The `VisualStudioCodeCredential` will be 
-  re-enabled in the `DefaultAzureCredential` flow once a fix is in place. 
-  Issue [#25713](https://github.com/Azure/azure-sdk-for-python/issues/25713) tracks this. In the meantime 
+- Excluded `VisualStudioCodeCredential` from `DefaultAzureCredential` token chain by default as SDK
+  authentication via Visual Studio Code is broken due to
+  issue [#23249](https://github.com/Azure/azure-sdk-for-python/issues/23249). The `VisualStudioCodeCredential` will be
+  re-enabled in the `DefaultAzureCredential` flow once a fix is in place.
+  Issue [#25713](https://github.com/Azure/azure-sdk-for-python/issues/25713) tracks this. In the meantime
   Visual Studio Code users can authenticate their development environment using the [Azure CLI](https://learn.microsoft.com/cli/azure/).
 
 ### Other Changes

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -5,8 +5,8 @@
 from datetime import datetime
 import json
 import os
-import platform
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -23,6 +23,7 @@ from .._internal.decorators import log_get_token
 
 CLI_NOT_FOUND = "Azure CLI not found on path"
 COMMAND_LINE = "az account get-access-token --output json --resource {}"
+EXECUTABLE_NAME = "az"
 NOT_LOGGED_IN = "Please run 'az login' to set up an account"
 
 
@@ -130,6 +131,10 @@ def sanitize_output(output):
 
 
 def _run_command(command):
+    # Ensure executable exists in PATH first. This avoids a subprocess call that would fail anyway.
+    if shutil.which(EXECUTABLE_NAME) is None:
+        raise CredentialUnavailableError(message=CLI_NOT_FOUND)
+
     if sys.platform.startswith("win"):
         args = ["cmd", "/c", command]
     else:
@@ -141,16 +146,12 @@ def _run_command(command):
             "stderr": subprocess.PIPE,
             "cwd": working_directory,
             "universal_newlines": True,
+            "timeout": 10,
             "env": dict(os.environ, AZURE_CORE_NO_COLOR="true"),
         }
-        if platform.python_version() >= "3.3":
-            kwargs["timeout"] = 10
-
         return subprocess.check_output(args, **kwargs)
     except subprocess.CalledProcessError as ex:
         # non-zero return from shell
-        if ex.returncode == 127 or ex.stderr.startswith("'az' is not recognized"):
-            raise CredentialUnavailableError(message=CLI_NOT_FOUND)
         if "az login" in ex.stderr or "az account set" in ex.stderr:
             raise CredentialUnavailableError(message=NOT_LOGGED_IN)
 
@@ -161,7 +162,7 @@ def _run_command(command):
             message = "Failed to invoke Azure CLI"
         raise ClientAuthenticationError(message=message)
     except OSError as ex:
-        # failed to execute 'cmd' or '/bin/sh'; CLI may or may not be installed
+        # failed to execute 'cmd' or '/bin/sh'
         error = CredentialUnavailableError(message="Failed to execute '{}'".format(args[0]))
         six.raise_from(error, ex)
     except Exception as ex:  # pylint:disable=broad-except

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -152,6 +152,9 @@ def _run_command(command):
         return subprocess.check_output(args, **kwargs)
     except subprocess.CalledProcessError as ex:
         # non-zero return from shell
+        # Fallback check in case the executable is not found while executing subprocess.
+        if ex.returncode == 127 or ex.stderr.startswith("'az' is not recognized"):
+            raise CredentialUnavailableError(message=CLI_NOT_FOUND)
         if "az login" in ex.stderr or "az account set" in ex.stderr:
             raise CredentialUnavailableError(message=NOT_LOGGED_IN)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -121,6 +121,10 @@ async def _run_command(command: str) -> str:
     if proc.returncode == 0:
         return output
 
+    # Fallback check in case the executable is not found while executing subprocess.
+    if proc.returncode == 127 or stderr.startswith("'az' is not recognized"):
+        raise CredentialUnavailableError(CLI_NOT_FOUND)
+
     if "az login" in stderr or "az account set" in stderr:
         raise CredentialUnavailableError(message=NOT_LOGGED_IN)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -3,8 +3,9 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import asyncio
-import sys
 import os
+import shutil
+import sys
 from typing import List
 
 from azure.core.exceptions import ClientAuthenticationError
@@ -16,6 +17,7 @@ from ..._credentials.azure_cli import (
     AzureCliCredential as _SyncAzureCliCredential,
     CLI_NOT_FOUND,
     COMMAND_LINE,
+    EXECUTABLE_NAME,
     get_safe_working_dir,
     NOT_LOGGED_IN,
     parse_token,
@@ -86,6 +88,10 @@ class AzureCliCredential(AsyncContextManager):
 
 
 async def _run_command(command: str) -> str:
+    # Ensure executable exists in PATH first. This avoids a subprocess call that would fail anyway.
+    if shutil.which(EXECUTABLE_NAME) is None:
+        raise CredentialUnavailableError(message=CLI_NOT_FOUND)
+
     if sys.platform.startswith("win"):
         args = ("cmd", "/c " + command)
     else:
@@ -105,7 +111,7 @@ async def _run_command(command: str) -> str:
         output = stdout_b.decode()
         stderr = stderr_b.decode()
     except OSError as ex:
-        # failed to execute 'cmd' or '/bin/sh'; CLI may or may not be installed
+        # failed to execute 'cmd' or '/bin/sh'
         error = CredentialUnavailableError(message="Failed to execute '{}'".format(args[0]))
         raise error from ex
     except asyncio.TimeoutError as ex:
@@ -114,9 +120,6 @@ async def _run_command(command: str) -> str:
 
     if proc.returncode == 0:
         return output
-
-    if proc.returncode == 127 or stderr.startswith("'az' is not recognized"):
-        raise CredentialUnavailableError(CLI_NOT_FOUND)
 
     if "az login" in stderr or "az account set" in stderr:
         raise CredentialUnavailableError(message=NOT_LOGGED_IN)

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -5,7 +5,6 @@
 from datetime import datetime
 import json
 import re
-import sys
 
 from azure.identity import AzureCliCredential, CredentialUnavailableError
 from azure.identity._constants import EnvironmentVariables
@@ -65,28 +64,18 @@ def test_get_token():
         }
     )
 
-    with mock.patch(CHECK_OUTPUT, mock.Mock(return_value=successful_output)):
-        token = AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, mock.Mock(return_value=successful_output)):
+            token = AzureCliCredential().get_token("scope")
 
     assert token.token == access_token
     assert type(token.expires_on) == int
     assert token.expires_on == expected_expires_on
 
 
-def test_cli_not_installed_linux():
+def test_cli_not_installed():
     """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
-
-    stderr = "/bin/sh: 1: az: not found"
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(127, stderr=stderr)):
-        with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
-            AzureCliCredential().get_token("scope")
-
-
-def test_cli_not_installed_windows():
-    """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
-
-    stderr = "'az' is not recognized as an internal or external command, operable program or batch file."
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, stderr=stderr)):
+    with mock.patch("shutil.which", return_value=None):
         with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
             AzureCliCredential().get_token("scope")
 
@@ -94,36 +83,40 @@ def test_cli_not_installed_windows():
 def test_cannot_execute_shell():
     """The credential should raise CredentialUnavailableError when the subprocess doesn't start"""
 
-    with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=OSError())):
-        with pytest.raises(CredentialUnavailableError):
-            AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=OSError())):
+            with pytest.raises(CredentialUnavailableError):
+                AzureCliCredential().get_token("scope")
 
 
 def test_not_logged_in():
     """When the CLI isn't logged in, the credential should raise CredentialUnavailableError"""
 
     stderr = "ERROR: Please run 'az login' to setup account."
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, stderr=stderr)):
-        with pytest.raises(CredentialUnavailableError, match=NOT_LOGGED_IN):
-            AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, stderr=stderr)):
+            with pytest.raises(CredentialUnavailableError, match=NOT_LOGGED_IN):
+                AzureCliCredential().get_token("scope")
 
 
 def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 
     stderr = "something went wrong"
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(42, stderr=stderr)):
-        with pytest.raises(ClientAuthenticationError, match=stderr):
-            AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, raise_called_process_error(42, stderr=stderr)):
+            with pytest.raises(ClientAuthenticationError, match=stderr):
+                AzureCliCredential().get_token("scope")
 
 
 @pytest.mark.parametrize("output", TEST_ERROR_OUTPUTS)
 def test_parsing_error_does_not_expose_token(output):
     """Errors during CLI output parsing shouldn't expose access tokens in that output"""
 
-    with mock.patch(CHECK_OUTPUT, mock.Mock(return_value=output)):
-        with pytest.raises(ClientAuthenticationError) as ex:
-            AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, mock.Mock(return_value=output)):
+            with pytest.raises(ClientAuthenticationError) as ex:
+                AzureCliCredential().get_token("scope")
 
     assert "secret value" not in str(ex.value)
     assert "secret value" not in repr(ex.value)
@@ -133,23 +126,24 @@ def test_parsing_error_does_not_expose_token(output):
 def test_subprocess_error_does_not_expose_token(output):
     """Errors from the subprocess shouldn't expose access tokens in CLI output"""
 
-    with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, output=output)):
-        with pytest.raises(ClientAuthenticationError) as ex:
-            AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, output=output)):
+            with pytest.raises(ClientAuthenticationError) as ex:
+                AzureCliCredential().get_token("scope")
 
     assert "secret value" not in str(ex.value)
     assert "secret value" not in repr(ex.value)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 3), reason="Python 3.3 added timeout support")
 def test_timeout():
     """The credential should raise CredentialUnavailableError when the subprocess times out"""
 
     from subprocess import TimeoutExpired
 
-    with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=TimeoutExpired("", 42))):
-        with pytest.raises(CredentialUnavailableError):
-            AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=TimeoutExpired("", 42))):
+            with pytest.raises(CredentialUnavailableError):
+                AzureCliCredential().get_token("scope")
 
 
 def test_multitenant_authentication_class():
@@ -172,15 +166,17 @@ def test_multitenant_authentication_class():
             }
         )
 
-    with mock.patch(CHECK_OUTPUT, fake_check_output):
-        token = AzureCliCredential().get_token("scope")
-        assert token.token == first_token
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, fake_check_output):
+            token = AzureCliCredential().get_token("scope")
+            assert token.token == first_token
 
-        token = AzureCliCredential(tenant_id=default_tenant).get_token("scope")
-        assert token.token == first_token
+            token = AzureCliCredential(tenant_id=default_tenant).get_token("scope")
+            assert token.token == first_token
 
-        token = AzureCliCredential(tenant_id=second_tenant).get_token("scope")
-        assert token.token == second_token
+            token = AzureCliCredential(tenant_id=second_tenant).get_token("scope")
+            assert token.token == second_token
+
 
 def test_multitenant_authentication():
     default_tenant = "first-tenant"
@@ -203,19 +199,21 @@ def test_multitenant_authentication():
         )
 
     credential = AzureCliCredential()
-    with mock.patch(CHECK_OUTPUT, fake_check_output):
-        token = credential.get_token("scope")
-        assert token.token == first_token
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, fake_check_output):
+            token = credential.get_token("scope")
+            assert token.token == first_token
 
-        token = credential.get_token("scope", tenant_id=default_tenant)
-        assert token.token == first_token
+            token = credential.get_token("scope", tenant_id=default_tenant)
+            assert token.token == first_token
 
-        token = credential.get_token("scope", tenant_id=second_tenant)
-        assert token.token == second_token
+            token = credential.get_token("scope", tenant_id=second_tenant)
+            assert token.token == second_token
 
-        # should still default to the first tenant
-        token = credential.get_token("scope")
-        assert token.token == first_token
+            # should still default to the first tenant
+            token = credential.get_token("scope")
+            assert token.token == first_token
+
 
 def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
@@ -235,12 +233,13 @@ def test_multitenant_authentication_not_allowed():
         )
 
     credential = AzureCliCredential()
-    with mock.patch(CHECK_OUTPUT, fake_check_output):
-        token = credential.get_token("scope")
-        assert token.token == expected_token
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, fake_check_output):
+            token = credential.get_token("scope")
+            assert token.token == expected_token
 
-        with mock.patch.dict(
-            "os.environ", {EnvironmentVariables.AZURE_IDENTITY_DISABLE_MULTITENANTAUTH: "true"}
-        ):
-            token = credential.get_token("scope", tenant_id="un" + expected_tenant)
-        assert token.token == expected_token
+            with mock.patch.dict(
+                "os.environ", {EnvironmentVariables.AZURE_IDENTITY_DISABLE_MULTITENANTAUTH: "true"}
+            ):
+                token = credential.get_token("scope", tenant_id="un" + expected_tenant)
+            assert token.token == expected_token

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -89,72 +89,65 @@ async def test_get_token():
         }
     )
 
-    with mock.patch(SUBPROCESS_EXEC, mock_exec(successful_output)):
-        credential = AzureCliCredential()
-        token = await credential.get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock_exec(successful_output)):
+            credential = AzureCliCredential()
+            token = await credential.get_token("scope")
 
     assert token.token == access_token
     assert type(token.expires_on) == int
     assert token.expires_on == expected_expires_on
 
 
-async def test_cli_not_installed_linux():
+async def test_cli_not_installed():
     """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
 
-    stderr = "/bin/sh: 1: az: not found"
-    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=127)):
+    with mock.patch("shutil.which", return_value=None):
         with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
             credential = AzureCliCredential()
             await credential.get_token("scope")
-
-
-async def test_cli_not_installed_windows():
-    """The credential should raise CredentialUnavailableError when the CLI isn't installed"""
-
-    stderr = "'az' is not recognized as an internal or external command, operable program or batch file."
-    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=1)):
-        with pytest.raises(CredentialUnavailableError, match=CLI_NOT_FOUND):
-            credential = AzureCliCredential()
-            await credential.get_token("scope")
-
 
 async def test_cannot_execute_shell():
     """The credential should raise CredentialUnavailableError when the subprocess doesn't start"""
 
-    with mock.patch(SUBPROCESS_EXEC, mock.Mock(side_effect=OSError())):
-        with pytest.raises(CredentialUnavailableError):
-            credential = AzureCliCredential()
-            await credential.get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock.Mock(side_effect=OSError())):
+            with pytest.raises(CredentialUnavailableError):
+                credential = AzureCliCredential()
+                await credential.get_token("scope")
 
 
 async def test_not_logged_in():
     """When the CLI isn't logged in, the credential should raise CredentialUnavailableError"""
 
     stderr = "ERROR: Please run 'az login' to setup account."
-    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=1)):
-        with pytest.raises(CredentialUnavailableError, match=NOT_LOGGED_IN):
-            credential = AzureCliCredential()
-            await credential.get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=1)):
+            with pytest.raises(CredentialUnavailableError, match=NOT_LOGGED_IN):
+                credential = AzureCliCredential()
+                await credential.get_token("scope")
 
 
 async def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 
     stderr = "something went wrong"
-    with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=42)):
-        with pytest.raises(ClientAuthenticationError, match=stderr):
-            credential = AzureCliCredential()
-            await credential.get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=42)):
+            with pytest.raises(ClientAuthenticationError, match=stderr):
+                credential = AzureCliCredential()
+                await credential.get_token("scope")
 
 
 @pytest.mark.parametrize("output", TEST_ERROR_OUTPUTS)
 async def test_parsing_error_does_not_expose_token(output):
     """Errors during CLI output parsing shouldn't expose access tokens in that output"""
 
-    with mock.patch(SUBPROCESS_EXEC, mock_exec(output)):
-        with pytest.raises(ClientAuthenticationError) as ex:
-            credential = AzureCliCredential()
-            await credential.get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock_exec(output)):
+            with pytest.raises(ClientAuthenticationError) as ex:
+                credential = AzureCliCredential()
+                await credential.get_token("scope")
 
     assert "secret value" not in str(ex.value)
     assert "secret value" not in repr(ex.value)
@@ -164,10 +157,11 @@ async def test_parsing_error_does_not_expose_token(output):
 async def test_subprocess_error_does_not_expose_token(output):
     """Errors from the subprocess shouldn't expose access tokens in CLI output"""
 
-    with mock.patch(SUBPROCESS_EXEC, mock_exec(output, return_code=1)):
-        with pytest.raises(ClientAuthenticationError) as ex:
-            credential = AzureCliCredential()
-            await credential.get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock_exec(output, return_code=1)):
+            with pytest.raises(ClientAuthenticationError) as ex:
+                credential = AzureCliCredential()
+                await credential.get_token("scope")
 
     assert "secret value" not in str(ex.value)
     assert "secret value" not in repr(ex.value)
@@ -177,9 +171,10 @@ async def test_timeout():
     """The credential should kill the subprocess after a timeout"""
 
     proc = mock.Mock(communicate=mock.Mock(side_effect=asyncio.TimeoutError), returncode=None)
-    with mock.patch(SUBPROCESS_EXEC, mock.Mock(return_value=get_completed_future(proc))):
-        with pytest.raises(CredentialUnavailableError):
-            await AzureCliCredential().get_token("scope")
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock.Mock(return_value=get_completed_future(proc))):
+            with pytest.raises(CredentialUnavailableError):
+                await AzureCliCredential().get_token("scope")
 
     assert proc.communicate.call_count == 1
 
@@ -206,19 +201,20 @@ async def test_multitenant_authentication():
         return mock.Mock(communicate=mock.Mock(return_value=get_completed_future((output, b""))), returncode=0)
 
     credential = AzureCliCredential()
-    with mock.patch(SUBPROCESS_EXEC, fake_exec):
-        token = await credential.get_token("scope")
-        assert token.token == first_token
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, fake_exec):
+            token = await credential.get_token("scope")
+            assert token.token == first_token
 
-        token = await credential.get_token("scope", tenant_id=default_tenant)
-        assert token.token == first_token
+            token = await credential.get_token("scope", tenant_id=default_tenant)
+            assert token.token == first_token
 
-        token = await credential.get_token("scope", tenant_id=second_tenant)
-        assert token.token == second_token
+            token = await credential.get_token("scope", tenant_id=second_tenant)
+            assert token.token == second_token
 
-        # should still default to the first tenant
-        token = await credential.get_token("scope")
-        assert token.token == first_token
+            # should still default to the first tenant
+            token = await credential.get_token("scope")
+            assert token.token == first_token
 
 async def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
@@ -239,10 +235,11 @@ async def test_multitenant_authentication_not_allowed():
         return mock.Mock(communicate=mock.Mock(return_value=get_completed_future((output, b""))), returncode=0)
 
     credential = AzureCliCredential()
-    with mock.patch(SUBPROCESS_EXEC, fake_exec):
-        token = await credential.get_token("scope")
-        assert token.token == expected_token
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, fake_exec):
+            token = await credential.get_token("scope")
+            assert token.token == expected_token
 
-        with mock.patch.dict("os.environ", {EnvironmentVariables.AZURE_IDENTITY_DISABLE_MULTITENANTAUTH: "true"}):
-            token = await credential.get_token("scope", tenant_id="un" + expected_tenant)
-        assert token.token == expected_token
+            with mock.patch.dict("os.environ", {EnvironmentVariables.AZURE_IDENTITY_DISABLE_MULTITENANTAUTH: "true"}):
+                token = await credential.get_token("scope", tenant_id="un" + expected_tenant)
+            assert token.token == expected_token


### PR DESCRIPTION
# Description

This change updates AzureCliCredential to use "shutil.which" to verify that the "az" command is available before trying to get a token. This provides a more reliable and cross-platform way to check if the Azure CLI installed without having to parse error messages which may not always be in English.

Closes: #27965

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
