### PR TITLE
[Tables] Remove unnecessary python version checks

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_error.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_error.py
@@ -26,7 +26,6 @@ _ERROR_TYPE_NOT_SUPPORTED = "Type not supported when sending data to the service
 _ERROR_VALUE_TOO_LARGE = "{0} is too large to be cast to type {1}."
 _ERROR_UNKNOWN = "Unknown error ({0})"
 _ERROR_VALUE_NONE = "{0} should not be None."
-_ERROR_UNKNOWN_KEY_WRAP_ALGORITHM = "Unknown key wrap algorithm."
 
 # Storage table validation regex breakdown:
 # ^ Match start of string.
@@ -51,15 +50,8 @@ def _wrap_exception(ex, desired_type):
     msg = ""
     if len(ex.args) > 0:
         msg = ex.args[0]
-    if sys.version_info >= (3,):
-        # Automatic chaining in Python 3 means we keep the trace
-        return desired_type(msg)
-
-    # There isn't a good solution in 2 for keeping the stack trace
-    # in general, or that will not result in an error in 3
-    # However, we can keep the previous error type and message
+    return desired_type(msg)
     # TODO: In the future we will log the trace
-    return desired_type("{}: {}".format(ex.__class__.__name__, msg))
 
 
 def _validate_storage_tablename(table_name):

--- a/sdk/tables/azure-data-tables/azure/data/tables/_serialize.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_serialize.py
@@ -9,7 +9,6 @@ from uuid import UUID
 from datetime import datetime
 from math import isnan
 from enum import Enum
-import sys
 
 import six
 from azure.core import MatchConditions
@@ -122,10 +121,7 @@ def _to_entity_int32(value):
 
 
 def _to_entity_int64(value):
-    if sys.version_info < (3,):
-        int_value = int(value)
-    else:
-        int_value = int(value)
+    int_value = int(value)
     if int_value >= 2 ** 63 or int_value < -(2 ** 63):
         raise TypeError(_ERROR_VALUE_TOO_LARGE.format(str(value), EdmType.INT64))
     return EdmType.INT64, str(value)

--- a/sdk/tables/azure-data-tables/samples/sample_batching.py
+++ b/sdk/tables/azure-data-tables/samples/sample_batching.py
@@ -24,7 +24,6 @@ USAGE:
 
 
 import os
-import sys
 from dotenv import find_dotenv, load_dotenv
 
 
@@ -83,9 +82,8 @@ class CreateClients(object):
 
 
 if __name__ == "__main__":
-    if sys.version_info > (3, 5):
-        sample = CreateClients()
-        try:
-            sample.sample_transaction()
-        finally:
-            sample.clean_up()
+    sample = CreateClients()
+    try:
+        sample.sample_transaction()
+    finally:
+        sample.clean_up()

--- a/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------
 import pytest
 import platform
-import sys
 import os
 
 from devtools_testutils import AzureRecordedTestCase, recorded_by_proxy
@@ -31,7 +30,6 @@ _CONNECTION_ENDPOINTS_SECONDARY = {'table': 'TableSecondaryEndpoint', 'cosmos': 
 
 
 class TestTableClientCosmos(AzureRecordedTestCase, TableTestCase):
-    @pytest.mark.skipif(sys.version_info < (3, 0), reason="Malformed string")
     @cosmos_decorator
     @recorded_by_proxy
     def test_user_agent_default(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):


### PR DESCRIPTION
Since we only support python 3.7 and above, some version checks are not necessary now.