### PR TITLE
[ML][Pipelines] Copy early available property for pipeline component output

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
@@ -279,6 +279,7 @@ class PipelineComponentBuilder:
                     mode=value.mode,
                     description=value.description,
                     is_control=value.is_control,
+                    early_available=value.early_available,
                 )
 
             # hack: map component output type to valid pipeline output type

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
@@ -297,7 +297,11 @@ class PipelineComponentBuilder:
                 name=key,
                 data=None,
                 meta=Output(
-                    type=_map_type(meta), description=meta.description, mode=meta.mode, is_control=meta.is_control
+                    type=_map_type(meta),
+                    description=meta.description,
+                    mode=meta.mode,
+                    is_control=meta.is_control,
+                    early_available=meta.early_available,
                 ),
                 owner="pipeline",
                 description=self._args_description.get(key, None),

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/base.py
@@ -367,10 +367,15 @@ class NodeOutput(InputOutputBase, PipelineExpressionMixin):
         self._name = name
         self._owner = owner
         self._is_control = meta.is_control if meta is not None else None
+        self._early_available = meta.early_available if meta is not None else None
 
     @property
     def is_control(self) -> str:
         return self._is_control
+
+    @property
+    def early_available(self) -> str:
+        return self._early_available
 
     def _build_default_data(self):
         """Build default data when output not configured."""

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -2581,3 +2581,19 @@ class TestDSLPipeline:
         pipeline_job.settings.default_compute = "cpu-cluster"
         validate_result = pipeline_job._validate()
         assert validate_result.error_messages == {}
+
+    def test_dsl_pipeline_component_early_available_property(self):
+        component_func = load_component("./tests/test_configs/components/streaming_component_basic.yml")
+
+        @dsl.pipeline
+        def pipeline_component_func():
+            streaming_node = component_func()
+            return streaming_node.outputs
+
+        @dsl.pipeline
+        def root_pipeline_func():
+            node = pipeline_component_func()  # noqa: F841
+
+        pipeline_job = root_pipeline_func()
+        assert pipeline_job.jobs["node"].outputs.output.is_control is True
+        assert pipeline_job.jobs["node"].outputs.output.early_available is True

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -2590,10 +2590,16 @@ class TestDSLPipeline:
             streaming_node = component_func()
             return streaming_node.outputs
 
+        # one-layer pipeline job maintains the properties
+        pipeline_job = pipeline_component_func()
+        assert pipeline_job.outputs.output.is_control is True
+        assert pipeline_job.outputs.output.early_available is True
+
         @dsl.pipeline
         def root_pipeline_func():
             node = pipeline_component_func()  # noqa: F841
 
+        # pipeline component in pipeline job maintains the properties
         pipeline_job = root_pipeline_func()
         assert pipeline_job.jobs["node"].outputs.output.is_control is True
         assert pipeline_job.jobs["node"].outputs.output.early_available is True

--- a/sdk/ml/azure-ai-ml/tests/test_configs/components/streaming_component_basic.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/components/streaming_component_basic.yml
@@ -1,0 +1,23 @@
+$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+type: command
+
+name: microsoft_streaming_component_basic
+display_name: StreamingComponentBasic
+description: This is the basic streaming component
+tags:
+  tag: tagvalue
+  owner: sdkteam
+
+version: 0.0.1
+
+outputs:
+  output:
+    type: string
+    is_control: true
+    early_available: true
+
+command: >-
+  echo Hello World &
+  echo Hello Streaming Pipeline
+
+environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1


### PR DESCRIPTION
# Description

This PR targets to support the following scenario: consume component with early available output and return it as pipeline component output. Now the pipeline component output will also hold the early available property.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
