### PR TITLE
[Perf] Perfstress framework profiling enhancements

### DIFF
--- a/doc/dev/perfstress_tests.md
+++ b/doc/dev/perfstress_tests.md
@@ -82,11 +82,11 @@ class _PerfTestBase:
         # Can be optionally defined. Run once per test instance, after cleanup and global_cleanup.
         # The baseclasses will also define logic here, so if you override this method, make sure you include a call to super().
 
-    def run_all_sync(self, duration: int) -> None:
+    def run_all_sync(self, duration: int, *, run_profiler: bool = False, **kwargs) -> None:
         # Run all sync tests, including both warmup and duration. This method is implemented by the provided base
         # classes, there should be no need to overwrite this function.
 
-    async def run_all_async(self, duration: int) -> None:
+    async def run_all_async(self, duration: int, *, run_profiler: bool = False, **kwargs) -> None:
         # Run all async tests, including both warmup and duration. This method is implemented by the provided base
         # classes, there should be no need to overwrite this function.
 

--- a/doc/dev/perfstress_tests.md
+++ b/doc/dev/perfstress_tests.md
@@ -184,7 +184,8 @@ The framework has a series of common command line options built in:
 - `--no-cleanup` Whether to keep newly created resources after test run. Default is False (resources will be deleted).
 - `--insecure` Whether to run without SSL validation. Default is False.
 - `-x --test-proxies` Whether to run the tests against the test proxy server. Specify the URL(s) for the proxy endpoint(s) (e.g. "https://localhost:5001"). Multiple values should be semi-colon-separated.
-- `--profile` Whether to run the perftest with cProfile. If enabled (default is False), the output file of a single iteration will be written to the current working directory in the format `"cProfile-<TestClassName>-<TestID>-<sync|async>.pstats"`. **Note:** The profiler is not currently supported for the `EventPerfTest` baseclass.
+- `--profile` Whether to run the perftest with cProfile. **Note:** The profiler is not currently supported for the `EventPerfTest` baseclass.
+- `--profile-path` The file path to output profiling data to if profiling is enabled with `--profile`. If not specified, the output file of a single iteration will be written to the current working directory in the format `"cProfile-<TestClassName>-<TestID>-<sync|async>.pstats"`.
 
 ## Running with the test proxy
 Follow the instructions here to install and run the test proxy server:
@@ -443,7 +444,7 @@ class MessageReceiveTest(BatchPerfTest):
             min_messages=self.args.min_message_count
         )
         return len(messages)
-        
+
     @staticmethod
     def add_arguments(parser):
         super(MessageReceiveTest, MessageReceiveTest).add_arguments(parser)

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_batch_perf_test.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_batch_perf_test.py
@@ -214,5 +214,8 @@ class BatchPerfTest(_PerfTestBase):
         A sort key can be specified to establish how stats should be sorted, and a line count can also be
         specified to limit the number of lines printed.
         """
+        # Increase the precision of the pstats output
+        pstats.f8 = lambda x: f"{x:8.5f}"
+
         stats = pstats.Stats(profile).sort_stats(sort_key)
         stats.print_stats(count)

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_base.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_base.py
@@ -7,6 +7,13 @@ import os
 import abc
 import multiprocessing
 import argparse
+import pstats
+import cProfile
+from typing import Optional
+
+
+PSTATS_PRINT_DEFAULT_SORT_KEY = pstats.SortKey.TIME
+PSTATS_PRINT_DEFAULT_LINE_COUNT = 36
 
 
 class _PerfTestABC(abc.ABC):
@@ -49,7 +56,7 @@ class _PerfTestABC(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def cleanup(self):
+    async def cleanup(self) -> None:
         """
         Cleanup called once per parallel test instance.
         Used to cleanup state specific to this test instance.
@@ -76,13 +83,13 @@ class _PerfTestABC(abc.ABC):
         """
 
     @abc.abstractmethod
-    def run_all_sync(self, duration: int) -> None:
+    def run_all_sync(self, duration: int, *, run_profiler: bool = False, **kwargs) -> None:
         """
         Run all sync tests, including both warmup and duration.
         """
 
     @abc.abstractmethod
-    async def run_all_async(self, duration: int) -> None:
+    async def run_all_async(self, duration: int, *, run_profiler: bool = False, **kwargs) -> None:
         """
         Run all async tests, including both warmup and duration.
         """
@@ -105,16 +112,19 @@ class _PerfTestABC(abc.ABC):
 class _PerfTestBase(_PerfTestABC):
     """Base class for implementing a python perf test."""
 
-    args = {}
+    args: argparse.Namespace
     _global_parallel_index_lock = multiprocessing.Lock()
-    _global_parallel_index = 0
+    _global_parallel_index: int = 0
 
-    def __init__(self, arguments):
+    def __init__(self, arguments: argparse.Namespace):
         self.args = arguments
-        self._completed_operations = 0
-        self._last_completion_time = 0.0
-        self._parallel_index = _PerfTestBase._global_parallel_index
+        self._completed_operations: int = 0
+        self._last_completion_time: float = 0.0
+        self._parallel_index: int = _PerfTestBase._global_parallel_index
         _PerfTestBase._global_parallel_index += 1
+        self._profile: Optional[cProfile.Profile] = None
+        if self.args.profile:
+            self._profile = cProfile.Profile()
 
     @property
     def completed_operations(self) -> int:
@@ -180,13 +190,13 @@ class _PerfTestBase(_PerfTestABC):
         """
         return
 
-    def run_all_sync(self, duration: int) -> None:
+    def run_all_sync(self, duration: int, *, run_profiler: bool = False, **kwargs) -> None:
         """
         Run all sync tests, including both warmup and duration.
         """
         raise NotImplementedError("run_all_sync must be implemented for {}".format(self.__class__.__name__))
 
-    async def run_all_async(self, duration: int) -> None:
+    async def run_all_async(self, duration: int, *, run_profiler: bool = False, **kwargs) -> None:
         """
         Run all async tests, including both warmup and duration.
         """
@@ -208,3 +218,36 @@ class _PerfTestBase(_PerfTestABC):
         if not value:
             raise ValueError("Undefined environment variable {}".format(variable))
         return value
+
+    def _save_profile(self, sync: str, output_path: Optional[str] = None) -> None:
+        """
+        Dump the profiler data to the file path specified. If no path is specified, use the current working directory.
+        """
+        if self._profile:
+            profile_name = output_path or "{}/cProfile-{}-{}-{}.pstats".format(
+                os.getcwd(),
+                self.__class__.__name__,
+                self._parallel_index,
+                sync)
+            print("Dumping profile data to {}".format(profile_name))
+            self._profile.dump_stats(profile_name)
+        else:
+            print("No profile generated.")
+
+    def _print_profile_stats(
+        self,
+        *,
+        sort_key: pstats.SortKey = PSTATS_PRINT_DEFAULT_SORT_KEY,
+        count: int = PSTATS_PRINT_DEFAULT_LINE_COUNT
+    ) -> None:
+        """Print the profile stats to stdout.
+
+        A sort key can be specified to establish how stats should be sorted, and a line count can also be
+        specified to limit the number of lines printed.
+        """
+        if self._profile:
+            # Increase the precision of the pstats output
+            pstats.f8 = lambda x: f"{x:8.5f}"
+
+            stats = pstats.Stats(self._profile).sort_stats(sort_key)
+            stats.print_stats(count)

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_proc.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_proc.py
@@ -17,7 +17,7 @@ from ._perf_stress_base import _PerfTestABC, _PerfTestBase
 
 def run_process(index, args, module, test_name, num_tests, test_stages, results, status):
     """The child process main function.
-    
+
     Here we load the test class from the correct module and start it.
     """
     test_module = importlib.import_module(module)
@@ -28,7 +28,7 @@ def run_process(index, args, module, test_name, num_tests, test_stages, results,
 
 def _synchronize(stages, ignore_error=False):
     """Synchronize all processes by waiting on the barrier.
-    
+
     Optionally we can also ignore a broken barrier during the cleanup stages
     so that if some processes have failed, the others can still complete cleanup.
     """
@@ -125,7 +125,7 @@ async def _run_tests(duration: int, args, tests, results, status) -> None:
         else:
             tasks = [asyncio.create_task(test.run_all_async(duration)) for test in tests]
             await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-        
+
         # If any of the parallel test runs raised an exception, let it be propagated, after all tasks have
         # completed.
         # TODO: This will only raise the first Exception encountered. Once we migrate the perf pipelines
@@ -144,7 +144,7 @@ async def _run_tests(duration: int, args, tests, results, status) -> None:
 
 def _report_status(status: multiprocessing.JoinableQueue, tests: List[_PerfTestABC], stop: threading.Event):
     """Report ongoing status of running tests.
-    
+
     This is achieved by adding status to a joinable queue then waiting for that queue to be cleared
     by the parent processes. This should implicitly synchronize the status reporting across all child
     processes and the parent will dictate the frequency by which status is gathered.

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_proc.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_proc.py
@@ -60,14 +60,14 @@ async def _start_tests(index, test_class, num_tests, args, test_stages, results,
         _synchronize(test_stages["Post Setup"])
         await asyncio.gather(*[test.post_setup() for test in tests])
 
-        if args.warmup and not args.profile:
+        if args.warmup:
             # Waiting till all processes are ready to start "Warmup"
             _synchronize(test_stages["Warmup"])
-            await _run_tests(args.warmup, args, tests, results, status)
+            await _run_tests(args.warmup, args, tests, results, status, with_profiler=False)
 
         # Waiting till all processes are ready to start "Tests"
         _synchronize(test_stages["Tests"])
-        await _run_tests(args.duration, args, tests, results, status)
+        await _run_tests(args.duration, args, tests, results, status, with_profiler=args.profile)
 
         # Waiting till all processes have finished tests, ready to start "Pre Cleanup"
         _synchronize(test_stages["Pre Cleanup"])
@@ -107,7 +107,7 @@ async def _start_tests(index, test_class, num_tests, args, test_stages, results,
                 print(f"Failed to close tests: {e}")
 
 
-async def _run_tests(duration: int, args, tests, results, status) -> None:
+async def _run_tests(duration: int, args, tests, results, status, *, with_profiler: bool = False) -> None:
     """Run the listed tests either in parallel asynchronously or in a thread pool."""
     # Kick of a status monitoring thread.
     stop_status = threading.Event()
@@ -120,10 +120,10 @@ async def _run_tests(duration: int, args, tests, results, status) -> None:
     try:
         if args.sync:
             with ThreadPoolExecutor(max_workers=args.parallel) as ex:
-                tasks = [ex.submit(test.run_all_sync, duration) for test in tests]
+                tasks = [ex.submit(test.run_all_sync, duration, run_profiler=with_profiler) for test in tests]
                 wait(tasks, return_when=ALL_COMPLETED)
         else:
-            tasks = [asyncio.create_task(test.run_all_async(duration)) for test in tests]
+            tasks = [asyncio.create_task(test.run_all_async(duration, run_profiler=with_profiler)) for test in tests]
             await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
 
         # If any of the parallel test runs raised an exception, let it be propagated, after all tasks have

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
@@ -222,7 +222,7 @@ class _PerfStressRunner:
 
             # If a warm up is configured, wait till all tests have finished all setup
             # stages before beginning "Warmup".
-            if self.per_test_args.warmup and not self.per_test_args.profile:
+            if self.per_test_args.warmup:
                 self._next_stage("Warmup", track_status=True)
 
             # Wait till all tests have completed setup and warmup before beginning "Tests".

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
@@ -113,6 +113,10 @@ class _PerfStressRunner:
         self._test_class_to_run.add_arguments(per_test_arg_parser)
         self.per_test_args = per_test_arg_parser.parse_args(sys.argv[2:])
 
+        if self.per_test_args.profile and self.per_test_args.parallel > 1:
+            self.logger.warning("Warning: With profiling enabled, parallelism is disabled. Running with parallel=1.")
+            self.per_test_args.parallel = 1
+
         self.logger.info("")
         self.logger.info("=== Options ===")
         self.logger.info(args)

--- a/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
+++ b/tools/azure-devtools/src/azure_devtools/perfstress_tests/_perf_stress_runner.py
@@ -99,6 +99,9 @@ class _PerfStressRunner:
             "--profile", action="store_true", help="Run tests with profiler.  Default is False.", default=False
         )
         per_test_arg_parser.add_argument(
+            "--profile-path", nargs="?", type=str, help="File path to store profiler results. If not specified, results will be stored in the current directory."
+        )
+        per_test_arg_parser.add_argument(
             "-x", "--test-proxies", help="URIs of TestProxy Servers (separated by ';')",
             type=lambda s: s.split(';')
         )
@@ -215,7 +218,7 @@ class _PerfStressRunner:
 
             # If a warm up is configured, wait till all tests have finished all setup
             # stages before beginning "Warmup".
-            if self.per_test_args.warmup:
+            if self.per_test_args.warmup and not self.per_test_args.profile:
                 self._next_stage("Warmup", track_status=True)
 
             # Wait till all tests have completed setup and warmup before beginning "Tests".


### PR DESCRIPTION
When a user uses the `--profile` argument with the PerfStress framework, sorted pstats output of the cprofile data is now output to stdout.

Also a `--profile-path` argument is added to allow customization of the output file/path.

Also added a check in  _perf_stress_runner.py to not run the warmup stage if profile is True (this avoids a deadlock).

Related perf automation framework PR: https://github.com/Azure/azure-sdk-tools/pull/5533