### PR TITLE
[Storage] Matching `_shared` folder contents across all packages

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/authentication.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/authentication.py
@@ -6,14 +6,8 @@
 
 import logging
 import re
-import sys
 from typing import List, Tuple
-
-try:
-    from urllib.parse import urlparse, unquote
-except ImportError:
-    from urlparse import urlparse  # type: ignore
-    from urllib2 import unquote  # type: ignore
+from urllib.parse import unquote, urlparse
 
 try:
     from yarl import URL
@@ -38,14 +32,7 @@ def _wrap_exception(ex, desired_type):
     msg = ""
     if ex.args:
         msg = ex.args[0]
-    if sys.version_info >= (3,):
-        # Automatic chaining in Python 3 means we keep the trace
-        return desired_type(msg)
-    # There isn't a good solution in 2 for keeping the stack trace
-    # in general, or that will not result in an error in 3
-    # However, we can keep the previous error type and message
-    # TODO: In the future we will log the trace
-    return desired_type('{}: {}'.format(ex.__class__.__name__, msg))
+    return desired_type(msg)
 
 # This method attempts to emulate the sorting done by the service
 def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str, str]]:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -8,10 +8,10 @@ import uuid
 from typing import (  # pylint: disable=unused-import
     Any,
     Dict,
-    Tuple,
-    Union,
     Optional,
-    TYPE_CHECKING
+    Tuple,
+    TYPE_CHECKING,
+    Union,
 )
 
 try:
@@ -32,8 +32,8 @@ from azure.core.pipeline.policies import (
     ContentDecodePolicy,
     DistributedTracingPolicy,
     HttpLoggingPolicy,
-    RedirectPolicy,
     ProxyPolicy,
+    RedirectPolicy,
     UserAgentPolicy,
 )
 
@@ -44,6 +44,7 @@ from .shared_access_signature import QueryStringConstants
 from .request_handlers import serialize_batch_body, _get_batch_request_delimiter
 from .policies import (
     ExponentialRetry,
+    QueueMessagePolicy,
     StorageBearerTokenCredentialPolicy,
     StorageContentValidation,
     StorageHeadersPolicy,
@@ -51,7 +52,6 @@ from .policies import (
     StorageLoggingPolicy,
     StorageRequestHook,
     StorageResponseHook,
-    QueueMessagePolicy,
 )
 from .._version import VERSION
 from .response_handlers import process_storage_error, PartialBatchErrorException

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -385,9 +385,9 @@ def parse_connection_str(conn_str, credential, service):
                 f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
                 f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            primary =(
-                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
-                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
+            secondary = (
+                f"{conn_settings['ACCOUNTNAME']}-secondary."
+                f"{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -82,9 +82,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         self.scheme = parsed_url.scheme
 
         if service not in ["blob", "queue", "file-share", "dfs"]:
-            raise ValueError("Invalid service: {}".format(service))
+            raise ValueError(f"Invalid service: {service}")
         service_name = service.split('-')[0]
-        account = parsed_url.netloc.split(".{}.core.".format(service_name))
+        account = parsed_url.netloc.split(f".{service_name}.core.")
 
         self.account_name = account[0] if len(account) > 1 else None
         if not self.account_name and parsed_url.netloc.startswith("localhost") \
@@ -98,8 +98,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         secondary_hostname = None
         if hasattr(self.credential, "account_name"):
             self.account_name = self.credential.account_name
-            secondary_hostname = "{}-secondary.{}.{}".format(
-                self.credential.account_name, service_name, SERVICE_HOST_BASE)
+            secondary_hostname = f"{self.credential.account_name}-secondary.{service_name}.{SERVICE_HOST_BASE}"
 
         if not self._hosts:
             if len(account) > 1:
@@ -191,7 +190,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
             self._location_mode = value
             self._client._config.url = self.url  # pylint: disable=protected-access
         else:
-            raise ValueError("No host URL for location mode: {}".format(value))
+            raise ValueError(f"No host URL for location mode: {value}")
 
     @property
     def api_version(self):
@@ -204,9 +203,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
     def _format_query_string(self, sas_token, credential, snapshot=None, share_snapshot=None):
         query_str = "?"
         if snapshot:
-            query_str += "snapshot={}&".format(self.snapshot)
+            query_str += f"snapshot={self.snapshot}&"
         if share_snapshot:
-            query_str += "sharesnapshot={}&".format(self.snapshot)
+            query_str += f"sharesnapshot={self.snapshot}&"
         if sas_token and isinstance(credential, AzureSasCredential):
             raise ValueError(
                 "You cannot use AzureSasCredential when the resource URI also contains a Shared Access Signature.")
@@ -227,7 +226,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):
@@ -270,13 +269,10 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         batch_id = str(uuid.uuid1())
 
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version,
@@ -385,22 +381,22 @@ def parse_connection_str(conn_str, credential, service):
         if endpoints["secondary"] in conn_settings:
             raise ValueError("Connection string specifies only secondary endpoint.")
         try:
-            primary = "{}://{}.{}.{}".format(
-                conn_settings["DEFAULTENDPOINTSPROTOCOL"],
-                conn_settings["ACCOUNTNAME"],
-                service,
-                conn_settings["ENDPOINTSUFFIX"],
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            secondary = "{}-secondary.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings["ENDPOINTSUFFIX"]
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass
 
     if not primary:
         try:
-            primary = "https://{}.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings.get("ENDPOINTSUFFIX", SERVICE_HOST_BASE)
+            primary = (
+                f"https://{conn_settings['ACCOUNTNAME']}."
+                f"{service}.{conn_settings.get('ENDPOINTSUFFIX', SERVICE_HOST_BASE)}"
             )
         except KeyError:
             raise ValueError("Connection string missing required connection details.")
@@ -416,7 +412,7 @@ def create_configuration(**kwargs):
     config = Configuration(**kwargs)
     config.headers_policy = StorageHeadersPolicy(**kwargs)
     config.user_agent_policy = UserAgentPolicy(
-        sdk_moniker="storage-{}/{}".format(kwargs.pop('storage_sdk'), VERSION), **kwargs)
+        sdk_moniker=f"storage-{kwargs.pop('storage_sdk')}/{VERSION}", **kwargs)
     config.retry_policy = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
     config.logging_policy = StorageLoggingPolicy(**kwargs)
     config.proxy_policy = ProxyPolicy(**kwargs)
@@ -448,7 +444,7 @@ def create_configuration(**kwargs):
 def parse_query(query_str):
     sas_values = QueryStringConstants.to_list()
     parsed_query = {k: v[0] for k, v in parse_qs(query_str).items()}
-    sas_params = ["{}={}".format(k, quote(v, safe='')) for k, v in parsed_query.items() if k in sas_values]
+    sas_params = [f"{k}={quote(v, safe='')}" for k, v in parsed_query.items() if k in sas_values]
     sas_token = None
     if sas_params:
         sas_token = "&".join(sas_params)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
@@ -27,11 +27,11 @@ from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT
 from .authentication import SharedKeyCredentialPolicy
 from .base_client import create_configuration
 from .policies import (
+    QueueMessagePolicy,
     StorageContentValidation,
     StorageHeadersPolicy,
     StorageHosts,
     StorageRequestHook,
-    QueueMessagePolicy
 )
 from .policies_async import AsyncStorageBearerTokenCredentialPolicy, AsyncStorageResponseHook
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
@@ -75,7 +75,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']
@@ -119,13 +119,10 @@ class AsyncStorageAccountHostsMixin(object):
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/parser.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/parser.py
@@ -5,6 +5,10 @@
 # --------------------------------------------------------------------------
 
 import sys
+from datetime import datetime, timezone
+
+EPOCH_AS_FILETIME = 116444736000000000  # January 1, 1970 as MS filetime
+HUNDREDS_OF_NANOSECONDS = 10000000
 
 if sys.version_info < (3,):
     def _str(value):
@@ -18,3 +22,31 @@ else:
 
 def _to_utc_datetime(value):
     return value.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+def _rfc_1123_to_datetime(rfc_1123: str) -> datetime:
+    """Converts an RFC 1123 date string to a UTC datetime.
+    """
+    if not rfc_1123:
+        return None
+
+    return datetime.strptime(rfc_1123, "%a, %d %b %Y %H:%M:%S %Z")
+
+def _filetime_to_datetime(filetime: str) -> datetime:
+    """Converts an MS filetime string to a UTC datetime. "0" indicates None.
+    If parsing MS Filetime fails, tries RFC 1123 as backup.
+    """
+    if not filetime:
+        return None
+
+    # Try to convert to MS Filetime
+    try:
+        filetime = int(filetime)
+        if filetime == 0:
+            return None
+
+        return datetime.fromtimestamp((filetime - EPOCH_AS_FILETIME) / HUNDREDS_OF_NANOSECONDS, tz=timezone.utc)
+    except ValueError:
+        pass
+
+    # Try RFC 1123 as backup
+    return _rfc_1123_to_datetime(filetime)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -177,7 +177,7 @@ class StorageHosts(SansIOHTTPPolicy):
             # Lock retries to the specific location
             request.context.options['retry_to_secondary'] = False
             if use_location not in self.hosts:
-                raise ValueError("Attempting to use undefined host location {}".format(use_location))
+                raise ValueError(f"Attempting to use undefined host location {use_location}")
             if use_location != location_mode:
                 # Update request URL to use the specified location
                 updated = parsed_url._replace(netloc=self.hosts[use_location])
@@ -387,9 +387,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
-                raise AzureError(
-                    'MD5 mismatch. Expected value is \'{0}\', computed value is \'{1}\'.'.format(
-                        response.http_response.headers['content-md5'], computed_md5),
+                raise AzureError((
+                    f"MD5 mismatch. Expected value is '{response.http_response.headers['content-md5']}', "
+                    f"computed value is '{computed_md5}'."),
                     response=response.http_response
                 )
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
@@ -122,18 +122,18 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-            raise ValueError("Invalid page blob start_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(start_range))
+             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
-            raise ValueError("Invalid page blob end_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(end_range))
+            raise ValueError(f"Invalid page blob end_range: {end_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
 
     # Format based on whether end_range is present
     range_header = None
     if end_range is not None:
-        range_header = 'bytes={0}-{1}'.format(start_range, end_range)
+        range_header = f'bytes={start_range}-{end_range}'
     elif start_range is not None:
-        range_header = "bytes={0}-".format(start_range)
+        range_header = f"bytes={start_range}-"
 
     # Content MD5 can only be provided for a complete range less than 4MB in size
     range_validation = None
@@ -152,7 +152,7 @@ def add_metadata_headers(metadata=None):
     headers = {}
     if metadata:
         for key, value in metadata.items():
-            headers['x-ms-meta-{}'.format(key.strip())] = value.strip() if value else value
+            headers[f'x-ms-meta-{key.strip()}'] = value.strip() if value else value
     return headers
 
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
@@ -122,7 +122,7 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+            raise ValueError(f"Invalid page blob start_range: {start_range}. "
                              "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
             raise ValueError(f"Invalid page blob end_range: {end_range}. "

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -22,6 +22,7 @@ from azure.core.exceptions import (
 from .parser import _to_utc_datetime
 from .models import StorageErrorCode, UserDelegationKey, get_enum_value
 
+
 if TYPE_CHECKING:
     from datetime import datetime
     from azure.core.exceptions import AzureError

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -67,7 +67,10 @@ def normalize_headers(headers):
 
 
 def deserialize_metadata(response, obj, headers):  # pylint: disable=unused-argument
-    raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    try:
+        raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    except AttributeError:
+        raw_metadata = {k: v for k, v in response.headers.items() if k.startswith("x-ms-meta-")}
     return {k[10:]: v for k, v in raw_metadata.items()}
 
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -93,7 +93,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     if not storage_error.response:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException,
+                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -93,8 +93,7 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     if not storage_error.response:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException,
-                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message
@@ -164,11 +163,11 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
 
     # Error message should include all the error properties
     try:
-        error_message += "\nErrorCode:{}".format(error_code.value)
+        error_message += f"\nErrorCode:{error_code.value}"
     except AttributeError:
-        error_message += "\nErrorCode:{}".format(error_code)
+        error_message += f"\nErrorCode:{error_code}"
     for name, info in additional_data.items():
-        error_message += "\n{}:{}".format(name, info)
+        error_message += f"\n{name}:{info}"
 
     # No need to create an instance if it has already been serialized by the generated layer
     if serialized:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
@@ -151,6 +151,9 @@ class SharedAccessSignature(object):
         :param str protocol:
             Specifies the protocol permitted for a request made. The default value
             is https,http. See :class:`~azure.storage.common.models.Protocol` for possible values.
+        :keyword str encryption_scope:
+            Optional. If specified, this is the encryption scope to use when sending requests
+            authorized with this SAS URI.
         '''
         sas = _SharedAccessHelper()
         sas.add_base(permission, expiry, start, ip, protocol, self.x_ms_version)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
@@ -231,4 +231,4 @@ class _SharedAccessHelper(object):
                         sign_string(account_key, string_to_sign))
 
     def get_token(self):
-        return '&'.join(['{0}={1}'.format(n, url_quote(v)) for n, v in self.query_dict.items() if v is not None])
+        return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -255,7 +255,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         self.service.stage_block(
             block_id,
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -294,7 +294,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = "bytes={0}-{1}".format(chunk_offset, chunk_end)
+            content_range = f"bytes={chunk_offset}-{chunk_end}"
             computed_md5 = None
             self.response_headers = self.service.upload_pages(
                 body=chunk_data,
@@ -392,7 +392,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        return 'bytes={0}-{1}'.format(chunk_offset, chunk_end), response
+        return f'bytes={chunk_offset}-{chunk_end}', response
 
     # TODO: Implement this method.
     def _upload_substream_block(self, index, block_stream):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -283,7 +283,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         await self.service.stage_block(
             block_id,
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -323,7 +323,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+            content_range = f'bytes={chunk_offset}-{chunk_end}'
             computed_md5 = None
             self.response_headers = await self.service.upload_pages(
                 body=chunk_data,
@@ -417,7 +417,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        range_id = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+        range_id = f'bytes={chunk_offset}-{chunk_end}'
         return range_id, response
 
     # TODO: Implement this method.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_deserialize.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_deserialize.py
@@ -15,6 +15,7 @@ from azure.core.exceptions import HttpResponseError, DecodeError, ResourceModifi
 from ._models import FileProperties, DirectoryProperties, LeaseProperties, DeletedPathProperties, StaticWebsite, \
     RetentionPolicy, Metrics, AnalyticsLogging, PathProperties  # pylint: disable=protected-access
 from ._shared.models import StorageErrorCode
+from ._shared.response_handlers import deserialize_metadata
 
 if TYPE_CHECKING:
     pass
@@ -105,14 +106,6 @@ def normalize_headers(headers):
             key = key[5:]
         normalized[key.lower().replace('-', '_')] = value
     return normalized
-
-
-def deserialize_metadata(response, obj, headers):  # pylint: disable=unused-argument
-    try:
-        raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
-    except AttributeError:
-        raw_metadata = {k: v for k, v in response.headers.items() if k.startswith("x-ms-meta-")}
-    return {k[10:]: v for k, v in raw_metadata.items()}
 
 
 def process_storage_error(storage_error):   # pylint:disable=too-many-statements

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_deserialize.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_deserialize.py
@@ -192,11 +192,11 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
 
     # Error message should include all the error properties
     try:
-        error_message += "\nErrorCode:{}".format(error_code.value)
+        error_message += f"\nErrorCode:{error_code.value}"
     except AttributeError:
-        error_message += "\nErrorCode:{}".format(error_code)
+        error_message += f"\nErrorCode:{error_code}"
     for name, info in additional_data.items():
-        error_message += "\n{}:{}".format(name, info)
+        error_message += f"\n{name}:{info}"
 
     # No need to create an instance if it has already been serialized by the generated layer
     if serialized:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/authentication.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/authentication.py
@@ -6,14 +6,8 @@
 
 import logging
 import re
-import sys
 from typing import List, Tuple
-
-try:
-    from urllib.parse import urlparse, unquote
-except ImportError:
-    from urlparse import urlparse  # type: ignore
-    from urllib2 import unquote  # type: ignore
+from urllib.parse import unquote, urlparse
 
 try:
     from yarl import URL
@@ -38,14 +32,7 @@ def _wrap_exception(ex, desired_type):
     msg = ""
     if ex.args:
         msg = ex.args[0]
-    if sys.version_info >= (3,):
-        # Automatic chaining in Python 3 means we keep the trace
-        return desired_type(msg)
-    # There isn't a good solution in 2 for keeping the stack trace
-    # in general, or that will not result in an error in 3
-    # However, we can keep the previous error type and message
-    # TODO: In the future we will log the trace
-    return desired_type('{}: {}'.format(ex.__class__.__name__, msg))
+    return desired_type(msg)
 
 # This method attempts to emulate the sorting done by the service
 def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str, str]]:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/authentication.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/authentication.py
@@ -5,14 +5,15 @@
 # --------------------------------------------------------------------------
 
 import logging
+import re
 import sys
 from typing import List, Tuple
 
 try:
     from urllib.parse import urlparse, unquote
 except ImportError:
-    from urlparse import urlparse # type: ignore
-    from urllib2 import unquote # type: ignore
+    from urlparse import urlparse  # type: ignore
+    from urllib2 import unquote  # type: ignore
 
 try:
     from yarl import URL
@@ -29,9 +30,7 @@ from azure.core.pipeline.policies import SansIOHTTPPolicy
 
 from . import sign_string
 
-
 logger = logging.getLogger(__name__)
-
 
 
 # wraps a given exception with the desired exception type
@@ -164,4 +163,39 @@ class SharedKeyCredentialPolicy(SansIOHTTPPolicy):
             self._get_canonicalized_resource_query(request)
 
         self._add_authorization_header(request, string_to_sign)
-        #logger.debug("String_to_sign=%s", string_to_sign)
+        # logger.debug("String_to_sign=%s", string_to_sign)
+
+
+class StorageHttpChallenge(object):
+    def __init__(self, challenge):
+        """ Parses an HTTP WWW-Authentication Bearer challenge from the Storage service. """
+        if not challenge:
+            raise ValueError("Challenge cannot be empty")
+
+        self._parameters = {}
+        self.scheme, trimmed_challenge = challenge.strip().split(" ", 1)
+
+        # name=value pairs either comma or space separated with values possibly being
+        # enclosed in quotes
+        for item in re.split('[, ]', trimmed_challenge):
+            comps = item.split("=")
+            if len(comps) == 2:
+                key = comps[0].strip(' "')
+                value = comps[1].strip(' "')
+                if key:
+                    self._parameters[key] = value
+
+        # Extract and verify required parameters
+        self.authorization_uri = self._parameters.get('authorization_uri')
+        if not self.authorization_uri:
+            raise ValueError("Authorization Uri not found")
+
+        self.resource_id = self._parameters.get('resource_id')
+        if not self.resource_id:
+            raise ValueError("Resource id not found")
+
+        uri_path = urlparse(self.authorization_uri).path.lstrip("/")
+        self.tenant_id = uri_path.split("/")[0]
+
+    def get_value(self, key):
+        return self._parameters.get(key)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
@@ -29,6 +29,7 @@ from azure.core.pipeline import Pipeline
 from azure.core.pipeline.transport import RequestsTransport, HttpTransport
 from azure.core.pipeline.policies import (
     AzureSasCredentialPolicy,
+    BearerTokenCredentialPolicy,
     ContentDecodePolicy,
     DistributedTracingPolicy,
     HttpLoggingPolicy,
@@ -37,7 +38,7 @@ from azure.core.pipeline.policies import (
     UserAgentPolicy,
 )
 
-from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, SERVICE_HOST_BASE
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, SERVICE_HOST_BASE, STORAGE_OAUTH_SCOPE
 from .models import LocationMode
 from .authentication import SharedKeyCredentialPolicy
 from .shared_access_signature import QueryStringConstants
@@ -45,7 +46,6 @@ from .request_handlers import serialize_batch_body, _get_batch_request_delimiter
 from .policies import (
     ExponentialRetry,
     QueueMessagePolicy,
-    StorageBearerTokenCredentialPolicy,
     StorageContentValidation,
     StorageHeadersPolicy,
     StorageHosts,
@@ -221,7 +221,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, "get_token"):
-            self._credential_policy = StorageBearerTokenCredentialPolicy(credential)
+            self._credential_policy = BearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
@@ -385,9 +385,9 @@ def parse_connection_str(conn_str, credential, service):
                 f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
                 f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            primary =(
-                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
-                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
+            secondary = (
+                f"{conn_settings['ACCOUNTNAME']}-secondary."
+                f"{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
@@ -82,9 +82,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         self.scheme = parsed_url.scheme
 
         if service not in ["blob", "queue", "file-share", "dfs"]:
-            raise ValueError("Invalid service: {}".format(service))
+            raise ValueError(f"Invalid service: {service}")
         service_name = service.split('-')[0]
-        account = parsed_url.netloc.split(".{}.core.".format(service_name))
+        account = parsed_url.netloc.split(f".{service_name}.core.")
 
         self.account_name = account[0] if len(account) > 1 else None
         if not self.account_name and parsed_url.netloc.startswith("localhost") \
@@ -98,8 +98,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         secondary_hostname = None
         if hasattr(self.credential, "account_name"):
             self.account_name = self.credential.account_name
-            secondary_hostname = "{}-secondary.{}.{}".format(
-                self.credential.account_name, service_name, SERVICE_HOST_BASE)
+            secondary_hostname = f"{self.credential.account_name}-secondary.{service_name}.{SERVICE_HOST_BASE}"
 
         if not self._hosts:
             if len(account) > 1:
@@ -191,7 +190,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
             self._location_mode = value
             self._client._config.url = self.url  # pylint: disable=protected-access
         else:
-            raise ValueError("No host URL for location mode: {}".format(value))
+            raise ValueError(f"No host URL for location mode: {value}")
 
     @property
     def api_version(self):
@@ -204,9 +203,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
     def _format_query_string(self, sas_token, credential, snapshot=None, share_snapshot=None):
         query_str = "?"
         if snapshot:
-            query_str += "snapshot={}&".format(self.snapshot)
+            query_str += f"snapshot={self.snapshot}&"
         if share_snapshot:
-            query_str += "sharesnapshot={}&".format(self.snapshot)
+            query_str += f"sharesnapshot={self.snapshot}&"
         if sas_token and isinstance(credential, AzureSasCredential):
             raise ValueError(
                 "You cannot use AzureSasCredential when the resource URI also contains a Shared Access Signature.")
@@ -227,7 +226,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):
@@ -270,13 +269,10 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         batch_id = str(uuid.uuid1())
 
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version,
@@ -385,22 +381,22 @@ def parse_connection_str(conn_str, credential, service):
         if endpoints["secondary"] in conn_settings:
             raise ValueError("Connection string specifies only secondary endpoint.")
         try:
-            primary = "{}://{}.{}.{}".format(
-                conn_settings["DEFAULTENDPOINTSPROTOCOL"],
-                conn_settings["ACCOUNTNAME"],
-                service,
-                conn_settings["ENDPOINTSUFFIX"],
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            secondary = "{}-secondary.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings["ENDPOINTSUFFIX"]
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass
 
     if not primary:
         try:
-            primary = "https://{}.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings.get("ENDPOINTSUFFIX", SERVICE_HOST_BASE)
+            primary = (
+                f"https://{conn_settings['ACCOUNTNAME']}."
+                f"{service}.{conn_settings.get('ENDPOINTSUFFIX', SERVICE_HOST_BASE)}"
             )
         except KeyError:
             raise ValueError("Connection string missing required connection details.")
@@ -416,7 +412,7 @@ def create_configuration(**kwargs):
     config = Configuration(**kwargs)
     config.headers_policy = StorageHeadersPolicy(**kwargs)
     config.user_agent_policy = UserAgentPolicy(
-        sdk_moniker="storage-{}/{}".format(kwargs.pop('storage_sdk'), VERSION), **kwargs)
+        sdk_moniker=f"storage-{kwargs.pop('storage_sdk')}/{VERSION}", **kwargs)
     config.retry_policy = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
     config.logging_policy = StorageLoggingPolicy(**kwargs)
     config.proxy_policy = ProxyPolicy(**kwargs)
@@ -448,7 +444,7 @@ def create_configuration(**kwargs):
 def parse_query(query_str):
     sas_values = QueryStringConstants.to_list()
     parsed_query = {k: v[0] for k, v in parse_qs(query_str).items()}
-    sas_params = ["{}={}".format(k, quote(v, safe='')) for k, v in parsed_query.items() if k in sas_values]
+    sas_params = [f"{k}={quote(v, safe='')}" for k, v in parsed_query.items() if k in sas_values]
     sas_token = None
     if sas_params:
         sas_token = "&".join(sas_params)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
@@ -15,6 +15,7 @@ from azure.core.pipeline import AsyncPipeline
 from azure.core.async_paging import AsyncList
 from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.policies import (
+    AsyncBearerTokenCredentialPolicy,
     AsyncRedirectPolicy,
     AzureSasCredentialPolicy,
     ContentDecodePolicy,
@@ -23,7 +24,7 @@ from azure.core.pipeline.policies import (
 )
 from azure.core.pipeline.transport import AsyncHttpTransport
 
-from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, STORAGE_OAUTH_SCOPE
 from .authentication import SharedKeyCredentialPolicy
 from .base_client import create_configuration
 from .policies import (
@@ -33,7 +34,7 @@ from .policies import (
     StorageHosts,
     StorageRequestHook,
 )
-from .policies_async import AsyncStorageBearerTokenCredentialPolicy, AsyncStorageResponseHook
+from .policies_async import AsyncStorageResponseHook
 
 from .response_handlers import process_storage_error, PartialBatchErrorException
 
@@ -69,7 +70,7 @@ class AsyncStorageAccountHostsMixin(object):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, 'get_token'):
-            self._credential_policy = AsyncStorageBearerTokenCredentialPolicy(credential)
+            self._credential_policy = AsyncBearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
@@ -15,26 +15,25 @@ from azure.core.pipeline import AsyncPipeline
 from azure.core.async_paging import AsyncList
 from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.policies import (
-    ContentDecodePolicy,
-    AsyncBearerTokenCredentialPolicy,
     AsyncRedirectPolicy,
+    AzureSasCredentialPolicy,
+    ContentDecodePolicy,
     DistributedTracingPolicy,
     HttpLoggingPolicy,
-    AzureSasCredentialPolicy,
 )
 from azure.core.pipeline.transport import AsyncHttpTransport
 
-from .constants import STORAGE_OAUTH_SCOPE, CONNECTION_TIMEOUT, READ_TIMEOUT
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT
 from .authentication import SharedKeyCredentialPolicy
 from .base_client import create_configuration
 from .policies import (
+    QueueMessagePolicy,
     StorageContentValidation,
-    StorageRequestHook,
-    StorageHosts,
     StorageHeadersPolicy,
-    QueueMessagePolicy
+    StorageHosts,
+    StorageRequestHook,
 )
-from .policies_async import AsyncStorageResponseHook
+from .policies_async import AsyncStorageBearerTokenCredentialPolicy, AsyncStorageResponseHook
 
 from .response_handlers import process_storage_error, PartialBatchErrorException
 
@@ -70,7 +69,7 @@ class AsyncStorageAccountHostsMixin(object):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, 'get_token'):
-            self._credential_policy = AsyncBearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
+            self._credential_policy = AsyncStorageBearerTokenCredentialPolicy(credential)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):
@@ -111,7 +110,8 @@ class AsyncStorageAccountHostsMixin(object):
         return config, AsyncPipeline(config.transport, policies=policies)
 
     async def _batch_send(
-        self, *reqs: 'HttpRequest',
+        self,
+        *reqs,  # type: HttpRequest
         **kwargs
     ):
         """Given a series of request, do a Storage batch call.
@@ -119,18 +119,26 @@ class AsyncStorageAccountHostsMixin(object):
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='https://{}/?comp=batch'.format(self.primary_hostname),
+            url='{}://{}/{}?{}comp=batch{}{}'.format(
+                self.scheme,
+                self.primary_hostname,
+                kwargs.pop('path', ""),
+                kwargs.pop('restype', ""),
+                kwargs.pop('sas', ""),
+                kwargs.pop('timeout', "")
+            ),
             headers={
                 'x-ms-version': self.api_version
             }
         )
 
+        policies = [StorageHeadersPolicy()]
+        if self._credential_policy:
+            policies.append(self._credential_policy)
+
         request.set_multipart_mixed(
             *reqs,
-            policies=[
-                StorageHeadersPolicy(),
-                self._credential_policy
-            ],
+            policies=policies,
             enforce_https=False
         )
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
@@ -75,7 +75,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']
@@ -119,13 +119,10 @@ class AsyncStorageAccountHostsMixin(object):
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/constants.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/constants.py
@@ -13,6 +13,7 @@ X_MS_VERSION = _SUPPORTED_API_VERSIONS[-1]
 CONNECTION_TIMEOUT = 20
 READ_TIMEOUT = 60
 
+DEFAULT_OAUTH_SCOPE = "/.default"
 STORAGE_OAUTH_SCOPE = "https://storage.azure.com/.default"
 
 SERVICE_HOST_BASE = 'core.windows.net'

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/models.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/models.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=too-many-instance-attributes
-
 from enum import Enum
 
 from azure.core import CaseInsensitiveEnumMeta

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
@@ -177,7 +177,7 @@ class StorageHosts(SansIOHTTPPolicy):
             # Lock retries to the specific location
             request.context.options['retry_to_secondary'] = False
             if use_location not in self.hosts:
-                raise ValueError("Attempting to use undefined host location {}".format(use_location))
+                raise ValueError(f"Attempting to use undefined host location {use_location}")
             if use_location != location_mode:
                 # Update request URL to use the specified location
                 updated = parsed_url._replace(netloc=self.hosts[use_location])
@@ -387,9 +387,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
-                raise AzureError(
-                    'MD5 mismatch. Expected value is \'{0}\', computed value is \'{1}\'.'.format(
-                        response.http_response.headers['content-md5'], computed_md5),
+                raise AzureError((
+                    f"MD5 mismatch. Expected value is '{response.http_response.headers['content-md5']}', "
+                    f"computed value is '{computed_md5}'."),
                     response=response.http_response
                 )
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
@@ -30,14 +30,17 @@ except ImportError:
     )
 
 from azure.core.pipeline.policies import (
+    BearerTokenCredentialPolicy,
     HeadersPolicy,
-    SansIOHTTPPolicy,
-    NetworkTraceLoggingPolicy,
     HTTPPolicy,
-    RequestHistory
+    NetworkTraceLoggingPolicy,
+    RequestHistory,
+    SansIOHTTPPolicy,
 )
 from azure.core.exceptions import AzureError, ServiceRequestError, ServiceResponseError
 
+from .authentication import StorageHttpChallenge
+from .constants import DEFAULT_OAUTH_SCOPE, STORAGE_OAUTH_SCOPE
 from .models import LocationMode
 
 try:
@@ -46,6 +49,7 @@ except NameError:
     _unicode_type = str
 
 if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
@@ -292,18 +296,28 @@ class StorageResponseHook(HTTPPolicy):
 
     def send(self, request):
         # type: (PipelineRequest) -> PipelineResponse
-        data_stream_total = request.context.get('data_stream_total') or \
-            request.context.options.pop('data_stream_total', None)
-        download_stream_current = request.context.get('download_stream_current') or \
-            request.context.options.pop('download_stream_current', None)
-        upload_stream_current = request.context.get('upload_stream_current') or \
-            request.context.options.pop('upload_stream_current', None)
+        # Values could be 0
+        data_stream_total = request.context.get('data_stream_total')
+        if data_stream_total is None:
+            data_stream_total = request.context.options.pop('data_stream_total', None)
+        download_stream_current = request.context.get('download_stream_current')
+        if download_stream_current is None:
+            download_stream_current = request.context.options.pop('download_stream_current', None)
+        upload_stream_current = request.context.get('upload_stream_current')
+        if upload_stream_current is None:
+            upload_stream_current = request.context.options.pop('upload_stream_current', None)
+
         response_callback = request.context.get('response_callback') or \
             request.context.options.pop('raw_response_hook', self._response_callback)
 
         response = self.next.send(request)
+
         will_retry = is_retry(response, request.context.options.get('mode'))
-        if not will_retry and download_stream_current is not None:
+        # Auth error could come from Bearer challenge, in which case this request will be made again
+        is_auth_error = response.http_response.status_code == 401
+        should_update_counts = not (will_retry or is_auth_error)
+
+        if should_update_counts and download_stream_current is not None:
             download_stream_current += int(response.http_response.headers.get('Content-Length', 0))
             if data_stream_total is None:
                 content_range = response.http_response.headers.get('Content-Range')
@@ -311,7 +325,7 @@ class StorageResponseHook(HTTPPolicy):
                     data_stream_total = int(content_range.split(' ', 1)[1].split('/', 1)[1])
                 else:
                     data_stream_total = download_stream_current
-        elif not will_retry and upload_stream_current is not None:
+        elif should_update_counts and upload_stream_current is not None:
             upload_stream_current += int(response.http_request.headers.get('Content-Length', 0))
         for pipeline_obj in [request, response]:
             pipeline_obj.context['data_stream_total'] = data_stream_total
@@ -623,3 +637,24 @@ class LinearRetry(StorageRetryPolicy):
             if self.backoff > self.random_jitter_range else 0
         random_range_end = self.backoff + self.random_jitter_range
         return random_generator.uniform(random_range_start, random_range_end)
+
+
+class StorageBearerTokenCredentialPolicy(BearerTokenCredentialPolicy):
+    """ Custom Bearer token credential policy for following Storage Bearer challenges """
+
+    def __init__(self, credential, **kwargs):
+        # type: (TokenCredential, **Any) -> None
+        super(StorageBearerTokenCredentialPolicy, self).__init__(credential, STORAGE_OAUTH_SCOPE, **kwargs)
+
+    def on_challenge(self, request, response):
+        # type: (PipelineRequest, PipelineResponse) -> bool
+        try:
+            auth_header = response.http_response.headers.get("WWW-Authenticate")
+            challenge = StorageHttpChallenge(auth_header)
+        except ValueError:
+            return False
+
+        scope = challenge.resource_id + DEFAULT_OAUTH_SCOPE
+        self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        return True

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
@@ -11,6 +11,7 @@ from typing import (  # pylint: disable=unused-import
 
 import logging
 from os import fstat
+import stat
 from io import (SEEK_END, SEEK_SET, UnsupportedOperation)
 
 import isodate
@@ -70,7 +71,11 @@ def get_length(data):
             pass
         else:
             try:
-                return fstat(fileno).st_size
+                mode = fstat(fileno).st_mode
+                if stat.S_ISREG(mode) or stat.S_ISLNK(mode):
+                    #st_size only meaningful if regular file or symlink, other types
+                    # e.g. sockets may return misleading sizes like 0
+                    return fstat(fileno).st_size
             except OSError:
                 # Not a valid fileno, may be possible requests returned
                 # a socket number?

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
@@ -122,18 +122,18 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-            raise ValueError("Invalid page blob start_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(start_range))
+             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
-            raise ValueError("Invalid page blob end_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(end_range))
+            raise ValueError(f"Invalid page blob end_range: {end_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
 
     # Format based on whether end_range is present
     range_header = None
     if end_range is not None:
-        range_header = 'bytes={0}-{1}'.format(start_range, end_range)
+        range_header = f'bytes={start_range}-{end_range}'
     elif start_range is not None:
-        range_header = "bytes={0}-".format(start_range)
+        range_header = f"bytes={start_range}-"
 
     # Content MD5 can only be provided for a complete range less than 4MB in size
     range_validation = None
@@ -152,7 +152,7 @@ def add_metadata_headers(metadata=None):
     headers = {}
     if metadata:
         for key, value in metadata.items():
-            headers['x-ms-meta-{}'.format(key.strip())] = value.strip() if value else value
+            headers[f'x-ms-meta-{key.strip()}'] = value.strip() if value else value
     return headers
 
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
@@ -122,7 +122,7 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+            raise ValueError(f"Invalid page blob start_range: {start_range}. "
                              "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
             raise ValueError(f"Invalid page blob end_range: {end_range}. "

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -67,7 +67,7 @@ def normalize_headers(headers):
 
 
 def deserialize_metadata(response, obj, headers):  # pylint: disable=unused-argument
-    raw_metadata = {k: v for k, v in response.headers.items() if k.startswith("x-ms-meta-")}
+    raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
     return {k[10:]: v for k, v in raw_metadata.items()}
 
 
@@ -81,6 +81,10 @@ def return_headers_and_deserialized(response, deserialized, response_headers):  
 
 def return_context_and_deserialized(response, deserialized, response_headers):  # pylint: disable=unused-argument
     return response.http_response.location_mode, deserialized
+
+
+def return_raw_deserialized(response, *_):
+    return response.http_response.location_mode, response.context[ContentDecodePolicy.CONTEXT_NAME]
 
 
 def process_storage_error(storage_error):   # pylint:disable=too-many-statements

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -67,7 +67,10 @@ def normalize_headers(headers):
 
 
 def deserialize_metadata(response, obj, headers):  # pylint: disable=unused-argument
-    raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    try:
+        raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    except AttributeError:
+        raw_metadata = {k: v for k, v in response.headers.items() if k.startswith("x-ms-meta-")}
     return {k[10:]: v for k, v in raw_metadata.items()}
 
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -93,7 +93,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     if not storage_error.response:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException,
+                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -93,8 +93,7 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     if not storage_error.response:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException,
-                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message
@@ -164,11 +163,11 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
 
     # Error message should include all the error properties
     try:
-        error_message += "\nErrorCode:{}".format(error_code.value)
+        error_message += f"\nErrorCode:{error_code.value}"
     except AttributeError:
-        error_message += "\nErrorCode:{}".format(error_code)
+        error_message += f"\nErrorCode:{error_code}"
     for name, info in additional_data.items():
-        error_message += "\n{}:{}".format(name, info)
+        error_message += f"\n{name}:{info}"
 
     # No need to create an instance if it has already been serialized by the generated layer
     if serialized:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
@@ -39,8 +39,6 @@ class QueryStringConstants(object):
     SIGNED_KEY_EXPIRY = 'ske'
     SIGNED_KEY_SERVICE = 'sks'
     SIGNED_KEY_VERSION = 'skv'
-
-    # for blob only
     SIGNED_ENCRYPTION_SCOPE = 'ses'
 
     # for ADLS
@@ -78,7 +76,6 @@ class QueryStringConstants(object):
             QueryStringConstants.SIGNED_KEY_EXPIRY,
             QueryStringConstants.SIGNED_KEY_SERVICE,
             QueryStringConstants.SIGNED_KEY_VERSION,
-            # for blob only
             QueryStringConstants.SIGNED_ENCRYPTION_SCOPE,
             # for ADLS
             QueryStringConstants.SIGNED_AUTHORIZED_OID,
@@ -231,4 +228,4 @@ class _SharedAccessHelper(object):
                         sign_string(account_key, string_to_sign))
 
     def get_token(self):
-        return '&'.join(['{0}={1}'.format(n, url_quote(v)) for n, v in self.query_dict.items() if v is not None])
+        return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
@@ -39,6 +39,8 @@ class QueryStringConstants(object):
     SIGNED_KEY_EXPIRY = 'ske'
     SIGNED_KEY_SERVICE = 'sks'
     SIGNED_KEY_VERSION = 'skv'
+
+    # for blob only
     SIGNED_ENCRYPTION_SCOPE = 'ses'
 
     # for ADLS
@@ -76,6 +78,7 @@ class QueryStringConstants(object):
             QueryStringConstants.SIGNED_KEY_EXPIRY,
             QueryStringConstants.SIGNED_KEY_SERVICE,
             QueryStringConstants.SIGNED_KEY_VERSION,
+            # for blob only
             QueryStringConstants.SIGNED_ENCRYPTION_SCOPE,
             # for ADLS
             QueryStringConstants.SIGNED_AUTHORIZED_OID,
@@ -169,6 +172,9 @@ class _SharedAccessHelper(object):
         if val:
             self.query_dict[name] = _str(val) if val is not None else None
 
+    def add_encryption_scope(self, **kwargs):
+        self._add_query(QueryStringConstants.SIGNED_ENCRYPTION_SCOPE, kwargs.pop('encryption_scope', None))
+
     def add_base(self, permission, expiry, start, ip, protocol, x_ms_version):
         if isinstance(start, date):
             start = _to_utc_datetime(start)
@@ -192,9 +198,6 @@ class _SharedAccessHelper(object):
     def add_account(self, services, resource_types):
         self._add_query(QueryStringConstants.SIGNED_SERVICES, services)
         self._add_query(QueryStringConstants.SIGNED_RESOURCE_TYPES, resource_types)
-
-    def add_encryption_scope(self, **kwargs):
-        self._add_query(QueryStringConstants.SIGNED_ENCRYPTION_SCOPE, kwargs.pop('encryption_scope', None))
 
     def add_override_response_headers(self, cache_control,
                                       content_disposition,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -255,7 +255,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         self.service.stage_block(
             block_id,
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -294,7 +294,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = "bytes={0}-{1}".format(chunk_offset, chunk_end)
+            content_range = f"bytes={chunk_offset}-{chunk_end}"
             computed_md5 = None
             self.response_headers = self.service.upload_pages(
                 body=chunk_data,
@@ -392,7 +392,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        return 'bytes={0}-{1}'.format(chunk_offset, chunk_end), response
+        return f'bytes={chunk_offset}-{chunk_end}', response
 
     # TODO: Implement this method.
     def _upload_substream_block(self, index, block_stream):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -598,10 +598,11 @@ class IterStreamer(object):
                     chunk = chunk.encode(self.encoding)
                 data += chunk
                 count += len(chunk)
+        # This means count < size and what's leftover will be returned in this call.
         except StopIteration:
-            pass
+            self.leftover = b""
 
-        if count > size:
+        if count >= size:
             self.leftover = data[size:]
 
         return data[:size]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -283,7 +283,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         await self.service.stage_block(
             block_id,
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -323,7 +323,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+            content_range = f'bytes={chunk_offset}-{chunk_end}'
             computed_md5 = None
             self.response_headers = await self.service.upload_pages(
                 body=chunk_data,
@@ -417,7 +417,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        range_id = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+        range_id = f'bytes={chunk_offset}-{chunk_end}'
         return range_id, response
 
     # TODO: Implement this method.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/authentication.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/authentication.py
@@ -6,14 +6,8 @@
 
 import logging
 import re
-import sys
 from typing import List, Tuple
-
-try:
-    from urllib.parse import urlparse, unquote
-except ImportError:
-    from urlparse import urlparse  # type: ignore
-    from urllib2 import unquote  # type: ignore
+from urllib.parse import unquote, urlparse
 
 try:
     from yarl import URL
@@ -38,14 +32,7 @@ def _wrap_exception(ex, desired_type):
     msg = ""
     if ex.args:
         msg = ex.args[0]
-    if sys.version_info >= (3,):
-        # Automatic chaining in Python 3 means we keep the trace
-        return desired_type(msg)
-    # There isn't a good solution in 2 for keeping the stack trace
-    # in general, or that will not result in an error in 3
-    # However, we can keep the previous error type and message
-    # TODO: In the future we will log the trace
-    return desired_type('{}: {}'.format(ex.__class__.__name__, msg))
+    return desired_type(msg)
 
 # This method attempts to emulate the sorting done by the service
 def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str, str]]:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/authentication.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/authentication.py
@@ -5,14 +5,15 @@
 # --------------------------------------------------------------------------
 
 import logging
+import re
 import sys
 from typing import List, Tuple
 
 try:
     from urllib.parse import urlparse, unquote
 except ImportError:
-    from urlparse import urlparse # type: ignore
-    from urllib2 import unquote # type: ignore
+    from urlparse import urlparse  # type: ignore
+    from urllib2 import unquote  # type: ignore
 
 try:
     from yarl import URL
@@ -29,9 +30,7 @@ from azure.core.pipeline.policies import SansIOHTTPPolicy
 
 from . import sign_string
 
-
 logger = logging.getLogger(__name__)
-
 
 
 # wraps a given exception with the desired exception type
@@ -164,4 +163,39 @@ class SharedKeyCredentialPolicy(SansIOHTTPPolicy):
             self._get_canonicalized_resource_query(request)
 
         self._add_authorization_header(request, string_to_sign)
-        #logger.debug("String_to_sign=%s", string_to_sign)
+        # logger.debug("String_to_sign=%s", string_to_sign)
+
+
+class StorageHttpChallenge(object):
+    def __init__(self, challenge):
+        """ Parses an HTTP WWW-Authentication Bearer challenge from the Storage service. """
+        if not challenge:
+            raise ValueError("Challenge cannot be empty")
+
+        self._parameters = {}
+        self.scheme, trimmed_challenge = challenge.strip().split(" ", 1)
+
+        # name=value pairs either comma or space separated with values possibly being
+        # enclosed in quotes
+        for item in re.split('[, ]', trimmed_challenge):
+            comps = item.split("=")
+            if len(comps) == 2:
+                key = comps[0].strip(' "')
+                value = comps[1].strip(' "')
+                if key:
+                    self._parameters[key] = value
+
+        # Extract and verify required parameters
+        self.authorization_uri = self._parameters.get('authorization_uri')
+        if not self.authorization_uri:
+            raise ValueError("Authorization Uri not found")
+
+        self.resource_id = self._parameters.get('resource_id')
+        if not self.resource_id:
+            raise ValueError("Resource id not found")
+
+        uri_path = urlparse(self.authorization_uri).path.lstrip("/")
+        self.tenant_id = uri_path.split("/")[0]
+
+    def get_value(self, key):
+        return self._parameters.get(key)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -29,6 +29,7 @@ from azure.core.pipeline import Pipeline
 from azure.core.pipeline.transport import RequestsTransport, HttpTransport
 from azure.core.pipeline.policies import (
     AzureSasCredentialPolicy,
+    BearerTokenCredentialPolicy,
     ContentDecodePolicy,
     DistributedTracingPolicy,
     HttpLoggingPolicy,
@@ -37,7 +38,7 @@ from azure.core.pipeline.policies import (
     UserAgentPolicy,
 )
 
-from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, SERVICE_HOST_BASE
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, SERVICE_HOST_BASE, STORAGE_OAUTH_SCOPE
 from .models import LocationMode
 from .authentication import SharedKeyCredentialPolicy
 from .shared_access_signature import QueryStringConstants
@@ -45,7 +46,6 @@ from .request_handlers import serialize_batch_body, _get_batch_request_delimiter
 from .policies import (
     ExponentialRetry,
     QueueMessagePolicy,
-    StorageBearerTokenCredentialPolicy,
     StorageContentValidation,
     StorageHeadersPolicy,
     StorageHosts,
@@ -221,7 +221,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, "get_token"):
-            self._credential_policy = StorageBearerTokenCredentialPolicy(credential)
+            self._credential_policy = BearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -385,9 +385,9 @@ def parse_connection_str(conn_str, credential, service):
                 f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
                 f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            primary =(
-                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
-                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
+            secondary = (
+                f"{conn_settings['ACCOUNTNAME']}-secondary."
+                f"{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -82,9 +82,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         self.scheme = parsed_url.scheme
 
         if service not in ["blob", "queue", "file-share", "dfs"]:
-            raise ValueError("Invalid service: {}".format(service))
+            raise ValueError(f"Invalid service: {service}")
         service_name = service.split('-')[0]
-        account = parsed_url.netloc.split(".{}.core.".format(service_name))
+        account = parsed_url.netloc.split(f".{service_name}.core.")
 
         self.account_name = account[0] if len(account) > 1 else None
         if not self.account_name and parsed_url.netloc.startswith("localhost") \
@@ -98,8 +98,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         secondary_hostname = None
         if hasattr(self.credential, "account_name"):
             self.account_name = self.credential.account_name
-            secondary_hostname = "{}-secondary.{}.{}".format(
-                self.credential.account_name, service_name, SERVICE_HOST_BASE)
+            secondary_hostname = f"{self.credential.account_name}-secondary.{service_name}.{SERVICE_HOST_BASE}"
 
         if not self._hosts:
             if len(account) > 1:
@@ -191,7 +190,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
             self._location_mode = value
             self._client._config.url = self.url  # pylint: disable=protected-access
         else:
-            raise ValueError("No host URL for location mode: {}".format(value))
+            raise ValueError(f"No host URL for location mode: {value}")
 
     @property
     def api_version(self):
@@ -204,9 +203,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
     def _format_query_string(self, sas_token, credential, snapshot=None, share_snapshot=None):
         query_str = "?"
         if snapshot:
-            query_str += "snapshot={}&".format(self.snapshot)
+            query_str += f"snapshot={self.snapshot}&"
         if share_snapshot:
-            query_str += "sharesnapshot={}&".format(self.snapshot)
+            query_str += f"sharesnapshot={self.snapshot}&"
         if sas_token and isinstance(credential, AzureSasCredential):
             raise ValueError(
                 "You cannot use AzureSasCredential when the resource URI also contains a Shared Access Signature.")
@@ -227,7 +226,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):
@@ -270,13 +269,10 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         batch_id = str(uuid.uuid1())
 
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version,
@@ -385,22 +381,22 @@ def parse_connection_str(conn_str, credential, service):
         if endpoints["secondary"] in conn_settings:
             raise ValueError("Connection string specifies only secondary endpoint.")
         try:
-            primary = "{}://{}.{}.{}".format(
-                conn_settings["DEFAULTENDPOINTSPROTOCOL"],
-                conn_settings["ACCOUNTNAME"],
-                service,
-                conn_settings["ENDPOINTSUFFIX"],
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            secondary = "{}-secondary.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings["ENDPOINTSUFFIX"]
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass
 
     if not primary:
         try:
-            primary = "https://{}.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings.get("ENDPOINTSUFFIX", SERVICE_HOST_BASE)
+            primary = (
+                f"https://{conn_settings['ACCOUNTNAME']}."
+                f"{service}.{conn_settings.get('ENDPOINTSUFFIX', SERVICE_HOST_BASE)}"
             )
         except KeyError:
             raise ValueError("Connection string missing required connection details.")
@@ -416,7 +412,7 @@ def create_configuration(**kwargs):
     config = Configuration(**kwargs)
     config.headers_policy = StorageHeadersPolicy(**kwargs)
     config.user_agent_policy = UserAgentPolicy(
-        sdk_moniker="storage-{}/{}".format(kwargs.pop('storage_sdk'), VERSION), **kwargs)
+        sdk_moniker=f"storage-{kwargs.pop('storage_sdk')}/{VERSION}", **kwargs)
     config.retry_policy = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
     config.logging_policy = StorageLoggingPolicy(**kwargs)
     config.proxy_policy = ProxyPolicy(**kwargs)
@@ -448,7 +444,7 @@ def create_configuration(**kwargs):
 def parse_query(query_str):
     sas_values = QueryStringConstants.to_list()
     parsed_query = {k: v[0] for k, v in parse_qs(query_str).items()}
-    sas_params = ["{}={}".format(k, quote(v, safe='')) for k, v in parsed_query.items() if k in sas_values]
+    sas_params = [f"{k}={quote(v, safe='')}" for k, v in parsed_query.items() if k in sas_values]
     sas_token = None
     if sas_params:
         sas_token = "&".join(sas_params)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
@@ -15,6 +15,7 @@ from azure.core.pipeline import AsyncPipeline
 from azure.core.async_paging import AsyncList
 from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.policies import (
+    AsyncBearerTokenCredentialPolicy,
     AsyncRedirectPolicy,
     AzureSasCredentialPolicy,
     ContentDecodePolicy,
@@ -23,7 +24,7 @@ from azure.core.pipeline.policies import (
 )
 from azure.core.pipeline.transport import AsyncHttpTransport
 
-from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, STORAGE_OAUTH_SCOPE
 from .authentication import SharedKeyCredentialPolicy
 from .base_client import create_configuration
 from .policies import (
@@ -33,7 +34,7 @@ from .policies import (
     StorageHosts,
     StorageRequestHook,
 )
-from .policies_async import AsyncStorageBearerTokenCredentialPolicy, AsyncStorageResponseHook
+from .policies_async import AsyncStorageResponseHook
 
 from .response_handlers import process_storage_error, PartialBatchErrorException
 
@@ -69,7 +70,7 @@ class AsyncStorageAccountHostsMixin(object):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, 'get_token'):
-            self._credential_policy = AsyncStorageBearerTokenCredentialPolicy(credential)
+            self._credential_policy = AsyncBearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
@@ -15,26 +15,25 @@ from azure.core.pipeline import AsyncPipeline
 from azure.core.async_paging import AsyncList
 from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.policies import (
-    ContentDecodePolicy,
-    AsyncBearerTokenCredentialPolicy,
     AsyncRedirectPolicy,
+    AzureSasCredentialPolicy,
+    ContentDecodePolicy,
     DistributedTracingPolicy,
     HttpLoggingPolicy,
-    AzureSasCredentialPolicy,
 )
 from azure.core.pipeline.transport import AsyncHttpTransport
 
-from .constants import STORAGE_OAUTH_SCOPE, CONNECTION_TIMEOUT, READ_TIMEOUT
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT
 from .authentication import SharedKeyCredentialPolicy
 from .base_client import create_configuration
 from .policies import (
+    QueueMessagePolicy,
     StorageContentValidation,
-    StorageRequestHook,
-    StorageHosts,
     StorageHeadersPolicy,
-    QueueMessagePolicy
+    StorageHosts,
+    StorageRequestHook,
 )
-from .policies_async import AsyncStorageResponseHook
+from .policies_async import AsyncStorageBearerTokenCredentialPolicy, AsyncStorageResponseHook
 
 from .response_handlers import process_storage_error, PartialBatchErrorException
 
@@ -70,7 +69,7 @@ class AsyncStorageAccountHostsMixin(object):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, 'get_token'):
-            self._credential_policy = AsyncBearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
+            self._credential_policy = AsyncStorageBearerTokenCredentialPolicy(credential)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):
@@ -111,7 +110,8 @@ class AsyncStorageAccountHostsMixin(object):
         return config, AsyncPipeline(config.transport, policies=policies)
 
     async def _batch_send(
-        self, *reqs: 'HttpRequest',
+        self,
+        *reqs,  # type: HttpRequest
         **kwargs
     ):
         """Given a series of request, do a Storage batch call.
@@ -119,18 +119,26 @@ class AsyncStorageAccountHostsMixin(object):
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='https://{}/?comp=batch'.format(self.primary_hostname),
+            url='{}://{}/{}?{}comp=batch{}{}'.format(
+                self.scheme,
+                self.primary_hostname,
+                kwargs.pop('path', ""),
+                kwargs.pop('restype', ""),
+                kwargs.pop('sas', ""),
+                kwargs.pop('timeout', "")
+            ),
             headers={
                 'x-ms-version': self.api_version
             }
         )
 
+        policies = [StorageHeadersPolicy()]
+        if self._credential_policy:
+            policies.append(self._credential_policy)
+
         request.set_multipart_mixed(
             *reqs,
-            policies=[
-                StorageHeadersPolicy(),
-                self._credential_policy
-            ],
+            policies=policies,
             enforce_https=False
         )
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
@@ -75,7 +75,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']
@@ -119,13 +119,10 @@ class AsyncStorageAccountHostsMixin(object):
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/constants.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/constants.py
@@ -13,6 +13,7 @@ X_MS_VERSION = _SUPPORTED_API_VERSIONS[-1]
 CONNECTION_TIMEOUT = 20
 READ_TIMEOUT = 60
 
+DEFAULT_OAUTH_SCOPE = "/.default"
 STORAGE_OAUTH_SCOPE = "https://storage.azure.com/.default"
 
 SERVICE_HOST_BASE = 'core.windows.net'

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/models.py
@@ -4,10 +4,10 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=too-many-instance-attributes
-
 from enum import Enum
 
 from azure.core import CaseInsensitiveEnumMeta
+
 
 def get_enum_value(value):
     if value is None or value in ["None", ""]:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/parser.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/parser.py
@@ -5,6 +5,10 @@
 # --------------------------------------------------------------------------
 
 import sys
+from datetime import datetime, timezone
+
+EPOCH_AS_FILETIME = 116444736000000000  # January 1, 1970 as MS filetime
+HUNDREDS_OF_NANOSECONDS = 10000000
 
 if sys.version_info < (3,):
     def _str(value):
@@ -18,3 +22,31 @@ else:
 
 def _to_utc_datetime(value):
     return value.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+def _rfc_1123_to_datetime(rfc_1123: str) -> datetime:
+    """Converts an RFC 1123 date string to a UTC datetime.
+    """
+    if not rfc_1123:
+        return None
+
+    return datetime.strptime(rfc_1123, "%a, %d %b %Y %H:%M:%S %Z")
+
+def _filetime_to_datetime(filetime: str) -> datetime:
+    """Converts an MS filetime string to a UTC datetime. "0" indicates None.
+    If parsing MS Filetime fails, tries RFC 1123 as backup.
+    """
+    if not filetime:
+        return None
+
+    # Try to convert to MS Filetime
+    try:
+        filetime = int(filetime)
+        if filetime == 0:
+            return None
+
+        return datetime.fromtimestamp((filetime - EPOCH_AS_FILETIME) / HUNDREDS_OF_NANOSECONDS, tz=timezone.utc)
+    except ValueError:
+        pass
+
+    # Try RFC 1123 as backup
+    return _rfc_1123_to_datetime(filetime)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
@@ -177,7 +177,7 @@ class StorageHosts(SansIOHTTPPolicy):
             # Lock retries to the specific location
             request.context.options['retry_to_secondary'] = False
             if use_location not in self.hosts:
-                raise ValueError("Attempting to use undefined host location {}".format(use_location))
+                raise ValueError(f"Attempting to use undefined host location {use_location}")
             if use_location != location_mode:
                 # Update request URL to use the specified location
                 updated = parsed_url._replace(netloc=self.hosts[use_location])
@@ -387,9 +387,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
-                raise AzureError(
-                    'MD5 mismatch. Expected value is \'{0}\', computed value is \'{1}\'.'.format(
-                        response.http_response.headers['content-md5'], computed_md5),
+                raise AzureError((
+                    f"MD5 mismatch. Expected value is '{response.http_response.headers['content-md5']}', "
+                    f"computed value is '{computed_md5}'."),
                     response=response.http_response
                 )
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
@@ -30,14 +30,17 @@ except ImportError:
     )
 
 from azure.core.pipeline.policies import (
+    BearerTokenCredentialPolicy,
     HeadersPolicy,
-    SansIOHTTPPolicy,
-    NetworkTraceLoggingPolicy,
     HTTPPolicy,
-    RequestHistory
+    NetworkTraceLoggingPolicy,
+    RequestHistory,
+    SansIOHTTPPolicy,
 )
 from azure.core.exceptions import AzureError, ServiceRequestError, ServiceResponseError
 
+from .authentication import StorageHttpChallenge
+from .constants import DEFAULT_OAUTH_SCOPE, STORAGE_OAUTH_SCOPE
 from .models import LocationMode
 
 try:
@@ -46,6 +49,7 @@ except NameError:
     _unicode_type = str
 
 if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
@@ -292,18 +296,28 @@ class StorageResponseHook(HTTPPolicy):
 
     def send(self, request):
         # type: (PipelineRequest) -> PipelineResponse
-        data_stream_total = request.context.get('data_stream_total') or \
-            request.context.options.pop('data_stream_total', None)
-        download_stream_current = request.context.get('download_stream_current') or \
-            request.context.options.pop('download_stream_current', None)
-        upload_stream_current = request.context.get('upload_stream_current') or \
-            request.context.options.pop('upload_stream_current', None)
+        # Values could be 0
+        data_stream_total = request.context.get('data_stream_total')
+        if data_stream_total is None:
+            data_stream_total = request.context.options.pop('data_stream_total', None)
+        download_stream_current = request.context.get('download_stream_current')
+        if download_stream_current is None:
+            download_stream_current = request.context.options.pop('download_stream_current', None)
+        upload_stream_current = request.context.get('upload_stream_current')
+        if upload_stream_current is None:
+            upload_stream_current = request.context.options.pop('upload_stream_current', None)
+
         response_callback = request.context.get('response_callback') or \
             request.context.options.pop('raw_response_hook', self._response_callback)
 
         response = self.next.send(request)
+
         will_retry = is_retry(response, request.context.options.get('mode'))
-        if not will_retry and download_stream_current is not None:
+        # Auth error could come from Bearer challenge, in which case this request will be made again
+        is_auth_error = response.http_response.status_code == 401
+        should_update_counts = not (will_retry or is_auth_error)
+
+        if should_update_counts and download_stream_current is not None:
             download_stream_current += int(response.http_response.headers.get('Content-Length', 0))
             if data_stream_total is None:
                 content_range = response.http_response.headers.get('Content-Range')
@@ -311,7 +325,7 @@ class StorageResponseHook(HTTPPolicy):
                     data_stream_total = int(content_range.split(' ', 1)[1].split('/', 1)[1])
                 else:
                     data_stream_total = download_stream_current
-        elif not will_retry and upload_stream_current is not None:
+        elif should_update_counts and upload_stream_current is not None:
             upload_stream_current += int(response.http_request.headers.get('Content-Length', 0))
         for pipeline_obj in [request, response]:
             pipeline_obj.context['data_stream_total'] = data_stream_total
@@ -623,3 +637,24 @@ class LinearRetry(StorageRetryPolicy):
             if self.backoff > self.random_jitter_range else 0
         random_range_end = self.backoff + self.random_jitter_range
         return random_generator.uniform(random_range_start, random_range_end)
+
+
+class StorageBearerTokenCredentialPolicy(BearerTokenCredentialPolicy):
+    """ Custom Bearer token credential policy for following Storage Bearer challenges """
+
+    def __init__(self, credential, **kwargs):
+        # type: (TokenCredential, **Any) -> None
+        super(StorageBearerTokenCredentialPolicy, self).__init__(credential, STORAGE_OAUTH_SCOPE, **kwargs)
+
+    def on_challenge(self, request, response):
+        # type: (PipelineRequest, PipelineResponse) -> bool
+        try:
+            auth_header = response.http_response.headers.get("WWW-Authenticate")
+            challenge = StorageHttpChallenge(auth_header)
+        except ValueError:
+            return False
+
+        scope = challenge.resource_id + DEFAULT_OAUTH_SCOPE
+        self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        return True

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
@@ -11,6 +11,7 @@ from typing import (  # pylint: disable=unused-import
 
 import logging
 from os import fstat
+import stat
 from io import (SEEK_END, SEEK_SET, UnsupportedOperation)
 
 import isodate
@@ -70,7 +71,11 @@ def get_length(data):
             pass
         else:
             try:
-                return fstat(fileno).st_size
+                mode = fstat(fileno).st_mode
+                if stat.S_ISREG(mode) or stat.S_ISLNK(mode):
+                    #st_size only meaningful if regular file or symlink, other types
+                    # e.g. sockets may return misleading sizes like 0
+                    return fstat(fileno).st_size
             except OSError:
                 # Not a valid fileno, may be possible requests returned
                 # a socket number?

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
@@ -122,18 +122,18 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-            raise ValueError("Invalid page blob start_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(start_range))
+             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
-            raise ValueError("Invalid page blob end_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(end_range))
+            raise ValueError(f"Invalid page blob end_range: {end_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
 
     # Format based on whether end_range is present
     range_header = None
     if end_range is not None:
-        range_header = 'bytes={0}-{1}'.format(start_range, end_range)
+        range_header = f'bytes={start_range}-{end_range}'
     elif start_range is not None:
-        range_header = "bytes={0}-".format(start_range)
+        range_header = f"bytes={start_range}-"
 
     # Content MD5 can only be provided for a complete range less than 4MB in size
     range_validation = None
@@ -152,7 +152,7 @@ def add_metadata_headers(metadata=None):
     headers = {}
     if metadata:
         for key, value in metadata.items():
-            headers['x-ms-meta-{}'.format(key.strip())] = value.strip() if value else value
+            headers[f'x-ms-meta-{key.strip()}'] = value.strip() if value else value
     return headers
 
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
@@ -122,7 +122,7 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+            raise ValueError(f"Invalid page blob start_range: {start_range}. "
                              "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
             raise ValueError(f"Invalid page blob end_range: {end_range}. "

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
@@ -67,7 +67,10 @@ def normalize_headers(headers):
 
 
 def deserialize_metadata(response, obj, headers):  # pylint: disable=unused-argument
-    raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    try:
+        raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    except AttributeError:
+        raw_metadata = {k: v for k, v in response.headers.items() if k.startswith("x-ms-meta-")}
     return {k[10:]: v for k, v in raw_metadata.items()}
 
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
@@ -93,7 +93,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     if not storage_error.response:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException,
+                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
@@ -93,8 +93,7 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     if not storage_error.response:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException,
-                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message
@@ -164,11 +163,11 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
 
     # Error message should include all the error properties
     try:
-        error_message += "\nErrorCode:{}".format(error_code.value)
+        error_message += f"\nErrorCode:{error_code.value}"
     except AttributeError:
-        error_message += "\nErrorCode:{}".format(error_code)
+        error_message += f"\nErrorCode:{error_code}"
     for name, info in additional_data.items():
-        error_message += "\n{}:{}".format(name, info)
+        error_message += f"\n{name}:{info}"
 
     # No need to create an instance if it has already been serialized by the generated layer
     if serialized:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
@@ -83,6 +83,10 @@ def return_context_and_deserialized(response, deserialized, response_headers):  
     return response.http_response.location_mode, deserialized
 
 
+def return_raw_deserialized(response, *_):
+    return response.http_response.location_mode, response.context[ContentDecodePolicy.CONTEXT_NAME]
+
+
 def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     raise_error = HttpResponseError
     serialized = False

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
@@ -220,4 +220,4 @@ class _SharedAccessHelper(object):
                         sign_string(account_key, string_to_sign))
 
     def get_token(self):
-        return '&'.join(['{0}={1}'.format(n, url_quote(v)) for n, v in self.query_dict.items() if v is not None])
+        return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -255,7 +255,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         self.service.stage_block(
             block_id,
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -294,7 +294,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = "bytes={0}-{1}".format(chunk_offset, chunk_end)
+            content_range = f"bytes={chunk_offset}-{chunk_end}"
             computed_md5 = None
             self.response_headers = self.service.upload_pages(
                 body=chunk_data,
@@ -392,7 +392,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        return 'bytes={0}-{1}'.format(chunk_offset, chunk_end), response
+        return f'bytes={chunk_offset}-{chunk_end}', response
 
     # TODO: Implement this method.
     def _upload_substream_block(self, index, block_stream):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -283,7 +283,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         await self.service.stage_block(
             block_id,
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -323,7 +323,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+            content_range = f'bytes={chunk_offset}-{chunk_end}'
             computed_md5 = None
             self.response_headers = await self.service.upload_pages(
                 body=chunk_data,
@@ -417,7 +417,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        range_id = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+        range_id = f'bytes={chunk_offset}-{chunk_end}'
         return range_id, response
 
     # TODO: Implement this method.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_deserialize.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_deserialize.py
@@ -9,11 +9,7 @@ from azure.core.exceptions import ResourceExistsError
 
 from ._shared.models import StorageErrorCode
 from ._models import QueueProperties
-
-
-def deserialize_metadata(response, obj, headers):
-    raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
-    return {k[10:]: v for k, v in raw_metadata.items()}
+from ._shared.response_handlers import deserialize_metadata
 
 
 def deserialize_queue_properties(response, obj, headers):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/authentication.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/authentication.py
@@ -6,14 +6,8 @@
 
 import logging
 import re
-import sys
 from typing import List, Tuple
-
-try:
-    from urllib.parse import urlparse, unquote
-except ImportError:
-    from urlparse import urlparse  # type: ignore
-    from urllib2 import unquote  # type: ignore
+from urllib.parse import unquote, urlparse
 
 try:
     from yarl import URL
@@ -38,14 +32,7 @@ def _wrap_exception(ex, desired_type):
     msg = ""
     if ex.args:
         msg = ex.args[0]
-    if sys.version_info >= (3,):
-        # Automatic chaining in Python 3 means we keep the trace
-        return desired_type(msg)
-    # There isn't a good solution in 2 for keeping the stack trace
-    # in general, or that will not result in an error in 3
-    # However, we can keep the previous error type and message
-    # TODO: In the future we will log the trace
-    return desired_type('{}: {}'.format(ex.__class__.__name__, msg))
+    return desired_type(msg)
 
 # This method attempts to emulate the sorting done by the service
 def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str, str]]:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/authentication.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/authentication.py
@@ -5,13 +5,15 @@
 # --------------------------------------------------------------------------
 
 import logging
+import re
+import sys
 from typing import List, Tuple
 
 try:
     from urllib.parse import urlparse, unquote
 except ImportError:
-    from urlparse import urlparse # type: ignore
-    from urllib2 import unquote # type: ignore
+    from urlparse import urlparse  # type: ignore
+    from urllib2 import unquote  # type: ignore
 
 try:
     from yarl import URL
@@ -28,9 +30,7 @@ from azure.core.pipeline.policies import SansIOHTTPPolicy
 
 from . import sign_string
 
-
 logger = logging.getLogger(__name__)
-
 
 
 # wraps a given exception with the desired exception type
@@ -38,7 +38,14 @@ def _wrap_exception(ex, desired_type):
     msg = ""
     if ex.args:
         msg = ex.args[0]
-    return desired_type(msg)
+    if sys.version_info >= (3,):
+        # Automatic chaining in Python 3 means we keep the trace
+        return desired_type(msg)
+    # There isn't a good solution in 2 for keeping the stack trace
+    # in general, or that will not result in an error in 3
+    # However, we can keep the previous error type and message
+    # TODO: In the future we will log the trace
+    return desired_type('{}: {}'.format(ex.__class__.__name__, msg))
 
 # This method attempts to emulate the sorting done by the service
 def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
@@ -156,4 +163,39 @@ class SharedKeyCredentialPolicy(SansIOHTTPPolicy):
             self._get_canonicalized_resource_query(request)
 
         self._add_authorization_header(request, string_to_sign)
-        #logger.debug("String_to_sign=%s", string_to_sign)
+        # logger.debug("String_to_sign=%s", string_to_sign)
+
+
+class StorageHttpChallenge(object):
+    def __init__(self, challenge):
+        """ Parses an HTTP WWW-Authentication Bearer challenge from the Storage service. """
+        if not challenge:
+            raise ValueError("Challenge cannot be empty")
+
+        self._parameters = {}
+        self.scheme, trimmed_challenge = challenge.strip().split(" ", 1)
+
+        # name=value pairs either comma or space separated with values possibly being
+        # enclosed in quotes
+        for item in re.split('[, ]', trimmed_challenge):
+            comps = item.split("=")
+            if len(comps) == 2:
+                key = comps[0].strip(' "')
+                value = comps[1].strip(' "')
+                if key:
+                    self._parameters[key] = value
+
+        # Extract and verify required parameters
+        self.authorization_uri = self._parameters.get('authorization_uri')
+        if not self.authorization_uri:
+            raise ValueError("Authorization Uri not found")
+
+        self.resource_id = self._parameters.get('resource_id')
+        if not self.resource_id:
+            raise ValueError("Resource id not found")
+
+        uri_path = urlparse(self.authorization_uri).path.lstrip("/")
+        self.tenant_id = uri_path.split("/")[0]
+
+    def get_value(self, key):
+        return self._parameters.get(key)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -29,6 +29,7 @@ from azure.core.pipeline import Pipeline
 from azure.core.pipeline.transport import RequestsTransport, HttpTransport
 from azure.core.pipeline.policies import (
     AzureSasCredentialPolicy,
+    BearerTokenCredentialPolicy,
     ContentDecodePolicy,
     DistributedTracingPolicy,
     HttpLoggingPolicy,
@@ -37,7 +38,7 @@ from azure.core.pipeline.policies import (
     UserAgentPolicy,
 )
 
-from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, SERVICE_HOST_BASE
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, SERVICE_HOST_BASE, STORAGE_OAUTH_SCOPE
 from .models import LocationMode
 from .authentication import SharedKeyCredentialPolicy
 from .shared_access_signature import QueryStringConstants
@@ -45,7 +46,6 @@ from .request_handlers import serialize_batch_body, _get_batch_request_delimiter
 from .policies import (
     ExponentialRetry,
     QueueMessagePolicy,
-    StorageBearerTokenCredentialPolicy,
     StorageContentValidation,
     StorageHeadersPolicy,
     StorageHosts,
@@ -221,7 +221,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, "get_token"):
-            self._credential_policy = StorageBearerTokenCredentialPolicy(credential)
+            self._credential_policy = BearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -385,9 +385,9 @@ def parse_connection_str(conn_str, credential, service):
                 f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
                 f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            primary =(
-                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
-                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
+            secondary = (
+                f"{conn_settings['ACCOUNTNAME']}-secondary."
+                f"{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -82,9 +82,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         self.scheme = parsed_url.scheme
 
         if service not in ["blob", "queue", "file-share", "dfs"]:
-            raise ValueError("Invalid service: {}".format(service))
+            raise ValueError(f"Invalid service: {service}")
         service_name = service.split('-')[0]
-        account = parsed_url.netloc.split(".{}.core.".format(service_name))
+        account = parsed_url.netloc.split(f".{service_name}.core.")
 
         self.account_name = account[0] if len(account) > 1 else None
         if not self.account_name and parsed_url.netloc.startswith("localhost") \
@@ -98,8 +98,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         secondary_hostname = None
         if hasattr(self.credential, "account_name"):
             self.account_name = self.credential.account_name
-            secondary_hostname = "{}-secondary.{}.{}".format(
-                self.credential.account_name, service_name, SERVICE_HOST_BASE)
+            secondary_hostname = f"{self.credential.account_name}-secondary.{service_name}.{SERVICE_HOST_BASE}"
 
         if not self._hosts:
             if len(account) > 1:
@@ -191,7 +190,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
             self._location_mode = value
             self._client._config.url = self.url  # pylint: disable=protected-access
         else:
-            raise ValueError("No host URL for location mode: {}".format(value))
+            raise ValueError(f"No host URL for location mode: {value}")
 
     @property
     def api_version(self):
@@ -204,9 +203,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
     def _format_query_string(self, sas_token, credential, snapshot=None, share_snapshot=None):
         query_str = "?"
         if snapshot:
-            query_str += "snapshot={}&".format(self.snapshot)
+            query_str += f"snapshot={self.snapshot}&"
         if share_snapshot:
-            query_str += "sharesnapshot={}&".format(self.snapshot)
+            query_str += f"sharesnapshot={self.snapshot}&"
         if sas_token and isinstance(credential, AzureSasCredential):
             raise ValueError(
                 "You cannot use AzureSasCredential when the resource URI also contains a Shared Access Signature.")
@@ -227,7 +226,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):
@@ -270,13 +269,10 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         batch_id = str(uuid.uuid1())
 
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version,
@@ -385,22 +381,22 @@ def parse_connection_str(conn_str, credential, service):
         if endpoints["secondary"] in conn_settings:
             raise ValueError("Connection string specifies only secondary endpoint.")
         try:
-            primary = "{}://{}.{}.{}".format(
-                conn_settings["DEFAULTENDPOINTSPROTOCOL"],
-                conn_settings["ACCOUNTNAME"],
-                service,
-                conn_settings["ENDPOINTSUFFIX"],
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
-            secondary = "{}-secondary.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings["ENDPOINTSUFFIX"]
+            primary =(
+                f"{conn_settings['DEFAULTENDPOINTSPROTOCOL']}://"
+                f"{conn_settings['ACCOUNTNAME']}.{service}.{conn_settings['ENDPOINTSUFFIX']}"
             )
         except KeyError:
             pass
 
     if not primary:
         try:
-            primary = "https://{}.{}.{}".format(
-                conn_settings["ACCOUNTNAME"], service, conn_settings.get("ENDPOINTSUFFIX", SERVICE_HOST_BASE)
+            primary = (
+                f"https://{conn_settings['ACCOUNTNAME']}."
+                f"{service}.{conn_settings.get('ENDPOINTSUFFIX', SERVICE_HOST_BASE)}"
             )
         except KeyError:
             raise ValueError("Connection string missing required connection details.")
@@ -416,7 +412,7 @@ def create_configuration(**kwargs):
     config = Configuration(**kwargs)
     config.headers_policy = StorageHeadersPolicy(**kwargs)
     config.user_agent_policy = UserAgentPolicy(
-        sdk_moniker="storage-{}/{}".format(kwargs.pop('storage_sdk'), VERSION), **kwargs)
+        sdk_moniker=f"storage-{kwargs.pop('storage_sdk')}/{VERSION}", **kwargs)
     config.retry_policy = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
     config.logging_policy = StorageLoggingPolicy(**kwargs)
     config.proxy_policy = ProxyPolicy(**kwargs)
@@ -448,7 +444,7 @@ def create_configuration(**kwargs):
 def parse_query(query_str):
     sas_values = QueryStringConstants.to_list()
     parsed_query = {k: v[0] for k, v in parse_qs(query_str).items()}
-    sas_params = ["{}={}".format(k, quote(v, safe='')) for k, v in parsed_query.items() if k in sas_values]
+    sas_params = [f"{k}={quote(v, safe='')}" for k, v in parsed_query.items() if k in sas_values]
     sas_token = None
     if sas_params:
         sas_token = "&".join(sas_params)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
@@ -15,6 +15,7 @@ from azure.core.pipeline import AsyncPipeline
 from azure.core.async_paging import AsyncList
 from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.policies import (
+    AsyncBearerTokenCredentialPolicy,
     AsyncRedirectPolicy,
     AzureSasCredentialPolicy,
     ContentDecodePolicy,
@@ -23,7 +24,7 @@ from azure.core.pipeline.policies import (
 )
 from azure.core.pipeline.transport import AsyncHttpTransport
 
-from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT
+from .constants import CONNECTION_TIMEOUT, READ_TIMEOUT, STORAGE_OAUTH_SCOPE
 from .authentication import SharedKeyCredentialPolicy
 from .base_client import create_configuration
 from .policies import (
@@ -33,7 +34,7 @@ from .policies import (
     StorageHosts,
     StorageRequestHook,
 )
-from .policies_async import AsyncStorageBearerTokenCredentialPolicy, AsyncStorageResponseHook
+from .policies_async import AsyncStorageResponseHook
 
 from .response_handlers import process_storage_error, PartialBatchErrorException
 
@@ -69,7 +70,7 @@ class AsyncStorageAccountHostsMixin(object):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None
         if hasattr(credential, 'get_token'):
-            self._credential_policy = AsyncStorageBearerTokenCredentialPolicy(credential)
+            self._credential_policy = AsyncBearerTokenCredentialPolicy(credential, STORAGE_OAUTH_SCOPE)
         elif isinstance(credential, SharedKeyCredentialPolicy):
             self._credential_policy = credential
         elif isinstance(credential, AzureSasCredential):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
@@ -75,7 +75,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError(f"Unsupported credential: {credential}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']
@@ -119,13 +119,10 @@ class AsyncStorageAccountHostsMixin(object):
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='{}://{}/{}?{}comp=batch{}{}'.format(
-                self.scheme,
-                self.primary_hostname,
-                kwargs.pop('path', ""),
-                kwargs.pop('restype', ""),
-                kwargs.pop('sas', ""),
-                kwargs.pop('timeout', "")
+            url=(
+                f'{self.scheme}://{self.primary_hostname}/'
+                f"{kwargs.pop('path', '')}?{kwargs.pop('restype', '')}"
+                f"comp=batch{kwargs.pop('sas', '')}{kwargs.pop('timeout', '')}"
             ),
             headers={
                 'x-ms-version': self.api_version

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/constants.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/constants.py
@@ -13,6 +13,7 @@ X_MS_VERSION = _SUPPORTED_API_VERSIONS[-1]
 CONNECTION_TIMEOUT = 20
 READ_TIMEOUT = 60
 
+DEFAULT_OAUTH_SCOPE = "/.default"
 STORAGE_OAUTH_SCOPE = "https://storage.azure.com/.default"
 
 SERVICE_HOST_BASE = 'core.windows.net'

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=too-many-instance-attributes
-
 from enum import Enum
 
 from azure.core import CaseInsensitiveEnumMeta

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/parser.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/parser.py
@@ -5,6 +5,10 @@
 # --------------------------------------------------------------------------
 
 import sys
+from datetime import datetime, timezone
+
+EPOCH_AS_FILETIME = 116444736000000000  # January 1, 1970 as MS filetime
+HUNDREDS_OF_NANOSECONDS = 10000000
 
 if sys.version_info < (3,):
     def _str(value):
@@ -18,3 +22,31 @@ else:
 
 def _to_utc_datetime(value):
     return value.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+def _rfc_1123_to_datetime(rfc_1123: str) -> datetime:
+    """Converts an RFC 1123 date string to a UTC datetime.
+    """
+    if not rfc_1123:
+        return None
+
+    return datetime.strptime(rfc_1123, "%a, %d %b %Y %H:%M:%S %Z")
+
+def _filetime_to_datetime(filetime: str) -> datetime:
+    """Converts an MS filetime string to a UTC datetime. "0" indicates None.
+    If parsing MS Filetime fails, tries RFC 1123 as backup.
+    """
+    if not filetime:
+        return None
+
+    # Try to convert to MS Filetime
+    try:
+        filetime = int(filetime)
+        if filetime == 0:
+            return None
+
+        return datetime.fromtimestamp((filetime - EPOCH_AS_FILETIME) / HUNDREDS_OF_NANOSECONDS, tz=timezone.utc)
+    except ValueError:
+        pass
+
+    # Try RFC 1123 as backup
+    return _rfc_1123_to_datetime(filetime)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -119,6 +119,12 @@ def urljoin(base_url, stub_url):
 class QueueMessagePolicy(SansIOHTTPPolicy):
 
     def on_request(self, request):
+        # Hack to fix generated code adding '/messages' after SAS parameters
+        includes_messages = request.http_request.url.endswith('/messages')
+        if includes_messages:
+            request.http_request.url = request.http_request.url[:-(len('/messages'))]
+            request.http_request.url = urljoin(request.http_request.url, 'messages')
+
         message_id = request.context.options.pop('queue_message_id', None)
         if message_id:
             request.http_request.url = urljoin(

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -183,7 +183,7 @@ class StorageHosts(SansIOHTTPPolicy):
             # Lock retries to the specific location
             request.context.options['retry_to_secondary'] = False
             if use_location not in self.hosts:
-                raise ValueError("Attempting to use undefined host location {}".format(use_location))
+                raise ValueError(f"Attempting to use undefined host location {use_location}")
             if use_location != location_mode:
                 # Update request URL to use the specified location
                 updated = parsed_url._replace(netloc=self.hosts[use_location])
@@ -393,9 +393,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
-                raise AzureError(
-                    'MD5 mismatch. Expected value is \'{0}\', computed value is \'{1}\'.'.format(
-                        response.http_response.headers['content-md5'], computed_md5),
+                raise AzureError((
+                    f"MD5 mismatch. Expected value is '{response.http_response.headers['content-md5']}', "
+                    f"computed value is '{computed_md5}'."),
                     response=response.http_response
                 )
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -30,14 +30,17 @@ except ImportError:
     )
 
 from azure.core.pipeline.policies import (
+    BearerTokenCredentialPolicy,
     HeadersPolicy,
-    SansIOHTTPPolicy,
-    NetworkTraceLoggingPolicy,
     HTTPPolicy,
-    RequestHistory
+    NetworkTraceLoggingPolicy,
+    RequestHistory,
+    SansIOHTTPPolicy,
 )
 from azure.core.exceptions import AzureError, ServiceRequestError, ServiceResponseError
 
+from .authentication import StorageHttpChallenge
+from .constants import DEFAULT_OAUTH_SCOPE, STORAGE_OAUTH_SCOPE
 from .models import LocationMode
 
 try:
@@ -46,6 +49,7 @@ except NameError:
     _unicode_type = str
 
 if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
@@ -115,12 +119,6 @@ def urljoin(base_url, stub_url):
 class QueueMessagePolicy(SansIOHTTPPolicy):
 
     def on_request(self, request):
-        # Hack to fix generated code adding '/messages' after SAS parameters
-        includes_messages = request.http_request.url.endswith('/messages')
-        if includes_messages:
-            request.http_request.url = request.http_request.url[:-(len('/messages'))]
-            request.http_request.url = urljoin(request.http_request.url, 'messages')
-
         message_id = request.context.options.pop('queue_message_id', None)
         if message_id:
             request.http_request.url = urljoin(
@@ -179,7 +177,7 @@ class StorageHosts(SansIOHTTPPolicy):
             # Lock retries to the specific location
             request.context.options['retry_to_secondary'] = False
             if use_location not in self.hosts:
-                raise ValueError(f"Attempting to use undefined host location {use_location}")
+                raise ValueError("Attempting to use undefined host location {}".format(use_location))
             if use_location != location_mode:
                 # Update request URL to use the specified location
                 updated = parsed_url._replace(netloc=self.hosts[use_location])
@@ -298,18 +296,28 @@ class StorageResponseHook(HTTPPolicy):
 
     def send(self, request):
         # type: (PipelineRequest) -> PipelineResponse
-        data_stream_total = request.context.get('data_stream_total') or \
-            request.context.options.pop('data_stream_total', None)
-        download_stream_current = request.context.get('download_stream_current') or \
-            request.context.options.pop('download_stream_current', None)
-        upload_stream_current = request.context.get('upload_stream_current') or \
-            request.context.options.pop('upload_stream_current', None)
+        # Values could be 0
+        data_stream_total = request.context.get('data_stream_total')
+        if data_stream_total is None:
+            data_stream_total = request.context.options.pop('data_stream_total', None)
+        download_stream_current = request.context.get('download_stream_current')
+        if download_stream_current is None:
+            download_stream_current = request.context.options.pop('download_stream_current', None)
+        upload_stream_current = request.context.get('upload_stream_current')
+        if upload_stream_current is None:
+            upload_stream_current = request.context.options.pop('upload_stream_current', None)
+
         response_callback = request.context.get('response_callback') or \
             request.context.options.pop('raw_response_hook', self._response_callback)
 
         response = self.next.send(request)
+
         will_retry = is_retry(response, request.context.options.get('mode'))
-        if not will_retry and download_stream_current is not None:
+        # Auth error could come from Bearer challenge, in which case this request will be made again
+        is_auth_error = response.http_response.status_code == 401
+        should_update_counts = not (will_retry or is_auth_error)
+
+        if should_update_counts and download_stream_current is not None:
             download_stream_current += int(response.http_response.headers.get('Content-Length', 0))
             if data_stream_total is None:
                 content_range = response.http_response.headers.get('Content-Range')
@@ -317,7 +325,7 @@ class StorageResponseHook(HTTPPolicy):
                     data_stream_total = int(content_range.split(' ', 1)[1].split('/', 1)[1])
                 else:
                     data_stream_total = download_stream_current
-        elif not will_retry and upload_stream_current is not None:
+        elif should_update_counts and upload_stream_current is not None:
             upload_stream_current += int(response.http_request.headers.get('Content-Length', 0))
         for pipeline_obj in [request, response]:
             pipeline_obj.context['data_stream_total'] = data_stream_total
@@ -379,9 +387,9 @@ class StorageContentValidation(SansIOHTTPPolicy):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
-                raise AzureError((
-                    f"MD5 mismatch. Expected value is '{response.http_response.headers['content-md5']}', "
-                    f"computed value is '{computed_md5}'."),
+                raise AzureError(
+                    'MD5 mismatch. Expected value is \'{0}\', computed value is \'{1}\'.'.format(
+                        response.http_response.headers['content-md5'], computed_md5),
                     response=response.http_response
                 )
 
@@ -629,3 +637,24 @@ class LinearRetry(StorageRetryPolicy):
             if self.backoff > self.random_jitter_range else 0
         random_range_end = self.backoff + self.random_jitter_range
         return random_generator.uniform(random_range_start, random_range_end)
+
+
+class StorageBearerTokenCredentialPolicy(BearerTokenCredentialPolicy):
+    """ Custom Bearer token credential policy for following Storage Bearer challenges """
+
+    def __init__(self, credential, **kwargs):
+        # type: (TokenCredential, **Any) -> None
+        super(StorageBearerTokenCredentialPolicy, self).__init__(credential, STORAGE_OAUTH_SCOPE, **kwargs)
+
+    def on_challenge(self, request, response):
+        # type: (PipelineRequest, PipelineResponse) -> bool
+        try:
+            auth_header = response.http_response.headers.get("WWW-Authenticate")
+            challenge = StorageHttpChallenge(auth_header)
+        except ValueError:
+            return False
+
+        scope = challenge.resource_id + DEFAULT_OAUTH_SCOPE
+        self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        return True

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
@@ -122,18 +122,18 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-            raise ValueError("Invalid page blob start_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(start_range))
+             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
-            raise ValueError("Invalid page blob end_range: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(end_range))
+            raise ValueError(f"Invalid page blob end_range: {end_range}. "
+                             "The size must be aligned to a 512-byte boundary.")
 
     # Format based on whether end_range is present
     range_header = None
     if end_range is not None:
-        range_header = 'bytes={0}-{1}'.format(start_range, end_range)
+        range_header = f'bytes={start_range}-{end_range}'
     elif start_range is not None:
-        range_header = "bytes={0}-".format(start_range)
+        range_header = f"bytes={start_range}-"
 
     # Content MD5 can only be provided for a complete range less than 4MB in size
     range_validation = None
@@ -152,7 +152,7 @@ def add_metadata_headers(metadata=None):
     headers = {}
     if metadata:
         for key, value in metadata.items():
-            headers['x-ms-meta-{}'.format(key.strip())] = value.strip() if value else value
+            headers[f'x-ms-meta-{key.strip()}'] = value.strip() if value else value
     return headers
 
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
@@ -122,7 +122,7 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-             raise ValueError(f"Invalid page blob start_range: {start_range}. "
+            raise ValueError(f"Invalid page blob start_range: {start_range}. "
                              "The size must be aligned to a 512-byte boundary.")
         if end_range is not None and end_range % 512 != 511:
             raise ValueError(f"Invalid page blob end_range: {end_range}. "

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
@@ -11,6 +11,7 @@ from typing import (  # pylint: disable=unused-import
 
 import logging
 from os import fstat
+import stat
 from io import (SEEK_END, SEEK_SET, UnsupportedOperation)
 
 import isodate
@@ -41,10 +42,9 @@ def serialize_iso(attr):
         if utc.tm_year > 9999 or utc.tm_year < 1:
             raise OverflowError("Hit max or min date")
 
-        date = (
-            f"{utc.tm_year:04}-{utc.tm_mon:02}-{utc.tm_mday:02}"
-            f"T{utc.tm_hour:02}:{utc.tm_min:02}:{utc.tm_sec:02}"
-        )
+        date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(
+            utc.tm_year, utc.tm_mon, utc.tm_mday,
+            utc.tm_hour, utc.tm_min, utc.tm_sec)
         return date + 'Z'
     except (ValueError, OverflowError) as err:
         msg = "Unable to serialize datetime object."
@@ -71,7 +71,11 @@ def get_length(data):
             pass
         else:
             try:
-                return fstat(fileno).st_size
+                mode = fstat(fileno).st_mode
+                if stat.S_ISREG(mode) or stat.S_ISLNK(mode):
+                    #st_size only meaningful if regular file or symlink, other types
+                    # e.g. sockets may return misleading sizes like 0
+                    return fstat(fileno).st_size
             except OSError:
                 # Not a valid fileno, may be possible requests returned
                 # a socket number?
@@ -118,18 +122,18 @@ def validate_and_format_range_headers(
     # Page ranges must be 512 aligned
     if align_to_page:
         if start_range is not None and start_range % 512 != 0:
-            raise ValueError(f"Invalid page blob start_range: {start_range}. "
-                             "The size must be aligned to a 512-byte boundary.")
+            raise ValueError("Invalid page blob start_range: {0}. "
+                             "The size must be aligned to a 512-byte boundary.".format(start_range))
         if end_range is not None and end_range % 512 != 511:
-            raise ValueError(f"Invalid page blob end_range: {end_range}. "
-                             "The size must be aligned to a 512-byte boundary.")
+            raise ValueError("Invalid page blob end_range: {0}. "
+                             "The size must be aligned to a 512-byte boundary.".format(end_range))
 
     # Format based on whether end_range is present
     range_header = None
     if end_range is not None:
-        range_header = f'bytes={start_range}-{end_range}'
+        range_header = 'bytes={0}-{1}'.format(start_range, end_range)
     elif start_range is not None:
-        range_header = f"bytes={start_range}-"
+        range_header = "bytes={0}-".format(start_range)
 
     # Content MD5 can only be provided for a complete range less than 4MB in size
     range_validation = None
@@ -148,7 +152,7 @@ def add_metadata_headers(metadata=None):
     headers = {}
     if metadata:
         for key, value in metadata.items():
-            headers[f'x-ms-meta-{key.strip()}'] = value.strip() if value else value
+            headers['x-ms-meta-{}'.format(key.strip())] = value.strip() if value else value
     return headers
 
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
@@ -67,7 +67,10 @@ def normalize_headers(headers):
 
 
 def deserialize_metadata(response, obj, headers):  # pylint: disable=unused-argument
-    raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    try:
+        raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    except AttributeError:
+        raw_metadata = {k: v for k, v in response.headers.items() if k.startswith("x-ms-meta-")}
     return {k[10:]: v for k, v in raw_metadata.items()}
 
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
@@ -93,7 +93,8 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     if not storage_error.response or storage_error.response.status_code in [200, 204]:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException,
+                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
@@ -90,11 +90,10 @@ def return_raw_deserialized(response, *_):
 def process_storage_error(storage_error):   # pylint:disable=too-many-statements
     raise_error = HttpResponseError
     serialized = False
-    if not storage_error.response:
+    if not storage_error.response or storage_error.response.status_code in [200, 204]:
         raise storage_error
     # If it is one of those three then it has been serialized prior by the generated layer.
-    if isinstance(storage_error, (PartialBatchErrorException,
-                                  ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
+    if isinstance(storage_error, (PartialBatchErrorException, ClientAuthenticationError, ResourceNotFoundError, ResourceExistsError)):
         serialized = True
     error_code = storage_error.response.headers.get('x-ms-error-code')
     error_message = storage_error.message
@@ -164,11 +163,11 @@ def process_storage_error(storage_error):   # pylint:disable=too-many-statements
 
     # Error message should include all the error properties
     try:
-        error_message += "\nErrorCode:{}".format(error_code.value)
+        error_message += f"\nErrorCode:{error_code.value}"
     except AttributeError:
-        error_message += "\nErrorCode:{}".format(error_code)
+        error_message += f"\nErrorCode:{error_code}"
     for name, info in additional_data.items():
-        error_message += "\n{}:{}".format(name, info)
+        error_message += f"\n{name}:{info}"
 
     # No need to create an instance if it has already been serialized by the generated layer
     if serialized:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -220,4 +220,4 @@ class _SharedAccessHelper(object):
                         sign_string(account_key, string_to_sign))
 
     def get_token(self):
-        return '&'.join(['{0}={1}'.format(n, url_quote(v)) for n, v in self.query_dict.items() if v is not None])
+        return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -220,4 +220,4 @@ class _SharedAccessHelper(object):
                         sign_string(account_key, string_to_sign))
 
     def get_token(self):
-        return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])
+        return '&'.join(['{0}={1}'.format(n, url_quote(v)) for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -255,7 +255,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         self.service.stage_block(
             block_id,
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -294,7 +294,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = "bytes={0}-{1}".format(chunk_offset, chunk_end)
+            content_range = f"bytes={chunk_offset}-{chunk_end}"
             computed_md5 = None
             self.response_headers = self.service.upload_pages(
                 body=chunk_data,
@@ -392,7 +392,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        return 'bytes={0}-{1}'.format(chunk_offset, chunk_end), response
+        return f'bytes={chunk_offset}-{chunk_end}', response
 
     # TODO: Implement this method.
     def _upload_substream_block(self, index, block_stream):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -255,7 +255,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = f'{chunk_offset:032d}'
+        index = '{0:032d}'.format(chunk_offset)
         block_id = encode_base64(url_quote(encode_base64(index)))
         self.service.stage_block(
             block_id,
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -294,7 +294,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = f"bytes={chunk_offset}-{chunk_end}"
+            content_range = "bytes={0}-{1}".format(chunk_offset, chunk_end)
             computed_md5 = None
             self.response_headers = self.service.upload_pages(
                 body=chunk_data,
@@ -392,7 +392,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        return f'bytes={chunk_offset}-{chunk_end}', response
+        return 'bytes={0}-{1}'.format(chunk_offset, chunk_end), response
 
     # TODO: Implement this method.
     def _upload_substream_block(self, index, block_stream):
@@ -598,10 +598,11 @@ class IterStreamer(object):
                     chunk = chunk.encode(self.encoding)
                 data += chunk
                 count += len(chunk)
+        # This means count < size and what's leftover will be returned in this call.
         except StopIteration:
-            pass
+            self.leftover = b""
 
-        if count > size:
+        if count >= size:
             self.leftover = data[size:]
 
         return data[:size]

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -269,7 +269,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -283,7 +283,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = '{0:032d}'.format(chunk_offset)
+        index = f'{chunk_offset:032d}'
         block_id = encode_base64(url_quote(encode_base64(index)))
         await self.service.stage_block(
             block_id,
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
+            block_id = f'BlockId{index/self.chunk_size:05%}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -323,7 +323,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+            content_range = f'bytes={chunk_offset}-{chunk_end}'
             computed_md5 = None
             self.response_headers = await self.service.upload_pages(
                 body=chunk_data,
@@ -417,7 +417,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        range_id = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
+        range_id = f'bytes={chunk_offset}-{chunk_end}'
         return range_id, response
 
     # TODO: Implement this method.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -283,7 +283,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_chunk(self, chunk_offset, chunk_data):
         # TODO: This is incorrect, but works with recording.
-        index = f'{chunk_offset:032d}'
+        index = '{0:032d}'.format(chunk_offset)
         block_id = encode_base64(url_quote(encode_base64(index)))
         await self.service.stage_block(
             block_id,
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05d}'
+            block_id = 'BlockId{}'.format("%05d" % (index/self.chunk_size))
             await self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -323,7 +323,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
         # avoid uploading the empty pages
         if not self._is_chunk_empty(chunk_data):
             chunk_end = chunk_offset + len(chunk_data) - 1
-            content_range = f'bytes={chunk_offset}-{chunk_end}'
+            content_range = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
             computed_md5 = None
             self.response_headers = await self.service.upload_pages(
                 body=chunk_data,
@@ -417,7 +417,7 @@ class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
             upload_stream_current=self.progress_total,
             **self.request_options
         )
-        range_id = f'bytes={chunk_offset}-{chunk_end}'
+        range_id = 'bytes={0}-{1}'.format(chunk_offset, chunk_end)
         return range_id, response
 
     # TODO: Implement this method.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -296,7 +296,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{index/self.chunk_size:05%}'
+            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),


### PR DESCRIPTION
This PR aims to unify all the contents of the `_shared` folders for the blob, datalake, queue, and file-share packages.

In general, my process was to use blob's `_shared` folder as the "source of truth" for most things as it is where most new changes will be added (and then not uniformly added to the other `_shared` folders)

Things to callout when unifying:

- Biggest change came from: Support for Oauth import/export managed disks [here](https://github.com/Azure/azure-sdk-for-python/pull/22984). I am assuming this will go everywhere eventually so most of the work was getting the shared folders to all contain these changes (please correct me if this won't go everywhere, then I will have to make all the packages look similar to each other excluding this change 😢)
- `shared_access_signature.py` will be different for file-share and queue since they do **not** support encryption scope
- `parser.py` is mostly barren except for in blob -- I opted to copy blob's `parser.py` to every other file (which is likely overkill) just because I anticipate most new features in blob that require these parser changes will eventually trickle down to other packages
- In `response_handlers.py` metadata parsing went from `response.headers.items` to `response.http_reponse.headers.items`. Not sure how this will play out because I'm assuming if it works in its current state, will the same information be contained in `response.http_response` vs `response.headers`? Pending pipeline run for the answer 😄 
- In `policies.py` specifically the `on_request` method, the `queue` package is the only file with this workaround (and thus will differ from other files):
```
# Hack to fix generated code adding '/messages' after SAS parameters
        includes_messages = request.http_request.url.endswith('/messages')
        if includes_messages:
            request.http_request.url = request.http_request.url[:-(len('/messages'))]
            request.http_request.url = urljoin(request.http_request.url, 'messages')
```

Therefore, the only differences in the `_shared` folders now is:
- Queue generated code hack
- `shared_access_signature.py` differences for packages that don't support encryption scope (file-share & queue)
- Docstring differences that callout the package name