### PR TITLE
[Storage] Remove `six` library from Python SDK

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -14,7 +14,6 @@ from typing import (
 from urllib.parse import urlparse, quote, unquote
 import warnings
 
-import six
 from typing_extensions import Self
 
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError, ResourceExistsError
@@ -191,7 +190,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
 
     def _format_url(self, hostname):
         container_name = self.container_name
-        if isinstance(container_name, six.text_type):
+        if isinstance(container_name, str):
             container_name = container_name.encode('UTF-8')
         return "{}://{}/{}/{}{}".format(
             self.scheme,
@@ -2349,7 +2348,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         if self.require_encryption or (self.key_encryption_key is not None):
             raise ValueError(_ERROR_UNSUPPORTED_METHOD_FOR_ENCRYPTION)
         block_id = encode_base64(str(block_id))
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode(kwargs.pop('encoding', 'UTF-8'))  # type: ignore
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         if length is None:
@@ -3338,7 +3337,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             **kwargs
         ):
         # type: (...) -> Dict[str, Any]
-        if isinstance(page, six.text_type):
+        if isinstance(page, str):
             page = page.encode(kwargs.pop('encoding', 'UTF-8'))
         if self.require_encryption or (self.key_encryption_key is not None):
             raise ValueError(_ERROR_UNSUPPORTED_METHOD_FOR_ENCRYPTION)
@@ -3765,7 +3764,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         if self.require_encryption or (self.key_encryption_key is not None):
             raise ValueError(_ERROR_UNSUPPORTED_METHOD_FOR_ENCRYPTION)
 
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode(kwargs.pop('encoding', 'UTF-8')) # type: ignore
         if length is None:
             length = get_length(data)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -12,7 +12,6 @@ from typing import (
 )
 from urllib.parse import urlparse, quote, unquote
 
-import six
 from typing_extensions import Self
 
 from azure.core import MatchConditions
@@ -170,7 +169,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     def _format_url(self, hostname):
         container_name = self.container_name
-        if isinstance(container_name, six.text_type):
+        if isinstance(container_name, str):
             container_name = container_name.encode('UTF-8')
         return "{}://{}/{}{}".format(
             self.scheme,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/__init__.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/__init__.py
@@ -13,8 +13,6 @@ try:
 except ImportError:
     from urllib2 import quote, unquote # type: ignore
 
-import six
-
 
 def url_quote(url):
     return quote(url)
@@ -25,14 +23,14 @@ def url_unquote(url):
 
 
 def encode_base64(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')
 
 
 def decode_base64_to_bytes(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     return base64.b64decode(data)
 
@@ -46,9 +44,9 @@ def sign_string(key, string_to_sign, key_is_base64=True):
     if key_is_base64:
         key = decode_base64_to_bytes(key)
     else:
-        if isinstance(key, six.text_type):
+        if isinstance(key, str):
             key = key.encode('utf-8')
-    if isinstance(string_to_sign, six.text_type):
+    if isinstance(string_to_sign, str):
         string_to_sign = string_to_sign.encode('utf-8')
     signed_hmac_sha256 = hmac.HMAC(key, string_to_sign, hashlib.sha256)
     digest = signed_hmac_sha256.digest()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -20,8 +20,6 @@ except ImportError:
     from urlparse import parse_qs  # type: ignore
     from urllib2 import quote  # type: ignore
 
-import six
-
 from azure.core.configuration import Configuration
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
 from azure.core.exceptions import HttpResponseError
@@ -348,7 +346,7 @@ class TransportWrapper(HttpTransport):
 
 
 def _format_shared_key_credential(account_name, credential):
-    if isinstance(credential, six.string_types):
+    if isinstance(credential, str):
         if not account_name:
             raise ValueError("Unable to determine account name for shared key credential.")
         credential = {"account_name": account_name, "account_key": credential}
@@ -458,7 +456,7 @@ def parse_query(query_str):
 
 
 def is_credential_sastoken(credential):
-    if not credential or not isinstance(credential, six.string_types):
+    if not credential or not isinstance(credential, str):
         return False
 
     sas_values = QueryStringConstants.to_list()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -11,7 +11,6 @@ from itertools import islice
 from math import ceil
 from threading import Lock
 
-import six
 from azure.core.tracing.common import with_current_context
 
 from . import encode_base64, url_quote
@@ -164,7 +163,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
                 temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError("Blob data should be of type bytes.")
                 data += temp or b""
 
@@ -594,7 +593,7 @@ class IterStreamer(object):
         try:
             while count < size:
                 chunk = self.__next__()
-                if isinstance(chunk, six.text_type):
+                if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk
                 count += len(chunk)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -13,8 +13,6 @@ from itertools import islice
 from math import ceil
 from typing import AsyncGenerator, Union
 
-import six
-
 from . import encode_base64, url_quote
 from .request_handlers import get_length
 from .response_handlers import return_response_headers
@@ -192,7 +190,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                     temp = await self.stream.read(read_size)
                 else:
                     temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
@@ -8,7 +8,6 @@
 from io import SEEK_SET, UnsupportedOperation
 from typing import TypeVar, TYPE_CHECKING
 
-import six
 from azure.core.exceptions import ResourceExistsError, ResourceModifiedError, HttpResponseError
 
 from ._shared.response_handlers import process_storage_error, return_response_headers
@@ -96,7 +95,7 @@ def upload_block_blob(  # pylint: disable=too-many-locals, too-many-statements
         if adjusted_count is not None and (adjusted_count <= blob_settings.max_single_put_size):
             try:
                 data = data.read(length)
-                if not isinstance(data, six.binary_type):
+                if not isinstance(data, bytes):
                     raise TypeError('Blob data should be of type bytes.')
             except AttributeError:
                 pass

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
@@ -9,7 +9,6 @@ import asyncio
 from io import SEEK_SET, UnsupportedOperation
 from typing import TypeVar, TYPE_CHECKING
 
-import six
 from azure.core.exceptions import ResourceModifiedError, HttpResponseError
 
 from .._shared.response_handlers import process_storage_error, return_response_headers
@@ -75,7 +74,7 @@ async def upload_block_blob(  # pylint: disable=too-many-locals, too-many-statem
                     data = await data.read(length)
                 else:
                     data = data.read(length)
-                if not isinstance(data, six.binary_type):
+                if not isinstance(data, bytes):
                     raise TypeError('Blob data should be of type bytes.')
             except AttributeError:
                 pass

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -10,7 +10,6 @@ from typing import (
 )
 from urllib.parse import quote, unquote
 
-import six
 from typing_extensions import Self
 
 from azure.core.exceptions import HttpResponseError
@@ -454,7 +453,7 @@ class DataLakeFileClient(PathClient):
         ):
         # type: (...) -> Dict[str, Any]
 
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode(kwargs.pop('encoding', 'UTF-8'))  # type: ignore
         if length is None:
             length = get_length(data)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -8,7 +8,6 @@ import functools
 from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 from urllib.parse import urlparse, quote, unquote
 
-import six
 from typing_extensions import Self
 
 from azure.core.pipeline import Pipeline
@@ -121,7 +120,7 @@ class FileSystemClient(StorageAccountHostsMixin):
 
     def _format_url(self, hostname):
         file_system_name = self.file_system_name
-        if isinstance(file_system_name, six.text_type):
+        if isinstance(file_system_name, str):
             file_system_name = file_system_name.encode('UTF-8')
         return "{}://{}/{}{}".format(
             self.scheme,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -10,8 +10,6 @@ from typing import ( # pylint: disable=unused-import
 )
 from urllib.parse import urlparse, quote
 
-import six
-
 from azure.core.exceptions import AzureError, HttpResponseError
 from azure.storage.blob import BlobClient
 from ._data_lake_lease import DataLakeLeaseClient
@@ -129,7 +127,7 @@ class PathClient(StorageAccountHostsMixin):
 
     def _format_url(self, hostname):
         file_system_name = self.file_system_name
-        if isinstance(file_system_name, six.text_type):
+        if isinstance(file_system_name, str):
             file_system_name = file_system_name.encode('UTF-8')
         return "{}://{}/{}/{}{}".format(
             self.scheme,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/__init__.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/__init__.py
@@ -13,8 +13,6 @@ try:
 except ImportError:
     from urllib2 import quote, unquote # type: ignore
 
-import six
-
 
 def url_quote(url):
     return quote(url)
@@ -25,14 +23,14 @@ def url_unquote(url):
 
 
 def encode_base64(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')
 
 
 def decode_base64_to_bytes(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     return base64.b64decode(data)
 
@@ -46,9 +44,9 @@ def sign_string(key, string_to_sign, key_is_base64=True):
     if key_is_base64:
         key = decode_base64_to_bytes(key)
     else:
-        if isinstance(key, six.text_type):
+        if isinstance(key, str):
             key = key.encode('utf-8')
-    if isinstance(string_to_sign, six.text_type):
+    if isinstance(string_to_sign, str):
         string_to_sign = string_to_sign.encode('utf-8')
     signed_hmac_sha256 = hmac.HMAC(key, string_to_sign, hashlib.sha256)
     digest = signed_hmac_sha256.digest()

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
@@ -18,8 +18,6 @@ except ImportError:
     from urlparse import parse_qs  # type: ignore
     from urllib2 import quote  # type: ignore
 
-import six
-
 from azure.core.configuration import Configuration
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
 from azure.core.exceptions import HttpResponseError
@@ -345,7 +343,7 @@ class TransportWrapper(HttpTransport):
 
 
 def _format_shared_key_credential(account_name, credential):
-    if isinstance(credential, six.string_types):
+    if isinstance(credential, str):
         if not account_name:
             raise ValueError("Unable to determine account name for shared key credential.")
         credential = {"account_name": account_name, "account_key": credential}
@@ -455,7 +453,7 @@ def parse_query(query_str):
 
 
 def is_credential_sastoken(credential):
-    if not credential or not isinstance(credential, six.string_types):
+    if not credential or not isinstance(credential, str):
         return False
 
     sas_values = QueryStringConstants.to_list()

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -11,7 +11,6 @@ from itertools import islice
 from math import ceil
 from threading import Lock
 
-import six
 from azure.core.tracing.common import with_current_context
 
 from . import encode_base64, url_quote
@@ -164,7 +163,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
                 temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError("Blob data should be of type bytes.")
                 data += temp or b""
 
@@ -594,7 +593,7 @@ class IterStreamer(object):
         try:
             while count < size:
                 chunk = self.__next__()
-                if isinstance(chunk, six.text_type):
+                if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk
                 count += len(chunk)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -13,8 +13,6 @@ from itertools import islice
 from math import ceil
 from typing import AsyncGenerator, Union
 
-import six
-
 from . import encode_base64, url_quote
 from .request_handlers import get_length
 from .response_handlers import return_response_headers
@@ -192,7 +190,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                     temp = await self.stream.read(read_size)
                 else:
                     temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -13,7 +13,6 @@ from typing import (
 )
 from urllib.parse import urlparse, quote, unquote
 
-import six
 from typing_extensions import Self
 
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
@@ -171,7 +170,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         mode hostname.
         """
         share_name = self.share_name
-        if isinstance(share_name, six.text_type):
+        if isinstance(share_name, str):
             share_name = share_name.encode('UTF-8')
         directory_path = ""
         if self.directory_path:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -14,7 +14,6 @@ from typing import (
 )
 from urllib.parse import urlparse, quote, unquote
 
-import six
 from typing_extensions import Self
 
 from azure.core.exceptions import HttpResponseError
@@ -229,7 +228,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         mode hostname.
         """
         share_name = self.share_name
-        if isinstance(share_name, six.text_type):
+        if isinstance(share_name, str):
             share_name = share_name.encode('UTF-8')
         return "{}://{}/{}/{}{}".format(
             self.scheme,
@@ -1156,7 +1155,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         timeout = kwargs.pop('timeout', None)
         encoding = kwargs.pop('encoding', 'UTF-8')
         file_last_write_mode = kwargs.pop('file_last_write_mode', None)
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode(encoding)
 
         end_range = offset + length - 1  # Reformat to an inclusive range index

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -9,7 +9,6 @@ from typing import (
 )
 from urllib.parse import urlparse, quote, unquote
 
-import six
 from typing_extensions import Self
 
 from azure.core.exceptions import HttpResponseError
@@ -180,7 +179,7 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         mode hostname.
         """
         share_name = self.share_name
-        if isinstance(share_name, six.text_type):
+        if isinstance(share_name, str):
             share_name = share_name.encode('UTF-8')
         return "{}://{}/{}{}".format(
             self.scheme,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/__init__.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/__init__.py
@@ -13,8 +13,6 @@ try:
 except ImportError:
     from urllib2 import quote, unquote # type: ignore
 
-import six
-
 
 def url_quote(url):
     return quote(url)
@@ -25,14 +23,14 @@ def url_unquote(url):
 
 
 def encode_base64(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')
 
 
 def decode_base64_to_bytes(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     return base64.b64decode(data)
 
@@ -46,9 +44,9 @@ def sign_string(key, string_to_sign, key_is_base64=True):
     if key_is_base64:
         key = decode_base64_to_bytes(key)
     else:
-        if isinstance(key, six.text_type):
+        if isinstance(key, str):
             key = key.encode('utf-8')
-    if isinstance(string_to_sign, six.text_type):
+    if isinstance(string_to_sign, str):
         string_to_sign = string_to_sign.encode('utf-8')
     signed_hmac_sha256 = hmac.HMAC(key, string_to_sign, hashlib.sha256)
     digest = signed_hmac_sha256.digest()

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -18,8 +18,6 @@ except ImportError:
     from urlparse import parse_qs  # type: ignore
     from urllib2 import quote  # type: ignore
 
-import six
-
 from azure.core.configuration import Configuration
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
 from azure.core.exceptions import HttpResponseError
@@ -345,7 +343,7 @@ class TransportWrapper(HttpTransport):
 
 
 def _format_shared_key_credential(account_name, credential):
-    if isinstance(credential, six.string_types):
+    if isinstance(credential, str):
         if not account_name:
             raise ValueError("Unable to determine account name for shared key credential.")
         credential = {"account_name": account_name, "account_key": credential}
@@ -455,7 +453,7 @@ def parse_query(query_str):
 
 
 def is_credential_sastoken(credential):
-    if not credential or not isinstance(credential, six.string_types):
+    if not credential or not isinstance(credential, str):
         return False
 
     sas_values = QueryStringConstants.to_list()

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -11,7 +11,6 @@ from itertools import islice
 from math import ceil
 from threading import Lock
 
-import six
 from azure.core.tracing.common import with_current_context
 
 from . import encode_base64, url_quote
@@ -164,7 +163,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
                 temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError("Blob data should be of type bytes.")
                 data += temp or b""
 
@@ -594,7 +593,7 @@ class IterStreamer(object):
         try:
             while count < size:
                 chunk = self.__next__()
-                if isinstance(chunk, six.text_type):
+                if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk
                 count += len(chunk)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -13,8 +13,6 @@ from itertools import islice
 from math import ceil
 from typing import AsyncGenerator, Union
 
-import six
-
 from . import encode_base64, url_quote
 from .request_handlers import get_length
 from .response_handlers import return_response_headers
@@ -192,7 +190,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                     temp = await self.stream.read(read_size)
                 else:
                     temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -15,8 +15,6 @@ from typing import (
     TYPE_CHECKING
 )
 
-import six
-
 from azure.core.async_paging import AsyncItemPaged
 from azure.core.exceptions import HttpResponseError
 from azure.core.tracing.decorator import distributed_trace
@@ -393,7 +391,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         timeout = kwargs.pop('timeout', None)
         encoding = kwargs.pop('encoding', 'UTF-8')
 
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode(encoding)
         if length is None:
             length = get_length(data)
@@ -1035,7 +1033,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         timeout = kwargs.pop('timeout', None)
         encoding = kwargs.pop('encoding', 'UTF-8')
         file_last_write_mode = kwargs.pop('file_last_write_mode', None)
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode(encoding)
         end_range = offset + length - 1  # Reformat to an inclusive range index
         content_range = 'bytes={0}-{1}'.format(offset, end_range)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_message_encoding.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_message_encoding.py
@@ -8,7 +8,6 @@
 import sys
 from base64 import b64encode, b64decode
 
-import six
 from azure.core.exceptions import DecodeError
 
 from ._encryption import decrypt_queue_message, encrypt_queue_message, _ENCRYPTION_PROTOCOL_V1
@@ -79,7 +78,7 @@ class TextBase64EncodePolicy(MessageEncodePolicy):
     """
 
     def encode(self, content):
-        if not isinstance(content, six.text_type):
+        if not isinstance(content, str):
             raise TypeError("Message content must be text for base 64 encoding.")
         return b64encode(content.encode('utf-8')).decode('utf-8')
 
@@ -111,7 +110,7 @@ class BinaryBase64EncodePolicy(MessageEncodePolicy):
     """
 
     def encode(self, content):
-        if not isinstance(content, six.binary_type):
+        if not isinstance(content, bytes):
             raise TypeError("Message content must be bytes for base 64 encoding.")
         return b64encode(content).decode('utf-8')
 
@@ -139,7 +138,7 @@ class NoEncodePolicy(MessageEncodePolicy):
     """Bypass any message content encoding."""
 
     def encode(self, content):
-        if isinstance(content, six.binary_type) and sys.version_info > (3,):
+        if isinstance(content, bytes) and sys.version_info > (3,):
             raise TypeError(
                 "Message content must not be bytes. Use the BinaryBase64EncodePolicy to send bytes."
             )

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -11,7 +11,6 @@ from typing import (  # pylint: disable=unused-import
     TYPE_CHECKING)
 from urllib.parse import urlparse, quote, unquote
 
-import six
 from typing_extensions import Self
 
 from azure.core.exceptions import HttpResponseError
@@ -114,7 +113,7 @@ class QueueClient(StorageAccountHostsMixin, StorageEncryptionMixin):
         mode hostname.
         """
         queue_name = self.queue_name
-        if isinstance(queue_name, six.text_type):
+        if isinstance(queue_name, str):
             queue_name = queue_name.encode('UTF-8')
         return (
             f"{self.scheme}://{hostname}"

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/__init__.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/__init__.py
@@ -13,8 +13,6 @@ try:
 except ImportError:
     from urllib2 import quote, unquote # type: ignore
 
-import six
-
 
 def url_quote(url):
     return quote(url)
@@ -25,14 +23,14 @@ def url_unquote(url):
 
 
 def encode_base64(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')
 
 
 def decode_base64_to_bytes(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     return base64.b64decode(data)
 
@@ -46,9 +44,9 @@ def sign_string(key, string_to_sign, key_is_base64=True):
     if key_is_base64:
         key = decode_base64_to_bytes(key)
     else:
-        if isinstance(key, six.text_type):
+        if isinstance(key, str):
             key = key.encode('utf-8')
-    if isinstance(string_to_sign, six.text_type):
+    if isinstance(string_to_sign, str):
         string_to_sign = string_to_sign.encode('utf-8')
     signed_hmac_sha256 = hmac.HMAC(key, string_to_sign, hashlib.sha256)
     digest = signed_hmac_sha256.digest()

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -18,8 +18,6 @@ except ImportError:
     from urlparse import parse_qs  # type: ignore
     from urllib2 import quote  # type: ignore
 
-import six
-
 from azure.core.configuration import Configuration
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
 from azure.core.exceptions import HttpResponseError
@@ -342,7 +340,7 @@ class TransportWrapper(HttpTransport):
 
 
 def _format_shared_key_credential(account_name, credential):
-    if isinstance(credential, six.string_types):
+    if isinstance(credential, str):
         if not account_name:
             raise ValueError("Unable to determine account name for shared key credential.")
         credential = {"account_name": account_name, "account_key": credential}
@@ -452,7 +450,7 @@ def parse_query(query_str):
 
 
 def is_credential_sastoken(credential):
-    if not credential or not isinstance(credential, six.string_types):
+    if not credential or not isinstance(credential, str):
         return False
 
     sas_values = QueryStringConstants.to_list()

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -11,7 +11,6 @@ from itertools import islice
 from math import ceil
 from threading import Lock
 
-import six
 from azure.core.tracing.common import with_current_context
 
 from . import encode_base64, url_quote
@@ -164,7 +163,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
                 temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError("Blob data should be of type bytes.")
                 data += temp or b""
 
@@ -594,7 +593,7 @@ class IterStreamer(object):
         try:
             while count < size:
                 chunk = self.__next__()
-                if isinstance(chunk, six.text_type):
+                if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk
                 count += len(chunk)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -13,8 +13,6 @@ from itertools import islice
 from math import ceil
 from typing import AsyncGenerator, Union
 
-import six
-
 from . import encode_base64, url_quote
 from .request_handlers import get_length
 from .response_handlers import return_response_headers
@@ -192,7 +190,7 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                     temp = await self.stream.read(read_size)
                 else:
                     temp = self.stream.read(read_size)
-                if not isinstance(temp, six.binary_type):
+                if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""
 

--- a/sdk/storage/azure-storage-queue/tests/test_queue_encryption.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_encryption.py
@@ -11,7 +11,6 @@ from json import dumps, loads
 from unittest import mock
 
 import pytest
-import six
 from azure.core.exceptions import ResourceExistsError, HttpResponseError
 from azure.storage.queue import (
     BinaryBase64DecodePolicy,
@@ -48,7 +47,7 @@ TEST_QUEUE_PREFIX = 'encryptionqueue'
 # ------------------------------------------------------------------------------
 
 def _decode_base64_to_bytes(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     return b64decode(data)
 

--- a/sdk/storage/azure-storage-queue/tests/test_queue_encryption_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_encryption_async.py
@@ -11,7 +11,6 @@ from json import dumps, loads
 from unittest import mock
 
 import pytest
-import six
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.queue import BinaryBase64DecodePolicy, BinaryBase64EncodePolicy, VERSION
 from azure.storage.queue.aio import QueueServiceClient
@@ -42,7 +41,7 @@ TEST_QUEUE_PREFIX = 'encryptionqueue'
 # ------------------------------------------------------------------------------
 
 def _decode_base64_to_bytes(data):
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode('utf-8')
         return b64decode(data)
 


### PR DESCRIPTION
This PR is a general improvement to the Python SDK to remove the use of `six` (which was mostly for Python 2 types compatibility) library.