### PR TITLE
Added type hints for using credentials

### DIFF
--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any, Tuple, Union
 
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.credentials import AccessToken
@@ -18,7 +18,7 @@ from ._api_versions import DEFAULT_VERSION
 from ._utils import convert_timedelta_to_mins
 
 if TYPE_CHECKING:
-    from azure.core.credentials import TokenCredential
+    from azure.core.credentials import TokenCredential, AzureKeyCredential
     from ._generated.models import CommunicationTokenScope
 
 
@@ -27,8 +27,8 @@ class CommunicationIdentityClient(object):
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param TokenCredential credential:
-        The TokenCredential we use to authenticate against the service.
+    :param Union[TokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     :keyword api_version: Azure Communication Identity API version.
         Default value is "2022-06-01". Note that overriding this default value may result in unsupported behavior.
     :paramtype api_version: str
@@ -43,7 +43,7 @@ class CommunicationIdentityClient(object):
     def __init__(
             self,
             endpoint, # type: str
-            credential, # type: TokenCredential
+            credential, # type: Union[TokenCredential, AzureKeyCredential]
             **kwargs # type: Any
         ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
@@ -15,6 +15,8 @@ from .._shared.models import CommunicationUserIdentifier
 from .._version import SDK_MONIKER
 from .._api_versions import DEFAULT_VERSION
 from .._utils import convert_timedelta_to_mins
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.credentials import AzureKeyCredential
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
@@ -18,6 +18,7 @@ from .._utils import convert_timedelta_to_mins
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.credentials import AzureKeyCredential
     from .._generated.models import CommunicationTokenScope
 
 
@@ -26,8 +27,8 @@ class CommunicationIdentityClient:
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param AsyncTokenCredential credential:
-        The AsyncTokenCredential we use to authenticate against the service.
+    :param Union[AsyncTokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     :keyword api_version: Azure Communication Identity API version.
         Default value is "2022-06-01". Note that overriding this default value may result in unsupported behavior.
     :paramtype api_version: str
@@ -42,7 +43,7 @@ class CommunicationIdentityClient:
     def __init__(
             self,
             endpoint: str,
-            credential: 'AsyncTokenCredential',
+            credential: Union[AsyncTokenCredential, AzureKeyCredential],
             **kwargs
         ) -> None:
         try:

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, List, Union, Tuple
 
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.credentials import AzureKeyCredential
 
 from .._generated.aio._communication_identity_client\
     import CommunicationIdentityClient as CommunicationIdentityClientGen
@@ -15,12 +17,8 @@ from .._shared.models import CommunicationUserIdentifier
 from .._version import SDK_MONIKER
 from .._api_versions import DEFAULT_VERSION
 from .._utils import convert_timedelta_to_mins
-from azure.core.credentials_async import AsyncTokenCredential
-from azure.core.credentials import AzureKeyCredential
 
 if TYPE_CHECKING:
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.credentials import AzureKeyCredential
     from .._generated.models import CommunicationTokenScope
 
 

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_communication_relay_client.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_communication_relay_client.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from azure.core.tracing.decorator import distributed_trace
 
@@ -17,7 +17,7 @@ from ._generated.models import CommunicationRelayConfiguration
 from ._api_versions import DEFAULT_VERSION
 
 if TYPE_CHECKING:
-    from azure.core.credentials import TokenCredential
+    from azure.core.credentials import TokenCredential, AzureKeyCredential
     from azure.communication.identity import CommunicationUserIdentifier
     from azure.communication.networktraversal import RouteType
 
@@ -26,8 +26,8 @@ class CommunicationRelayClient(object):
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param TokenCredential credential:
-        The TokenCredential we use to authenticate against the service.
+    :param Union[TokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     :keyword api_version: Azure Communication Network Traversal API version.
         Default value is "2022-03-01-preview".
         Note that overriding this default value may result in unsupported behavior.
@@ -41,7 +41,7 @@ class CommunicationRelayClient(object):
     def __init__(
             self,
             endpoint, # type: str
-            credential, # type: TokenCredential
+            credential, # type: Union[TokenCredential, AzureKeyCredential]
             **kwargs # type: Any
         ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
@@ -15,6 +15,7 @@ from .._api_versions import DEFAULT_VERSION
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.credentials import AzureKeyCredential
     from .._generated.models import CommunicationRelayConfiguration
     from azure.communication.identity import CommunicationUserIdentifier
     from azure.communication.networktraversal import RouteType
@@ -25,8 +26,8 @@ class CommunicationRelayClient:
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param AsyncTokenCredential credential:
-        The AsyncTokenCredential we use to authenticate against the service.
+    :param Union[AsyncTokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     :keyword api_version: Azure Communication Network Traversal API version.
         Default value is "2022-03-01-preview".
         Note that overriding this default value may result in unsupported behavior.
@@ -41,7 +42,7 @@ class CommunicationRelayClient:
     def __init__(
         self,
         endpoint: str,
-        credential: 'AsyncTokenCredential',
+        credential: Union[AsyncTokenCredential, AzureKeyCredential],
         **kwargs
         ) -> None:
         # pylint: disable=bad-option-value, disable=raise-missing-from

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
@@ -7,17 +7,16 @@
 from typing import TYPE_CHECKING, Optional, Union
 
 from azure.core.tracing.decorator_async import distributed_trace_async
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.credentials import AzureKeyCredential
+
 from .._generated.aio._communication_network_traversal_client\
     import CommunicationNetworkTraversalClient as CommunicationNetworkTraversalClientGen
 from .._shared.utils import parse_connection_str, get_authentication_policy
 from .._version import SDK_MONIKER
 from .._api_versions import DEFAULT_VERSION
-from azure.core.credentials_async import AsyncTokenCredential
-from azure.core.credentials import AzureKeyCredential
 
 if TYPE_CHECKING:
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.credentials import AzureKeyCredential
     from .._generated.models import CommunicationRelayConfiguration
     from azure.communication.identity import CommunicationUserIdentifier
     from azure.communication.networktraversal import RouteType

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
@@ -12,10 +12,12 @@ from .._generated.aio._communication_network_traversal_client\
 from .._shared.utils import parse_connection_str, get_authentication_policy
 from .._version import SDK_MONIKER
 from .._api_versions import DEFAULT_VERSION
+from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.credentials import AzureKeyCredential
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.credentials import AzureKeyCredential
     from .._generated.models import CommunicationRelayConfiguration
     from azure.communication.identity import CommunicationUserIdentifier
     from azure.communication.networktraversal import RouteType

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/aio/_communication_relay_client_async.py
@@ -12,10 +12,10 @@ from .._generated.aio._communication_network_traversal_client\
 from .._shared.utils import parse_connection_str, get_authentication_policy
 from .._version import SDK_MONIKER
 from .._api_versions import DEFAULT_VERSION
+from azure.core.credentials import AzureKeyCredential
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.credentials import AzureKeyCredential
     from .._generated.models import CommunicationRelayConfiguration
     from azure.communication.identity import CommunicationUserIdentifier
     from azure.communication.networktraversal import RouteType

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_phone_numbers_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_phone_numbers_client.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.exceptions import HttpResponseError
 from ._generated._phone_numbers_client import PhoneNumbersClient as PhoneNumbersClientGen
@@ -17,7 +17,7 @@ _DEFAULT_POLLING_INTERVAL_IN_SECONDS = 2
 
 if TYPE_CHECKING:
     from typing import Any
-    from azure.core.credentials import TokenCredential
+    from azure.core.credentials import TokenCredential, AzureKeyCredential
     from azure.core.paging import ItemPaged
     from azure.core.polling import LROPoller
     from ._generated.models import PhoneNumberSearchResult, PurchasedPhoneNumber, PhoneNumberCapabilities
@@ -29,8 +29,8 @@ class PhoneNumbersClient(object):
     This client provides operations to interact with the phone numbers service
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param TokenCredential credential:
-        The credentials with which to authenticate.
+    :param Union[TokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     :keyword api_version: Azure Communication Phone Number API version.
         The default value is "2022-01-11-preview2".
         Note that overriding this default value may result in unsupported behavior.
@@ -39,7 +39,7 @@ class PhoneNumbersClient(object):
     def __init__(
         self,
         endpoint, # type: str
-        credential, # type: TokenCredential
+        credential, # type: Union[TokenCredential, AzureKeyCredential]
         **kwargs # type: Any
     ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/aio/_phone_numbers_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/aio/_phone_numbers_client_async.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.paging import ItemPaged
@@ -20,6 +20,7 @@ _DEFAULT_POLLING_INTERVAL_IN_SECONDS = 2
 if TYPE_CHECKING:
     from typing import Any
     from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.credentials import AzureKeyCredential
     from azure.core.async_paging import AsyncItemPaged
     from azure.core.polling import AsyncLROPoller
     from .._generated.models import PhoneNumberSearchResult, PurchasedPhoneNumber, PhoneNumberCapabilities
@@ -30,8 +31,8 @@ class PhoneNumbersClient(object):
     This client provides operations to interact with the phone numbers service
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param AsyncTokenCredential credential:
-        The credentials with which to authenticate.
+    :param Union[AsyncTokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     :keyword api_version: Azure Communication Phone Number API version.
         The default value is "2022-01-11-preview2".
         Note that overriding this default value may result in unsupported behavior.
@@ -40,7 +41,7 @@ class PhoneNumbersClient(object):
     def __init__(
                 self,
                 endpoint, # type: str
-                credential, # type: AsyncTokenCredential
+                credential, # type: Union[AsyncTokenCredential, AzureKeyCredential],
                 **kwargs # type: Any
         ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_sms_client.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_sms_client.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from typing import Any, Union
 from uuid import uuid4
 from azure.core.tracing.decorator import distributed_trace
 from azure.communication.sms._generated.models import (
@@ -12,6 +13,7 @@ from azure.communication.sms._generated.models import (
     SmsSendOptions,
 )
 from azure.communication.sms._models import SmsSendResult
+from azure.core.credentials import TokenCredential, AzureKeyCredential
 
 from ._generated._azure_communication_sms_service import AzureCommunicationSMSService
 from ._shared.utils import parse_connection_str, get_authentication_policy, get_current_utc_time
@@ -24,12 +26,12 @@ class SmsClient(object): # pylint: disable=client-accepts-api-version-keyword
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param TokenCredential credential:
-        The TokenCredential we use to authenticate against the service.
+    :param Union[TokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     """
     def __init__(
             self, endpoint, # type: str
-            credential, # type: TokenCredential
+            credential, # type: Union[TokenCredential, AzureKeyCredential]
             **kwargs # type: Any
         ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_sms_client.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_sms_client.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from typing import Any, Union
+from typing import Union
 from uuid import uuid4
 from azure.core.tracing.decorator import distributed_trace
 from azure.communication.sms._generated.models import (

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/aio/_sms_client_async.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/aio/_sms_client_async.py
@@ -13,12 +13,11 @@ from azure.communication.sms._generated.models import (
     SmsSendOptions,
 )
 from azure.communication.sms._models import SmsSendResult
+from azure.core.credentials import AzureKeyCredential
 
 from .._generated.aio._azure_communication_sms_service import AzureCommunicationSMSService
 from .._shared.utils import parse_connection_str, get_authentication_policy, get_current_utc_time
 from .._version import SDK_MONIKER
-from azure.core.credentials_async import AsyncTokenCredential
-from azure.core.credentials import AzureKeyCredential
 
 class SmsClient(object): # pylint: disable=client-accepts-api-version-keyword
     """A client to interact with the AzureCommunicationService Sms gateway asynchronously.

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/aio/_sms_client_async.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/aio/_sms_client_async.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from typing import Union
 from uuid import uuid4
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.communication.sms._generated.models import (
@@ -16,6 +17,8 @@ from azure.communication.sms._models import SmsSendResult
 from .._generated.aio._azure_communication_sms_service import AzureCommunicationSMSService
 from .._shared.utils import parse_connection_str, get_authentication_policy, get_current_utc_time
 from .._version import SDK_MONIKER
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.credentials import AzureKeyCredential
 
 class SmsClient(object): # pylint: disable=client-accepts-api-version-keyword
     """A client to interact with the AzureCommunicationService Sms gateway asynchronously.
@@ -24,12 +27,12 @@ class SmsClient(object): # pylint: disable=client-accepts-api-version-keyword
 
    :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param AsyncTokenCredential credential:
-        The AsyncTokenCredential we use to authenticate against the service.
+    :param Union[AsyncTokenCredential, AzureKeyCredential] credential:
+        The credential we use to authenticate against the service.
     """
     def __init__(
             self, endpoint,  # type: str
-            credential,  # type: AsyncTokenCredential
+            credential,  # type: Union[AsyncTokenCredential, AzureKeyCredential],
             **kwargs  # type: Any
         ):
         # type: (...) -> None


### PR DESCRIPTION
# Description

This pull requests adds type hints and updates xmldoc descriptions for using credentials. After `get_authentication_policy` method got support for TokenCredential and AzureKeyCredential (https://github.com/Azure/azure-sdk-for-python/pull/27607/files#diff-af0726c09f5f21429e332b966319cd24aab71853097d71688bcda3e652f8bc49), we want users to be aware of the types that can be used in client constructors that call  `get_authentication_policy`.

 `get_authentication_policy` method is currently used only in Communication Identity, Communication Relay, Phone Numbers and SMS clients. Other clients use different authentication methods, thus, no change in type hints was done to them.

User story for reference: [User Story 3067523](https://skype.visualstudio.com/SPOOL/_workitems/edit/3067523): [SDK][Python] Update type hints with AzureKeyCredential
# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
