### PR TITLE
[Monitor][Ingestion] Add additional perf options

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/README.md
@@ -29,7 +29,6 @@ AZURE_MONITOR_STREAM_NAME=<The data collection stream name>
 
 These options are available for all perf tests:
 - `--duration=10` Number of seconds to run as many operations (the "run" function) as possible. Default is 10.
-- `--iterations=1` Number of test iterations to run. Default is 1.
 - `--parallel=1` Number of tests to run in parallel. Default is 1.
 - `--warm-up=5` Number of seconds to spend warming up the connection before measuring begins. Default is 5.
 - `--sync` Whether to run the tests in sync or async. Default is False (async).
@@ -40,6 +39,8 @@ These options are available for all perf tests:
 
 These options are available for all ingestion perf tests:
 - `-n`, `--num-logs` Number of logs to be uploaded. Defaults to 100.
+- `-l`, `--log-content-length` Length of the "AdditionalContext" value for each log entry. Use this to increase the size of each log entry. Defaults to 20.
+- `-r`, `--random-log-content` Whether to use a random alphanumeric string for each "AdditionalContext" entry as opposed to a string comprised of a single repeating character. Use this to decrease the compression ratio when the logs are gzipped. Defaults to False.
 
 ### Available tests
 

--- a/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/perf_tests/upload_logs.py
@@ -4,12 +4,25 @@
 # license information.
 #--------------------------------------------------------------------------
 from datetime import datetime
+import json
+import random
+import string
 
 from azure_devtools.perfstress_tests import PerfStressTest
 from azure.identity import DefaultAzureCredential
 from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
 from azure.monitor.ingestion import LogsIngestionClient
 from azure.monitor.ingestion.aio import LogsIngestionClient as AsyncLogsIngestionClient
+
+
+ALPHANUMERIC_CHARACTERS = string.ascii_letters + string.digits
+
+def _get_random_string(length: int):
+    return ''.join(random.choice(ALPHANUMERIC_CHARACTERS) for _ in range(length))
+
+
+def _get_repeating_string(length: int):
+    return "a" * length
 
 
 class UploadLogsTest(PerfStressTest):
@@ -43,19 +56,27 @@ class UploadLogsTest(PerfStressTest):
     async def setup(self):
         await super().setup()
         # Create log entries to upload
-        # TODO: Parameterize the size of each log entry
         self.logs = []
         for i in range(self.args.num_logs):
+            content =  _get_random_string(self.args.log_content_length) if self.args.random_log_content \
+                else _get_repeating_string(self.args.log_content_length)
             self.logs.append({
                 "Time": datetime.now().isoformat(),
                 "Computer": f"Computer {i}",
-                "AdditionalContext": "some additional context"
+                "AdditionalContext": content
             })
+        print(f'{len(json.dumps(self.logs))} bytes of logs to be uploaded.')
 
     @staticmethod
     def add_arguments(parser):
         super(UploadLogsTest, UploadLogsTest).add_arguments(parser)
-        parser.add_argument("-n", "--num-logs", nargs="?", type=int, help="Number of logs to be uploaded. Defaults to 100", default=100)
+        parser.add_argument("-n", "--num-logs", nargs="?", type=int,
+            help="Number of logs to be uploaded. Defaults to 100", default=100)
+        parser.add_argument("-l", "--log-content-length", nargs="?", type=int,
+            help="Length of the 'AdditionalContext' value for each log entry. Defaults to 20", default=20)
+        parser.add_argument("-r", "--random-log-content", action="store_true",
+            help="Whether to use a random alphanumeric string for each 'AdditionalContext' value. "
+                 "If False, uses a repeating 'a' character. Defaults to False", default=False)
 
     def run_sync(self):
         self.client.upload(


### PR DESCRIPTION
This adds two additional arguments to the UploadLogsTest:

`--log-content-length` - An integer allowing a user to control the length of each log entry to be uploaded.
`--random-log-content` - Whether the log content should be a random alphanumeric string instead of a repeating character.


