### PR TITLE
[Perf] Use Python 3.11 in perf test pipelines

### DIFF
--- a/eng/pipelines/templates/jobs/perf.yml
+++ b/eng/pipelines/templates/jobs/perf.yml
@@ -30,7 +30,7 @@ extends:
     Variables:
     - template: /eng/pipelines/templates/variables/globals.yml
     - name: PythonVersion
-      value: '3.7'
+      value: '3.11'
     Language: Python
     InstallLanguageSteps:
     - task: UsePythonVersion@0


### PR DESCRIPTION
Evaluating Python 3.11 performance in the pipeline.
