### PR TITLE
[Key Vault] Python 3-style typing and formatting

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -39,7 +39,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def create_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", definition_id: str, principal_id: str, **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", definition_id: str, principal_id: str, **kwargs
     ) -> KeyVaultRoleAssignment:
         """Create a role assignment.
 
@@ -73,7 +73,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def delete_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> None:
         """Delete a role assignment.
 
@@ -94,7 +94,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -113,7 +113,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_role_assignments(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
     ) -> "ItemPaged[KeyVaultRoleAssignment]":
         """List all role assignments for a scope.
 
@@ -132,7 +132,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def set_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
     ) -> "KeyVaultRoleDefinition":
         """Creates or updates a custom role definition.
 
@@ -188,7 +188,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> "KeyVaultRoleDefinition":
         """Get the specified role definition.
 
@@ -207,7 +207,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def delete_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> None:
         """Deletes a custom role definition.
 
@@ -228,7 +228,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_role_definitions(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
     ) -> "ItemPaged[KeyVaultRoleDefinition]":
         """List all role definitions applicable at and above a scope.
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -38,8 +38,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def create_role_assignment(self, scope, definition_id, principal_id, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], str, str, **Any) -> KeyVaultRoleAssignment
+    def create_role_assignment(
+        self, scope: "Union[str, KeyVaultRoleScope]", definition_id: str, principal_id: str, **kwargs: "Any"
+    ) -> KeyVaultRoleAssignment:
         """Create a role assignment.
 
         :param scope: scope the role assignment will apply over. :class:`KeyVaultRoleScope` defines common
@@ -48,8 +49,10 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :param str definition_id: ID of the role's definition
         :param str principal_id: Azure Active Directory object ID of the principal which will be assigned the role. The
             principal can be a user, service principal, or security group.
+
         :keyword name: a name for the role assignment. Must be a UUID.
         :paramtype name: str or uuid.UUID
+
         :rtype: ~azure.keyvault.administration.KeyVaultRoleAssignment
         """
         name = kwargs.pop("name", None) or uuid4()
@@ -69,8 +72,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return KeyVaultRoleAssignment._from_generated(assignment)
 
     @distributed_trace
-    def delete_role_assignment(self, scope, name, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], Union[str, UUID], **Any) -> None
+    def delete_role_assignment(
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+    ) -> None:
         """Delete a role assignment.
 
         :param scope: the assignment's scope, for example "/", "/keys", or "/keys/<specific key identifier>"
@@ -78,6 +82,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role assignment's name.
         :type name: str or uuid.UUID
+
         :returns: None
         """
         try:
@@ -88,8 +93,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
             pass
 
     @distributed_trace
-    def get_role_assignment(self, scope, name, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], Union[str, UUID], **Any) -> KeyVaultRoleAssignment
+    def get_role_assignment(
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+    ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
         :param scope: the assignment's scope, for example "/", "/keys", or "/keys/<specific key identifier>"
@@ -97,6 +103,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role assignment's name.
         :type name: str or uuid.UUID
+
         :rtype: ~azure.keyvault.administration.KeyVaultRoleAssignment
         """
         assignment = self._client.role_assignments.get(
@@ -105,13 +112,15 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return KeyVaultRoleAssignment._from_generated(assignment)
 
     @distributed_trace
-    def list_role_assignments(self, scope, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], **Any) -> ItemPaged[KeyVaultRoleAssignment]
+    def list_role_assignments(
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+    ) -> "ItemPaged[KeyVaultRoleAssignment]":
         """List all role assignments for a scope.
 
         :param scope: scope of the role assignments. :class:`KeyVaultRoleScope` defines common broad scopes.
             Specify a narrower scope as a string.
         :type scope: str or KeyVaultRoleScope
+
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.administration.KeyVaultRoleAssignment]
         """
         return self._client.role_assignments.list_for_scope(
@@ -122,8 +131,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def set_role_definition(self, scope, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], **Any) -> KeyVaultRoleDefinition
+    def set_role_definition(
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+    ) -> "KeyVaultRoleDefinition":
         """Creates or updates a custom role definition.
 
         To update a role definition, specify the definition's ``name``.
@@ -131,6 +141,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :param scope: scope of the role definition. :class:`KeyVaultRoleScope` defines common broad scopes.
             Specify a narrower scope as a string. Managed HSM only supports '/', or KeyVaultRoleScope.GLOBAL.
         :type scope: str or KeyVaultRoleScope
+
         :keyword name: the role definition's name, a UUID. When this argument has a value, the client will create a new
             role definition with this name or update an existing role definition, if one exists with the given name.
             When this argument has no value, a new role definition will be created with a generated name.
@@ -144,6 +155,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :paramtype permissions: Iterable[KeyVaultPermission]
         :keyword assignable_scopes: the scopes for which the role definition can be assigned.
         :paramtype assignable_scopes: Iterable[str] or Iterable[KeyVaultRoleScope]
+
         :returns: The created or updated role definition
         :rtype: ~azure.keyvault.administration.KeyVaultRoleDefinition
         """
@@ -175,8 +187,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return KeyVaultRoleDefinition._from_generated(definition)
 
     @distributed_trace
-    def get_role_definition(self, scope, name, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], Union[str, UUID], **Any) -> KeyVaultRoleDefinition
+    def get_role_definition(
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+    ) -> "KeyVaultRoleDefinition":
         """Get the specified role definition.
 
         :param scope: scope of the role definition. :class:`KeyVaultRoleScope` defines common broad scopes.
@@ -184,6 +197,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role definition's name.
         :type name: str or uuid.UUID
+
         :rtype: ~azure.keyvault.administration.KeyVaultRoleDefinition
         """
         definition = self._client.role_definitions.get(
@@ -192,8 +206,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return KeyVaultRoleDefinition._from_generated(definition)
 
     @distributed_trace
-    def delete_role_definition(self, scope, name, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], Union[str, UUID], **Any) -> None
+    def delete_role_definition(
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+    ) -> None:
         """Deletes a custom role definition.
 
         :param scope: scope of the role definition. :class:`KeyVaultRoleScope` defines common broad scopes.
@@ -201,6 +216,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role definition's name.
         :type name: str or uuid.UUID
+
         :returns: None
         """
         try:
@@ -211,13 +227,15 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
             pass
 
     @distributed_trace
-    def list_role_definitions(self, scope, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], **Any) -> ItemPaged[KeyVaultRoleDefinition]
+    def list_role_definitions(
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+    ) -> "ItemPaged[KeyVaultRoleDefinition]":
         """List all role definitions applicable at and above a scope.
 
         :param scope: scope of the role definitions. :class:`KeyVaultRoleScope` defines common broad scopes.
             Specify a narrower scope as a string.
         :type scope: str or KeyVaultRoleScope
+
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.administration.KeyVaultRoleDefinition]
         """
         return self._client.role_definitions.list(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -43,7 +43,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
 
     # pylint:disable=protected-access
     def begin_backup(
-        self, blob_storage_url: str, sas_token: str, **kwargs: "Any"
+        self, blob_storage_url: str, sas_token: str, **kwargs
     ) -> "LROPoller[KeyVaultBackupResult]":
         """Begin a full backup of the Key Vault.
 
@@ -98,7 +98,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             **kwargs
         )
 
-    def begin_restore(self, folder_url: str, sas_token: str, **kwargs: "Any") -> "LROPoller":
+    def begin_restore(self, folder_url: str, sas_token: str, **kwargs) -> "LROPoller":
         """Restore a Key Vault backup.
 
         This method restores either a complete Key Vault backup or when ``key_name`` has a value, a single key.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -42,14 +42,17 @@ class KeyVaultBackupClient(KeyVaultClientBase):
     """
 
     # pylint:disable=protected-access
-    def begin_backup(self, blob_storage_url, sas_token, **kwargs):
-        # type: (str, str, **Any) -> LROPoller[KeyVaultBackupResult]
+    def begin_backup(
+        self, blob_storage_url: str, sas_token: str, **kwargs: "Any"
+    ) -> "LROPoller[KeyVaultBackupResult]":
         """Begin a full backup of the Key Vault.
 
         :param str blob_storage_url: URL of the blob storage container in which the backup will be stored, for example
             https://<account>.blob.core.windows.net/backup
         :param str sas_token: a Shared Access Signature (SAS) token authorizing access to the blob storage resource
+
         :keyword str continuation_token: a continuation token to restart polling from a saved state
+
         :returns: An :class:`~azure.core.polling.LROPoller` instance. Call `result()` on this object to wait for the
             operation to complete and get a :class:`KeyVaultBackupResult`.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.administration.KeyVaultBackupResult]
@@ -95,8 +98,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             **kwargs
         )
 
-    def begin_restore(self, folder_url, sas_token, **kwargs):
-        # type: (str, str, **Any) -> LROPoller
+    def begin_restore(self, folder_url: str, sas_token: str, **kwargs: "Any") -> "LROPoller":
         """Restore a Key Vault backup.
 
         This method restores either a complete Key Vault backup or when ``key_name`` has a value, a single key.
@@ -105,8 +107,10 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             :class:`KeyVaultBackupResult` returned by :func:`begin_backup`, for example
             https://<account>.blob.core.windows.net/backup/mhsm-account-2020090117323313
         :param str sas_token: a Shared Access Signature (SAS) token authorizing access to the blob storage resource
+
         :keyword str continuation_token: a continuation token to restart polling from a saved state
         :keyword str key_name: name of a single key in the backup. When set, only this key will be restored.
+
         :rtype: ~azure.core.polling.LROPoller
 
         Examples:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/__init__.py
@@ -23,21 +23,21 @@ __all__ = [
 _VaultId = namedtuple("_VaultId", ["vault_url", "collection", "name", "version"])
 
 
-def parse_vault_id(url):
+def parse_vault_id(url: str) -> "_VaultId":
     try:
         parsed_uri = urlparse(url)
     except Exception:  # pylint: disable=broad-except
-        raise ValueError("'{}' is not a valid url".format(url))
+        raise ValueError(f"'{url}' is not a valid url")
     if not (parsed_uri.scheme and parsed_uri.hostname):
-        raise ValueError("'{}' is not a valid url".format(url))
+        raise ValueError(f"'{url}' is not a valid url")
 
     path = list(filter(None, parsed_uri.path.split("/")))
 
     if len(path) < 2 or len(path) > 3:
-        raise ValueError("'{}' is not a valid vault url".format(url))
+        raise ValueError(f"'{url}' is not a valid vault url")
 
     return _VaultId(
-        vault_url="{}://{}".format(parsed_uri.scheme, parsed_uri.hostname),
+        vault_url=f"{parsed_uri.scheme}://{parsed_uri.hostname}",
         collection=path[0],
         name=path[1],
         version=path[2] if len(path) == 3 else None,
@@ -47,8 +47,7 @@ def parse_vault_id(url):
 BackupLocation = namedtuple("BackupLocation", ["container_url", "folder_name"])
 
 
-def parse_folder_url(folder_url):
-    # type: (str) -> BackupLocation
+def parse_folder_url(folder_url: str) -> "BackupLocation":
     """Parse the blob container URL and folder name from a backup's blob storage URL.
 
     For example, https://<account>.blob.core.windows.net/backup/mhsm-account-2020090117323313 parses to
@@ -66,7 +65,7 @@ def parse_folder_url(folder_url):
         folder_name = stripped_path[len(container) + 1 :]
 
         # this intentionally discards any SAS token in the URL--methods require the SAS token as a separate parameter
-        container_url = "{}://{}/{}".format(parsed.scheme, parsed.netloc, container)
+        container_url = f"{parsed.scheme}://{parsed.netloc}/{container}"
 
         return BackupLocation(container_url, folder_name)
     except:  # pylint:disable=broad-except

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -50,7 +50,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class AsyncKeyVaultClientBase(object):
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
@@ -63,8 +63,8 @@ class AsyncKeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -35,17 +35,15 @@ if TYPE_CHECKING:
     from azure.core.pipeline import PipelineResponse
 
 
-def _enforce_tls(request):
-    # type: (PipelineRequest) -> None
+def _enforce_tls(request: PipelineRequest) -> None:
     if not request.http_request.url.lower().startswith("https"):
         raise ServiceRequestError(
             "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
         )
 
 
-def _update_challenge(request, challenger):
-    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
-    """parse challenge from challenger, cache it, return it"""
+def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") -> HttpChallenge:
+    """Parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
         request.http_request.url,
@@ -57,17 +55,15 @@ def _update_challenge(request, challenger):
 
 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
-    """policy for handling HTTP authentication challenges"""
+    """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential, *scopes, **kwargs):
-        # type: (TokenCredential, *str, **Any) -> None
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    def on_request(self, request):
-        # type: (PipelineRequest) -> None
+    def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -78,7 +74,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,
@@ -90,8 +86,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
             request.http_request.set_json_body(None)
             request.http_request.headers["Content-Length"] = "0"
 
-    def on_challenge(self, request, response):
-        # type: (PipelineRequest, PipelineResponse) -> bool
+    def on_challenge(self, request: PipelineRequest, response: "PipelineResponse") -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
@@ -119,6 +114,5 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         return True
 
     @property
-    def _need_new_token(self):
-        # type: () -> bool
+    def _need_new_token(self) -> bool:
         return not self._token or self._token.expires_on - time.time() < 300

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -57,7 +57,7 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
@@ -32,8 +32,7 @@ DEFAULT_VERSION = ApiVersion.V7_4_PREVIEW_1
 
 
 class KeyVaultClientBase(object):
-    def __init__(self, vault_url, credential, **kwargs):
-        # type: (str, TokenCredential, **Any) -> None
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -72,26 +71,22 @@ class KeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._vault_url
 
-    def __enter__(self):
-        # type: () -> KeyVaultClientBase
+    def __enter__(self) -> "KeyVaultClientBase":
         self._client.__enter__()
         return self
 
-    def __exit__(self, *args):
-        # type: (*Any) -> None
+    def __exit__(self, *args: "Any") -> None:
         self._client.__exit__(*args)
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """Close sockets opened by the client.
 
         Calling this method is unnecessary when using the client as a context manager.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
@@ -32,7 +32,7 @@ DEFAULT_VERSION = ApiVersion.V7_4_PREVIEW_1
 
 
 class KeyVaultClientBase(object):
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/exceptions.py
@@ -12,16 +12,15 @@ from azure.core.pipeline.policies import ContentDecodePolicy
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Optional, Type
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.rest import HttpResponse
 
 
-def _get_exception_for_key_vault_error(cls, response):
-    # type: (Type[HttpResponseError], HttpResponse) -> HttpResponseError
+def _get_exception_for_key_vault_error(cls: "Type[HttpResponseError]", response: "HttpResponse") -> HttpResponseError:
     """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
 
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])  # type: Optional[str]
+        message = f"({body['error']['code']}) {body['error']['message']}"  # type: Optional[str]
     except (DecodeError, KeyError):
         # Key Vault error response bodies should have the expected shape and be de-serializable.
         # If we somehow land here, we'll take HttpResponse's default message.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge.py
@@ -2,18 +2,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from typing import TYPE_CHECKING
+from urllib import parse
+
+if TYPE_CHECKING:
+    from typing import Dict, MutableMapping, Optional
 
 
 class HttpChallenge(object):
-    def __init__(self, request_uri, challenge, response_headers=None):
-        """ Parses an HTTP WWW-Authentication Bearer challenge from a server. """
+    def __init__(self, request_uri: str, challenge: str, response_headers: "MutableMapping[str, str]" = None) -> None:
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
-        self._parameters = {}
+        self._parameters = {}  # type: Dict[str, str]
 
         # get the scheme of the challenge and remove from the challenge string
         trimmed_challenge = self._validate_challenge(challenge)
@@ -42,7 +43,8 @@ class HttpChallenge(object):
 
         authorization_uri = self.get_authorization_server()
         # the authorization server URI should look something like https://login.windows.net/tenant-id
-        uri_path = parse.urlparse(authorization_uri).path.lstrip("/")
+        raw_uri_path = str(parse.urlparse(authorization_uri).path)
+        uri_path = raw_uri_path.lstrip("/")
         self.tenant_id = uri_path.split("/")[0] or None
 
         # if the response headers were supplied
@@ -51,27 +53,25 @@ class HttpChallenge(object):
             self.server_signature_key = response_headers.get("x-ms-message-signing-key", None)
             self.server_encryption_key = response_headers.get("x-ms-message-encryption-key", None)
 
-    def is_bearer_challenge(self):
-        """ Tests whether the HttpChallenge a Bearer challenge.
-        rtype: bool """
+    def is_bearer_challenge(self) -> bool:
+        """Tests whether the HttpChallenge a Bearer challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "bearer"
 
-    def is_pop_challenge(self):
-        """ Tests whether the HttpChallenge is a proof of possession challenge.
-        rtype: bool """
+    def is_pop_challenge(self) -> bool:
+        """Tests whether the HttpChallenge is a proof of possession challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "pop"
 
-    def get_value(self, key):
+    def get_value(self, key: str) -> "Optional[str]":
         return self._parameters.get(key)
 
-    def get_authorization_server(self):
-        """ Returns the URI for the authorization server if present, otherwise empty string. """
+    def get_authorization_server(self) -> "Optional[str]":
+        """Returns the URI for the authorization server if present, otherwise empty string."""
         value = ""
         for key in ["authorization_uri", "authorization"]:
             value = self.get_value(key) or ""
@@ -79,41 +79,41 @@ class HttpChallenge(object):
                 break
         return value
 
-    def get_resource(self):
-        """ Returns the resource if present, otherwise empty string. """
+    def get_resource(self) -> str:
+        """Returns the resource if present, otherwise empty string."""
         return self.get_value("resource") or ""
 
-    def get_scope(self):
-        """ Returns the scope if present, otherwise empty string. """
+    def get_scope(self) -> str:
+        """Returns the scope if present, otherwise empty string."""
         return self.get_value("scope") or ""
 
-    def supports_pop(self):
-        """ Returns True if challenge supports pop token auth else False """
+    def supports_pop(self) -> bool:
+        """Returns True if challenge supports pop token auth else False."""
         return self._parameters.get("supportspop", "").lower() == "true"
 
-    def supports_message_protection(self):
-        """ Returns True if challenge vault supports message protection """
-        return self.supports_pop() and self.server_encryption_key and self.server_signature_key
+    def supports_message_protection(self) -> bool:
+        """Returns True if challenge vault supports message protection."""
+        return self.supports_pop() and self.server_encryption_key and self.server_signature_key  # type: ignore
 
     # pylint:disable=no-self-use
-    def _validate_challenge(self, challenge):
-        """ Verifies that the challenge is a valid auth challenge and returns the key=value pairs. """
+    def _validate_challenge(self, challenge: str) -> str:
+        """Verifies that the challenge is a valid auth challenge and returns the key=value pairs."""
         if not challenge:
             raise ValueError("Challenge cannot be empty")
 
         return challenge.strip()
 
     # pylint:disable=no-self-use
-    def _validate_request_uri(self, uri):
-        """ Extracts the host authority from the given URI. """
+    def _validate_request_uri(self, uri: str) -> str:
+        """Extracts the host authority from the given URI."""
         if not uri:
             raise ValueError("request_uri cannot be empty")
 
-        uri = parse.urlparse(uri)
-        if not uri.netloc:
+        parsed = parse.urlparse(uri)
+        if not parsed.netloc:
             raise ValueError("request_uri must be an absolute URI")
 
-        if uri.scheme.lower() not in ["http", "https"]:
+        if parsed.scheme.lower() not in ["http", "https"]:
             raise ValueError("request_uri must be HTTP or HTTPS")
 
-        return uri.netloc
+        return parsed.netloc

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge_cache.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/http_challenge_cache.py
@@ -3,11 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import threading
-
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from urllib import parse
 
 try:
     from typing import TYPE_CHECKING
@@ -16,7 +12,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from typing import Dict
+    from typing import Dict, Optional
     from .http_challenge import HttpChallenge
 
 
@@ -24,10 +20,11 @@ _cache = {}  # type: Dict[str, HttpChallenge]
 _lock = threading.Lock()
 
 
-def get_challenge_for_url(url):
-    """ Gets the challenge for the cached URL.
-    :param url: the URL the challenge is cached for.
-    :rtype: HttpBearerChallenge """
+def get_challenge_for_url(url: str) -> "Optional[HttpChallenge]":
+    """Gets the challenge for the cached URL.
+
+    :param str url: the URL the challenge is cached for.
+    """
 
     if not url:
         raise ValueError("URL cannot be None")
@@ -38,7 +35,7 @@ def get_challenge_for_url(url):
         return _cache.get(key)
 
 
-def _get_cache_key(url):
+def _get_cache_key(url: str) -> str:
     """Use the URL's netloc as cache key except when the URL specifies the default port for its scheme. In that case
     use the netloc without the port. That is to say, https://foo.bar and https://foo.bar:443 are considered equivalent.
 
@@ -52,22 +49,27 @@ def _get_cache_key(url):
     return parsed.netloc
 
 
-def remove_challenge_for_url(url):
-    """ Removes the cached challenge for the specified URL.
-    :param url: the URL for which to remove the cached challenge """
+def remove_challenge_for_url(url: str) -> None:
+    """Removes the cached challenge for the specified URL.
+
+    :param str url: the URL for which to remove the cached challenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
-    url = parse.urlparse(url)
+    parsed = parse.urlparse(url)
 
     with _lock:
-        del _cache[url.netloc]
+        del _cache[parsed.netloc]
 
 
-def set_challenge_for_url(url, challenge):
-    """ Caches the challenge for the specified URL.
-    :param url: the URL for which to cache the challenge
-    :param challenge: the challenge to cache """
+def set_challenge_for_url(url: str, challenge: "HttpChallenge") -> None:
+    """Caches the challenge for the specified URL.
+
+    :param str url: the URL for which to cache the challenge
+    :param challenge: the challenge to cache
+    :type challenge: HttpChallenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
@@ -82,8 +84,8 @@ def set_challenge_for_url(url, challenge):
         _cache[src_url.netloc] = challenge
 
 
-def clear():
-    """ Clears the cache. """
+def clear() -> None:
+    """Clears the cache."""
 
     with _lock:
         _cache.clear()

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/polling.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/polling.py
@@ -3,23 +3,28 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import base64
+from typing import TYPE_CHECKING
 
 from azure.core.polling.base_polling import LROBasePolling, OperationFailed, OperationResourcePolling
 
+if TYPE_CHECKING:
+    from azure.core.pipeline import PipelineResponse
+    from azure.core.rest import HttpResponse
+
 
 class KeyVaultBackupClientPolling(OperationResourcePolling):
-    def __init__(self):
-        self._polling_url = None
+    def __init__(self) -> None:
+        self._polling_url = ""
         super(KeyVaultBackupClientPolling, self).__init__(operation_location_header="azure-asyncoperation")
 
-    def get_polling_url(self):
+    def get_polling_url(self) -> str:
         return self._polling_url
 
-    def get_final_get_url(self, pipeline_response):
+    def get_final_get_url(self, pipeline_response: "PipelineResponse") -> None:
         return None
 
-    def set_initial_status(self, pipeline_response):
-        response = pipeline_response.http_response
+    def set_initial_status(self, pipeline_response: "PipelineResponse") -> str:
+        response = pipeline_response.http_response  # type: HttpResponse
         self._polling_url = response.headers["azure-asyncoperation"]
 
         if response.status_code in {200, 201, 202, 204}:
@@ -28,6 +33,5 @@ class KeyVaultBackupClientPolling(OperationResourcePolling):
 
 
 class KeyVaultBackupClientPollingMethod(LROBasePolling):
-    def get_continuation_token(self):
-        # type: () -> str
+    def get_continuation_token(self) -> str:
         return base64.b64encode(self._operation.get_polling_url().encode()).decode("ascii")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -2,9 +2,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any
+from typing import TYPE_CHECKING
 
 from ._enums import SettingType
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Union
+    from azure.core.rest import HttpResponse
+    from ._generated_models import (
+        FullBackupOperation,
+        Permission,
+        RoleAssignment,
+        RoleAssignmentProperties,
+        RoleAssignmentPropertiesWithScope,
+        RoleDefinition,
+        Setting,
+    )
 
 
 class KeyVaultPermission(object):
@@ -18,15 +31,14 @@ class KeyVaultPermission(object):
      other role definitions assigned to a principal.
     """
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: "Any") -> None:
         self.actions = kwargs.get("actions")
         self.not_actions = kwargs.get("not_actions")
         self.data_actions = kwargs.get("data_actions")
         self.not_data_actions = kwargs.get("not_data_actions")
 
     @classmethod
-    def _from_generated(cls, permissions):
+    def _from_generated(cls, permissions: "Permission") -> "KeyVaultPermission":
         return cls(
             actions=permissions.actions,
             not_actions=permissions.not_actions,
@@ -44,25 +56,25 @@ class KeyVaultRoleAssignment(object):
     :ivar str type: type of the assignment
     """
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: "Any") -> None:
         self.name = kwargs.get("name")
         self.properties = kwargs.get("properties")
         self.role_assignment_id = kwargs.get("role_assignment_id")
         self.type = kwargs.get("assignment_type")
 
-    def __repr__(self):
-        # type: () -> str
-        return "KeyVaultRoleAssignment<{}>".format(self.role_assignment_id)
+    def __repr__(self) -> str:
+        return f"KeyVaultRoleAssignment<{self.role_assignment_id}>"
 
     @classmethod
-    def _from_generated(cls, role_assignment):
+    def _from_generated(cls, role_assignment: "RoleAssignment") -> "KeyVaultRoleAssignment":
         # pylint:disable=protected-access
         return cls(
             role_assignment_id=role_assignment.id,
             name=role_assignment.name,
             assignment_type=role_assignment.type,
-            properties=KeyVaultRoleAssignmentProperties._from_generated(role_assignment.properties),
+            properties=KeyVaultRoleAssignmentProperties._from_generated(role_assignment.properties)
+                if role_assignment.properties
+                else KeyVaultRoleAssignmentProperties(),
         )
 
 
@@ -75,20 +87,22 @@ class KeyVaultRoleAssignmentProperties(object):
     :ivar str scope: the scope of the assignment
     """
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: "Any") -> None:
         self.principal_id = kwargs.get("principal_id")
         self.role_definition_id = kwargs.get("role_definition_id")
         self.scope = kwargs.get("scope")
 
-    def __repr__(self):
-        # type: () -> str
-        return "KeyVaultRoleAssignmentProperties(principal_id={}, role_definition_id={}, scope={})".format(
-            self.principal_id, self.role_definition_id, self.scope
-        )[:1024]
+    def __repr__(self) -> str:
+        string = (
+            f"KeyVaultRoleAssignmentProperties(principal_id={self.principal_id}, "
+            + f"role_definition_id={self.role_definition_id}, scope={self.scope})"
+        )
+        return string[:1024]
 
     @classmethod
-    def _from_generated(cls, role_assignment_properties):
+    def _from_generated(
+        cls, role_assignment_properties: "Union[RoleAssignmentProperties, RoleAssignmentPropertiesWithScope]"
+    ) -> "KeyVaultRoleAssignmentProperties":
         # the generated RoleAssignmentProperties and RoleAssignmentPropertiesWithScope
         # models differ only in that the latter has a "scope" attribute
         return cls(
@@ -111,8 +125,7 @@ class KeyVaultRoleDefinition(object):
     :ivar str type: type of the role definition
     """
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: "Any") -> None:
         self.assignable_scopes = kwargs.get("assignable_scopes")
         self.description = kwargs.get("description")
         self.id = kwargs.get("id")
@@ -122,19 +135,18 @@ class KeyVaultRoleDefinition(object):
         self.role_type = kwargs.get("role_type")
         self.type = kwargs.get("type")
 
-    def __repr__(self):
-        # type: () -> str
-        return "KeyVaultRoleDefinition<{}>".format(self.id)
+    def __repr__(self) -> str:
+        return f"KeyVaultRoleDefinition<{self.id}>"
 
     @classmethod
-    def _from_generated(cls, definition):
+    def _from_generated(cls, definition: "RoleDefinition") -> "KeyVaultRoleDefinition":
         # pylint:disable=protected-access
         return cls(
             assignable_scopes=definition.assignable_scopes,
             description=definition.description,
             id=definition.id,
             name=definition.name,
-            permissions=[KeyVaultPermission._from_generated(p) for p in definition.permissions],
+            permissions=[KeyVaultPermission._from_generated(p) for p in definition.permissions or []],
             role_name=definition.role_name,
             role_type=definition.role_type,
             type=definition.type,
@@ -147,12 +159,15 @@ class KeyVaultBackupResult(object):
     :ivar str folder_url: URL of the Azure Blob Storage container containing the backup
     """
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    # pylint:disable=unused-argument
+
+    def __init__(self, **kwargs: "Any") -> None:
         self.folder_url = kwargs.get("folder_url")
 
     @classmethod
-    def _from_generated(cls, response, deserialized_operation, response_headers):  # pylint:disable=unused-argument
+    def _from_generated(
+        cls, response: "HttpResponse", deserialized_operation: "FullBackupOperation", response_headers: "Dict"
+    ) -> "KeyVaultBackupResult":
         return cls(folder_url=deserialized_operation.azure_storage_blob_container_uri)
 
 
@@ -164,11 +179,11 @@ class KeyVaultSetting(object):
     :ivar SettingType type: The type specifier of the value.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: "Any") -> None:
         self.name = kwargs.get("name")
         self.value = kwargs.get("value")
         self.type = kwargs.get("type")
 
     @classmethod
-    def _from_generated(cls, setting):
+    def _from_generated(cls, setting: "Setting") -> "KeyVaultSetting":
         return cls(name=setting.name, value=setting.value, type=SettingType(setting.type))

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -31,7 +31,7 @@ class KeyVaultPermission(object):
      other role definitions assigned to a principal.
     """
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self.actions = kwargs.get("actions")
         self.not_actions = kwargs.get("not_actions")
         self.data_actions = kwargs.get("data_actions")
@@ -56,7 +56,7 @@ class KeyVaultRoleAssignment(object):
     :ivar str type: type of the assignment
     """
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self.name = kwargs.get("name")
         self.properties = kwargs.get("properties")
         self.role_assignment_id = kwargs.get("role_assignment_id")
@@ -87,7 +87,7 @@ class KeyVaultRoleAssignmentProperties(object):
     :ivar str scope: the scope of the assignment
     """
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self.principal_id = kwargs.get("principal_id")
         self.role_definition_id = kwargs.get("role_definition_id")
         self.scope = kwargs.get("scope")
@@ -125,7 +125,7 @@ class KeyVaultRoleDefinition(object):
     :ivar str type: type of the role definition
     """
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self.assignable_scopes = kwargs.get("assignable_scopes")
         self.description = kwargs.get("description")
         self.id = kwargs.get("id")
@@ -161,7 +161,7 @@ class KeyVaultBackupResult(object):
 
     # pylint:disable=unused-argument
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self.folder_url = kwargs.get("folder_url")
 
     @classmethod
@@ -179,7 +179,7 @@ class KeyVaultSetting(object):
     :ivar SettingType type: The type specifier of the value.
     """
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self.name = kwargs.get("name")
         self.value = kwargs.get("value")
         self.type = kwargs.get("type")

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_sdk_moniker.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_sdk_moniker.py
@@ -4,4 +4,4 @@
 # ------------------------------------
 from ._version import VERSION
 
-SDK_MONIKER = "keyvault-administration/{}".format(VERSION)
+SDK_MONIKER = f"keyvault-administration/{VERSION}"

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -30,7 +30,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_setting(self, name: str, **kwargs: Any) -> KeyVaultSetting:
+    def get_setting(self, name: str, **kwargs) -> KeyVaultSetting:
         """Gets the setting with the specified name.
 
         :param str name: The name of the account setting.
@@ -43,7 +43,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         return KeyVaultSetting._from_generated(result)
 
     @distributed_trace
-    def list_settings(self, **kwargs: Any) -> ItemPaged[KeyVaultSetting]:
+    def list_settings(self, **kwargs) -> ItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
         :returns: A paged object containing the account's settings.
@@ -63,7 +63,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         return ItemPaged(get_next, extract_data)
 
     @distributed_trace
-    def update_setting(self, name: str, value: str, **kwargs: Any) -> KeyVaultSetting:
+    def update_setting(self, name: str, value: str, **kwargs) -> KeyVaultSetting:
         """Updates a given account setting with the provided value.
 
         :param str name: The name of the account setting to update.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -2,12 +2,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import Any
+
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 
 from ._generated_models import UpdateSettingsRequest
 from ._internal import KeyVaultClientBase
 from ._models import KeyVaultSetting
+
 
 class KeyVaultSettingsClient(KeyVaultClientBase):
     """Provides methods to update, get, and list settings for an Azure Key Vault.
@@ -27,7 +30,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_setting(self, name: str, **kwargs) -> KeyVaultSetting:
+    def get_setting(self, name: str, **kwargs: Any) -> KeyVaultSetting:
         """Gets the setting with the specified name.
 
         :param str name: The name of the account setting.
@@ -40,7 +43,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         return KeyVaultSetting._from_generated(result)
 
     @distributed_trace
-    def list_settings(self, **kwargs) -> ItemPaged[KeyVaultSetting]:
+    def list_settings(self, **kwargs: Any) -> ItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
         :returns: A paged object containing the account's settings.
@@ -60,7 +63,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         return ItemPaged(get_next, extract_data)
 
     @distributed_trace
-    def update_setting(self, name: str, value: str, **kwargs) -> KeyVaultSetting:
+    def update_setting(self, name: str, value: str, **kwargs: Any) -> KeyVaultSetting:
         """Updates a given account setting with the provided value.
 
         :param str name: The name of the account setting to update.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any
-
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -40,7 +40,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def create_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", definition_id: str, principal_id: str, **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", definition_id: str, principal_id: str, **kwargs
     ) -> KeyVaultRoleAssignment:
         """Create a role assignment.
 
@@ -74,7 +74,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> None:
         """Delete a role assignment.
 
@@ -95,7 +95,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -114,7 +114,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_role_assignments(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
     ) -> "AsyncItemPaged[KeyVaultRoleAssignment]":
         """List all role assignments for a scope.
 
@@ -133,7 +133,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def set_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
     ) -> "KeyVaultRoleDefinition":
         """Creates or updates a custom role definition.
 
@@ -189,7 +189,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> "KeyVaultRoleDefinition":
         """Get the specified role definition.
 
@@ -208,7 +208,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
     ) -> None:
         """Deletes a custom role definition.
 
@@ -229,7 +229,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_role_definitions(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs: "Any"
+        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
     ) -> "AsyncItemPaged[KeyVaultRoleDefinition]":
         """List all role definitions applicable at and above a scope.
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -50,8 +50,10 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :param str definition_id: ID of the role's definition
         :param str principal_id: Azure Active Directory object ID of the principal which will be assigned the role. The
             principal can be a user, service principal, or security group.
+
         :keyword name: a name for the role assignment. Must be a UUID.
         :paramtype name: str or uuid.UUID
+
         :rtype: ~azure.keyvault.administration.KeyVaultRoleAssignment
         """
         name = kwargs.pop("name", None) or uuid4()
@@ -81,6 +83,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role assignment's name.
         :type name: str or uuid.UUID
+
         :returns: None
         """
         try:
@@ -101,6 +104,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role assignment's name.
         :type name: str or uuid.UUID
+
         :rtype: ~azure.keyvault.administration.KeyVaultRoleAssignment
         """
         assignment = await self._client.role_assignments.get(
@@ -117,6 +121,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :param scope: scope of the role assignments. :class:`KeyVaultRoleScope` defines common broad
             scopes. Specify a narrower scope as a string.
         :type scope: str or KeyVaultRoleScope
+
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.administration.KeyVaultRoleAssignment]
         """
         return self._client.role_assignments.list_for_scope(
@@ -137,6 +142,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :param scope: scope of the role definition. :class:`KeyVaultRoleScope` defines common broad scopes.
             Specify a narrower scope as a string. Managed HSM only supports '/', or KeyVaultRoleScope.GLOBAL.
         :type scope: str or KeyVaultRoleScope
+
         :keyword name: the role definition's name, a UUID. When this argument has a value, the client will create a new
             role definition with this name or update an existing role definition, if one exists with the given name.
             When this argument has no value, a new role definition will be created with a generated name.
@@ -150,6 +156,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :paramtype permissions: Iterable[KeyVaultPermission]
         :keyword assignable_scopes: the scopes for which the role definition can be assigned.
         :paramtype assignable_scopes: Iterable[str] or Iterable[KeyVaultRoleScope]
+
         :returns: The created or updated role definition
         :rtype: ~azure.keyvault.administration.KeyVaultRoleDefinition
         """
@@ -191,6 +198,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role definition's name.
         :type name: str or uuid.UUID
+
         :rtype: ~azure.keyvault.administration.KeyVaultRoleDefinition
         """
         definition = await self._client.role_definitions.get(
@@ -209,6 +217,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :type scope: str or KeyVaultRoleScope
         :param name: the role definition's name.
         :type name: str or uuid.UUID
+
         :returns: None
         """
         try:
@@ -227,6 +236,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :param scope: scope of the role definitions. :class:`KeyVaultRoleScope` defines common broad
             scopes. Specify a narrower scope as a string.
         :type scope: str or KeyVaultRoleScope
+
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.administration.KeyVaultRoleDefinition]
         """
         return self._client.role_definitions.list(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -44,7 +44,9 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
         :param str blob_storage_url: URL of the blob storage container in which the backup will be stored, for example
             https://<account>.blob.core.windows.net/backup
         :param str sas_token: a Shared Access Signature (SAS) token authorizing access to the blob storage resource
+
         :keyword str continuation_token: a continuation token to restart polling from a saved state
+
         :returns: An AsyncLROPoller. Call `result()` on this object to get a :class:`KeyVaultBackupResult`.
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.keyvault.administration.KeyVaultBackupResult]
 
@@ -99,8 +101,10 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             :func:`begin_backup`, for example
             https://<account>.blob.core.windows.net/backup/mhsm-account-2020090117323313
         :param str sas_token: a Shared Access Signature (SAS) token authorizing access to the blob storage resource
+
         :keyword str continuation_token: a continuation token to restart polling from a saved state
         :keyword str key_name: name of a single key in the backup. When set, only this key will be restored.
+
         :rtype: ~azure.core.polling.AsyncLROPoller
 
         Examples:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -37,7 +37,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
 
     # pylint:disable=protected-access
     async def begin_backup(
-        self, blob_storage_url: str, sas_token: str, **kwargs: "Any"
+        self, blob_storage_url: str, sas_token: str, **kwargs
     ) -> "AsyncLROPoller[KeyVaultBackupResult]":
         """Begin a full backup of the Key Vault.
 
@@ -91,7 +91,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             **kwargs
         )
 
-    async def begin_restore(self, folder_url: str, sas_token: str, **kwargs: "Any") -> "AsyncLROPoller":
+    async def begin_restore(self, folder_url: str, sas_token: str, **kwargs) -> "AsyncLROPoller":
         """Restore a Key Vault backup.
 
         This method restores either a complete Key Vault backup or when ``key_name`` has a value, a single key.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -30,7 +30,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace_async
-    async def get_setting(self, name: str, **kwargs: Any) -> KeyVaultSetting:
+    async def get_setting(self, name: str, **kwargs) -> KeyVaultSetting:
         """Gets the setting with the specified name.
 
         :param str name: The name of the account setting.
@@ -43,7 +43,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         return KeyVaultSetting._from_generated(result)
 
     @distributed_trace_async
-    async def list_settings(self, **kwargs: Any) -> AsyncItemPaged[KeyVaultSetting]:
+    async def list_settings(self, **kwargs) -> AsyncItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
         :returns: A :class:`~azure.keyvault.administration.GetSettingsResult` object containing the account's settings.
@@ -63,7 +63,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         return AsyncItemPaged(get_next, extract_data)
 
     @distributed_trace_async
-    async def update_setting(self, name: str, value: str, **kwargs: Any) -> KeyVaultSetting:
+    async def update_setting(self, name: str, value: str, **kwargs) -> KeyVaultSetting:
         """Updates a given account setting with the provided value.
 
         :param str name: The name of the account setting to update.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -2,12 +2,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import Any
+
 from azure.core.async_paging import AsyncItemPaged, AsyncList
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from .._generated_models import UpdateSettingsRequest
 from .._internal import AsyncKeyVaultClientBase
 from .._models import KeyVaultSetting
+
 
 class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
     """Provides methods to update, get, and list settings for an Azure Key Vault.
@@ -27,7 +30,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace_async
-    async def get_setting(self, name: str, **kwargs) -> KeyVaultSetting:
+    async def get_setting(self, name: str, **kwargs: Any) -> KeyVaultSetting:
         """Gets the setting with the specified name.
 
         :param str name: The name of the account setting.
@@ -40,7 +43,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         return KeyVaultSetting._from_generated(result)
 
     @distributed_trace_async
-    async def list_settings(self, **kwargs) -> AsyncItemPaged[KeyVaultSetting]:
+    async def list_settings(self, **kwargs: Any) -> AsyncItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
         :returns: A :class:`~azure.keyvault.administration.GetSettingsResult` object containing the account's settings.
@@ -60,7 +63,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         return AsyncItemPaged(get_next, extract_data)
 
     @distributed_trace_async
-    async def update_setting(self, name: str, value: str, **kwargs) -> KeyVaultSetting:
+    async def update_setting(self, name: str, value: str, **kwargs: Any) -> KeyVaultSetting:
         """Updates a given account setting with the provided value.
 
         :param str name: The name of the account setting to update.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any
-
 from azure.core.async_paging import AsyncItemPaged, AsyncList
 from azure.core.tracing.decorator_async import distributed_trace_async
 

--- a/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations.py
@@ -51,7 +51,7 @@ role_name = "customRole"
 scope = KeyVaultRoleScope.GLOBAL
 permissions = [KeyVaultPermission(data_actions=[KeyVaultDataAction.CREATE_HSM_KEY])]
 role_definition = client.set_role_definition(scope=scope, role_name=role_name, permissions=permissions)
-print("Role definition '{}' created successfully.".format(role_definition.role_name))
+print(f"Role definition '{role_definition.role_name}' created successfully.")
 
 # Let's update our role definition to allow reading keys, but not allow creating keys.
 # To update an existing definition, pass the name keyword argument to set_role_definition. This is the unique name
@@ -67,7 +67,7 @@ unique_definition_name = role_definition.name
 updated_definition = client.set_role_definition(
     scope=scope, name=unique_definition_name, role_name=role_name, permissions=new_permissions
 )
-print("Role definition '{}' updated successfully.".format(updated_definition.role_name))
+print(f"Role definition '{updated_definition.role_name}' updated successfully.")
 
 # Now let's create a role assignment to apply our role definition to our service principal.
 # Since we don't provide the name keyword argument to create_role_definition, a unique role assignment name (a GUID)

--- a/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations_async.py
@@ -49,7 +49,7 @@ async def run_sample():
     scope = KeyVaultRoleScope.GLOBAL
     permissions = [KeyVaultPermission(data_actions=[KeyVaultDataAction.CREATE_HSM_KEY])]
     role_definition = await client.set_role_definition(scope=scope, role_name=role_name, permissions=permissions)
-    print("Role definition '{}' created successfully.".format(role_definition.role_name))
+    print(f"Role definition '{role_definition.role_name}' created successfully.")
 
     # Let's update our role definition to allow reading keys, but not allow creating keys.
     # To update an existing definition, pass the name keyword argument to set_role_definition. This is the unique
@@ -65,7 +65,7 @@ async def run_sample():
     updated_definition = await client.set_role_definition(
         scope=scope, name=unique_definition_name, role_name=role_name, permissions=new_permissions
     )
-    print("Role definition '{}' updated successfully.".format(updated_definition.role_name))
+    print(f"Role definition '{updated_definition.role_name}' updated successfully.")
 
     # Now let's create a role assignment to apply our role definition to our service principal.
     # Since we don't provide the name keyword argument to create_role_definition, a unique role assignment name

--- a/sdk/keyvault/azure-keyvault-administration/setup.py
+++ b/sdk/keyvault/azure-keyvault-administration/setup.py
@@ -36,7 +36,7 @@ setup(
     name=PACKAGE_NAME,
     version=VERSION,
     include_package_data=True,
-    description="Microsoft Azure {} Client Library for Python".format(PACKAGE_PPRINT_NAME),
+    description=f"Microsoft Azure {PACKAGE_PPRINT_NAME} Client Library for Python",
     long_description=README + "\n\n" + CHANGELOG,
     long_description_content_type="text/markdown",
     license="MIT License",

--- a/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_async_test_case.py
@@ -21,7 +21,7 @@ class BaseClientPreparer(AzureRecordedTestCase):
             storage_name = os.environ.get("BLOB_STORAGE_ACCOUNT_NAME")
             storage_endpoint_suffix = os.environ.get("KEYVAULT_STORAGE_ENDPOINT_SUFFIX")
             container_name = os.environ.get("BLOB_CONTAINER_NAME")
-            self.container_uri = "https://{}.blob.{}/{}".format(storage_name, storage_endpoint_suffix, container_name)
+            self.container_uri = f"https://{storage_name}.blob.{storage_endpoint_suffix}/{container_name}"
 
             self.sas_token = os.environ.get("BLOB_STORAGE_SAS_TOKEN")
             

--- a/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_test_case.py
@@ -22,7 +22,7 @@ class BaseClientPreparer(AzureRecordedTestCase):
             storage_name = os.environ.get("BLOB_STORAGE_ACCOUNT_NAME")
             storage_endpoint_suffix = os.environ.get("KEYVAULT_STORAGE_ENDPOINT_SUFFIX")
             container_name = os.environ.get("BLOB_CONTAINER_NAME")
-            self.container_uri = "https://{}.blob.{}/{}".format(storage_name, storage_endpoint_suffix, container_name)
+            self.container_uri = f"https://{storage_name}.blob.{storage_endpoint_suffix}/{container_name}"
 
             self.sas_token = os.environ.get("BLOB_STORAGE_SAS_TOKEN")
             

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -31,7 +31,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, Dict, Iterable, List, Optional
+    from typing import Any, Iterable, List, Optional, Union
     from azure.core.paging import ItemPaged
 
 
@@ -65,34 +65,32 @@ class CertificateClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def begin_create_certificate(self, certificate_name, policy, **kwargs):
-        # type: (str, CertificatePolicy, **Any) -> LROPoller
+    def begin_create_certificate(
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs: "Any"
+    ) -> "LROPoller[Union[KeyVaultCertificate, CertificateOperation]]":
         """Creates a new certificate.
 
-        If this is the first version, the certificate resource is created. This
-        operation requires the certificates/create permission. The poller requires the
-        certificates/get permission, otherwise raises
-        an :class:`~azure.core.exceptions.HttpResponseError`
+        If this is the first version, the certificate resource is created. This operation requires the
+        certificates/create permission. The poller requires the certificates/get permission, otherwise raises an
+        :class:`~azure.core.exceptions.HttpResponseError`
 
         :param str certificate_name: The name of the certificate.
         :param policy: The management policy for the certificate. Either subject or one of the subject alternative
             name properties are required.
-        :type policy:
-            ~azure.keyvault.certificates.CertificatePolicy
+        :type policy: ~azure.keyvault.certificates.CertificatePolicy
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
-        :returns: An LROPoller for the create certificate operation. Waiting on the poller
-            gives you the certificate if creation is successful, the CertificateOperation if not.
+
+        :returns: An LROPoller for the create certificate operation. Waiting on the poller gives you the certificate if
+            creation is successful, or the CertificateOperation if not.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.KeyVaultCertificate or
             ~azure.keyvault.certificates.CertificateOperation]
+
         :raises:
             :class:`ValueError` if the certificate policy is invalid,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors.
-
-        Keyword arguments
-            - *enabled (bool)* - Determines whether the object is enabled.
-            - *tags (dict[str, str])* - Application specific metadata in the form of key-value pairs.
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -141,16 +139,17 @@ class CertificateClient(KeyVaultClientBase):
         return LROPoller(command, create_certificate_operation, lambda *_: None, create_certificate_polling)
 
     @distributed_trace
-    def get_certificate(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> KeyVaultCertificate
+    def get_certificate(self, certificate_name: str, **kwargs: "Any") -> KeyVaultCertificate:
         """Gets a certificate with its management policy attached. Requires certificates/get permission.
 
         Does not accept the version of the certificate as a parameter. To get a specific version of the
         certificate, call :func:`get_certificate_version`.
 
         :param str certificate_name: The name of the certificate in the given vault.
+
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -173,17 +172,20 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_certificate_version(self, certificate_name, version, **kwargs):
-        # type: (str, str, **Any) -> KeyVaultCertificate
+    def get_certificate_version(
+        self, certificate_name: str, version: str, **kwargs: "Any"
+    ) -> KeyVaultCertificate:
         """Gets a specific version of a certificate without returning its management policy.
 
-        Requires certificates/get permission. To get the latest version of the certificate,
-        or to get the certificate's policy as well, call :func:`get_certificate`.
+        Requires certificates/get permission. To get the latest version of the certificate, or to get the certificate's
+        policy as well, call :func:`get_certificate`.
 
         :param str certificate_name: The name of the certificate in the given vault.
         :param str version: The version of the certificate.
+
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -206,8 +208,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def begin_delete_certificate(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> LROPoller
+    def begin_delete_certificate(self, certificate_name: str, **kwargs: "Any") -> LROPoller[DeletedCertificate]:
         """Delete all versions of a certificate. Requires certificates/delete permission.
 
         When this method returns Key Vault has begun deleting the certificate. Deletion may take several seconds in a
@@ -215,12 +216,14 @@ class CertificateClient(KeyVaultClientBase):
         complete.
 
         :param str certificate_name: The name of the certificate to delete.
+
         :returns: A poller for the delete certificate operation. The poller's `result` method returns the
-         :class:`~azure.keyvault.certificates.DeletedCertificate` without waiting for deletion to complete. If the vault
-         has soft-delete enabled and you want to immediately, permanently delete the certificate with
-         :func:`purge_deleted_certificate`, call the poller's `wait` method first. It will block until the deletion is
-         complete. The `wait` method requires certificates/get permission.
+            :class:`~azure.keyvault.certificates.DeletedCertificate` without waiting for deletion to complete. If the
+            vault has soft-delete enabled and you want to immediately, permanently delete the certificate with
+            :func:`purge_deleted_certificate`, call the poller's `wait` method first. It will block until the deletion
+            is complete. The `wait` method requires certificates/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.DeletedCertificate]
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -252,17 +255,17 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_deleted_certificate(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> DeletedCertificate
+    def get_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> DeletedCertificate:
         """Get a deleted certificate. Possible only in a vault with soft-delete enabled.
 
-        Requires certificates/get permission. Retrieves the deleted certificate information
-        plus its attributes, such as retention interval, scheduled permanent deletion, and the
-        current deletion recovery level.
+        Requires certificates/get permission. Retrieves the deleted certificate information plus its attributes, such as
+        retention interval, scheduled permanent deletion, and the current deletion recovery level.
 
         :param str certificate_name: The name of the certificate.
+
         :return: The deleted certificate
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -281,21 +284,20 @@ class CertificateClient(KeyVaultClientBase):
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
 
     @distributed_trace
-    def purge_deleted_certificate(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> None
+    def purge_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> None:
         """Permanently deletes a deleted certificate. Possible only in vaults with soft-delete enabled.
 
-        Requires certificates/purge permission.
-
-        Performs an irreversible deletion of the specified certificate, without
+        Requires certificates/purge permission. Performs an irreversible deletion of the specified certificate, without
         possibility for recovery. The operation is not available if the
         :py:attr:`~azure.keyvault.certificates.CertificateProperties.recovery_level` does not specify 'Purgeable'.
         This method is only necessary for purging a certificate before its
         :py:attr:`~azure.keyvault.certificates.DeletedCertificate.scheduled_purge_date`.
 
         :param str certificate_name: The name of the certificate
+
         :return: None
         :rtype: None
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         self._client.purge_deleted_certificate(
@@ -303,22 +305,24 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def begin_recover_deleted_certificate(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> LROPoller
+    def begin_recover_deleted_certificate(
+        self, certificate_name: str, **kwargs: "Any"
+    ) -> LROPoller[KeyVaultCertificate]:
         """Recover a deleted certificate to its latest version. Possible only in a vault with soft-delete enabled.
 
-        Requires certificates/recover permission.
-
-        When this method returns Key Vault has begun recovering the certificate. Recovery may take several seconds. This
-        method therefore returns a poller enabling you to wait for recovery to complete. Waiting is only necessary when
-        you want to use the recovered certificate in another operation immediately.
+        Requires certificates/recover permission. When this method returns Key Vault has begun recovering the
+        certificate. Recovery may take several seconds. This method therefore returns a poller enabling you to wait for
+        recovery to complete. Waiting is only necessary when you want to use the recovered certificate in another
+        operation immediately.
 
         :param str certificate_name: The name of the deleted certificate to recover
+
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
-         :class:`~azure.keyvault.certificates.KeyVaultCertificate` without waiting for recovery to complete. If you want
-         to use the recovered certificate immediately, call the poller's `wait` method, which blocks until the
-         certificate is ready to use. The `wait` method requires certificate/get permission.
+            :class:`~azure.keyvault.certificates.KeyVaultCertificate` without waiting for recovery to complete. If you
+            want to use the recovered certificate immediately, call the poller's `wait` method, which blocks until the
+            certificate is ready to use. The `wait` method requires certificate/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.KeyVaultCertificate]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -345,19 +349,21 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def import_certificate(self, certificate_name, certificate_bytes, **kwargs):
-        # type: (str, bytes, **Any) -> KeyVaultCertificate
+    def import_certificate(
+        self, certificate_name: str, certificate_bytes: bytes, **kwargs: "Any"
+    ) -> KeyVaultCertificate:
         """Import a certificate created externally. Requires certificates/import permission.
 
         Imports an existing valid certificate, containing a private key, into Azure Key Vault. The certificate to be
         imported can be in either PFX or PEM format. If the certificate is in PEM format the PEM file must contain the
-        key as well as x509 certificates, and you must provide a ``policy``
-        with :attr:`~azure.keyvault.certificates.CertificatePolicy.content_type` of
+        key as well as x509 certificates, and you must provide a ``policy`` with
+        :attr:`~azure.keyvault.certificates.CertificatePolicy.content_type` of
         :attr:`~azure.keyvault.certificates.CertificateContentType.pem`.
 
         :param str certificate_name: The name of the certificate.
         :param bytes certificate_bytes: Bytes of the certificate object to import. This certificate
             needs to contain the private key.
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
@@ -367,8 +373,10 @@ class CertificateClient(KeyVaultClientBase):
             with :attr:`~azure.keyvault.certificates.CertificatePolicy.content_type` set to
             :attr:`~azure.keyvault.certificates.CertificateContentType.pem`.
         :paramtype policy: ~azure.keyvault.certificates.CertificatePolicy
+
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
@@ -399,15 +407,16 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_certificate_policy(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> CertificatePolicy
+    def get_certificate_policy(self, certificate_name: str, **kwargs: "Any") -> CertificatePolicy:
         """Gets the policy for a certificate. Requires certificates/get permission.
 
         Returns the specified certificate policy resources in the key vault.
 
         :param str certificate_name: The name of the certificate in a given key vault.
+
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.get_certificate_policy(
@@ -416,8 +425,9 @@ class CertificateClient(KeyVaultClientBase):
         return CertificatePolicy._from_certificate_policy_bundle(certificate_policy_bundle=bundle)
 
     @distributed_trace
-    def update_certificate_policy(self, certificate_name, policy, **kwargs):
-        # type: (str, CertificatePolicy, **Any) -> CertificatePolicy
+    def update_certificate_policy(
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs: "Any"
+    ) -> CertificatePolicy:
         """Updates the policy for a certificate. Requires certificates/update permission.
 
         Set specified members in the certificate policy. Leaves others as null.
@@ -425,8 +435,10 @@ class CertificateClient(KeyVaultClientBase):
         :param str certificate_name: The name of the certificate in the given vault.
         :param policy: The policy for the certificate.
         :type policy: ~azure.keyvault.certificates.CertificatePolicy
+
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.update_certificate_policy(
@@ -439,18 +451,21 @@ class CertificateClient(KeyVaultClientBase):
         return CertificatePolicy._from_certificate_policy_bundle(certificate_policy_bundle=bundle)
 
     @distributed_trace
-    def update_certificate_properties(self, certificate_name, version=None, **kwargs):
-        # type: (str, Optional[str], **Any) -> KeyVaultCertificate
+    def update_certificate_properties(
+        self, certificate_name: str, version: "Optional[str]" = None, **kwargs: "Any"
+    ) -> KeyVaultCertificate:
         """Change a certificate's properties. Requires certificates/update permission.
 
-        :param str certificate_name: The name of the certificate in the given key
-            vault.
+        :param str certificate_name: The name of the certificate in the given key vault.
         :param str version: The version of the certificate.
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
+
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -484,18 +499,19 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def backup_certificate(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> bytes
+    def backup_certificate(self, certificate_name: str, **kwargs: "Any") -> bytes:
         """Back up a certificate in a protected form useable only by Azure Key Vault.
 
-        Requires certificates/backup permission. This is intended to allow copying a certificate
-        from one vault to another. Both vaults must be owned by the same Azure subscription.
-        Also, backup / restore cannot be performed across geopolitical boundaries. For example, a backup
-        from a vault in a USA region cannot be restored to a vault in an EU region.
+        Requires certificates/backup permission. This is intended to allow copying a certificate from one vault to
+        another. Both vaults must be owned by the same Azure subscription. Also, backup / restore cannot be performed
+        across geopolitical boundaries. For example, a backup from a vault in a USA region cannot be restored to a vault
+        in an EU region.
 
         :param str certificate_name: The name of the certificate.
+
         :return: The backup blob containing the backed up certificate.
         :rtype: bytes
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -514,17 +530,18 @@ class CertificateClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_certificate_backup(self, backup, **kwargs):
-        # type: (bytes, **Any) -> KeyVaultCertificate
+    def restore_certificate_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultCertificate:
         """Restore a certificate backup to the vault. Requires certificates/restore permission.
 
-        This restores all versions of the certificate, with its name, attributes, and access control policies.
-        If the certificate's name is already in use, restoring it will fail. Also, the target vault must
-        be owned by the same Microsoft Azure subscription as the source vault.
+        This restores all versions of the certificate, with its name, attributes, and access control policies. If the
+        certificate's name is already in use, restoring it will fail. Also, the target vault must be owned by the same
+        Microsoft Azure subscription as the source vault.
 
         :param bytes backup: The backup blob associated with a certificate bundle.
+
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -544,19 +561,18 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def list_deleted_certificates(self, **kwargs):
-        # type: (**Any) -> ItemPaged[DeletedCertificate]
+    def list_deleted_certificates(self, **kwargs: "Any") -> "ItemPaged[DeletedCertificate]":
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
-        Requires certificates/get/list permission. Retrieves the certificates in the current vault which
-        are in a deleted state and ready for recovery or purging. This operation includes
-        deletion-specific information.
+        Requires certificates/get/list permission. Retrieves the certificates in the current vault which are in a
+        deleted state and ready for recovery or purging. This operation includes deletion-specific information.
 
-        :keyword bool include_pending: Specifies whether to include certificates which are
-         not completely deleted.
-        :return: An iterator like instance of DeletedCertificate
-        :rtype:
-         ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
+        :keyword bool include_pending: Specifies whether to include certificates which are not completely deleted.
+            Only available for API versions v7.0 and up.
+
+        :return: An iterator-like instance of DeletedCertificate
+        :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -585,17 +601,17 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_certificates(self, **kwargs):
-        # type: (**Any) -> ItemPaged[CertificateProperties]
+    def list_properties_of_certificates(self, **kwargs: "Any") -> "ItemPaged[CertificateProperties]":
         """List identifiers and properties of all certificates in the vault.
 
         Requires certificates/list permission.
 
-        :keyword bool include_pending: Specifies whether to include certificates which are not
-         completely provisioned.
-        :returns: An iterator like instance of CertificateProperties
-        :rtype:
-         ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+        :keyword bool include_pending: Specifies whether to include certificates which are not completely provisioned.
+            Only available for API versions v7.0 and up.
+
+        :returns: An iterator-like instance of CertificateProperties
+        :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -623,16 +639,18 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_certificate_versions(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> ItemPaged[CertificateProperties]
+    def list_properties_of_certificate_versions(
+        self, certificate_name: str, **kwargs: "Any"
+    ) -> "ItemPaged[CertificateProperties]":
         """List the identifiers and properties of a certificate's versions.
 
         Requires certificates/list permission.
 
         :param str certificate_name: The name of the certificate.
-        :returns: An iterator like instance of CertificateProperties
-        :rtype:
-         ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+
+        :returns: An iterator-like instance of CertificateProperties
+        :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -654,14 +672,15 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def set_contacts(self, contacts, **kwargs):
-        # type: (Iterable[CertificateContact], **Any) -> List[CertificateContact]
+    def set_contacts(self, contacts: "Iterable[CertificateContact]", **kwargs: "Any") -> "List[CertificateContact]":
         """Sets the certificate contacts for the key vault. Requires certificates/managecontacts permission.
 
         :param contacts: The contact list for the vault certificates.
         :type contacts: list[~azure.keyvault.certificates.CertificateContact]
+
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -683,12 +702,12 @@ class CertificateClient(KeyVaultClientBase):
         ]
 
     @distributed_trace
-    def get_contacts(self, **kwargs):
-        # type: (**Any) -> List[CertificateContact]
+    def get_contacts(self, **kwargs: "Any") -> "List[CertificateContact]":
         """Gets the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The certificate contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -703,12 +722,12 @@ class CertificateClient(KeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace
-    def delete_contacts(self, **kwargs):
-        # type: (**Any) -> List[CertificateContact]
+    def delete_contacts(self, **kwargs: "Any") -> "List[CertificateContact]":
         """Deletes the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -725,13 +744,14 @@ class CertificateClient(KeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace
-    def get_certificate_operation(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> CertificateOperation
+    def get_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
         """Gets the creation operation of a certificate. Requires the certificates/get permission.
 
         :param str certificate_name: The name of the certificate.
+
         :returns: The created CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -743,15 +763,16 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace
-    def delete_certificate_operation(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> CertificateOperation
+    def delete_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
         """Deletes and stops the creation operation for a specific certificate.
 
         Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
+
         :return: The deleted CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.delete_certificate_operation(
@@ -760,13 +781,14 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace
-    def cancel_certificate_operation(self, certificate_name, **kwargs):
-        # type: (str, **Any) -> CertificateOperation
+    def cancel_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
         """Cancels an in-progress certificate operation. Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
+
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.update_certificate_operation(
@@ -779,24 +801,27 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace
-    def merge_certificate(self, certificate_name, x509_certificates, **kwargs):
-        # type: (str, Iterable[bytes], **Any) -> KeyVaultCertificate
+    def merge_certificate(
+        self, certificate_name: str, x509_certificates: "Iterable[bytes]", **kwargs: "Any"
+    ) -> KeyVaultCertificate:
         """Merges a certificate or a certificate chain with a key pair existing on the server.
 
-        Requires the certificates/create permission. Performs the merging of a certificate or
-        certificate chain with a key pair currently available in the service.
-        Make sure when creating the certificate to merge using :func:`begin_create_certificate` that you set
-        its issuer to 'Unknown'. This way Key Vault knows that the certificate will not be signed
-        by an issuer known to it.
+        Requires the certificates/create permission. Performs the merging of a certificate or certificate chain with a
+        key pair currently available in the service. Make sure when creating the certificate to merge using
+        :func:`begin_create_certificate` that you set its issuer to 'Unknown'. This way Key Vault knows that the
+        certificate will not be signed by an issuer known to it.
 
         :param str certificate_name: The name of the certificate
         :param x509_certificates: The certificate or the certificate chain to merge.
         :type x509_certificates: list[bytes]
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
+
         :return: The merged certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
@@ -821,13 +846,14 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_issuer(self, issuer_name, **kwargs):
-        # type: (str, **Any) -> CertificateIssuer
+    def get_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
         """Gets the specified certificate issuer. Requires certificates/manageissuers/getissuers permission.
 
         :param str issuer_name: The name of the issuer.
+
         :return: The specified certificate issuer.
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -846,12 +872,12 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def create_issuer(self, issuer_name, provider, **kwargs):
-        # type: (str, str, **Any) -> CertificateIssuer
+    def create_issuer(self, issuer_name: str, provider: str, **kwargs: "Any") -> CertificateIssuer:
         """Sets the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
         :param str provider: The issuer provider.
+
         :keyword bool enabled: Whether the issuer is enabled for use.
         :keyword str account_id: The user name/account name/account id.
         :keyword str password: The password/secret/account key.
@@ -859,8 +885,10 @@ class CertificateClient(KeyVaultClientBase):
         :keyword admin_contacts: Contact details of the organization administrators of the
          certificate issuer.
         :paramtype admin_contacts: list[~azure.keyvault.certificates.AdministratorContact]
+
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -916,11 +944,11 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def update_issuer(self, issuer_name, **kwargs):
-        # type: (str, **Any) -> CertificateIssuer
+    def update_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
         """Updates the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
+
         :keyword bool enabled: Whether the issuer is enabled for use.
         :keyword str provider: The issuer provider
         :keyword str account_id: The user name/account name/account id.
@@ -928,8 +956,10 @@ class CertificateClient(KeyVaultClientBase):
         :keyword str organization_id: Id of the organization
         :keyword admin_contacts: Contact details of the organization administrators of the certificate issuer
         :paramtype admin_contacts: list[~azure.keyvault.certificates.AdministratorContact]
+
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
@@ -977,15 +1007,16 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def delete_issuer(self, issuer_name, **kwargs):
-        # type: (str, **Any) -> CertificateIssuer
+    def delete_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
         """Deletes the specified certificate issuer.
 
         Requires certificates/manageissuers/deleteissuers permission.
 
         :param str issuer_name: The name of the issuer.
+
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -1002,14 +1033,14 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def list_properties_of_issuers(self, **kwargs):
-        # type: (**Any) -> ItemPaged[IssuerProperties]
+    def list_properties_of_issuers(self, **kwargs: "Any") -> "ItemPaged[IssuerProperties]":
         """Lists properties of the certificate issuers for the key vault.
 
         Requires the certificates/manageissuers/getissuers permission.
 
-        :return: An iterator like instance of Issuers
+        :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -66,7 +66,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def begin_create_certificate(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs: "Any"
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs
     ) -> "LROPoller[Union[KeyVaultCertificate, CertificateOperation]]":
         """Creates a new certificate.
 
@@ -139,7 +139,7 @@ class CertificateClient(KeyVaultClientBase):
         return LROPoller(command, create_certificate_operation, lambda *_: None, create_certificate_polling)
 
     @distributed_trace
-    def get_certificate(self, certificate_name: str, **kwargs: "Any") -> KeyVaultCertificate:
+    def get_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:
         """Gets a certificate with its management policy attached. Requires certificates/get permission.
 
         Does not accept the version of the certificate as a parameter. To get a specific version of the
@@ -173,7 +173,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_certificate_version(
-        self, certificate_name: str, version: str, **kwargs: "Any"
+        self, certificate_name: str, version: str, **kwargs
     ) -> KeyVaultCertificate:
         """Gets a specific version of a certificate without returning its management policy.
 
@@ -208,7 +208,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def begin_delete_certificate(self, certificate_name: str, **kwargs: "Any") -> LROPoller[DeletedCertificate]:
+    def begin_delete_certificate(self, certificate_name: str, **kwargs) -> LROPoller[DeletedCertificate]:
         """Delete all versions of a certificate. Requires certificates/delete permission.
 
         When this method returns Key Vault has begun deleting the certificate. Deletion may take several seconds in a
@@ -255,7 +255,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> DeletedCertificate:
+    def get_deleted_certificate(self, certificate_name: str, **kwargs) -> DeletedCertificate:
         """Get a deleted certificate. Possible only in a vault with soft-delete enabled.
 
         Requires certificates/get permission. Retrieves the deleted certificate information plus its attributes, such as
@@ -284,7 +284,7 @@ class CertificateClient(KeyVaultClientBase):
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
 
     @distributed_trace
-    def purge_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> None:
+    def purge_deleted_certificate(self, certificate_name: str, **kwargs) -> None:
         """Permanently deletes a deleted certificate. Possible only in vaults with soft-delete enabled.
 
         Requires certificates/purge permission. Performs an irreversible deletion of the specified certificate, without
@@ -306,7 +306,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def begin_recover_deleted_certificate(
-        self, certificate_name: str, **kwargs: "Any"
+        self, certificate_name: str, **kwargs
     ) -> LROPoller[KeyVaultCertificate]:
         """Recover a deleted certificate to its latest version. Possible only in a vault with soft-delete enabled.
 
@@ -350,7 +350,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def import_certificate(
-        self, certificate_name: str, certificate_bytes: bytes, **kwargs: "Any"
+        self, certificate_name: str, certificate_bytes: bytes, **kwargs
     ) -> KeyVaultCertificate:
         """Import a certificate created externally. Requires certificates/import permission.
 
@@ -407,7 +407,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_certificate_policy(self, certificate_name: str, **kwargs: "Any") -> CertificatePolicy:
+    def get_certificate_policy(self, certificate_name: str, **kwargs) -> CertificatePolicy:
         """Gets the policy for a certificate. Requires certificates/get permission.
 
         Returns the specified certificate policy resources in the key vault.
@@ -426,7 +426,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def update_certificate_policy(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs: "Any"
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs
     ) -> CertificatePolicy:
         """Updates the policy for a certificate. Requires certificates/update permission.
 
@@ -452,7 +452,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def update_certificate_properties(
-        self, certificate_name: str, version: "Optional[str]" = None, **kwargs: "Any"
+        self, certificate_name: str, version: "Optional[str]" = None, **kwargs
     ) -> KeyVaultCertificate:
         """Change a certificate's properties. Requires certificates/update permission.
 
@@ -499,7 +499,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def backup_certificate(self, certificate_name: str, **kwargs: "Any") -> bytes:
+    def backup_certificate(self, certificate_name: str, **kwargs) -> bytes:
         """Back up a certificate in a protected form useable only by Azure Key Vault.
 
         Requires certificates/backup permission. This is intended to allow copying a certificate from one vault to
@@ -530,7 +530,7 @@ class CertificateClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_certificate_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultCertificate:
+    def restore_certificate_backup(self, backup: bytes, **kwargs) -> KeyVaultCertificate:
         """Restore a certificate backup to the vault. Requires certificates/restore permission.
 
         This restores all versions of the certificate, with its name, attributes, and access control policies. If the
@@ -561,7 +561,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def list_deleted_certificates(self, **kwargs: "Any") -> "ItemPaged[DeletedCertificate]":
+    def list_deleted_certificates(self, **kwargs) -> "ItemPaged[DeletedCertificate]":
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
         Requires certificates/get/list permission. Retrieves the certificates in the current vault which are in a
@@ -601,7 +601,7 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_certificates(self, **kwargs: "Any") -> "ItemPaged[CertificateProperties]":
+    def list_properties_of_certificates(self, **kwargs) -> "ItemPaged[CertificateProperties]":
         """List identifiers and properties of all certificates in the vault.
 
         Requires certificates/list permission.
@@ -640,7 +640,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_properties_of_certificate_versions(
-        self, certificate_name: str, **kwargs: "Any"
+        self, certificate_name: str, **kwargs
     ) -> "ItemPaged[CertificateProperties]":
         """List the identifiers and properties of a certificate's versions.
 
@@ -672,7 +672,7 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def set_contacts(self, contacts: "Iterable[CertificateContact]", **kwargs: "Any") -> "List[CertificateContact]":
+    def set_contacts(self, contacts: "Iterable[CertificateContact]", **kwargs) -> "List[CertificateContact]":
         """Sets the certificate contacts for the key vault. Requires certificates/managecontacts permission.
 
         :param contacts: The contact list for the vault certificates.
@@ -702,7 +702,7 @@ class CertificateClient(KeyVaultClientBase):
         ]
 
     @distributed_trace
-    def get_contacts(self, **kwargs: "Any") -> "List[CertificateContact]":
+    def get_contacts(self, **kwargs) -> "List[CertificateContact]":
         """Gets the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The certificate contacts for the key vault.
@@ -722,7 +722,7 @@ class CertificateClient(KeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace
-    def delete_contacts(self, **kwargs: "Any") -> "List[CertificateContact]":
+    def delete_contacts(self, **kwargs) -> "List[CertificateContact]":
         """Deletes the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The deleted contacts for the key vault.
@@ -744,7 +744,7 @@ class CertificateClient(KeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace
-    def get_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
+    def get_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
         """Gets the creation operation of a certificate. Requires the certificates/get permission.
 
         :param str certificate_name: The name of the certificate.
@@ -763,7 +763,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace
-    def delete_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
+    def delete_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
         """Deletes and stops the creation operation for a specific certificate.
 
         Requires the certificates/update permission.
@@ -781,7 +781,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace
-    def cancel_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
+    def cancel_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
         """Cancels an in-progress certificate operation. Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
@@ -802,7 +802,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def merge_certificate(
-        self, certificate_name: str, x509_certificates: "Iterable[bytes]", **kwargs: "Any"
+        self, certificate_name: str, x509_certificates: "Iterable[bytes]", **kwargs
     ) -> KeyVaultCertificate:
         """Merges a certificate or a certificate chain with a key pair existing on the server.
 
@@ -846,7 +846,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
+    def get_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
         """Gets the specified certificate issuer. Requires certificates/manageissuers/getissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -872,7 +872,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def create_issuer(self, issuer_name: str, provider: str, **kwargs: "Any") -> CertificateIssuer:
+    def create_issuer(self, issuer_name: str, provider: str, **kwargs) -> CertificateIssuer:
         """Sets the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -944,7 +944,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def update_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
+    def update_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
         """Updates the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -1007,7 +1007,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def delete_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
+    def delete_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
         """Deletes the specified certificate issuer.
 
         Requires certificates/manageissuers/deleteissuers permission.
@@ -1033,7 +1033,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def list_properties_of_issuers(self, **kwargs: "Any") -> "ItemPaged[IssuerProperties]":
+    def list_properties_of_issuers(self, **kwargs) -> "ItemPaged[IssuerProperties]":
         """Lists properties of the certificate issuers for the key vault.
 
         Requires the certificates/manageissuers/getissuers permission.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -33,22 +33,27 @@ class AdministratorContact(object):
     :param str phone: phone number of the issuer.
     """
 
-    def __init__(self, first_name=None, last_name=None, email=None, phone=None):
-        # type: (Optional[str], Optional[str], Optional[str], Optional[str]) -> None
+    def __init__(
+        self,
+        first_name: "Optional[str]" = None,
+        last_name: "Optional[str]" = None,
+        email: "Optional[str]" = None,
+        phone: "Optional[str]" = None,
+    ) -> None:
         self._first_name = first_name
         self._last_name = last_name
         self._phone = phone
         self._email = email
 
-    def __repr__(self):
-        # type () -> str
-        return "AdministratorContact(first_name={}, last_name={}, email={}, phone={})".format(
-            self.first_name, self.last_name, self.email, self.phone
-        )[:1024]
+    def __repr__(self) -> str:
+        result = (
+            f"AdministratorContact(first_name={self.first_name}, last_name={self.last_name}, "
+            + f"email={self.email}, phone={self.phone})"
+        )
+        return result[:1024]
 
     @classmethod
-    def _from_admin_detail(cls, admin_detail):
-        # type: (models.AdministratorDetails) -> AdministratorContact
+    def _from_admin_detail(cls, admin_detail: models.AdministratorDetails) -> "AdministratorContact":
         """Construct a AdministratorContact from an autorest-generated AdministratorDetailsBundle"""
         return cls(
             email=admin_detail.email_address,
@@ -58,26 +63,22 @@ class AdministratorContact(object):
         )
 
     @property
-    def email(self):
-        # type: () -> Optional[str]
+    def email(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._email
 
     @property
-    def first_name(self):
-        # type: () -> Optional[str]
+    def first_name(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._first_name
 
     @property
-    def last_name(self):
-        # type: () -> Optional[str]
+    def last_name(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._last_name
 
     @property
-    def phone(self):
-        # type: () -> Optional[str]
+    def phone(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._phone
 
@@ -91,19 +92,16 @@ class CertificateOperationError(object):
     :type inner_error: ~azure.keyvault.certificates.CertificateOperationError
     """
 
-    def __init__(self, code, message, inner_error):
-        # type: (str, str, CertificateOperationError) -> None
+    def __init__(self, code: str, message: str, inner_error: "CertificateOperationError") -> None:
         self._code = code
         self._message = message
         self._inner_error = inner_error
 
-    def __repr__(self):
-        # type () -> str
-        return "CertificateOperationError({}, {}, {})".format(self.code, self.message, self.inner_error)[:1024]
+    def __repr__(self) -> str:
+        return f"CertificateOperationError({self.code}, {self.message}, {self.inner_error})"[:1024]
 
     @classmethod
-    def _from_error_bundle(cls, error_bundle):
-        # type: (models.Error) -> CertificateOperationError
+    def _from_error_bundle(cls, error_bundle: models.Error) -> "CertificateOperationError":
         return cls(
             code=error_bundle.code,
             message=error_bundle.message,
@@ -111,8 +109,7 @@ class CertificateOperationError(object):
         )
 
     @property
-    def code(self):
-        # type: () -> str
+    def code(self) -> str:
         """The error code.
 
         :rtype: str
@@ -120,8 +117,7 @@ class CertificateOperationError(object):
         return self._code
 
     @property
-    def message(self):
-        # type: () -> str
+    def message(self) -> str:
         """The error message.
 
         :rtype: str
@@ -129,8 +125,7 @@ class CertificateOperationError(object):
         return self._message
 
     @property
-    def inner_error(self):
-        # type: () -> CertificateOperationError
+    def inner_error(self) -> "CertificateOperationError":
         """The error itself
 
         :return ~azure.keyvault.certificates.CertificateOperationError:
@@ -139,24 +134,22 @@ class CertificateOperationError(object):
 
 
 class CertificateProperties(object):
-    """Certificate properties consists of a certificates metadata.
-    """
+    """Certificate properties consists of a certificates metadata."""
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: "Any") -> None:
         self._attributes = kwargs.pop("attributes", None)
         self._id = kwargs.pop("cert_id", None)
         self._vault_id = KeyVaultCertificateIdentifier(self._id)
         self._x509_thumbprint = kwargs.pop("x509_thumbprint", None)
         self._tags = kwargs.pop("tags", None)
 
-    def __repr__(self):
-        # type () -> str
-        return "<CertificateProperties [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<CertificateProperties [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_certificate_item(cls, certificate_item):
-        # type: (Union[models.CertificateItem, models.CertificateBundle]) -> CertificateProperties
+    def _from_certificate_item(
+        cls, certificate_item: "Union[models.CertificateItem, models.CertificateBundle]"
+    ) -> "CertificateProperties":
         """Construct a CertificateProperties from an autorest-generated CertificateItem"""
         return cls(
             attributes=certificate_item.attributes,
@@ -166,8 +159,7 @@ class CertificateProperties(object):
         )
 
     @property
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """Certificate identifier.
 
         :rtype: str
@@ -175,8 +167,7 @@ class CertificateProperties(object):
         return self._id
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         """The name of the certificate.
 
         :rtype: str
@@ -184,8 +175,7 @@ class CertificateProperties(object):
         return self._vault_id.name
 
     @property
-    def enabled(self):
-        # type: () -> bool
+    def enabled(self) -> bool:
         """Whether the certificate is enabled or not.
 
         :rtype: bool
@@ -193,8 +183,7 @@ class CertificateProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self):
-        # type: () -> datetime
+    def not_before(self) -> "datetime":
         """The datetime before which the certificate is not valid.
 
         :rtype: ~datetime.datetime
@@ -202,8 +191,7 @@ class CertificateProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self):
-        # type: () -> datetime
+    def expires_on(self) -> "datetime":
         """The datetime when the certificate expires.
 
         :rtype: ~datetime.datetime
@@ -211,8 +199,7 @@ class CertificateProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self):
-        # type: () -> datetime
+    def created_on(self) -> "datetime":
         """The datetime when the certificate is created.
 
         :rtype: ~datetime.datetime
@@ -220,8 +207,7 @@ class CertificateProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self):
-        # type: () -> datetime
+    def updated_on(self) -> "datetime":
         """The datetime when the certificate was last updated.
 
         :rtype: ~datetime.datetime
@@ -229,8 +215,7 @@ class CertificateProperties(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def recoverable_days(self):
-        # type: () -> Optional[int]
+    def recoverable_days(self) -> "Optional[int]":
         """The number of days the certificate is retained before being deleted from a soft-delete enabled Key Vault.
 
         :rtype: int
@@ -241,8 +226,7 @@ class CertificateProperties(object):
         return None
 
     @property
-    def recovery_level(self):
-        # type: () -> models.DeletionRecoveryLevel
+    def recovery_level(self) -> models.DeletionRecoveryLevel:
         """The deletion recovery level currently in effect for the certificate.
 
         :rtype: models.DeletionRecoveryLevel
@@ -250,8 +234,7 @@ class CertificateProperties(object):
         return self._attributes.recovery_level if self._attributes else None
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         """URL of the vault containing the certificate
 
         :rtype: str
@@ -259,8 +242,7 @@ class CertificateProperties(object):
         return self._vault_id.vault_url
 
     @property
-    def x509_thumbprint(self):
-        # type: () -> bytes
+    def x509_thumbprint(self) -> bytes:
         """Thumbprint of the certificate.
 
         :rtype: bytes
@@ -268,8 +250,7 @@ class CertificateProperties(object):
         return self._x509_thumbprint
 
     @property
-    def tags(self):
-        # type: () -> Dict[str, str]
+    def tags(self) -> "Dict[str, str]":
         """Application specific metadata in the form of key-value pairs.
 
         :rtype: str
@@ -277,8 +258,7 @@ class CertificateProperties(object):
         return self._tags
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> "Optional[str]":
         """The version of the certificate
 
         :rtype: str or None
@@ -298,12 +278,11 @@ class KeyVaultCertificate(object):
 
     def __init__(
         self,
-        policy=None,  # type: Optional[CertificatePolicy]
-        properties=None,  # type: Optional[CertificateProperties]
-        cer=None,  # type: Optional[bytes]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> None
+        policy: "Optional[CertificatePolicy]" = None,
+        properties: "Optional[CertificateProperties]" = None,
+        cer: "Optional[bytes]" = None,
+        **kwargs: "Any",
+    ) -> None:
         self._properties = properties
         self._key_id = kwargs.get("key_id", None)
         self._secret_id = kwargs.get("secret_id")
@@ -312,11 +291,10 @@ class KeyVaultCertificate(object):
 
     def __repr__(self):
         # type () -> str
-        return "<KeyVaultCertificate [{}]>".format(self.id)[:1024]
+        return f"<KeyVaultCertificate [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_certificate_bundle(cls, certificate_bundle):
-        # type: (models.CertificateBundle) -> KeyVaultCertificate
+    def _from_certificate_bundle(cls, certificate_bundle: models.CertificateBundle) -> "KeyVaultCertificate":
         """Construct a certificate from an autorest-generated certificateBundle"""
         # pylint:disable=protected-access, line-too-long
 
@@ -334,8 +312,7 @@ class KeyVaultCertificate(object):
         )
 
     @property
-    def id(self):
-        # type: () -> Optional[str]
+    def id(self) -> "Optional[str]":
         """Certificate identifier.
 
         :rtype: str or None
@@ -343,8 +320,7 @@ class KeyVaultCertificate(object):
         return self._properties.id if self._properties else None
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> "Optional[str]":
         """The name of the certificate.
 
         :rtype: str or None
@@ -352,8 +328,7 @@ class KeyVaultCertificate(object):
         return self._properties.name if self._properties else None
 
     @property
-    def properties(self):
-        # type: () -> Optional[CertificateProperties]
+    def properties(self) -> "Optional[CertificateProperties]":
         """The certificate's properties
 
         :rtype: ~azure.keyvault.certificates.CertificateProperties or None
@@ -361,20 +336,17 @@ class KeyVaultCertificate(object):
         return self._properties
 
     @property
-    def key_id(self):
-        # type: () -> str
+    def key_id(self) -> str:
         """:rtype: str"""
         return self._key_id
 
     @property
-    def secret_id(self):
-        # type: () -> Optional[str]
+    def secret_id(self) -> "Optional[str]":
         """:rtype: Any or None"""
         return self._secret_id
 
     @property
-    def policy(self):
-        # type: () -> Optional[CertificatePolicy]
+    def policy(self) -> "Optional[CertificatePolicy]":
         """The management policy of the certificate.
 
         :rtype: ~azure.keyvault.certificates.CertificatePolicy or None
@@ -382,8 +354,7 @@ class KeyVaultCertificate(object):
         return self._policy
 
     @property
-    def cer(self):
-        # type: () -> Optional[bytes]
+    def cer(self) -> "Optional[bytes]":
         """The CER contents of the certificate.
 
         :rtype: bytes or None
@@ -395,7 +366,9 @@ class KeyVaultCertificateIdentifier(object):
     """Information about a KeyVaultCertificate parsed from a certificate ID.
 
     :param str source_id: the full original identifier of a certificate
+
     :raises ValueError: if the certificate ID is improperly formatted
+
     Example:
         .. literalinclude:: ../tests/test_parse_id.py
             :start-after: [START parse_key_vault_certificate_id]
@@ -405,28 +378,23 @@ class KeyVaultCertificateIdentifier(object):
             :dedent: 8
     """
 
-    def __init__(self, source_id):
-        # type: (str) -> None
+    def __init__(self, source_id: str) -> None:
         self._resource_id = parse_key_vault_id(source_id)
 
     @property
-    def source_id(self):
-        # type: () -> str
+    def source_id(self) -> str:
         return self._resource_id.source_id
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._resource_id.vault_url
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         return self._resource_id.name
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> "Optional[str]":
         return self._resource_id.version
 
 
@@ -454,19 +422,18 @@ class CertificateOperation(object):
 
     def __init__(
         self,
-        cert_operation_id=None,  # type: Optional[str]
-        issuer_name=None,  # type: Optional[Union[str, WellKnownIssuerNames]]
-        certificate_type=None,  # type: Optional[str]
-        certificate_transparency=False,  # type: Optional[bool]
-        csr=None,  # type: Optional[bytes]
-        cancellation_requested=False,  # type: Optional[bool]
-        status=None,  # type: Optional[str]
-        status_details=None,  # type: Optional[str]
-        error=None,  # type: Optional[CertificateOperationError]
-        target=None,  # type: Optional[str]
-        request_id=None,  # type: Optional[str]
-    ):
-        # type: (...) -> None
+        cert_operation_id: "Optional[str]" = None,
+        issuer_name: "Optional[Union[str, WellKnownIssuerNames]]" = None,
+        certificate_type: "Optional[str]" = None,
+        certificate_transparency: "Optional[bool]" = False,
+        csr: "Optional[bytes]" = None,
+        cancellation_requested: "Optional[bool]" = False,
+        status: "Optional[str]" = None,
+        status_details: "Optional[str]" = None,
+        error: "Optional[CertificateOperationError]" = None,
+        target: "Optional[str]" = None,
+        request_id: "Optional[str]" = None,
+    ) -> None:
         self._id = cert_operation_id
         self._vault_id = parse_key_vault_id(cert_operation_id) if cert_operation_id else None
         self._issuer_name = issuer_name
@@ -480,13 +447,13 @@ class CertificateOperation(object):
         self._target = target
         self._request_id = request_id
 
-    def __repr__(self):
-        # type () -> str
-        return "<CertificateOperation [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<CertificateOperation [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_certificate_operation_bundle(cls, certificate_operation_bundle):
-        # type: (models.CertificateOperation) -> CertificateOperation
+    def _from_certificate_operation_bundle(
+        cls, certificate_operation_bundle: models.CertificateOperation
+    ) -> "CertificateOperation":
         """Construct a CertificateOperation from an autorest-generated CertificateOperation"""
 
         issuer_parameters = certificate_operation_bundle.issuer_parameters
@@ -511,20 +478,17 @@ class CertificateOperation(object):
         )
 
     @property
-    def id(self):
-        # type: () -> Optional[str]
+    def id(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._id
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._vault_id.name if self._vault_id else None
 
     @property
-    def vault_url(self):
-        # type: () -> Optional[str]
+    def vault_url(self) -> "Optional[str]":
         """URL of the vault containing the CertificateOperation
 
         :rtype: str or None
@@ -532,8 +496,7 @@ class CertificateOperation(object):
         return self._vault_id.vault_url if self._vault_id else None
 
     @property
-    def issuer_name(self):
-        # type: () -> Union[str, WellKnownIssuerNames, None]
+    def issuer_name(self) -> "Union[str, WellKnownIssuerNames, None]":
         """The name of the issuer of the certificate.
 
         :rtype: str or ~azure.keyvault.certificates.WellKnownIssuerNames or None
@@ -541,8 +504,7 @@ class CertificateOperation(object):
         return self._issuer_name
 
     @property
-    def certificate_type(self):
-        # type: () -> Optional[str]
+    def certificate_type(self) -> "Optional[str]":
         """Type of certificate to be requested from the issuer provider.
 
         :rtype: str or None
@@ -550,8 +512,7 @@ class CertificateOperation(object):
         return self._certificate_type
 
     @property
-    def certificate_transparency(self):
-        # type: () -> Optional[bool]
+    def certificate_transparency(self) -> "Optional[bool]":
         """Whether certificates generated under this policy should be published to certificate
         transparency logs.
 
@@ -560,8 +521,7 @@ class CertificateOperation(object):
         return self._certificate_transparency
 
     @property
-    def csr(self):
-        # type: () -> Optional[bytes]
+    def csr(self) -> "Optional[bytes]":
         """The certificate signing request that is being used in this certificate operation.
 
         :rtype: bytes or None
@@ -569,8 +529,7 @@ class CertificateOperation(object):
         return self._csr
 
     @property
-    def cancellation_requested(self):
-        # type: () -> Optional[bool]
+    def cancellation_requested(self) -> "Optional[bool]":
         """Whether cancellation was requested on the certificate operation.
 
         :rtype: bool or None
@@ -578,26 +537,22 @@ class CertificateOperation(object):
         return self._cancellation_requested
 
     @property
-    def status(self):
-        # type: () -> Optional[str]
+    def status(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._status
 
     @property
-    def status_details(self):
-        # type: () -> Optional[str]
+    def status_details(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._status_details
 
     @property
-    def error(self):
-        # type: () -> Optional[CertificateOperationError]
+    def error(self) -> "Optional[CertificateOperationError]":
         """:rtype: ~azure.keyvault.certificates.CertificateOperationError or None"""
         return self._error
 
     @property
-    def target(self):
-        # type: () -> Optional[str]
+    def target(self) -> "Optional[str]":
         """Location which contains the result of the certificate operation.
 
         :rtype: str or None
@@ -605,8 +560,7 @@ class CertificateOperation(object):
         return self._target
 
     @property
-    def request_id(self):
-        # type: () -> Optional[str]
+    def request_id(self) -> "Optional[str]":
         """Identifier for the certificate operation.
 
         :rtype: str or None
@@ -620,6 +574,7 @@ class CertificatePolicy(object):
     :param Optional[str] issuer_name: Optional. Name of the referenced issuer object or reserved names; for example,
         :attr:`~azure.keyvault.certificates.WellKnownIssuerNames.self` or
         :attr:`~azure.keyvault.certificates.WellKnownIssuerNames.unknown`
+
     :keyword str subject: The subject name of the certificate. Should be a valid X509
         distinguished name. Either subject or one of the subject alternative name parameters are required for
         creating a certificate. This will be ignored when importing a certificate; the subject will be parsed from
@@ -654,16 +609,14 @@ class CertificatePolicy(object):
     :keyword str certificate_type: Type of certificate to be requested from the issuer provider.
     :keyword bool certificate_transparency: Indicates if the certificates generated under this policy
         should be published to certificate transparency logs.
-
     """
 
     # pylint:disable=too-many-instance-attributes
     def __init__(
         self,
-        issuer_name=None,  # type: Optional[str]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> None
+        issuer_name: "Optional[str]" = None,
+        **kwargs: "Any",
+    ) -> None:
         self._issuer_name = issuer_name
         self._subject = kwargs.pop("subject", None)
         self._attributes = kwargs.pop("attributes", None)
@@ -684,16 +637,13 @@ class CertificatePolicy(object):
         self._san_user_principal_names = kwargs.pop("san_user_principal_names", None) or None
 
     @classmethod
-    def get_default(cls):
+    def get_default(cls) -> "CertificatePolicy":
         return cls(issuer_name=WellKnownIssuerNames.self, subject="CN=DefaultPolicy")
 
-    def __repr__(self):
-        # type () -> str
-        return "<CertificatePolicy [issuer_name: {}]>".format(self.issuer_name)[:1024]
+    def __repr__(self) -> str:
+        return f"<CertificatePolicy [issuer_name: {self.issuer_name}]>"[:1024]
 
-    def _to_certificate_policy_bundle(self):
-        # type: (CertificatePolicy) -> models.CertificatePolicy
-
+    def _to_certificate_policy_bundle(self) -> models.CertificatePolicy:
         """Construct a version emulating the generated CertificatePolicy from a wrapped CertificatePolicy"""
         if self.issuer_name or self.certificate_type or self.certificate_transparency:
             issuer_parameters = models.IssuerParameters(
@@ -791,8 +741,9 @@ class CertificatePolicy(object):
         return policy_bundle
 
     @classmethod
-    def _from_certificate_policy_bundle(cls, certificate_policy_bundle):
-        # type: (Optional[models.CertificatePolicy]) -> CertificatePolicy
+    def _from_certificate_policy_bundle(
+        cls, certificate_policy_bundle: "Optional[models.CertificatePolicy]"
+    ) -> "CertificatePolicy":
         """Construct a CertificatePolicy from an autorest-generated CertificatePolicy"""
         if certificate_policy_bundle is None:
             return cls()
@@ -863,8 +814,7 @@ class CertificatePolicy(object):
         )
 
     @property
-    def exportable(self):
-        # type: () -> bool
+    def exportable(self) -> bool:
         """Whether the private key can be exported.
 
         :rtype: bool
@@ -872,8 +822,7 @@ class CertificatePolicy(object):
         return self._exportable
 
     @property
-    def key_type(self):
-        # type: () -> KeyType
+    def key_type(self) -> KeyType:
         """The type of key pair to be used for the certificate.
 
         :rtype: ~azure.keyvault.certificates.KeyType
@@ -881,8 +830,7 @@ class CertificatePolicy(object):
         return self._key_type
 
     @property
-    def key_size(self):
-        # type: () -> int
+    def key_size(self) -> int:
         """The key size in bits.
 
         :rtype: int
@@ -890,8 +838,7 @@ class CertificatePolicy(object):
         return self._key_size
 
     @property
-    def reuse_key(self):
-        # type: () -> bool
+    def reuse_key(self) -> bool:
         """Whether the same key pair will be used on certificate renewal.
 
         :rtype: bool
@@ -899,8 +846,7 @@ class CertificatePolicy(object):
         return self._reuse_key
 
     @property
-    def key_curve_name(self):
-        # type: () -> KeyCurveName
+    def key_curve_name(self) -> KeyCurveName:
         """Elliptic curve name.
 
         :rtype: ~azure.keyvault.certificates.KeyCurveName
@@ -908,8 +854,7 @@ class CertificatePolicy(object):
         return self._key_curve_name
 
     @property
-    def enhanced_key_usage(self):
-        # type: () -> List[str]
+    def enhanced_key_usage(self) -> "List[str]":
         """The enhanced key usage.
 
         :rtype: list[str]
@@ -917,8 +862,7 @@ class CertificatePolicy(object):
         return self._enhanced_key_usage
 
     @property
-    def key_usage(self):
-        # type: () -> List[KeyUsageType]
+    def key_usage(self) -> "List[KeyUsageType]":
         """List of key usages.
 
         :rtype: list[~azure.keyvault.certificates.KeyUsageType]
@@ -926,8 +870,7 @@ class CertificatePolicy(object):
         return self._key_usage
 
     @property
-    def content_type(self):
-        # type: () -> CertificateContentType
+    def content_type(self) -> CertificateContentType:
         """The media type (MIME type).
 
         :rtype: ~azure.keyvault.certificates.CertificateContentType
@@ -935,8 +878,7 @@ class CertificatePolicy(object):
         return self._content_type
 
     @property
-    def subject(self):
-        # type: () -> str
+    def subject(self) -> str:
         """The subject name of the certificate.
 
         :rtype: str
@@ -944,8 +886,7 @@ class CertificatePolicy(object):
         return self._subject
 
     @property
-    def san_emails(self):
-        # type: () -> Optional[Any]
+    def san_emails(self) -> "Optional[Any]":
         """The subject alternative email addresses.
 
         :rtype: Any or None
@@ -953,8 +894,7 @@ class CertificatePolicy(object):
         return self._san_emails
 
     @property
-    def san_dns_names(self):
-        # type: () -> Optional[Any]
+    def san_dns_names(self) -> "Optional[Any]":
         """The subject alternative domain names.
 
         :rtype: Any or None
@@ -962,8 +902,7 @@ class CertificatePolicy(object):
         return self._san_dns_names
 
     @property
-    def san_user_principal_names(self):
-        # type: () -> Optional[Any]
+    def san_user_principal_names(self) -> "Optional[Any]":
         """The subject alternative user principal names.
 
         :rtype: Any or None
@@ -971,8 +910,7 @@ class CertificatePolicy(object):
         return self._san_user_principal_names
 
     @property
-    def validity_in_months(self):
-        # type: () -> int
+    def validity_in_months(self) -> int:
         """The duration that the certificate is valid for in months.
 
         :rtype: int
@@ -980,8 +918,7 @@ class CertificatePolicy(object):
         return self._validity_in_months
 
     @property
-    def lifetime_actions(self):
-        # type: () -> List[LifetimeAction]
+    def lifetime_actions(self) -> "List[LifetimeAction]":
         """Actions and their triggers that will be performed by Key Vault over
         the lifetime of the certificate.
 
@@ -990,8 +927,7 @@ class CertificatePolicy(object):
         return self._lifetime_actions
 
     @property
-    def issuer_name(self):
-        # type: () -> Optional[str]
+    def issuer_name(self) -> "Optional[str]":
         """Name of the referenced issuer object or reserved names for the issuer
         of the certificate.
 
@@ -1000,8 +936,7 @@ class CertificatePolicy(object):
         return self._issuer_name
 
     @property
-    def certificate_type(self):
-        # type: () -> str
+    def certificate_type(self) -> str:
         """Type of certificate requested from the issuer provider.
 
         :rtype: str
@@ -1009,8 +944,7 @@ class CertificatePolicy(object):
         return self._certificate_type
 
     @property
-    def certificate_transparency(self):
-        # type: () -> bool
+    def certificate_transparency(self) -> bool:
         """Whether the certificates generated under this policy should be published
         to certificate transparency logs.
 
@@ -1019,8 +953,7 @@ class CertificatePolicy(object):
         return self._certificate_transparency
 
     @property
-    def enabled(self):
-        # type: () -> bool
+    def enabled(self) -> bool:
         """Whether the certificate is enabled or not.
 
         :rtype: bool
@@ -1028,8 +961,7 @@ class CertificatePolicy(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def created_on(self):
-        # type: () -> datetime
+    def created_on(self) -> "datetime":
         """The datetime when the certificate is created.
 
         :rtype: ~datetime.datetime
@@ -1037,8 +969,7 @@ class CertificatePolicy(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self):
-        # type: () -> datetime
+    def updated_on(self) -> "datetime":
         """The datetime when the certificate was last updated.
 
         :rtype: ~datetime.datetime
@@ -1054,41 +985,36 @@ class CertificateContact(object):
     :param str phone: phone number of a contact for the certificate.
     """
 
-    def __init__(self, email=None, name=None, phone=None):
-        # type: (Optional[str], Optional[str], Optional[str]) -> None
+    def __init__(
+        self, email: "Optional[str]" = None, name: "Optional[str]" = None, phone: "Optional[str]" = None
+    ) -> None:
         self._email = email
         self._name = name
         self._phone = phone
 
-    def __repr__(self):
-        # type () -> str
-        return "CertificateContact(email={}, name={}, phone={})".format(self.email, self.name, self.phone)[:1024]
+    def __repr__(self) -> str:
+        return f"CertificateContact(email={self.email}, name={self.name}, phone={self.phone})"[:1024]
 
-    def _to_certificate_contacts_item(self):
-        # type: (CertificateContact) -> models.Contact
+    def _to_certificate_contacts_item(self) -> models.Contact:
         return models.Contact(email_address=self.email, name=self.name, phone=self.phone)
 
     @classmethod
-    def _from_certificate_contacts_item(cls, contact_item):
-        # type: (models.Contact) -> CertificateContact
+    def _from_certificate_contacts_item(cls, contact_item: models.Contact) -> "CertificateContact":
         """Construct a CertificateContact from an autorest-generated ContactItem."""
         return cls(email=contact_item.email_address, name=contact_item.name, phone=contact_item.phone)
 
     @property
-    def email(self):
-        # type: () -> Optional[str]
+    def email(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._email
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._name
 
     @property
-    def phone(self):
-        # type: () -> Optional[str]
+    def phone(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._phone
 
@@ -1099,38 +1025,34 @@ class IssuerProperties(object):
     :param str provider: The issuer provider.
     """
 
-    def __init__(self, provider=None, **kwargs):
-        # type: (Optional[str], **Any) -> None
+    def __init__(self, provider: "Optional[str]" = None, **kwargs: "Any") -> None:
         self._id = kwargs.pop("issuer_id", None)
         self._vault_id = parse_key_vault_id(self._id)
         self._provider = provider
 
-    def __repr__(self):
-        # type () -> str
-        return "IssuerProperties(issuer_id={}, provider={})".format(self.id, self.provider)[:1024]
+    def __repr__(self) -> str:
+        return f"IssuerProperties(issuer_id={self.id}, provider={self.provider})"[:1024]
 
     @classmethod
-    def _from_issuer_item(cls, issuer_item):
-        # type: (Union[models.CertificateIssuerItem, models.IssuerBundle]) -> IssuerProperties
+    def _from_issuer_item(
+        cls, issuer_item: "Union[models.CertificateIssuerItem, models.IssuerBundle]"
+    ) -> "IssuerProperties":
         """Construct a IssuerProperties from an autorest-generated CertificateIssuerItem"""
         return cls(issuer_id=issuer_item.id, provider=issuer_item.provider)
 
     @property
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """:rtype: str"""
         return self._id
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
-        # Issuer name is listed under version under vault_id
+    def name(self) -> "Optional[str]":
         """:rtype: str or None"""
+        # Issuer name is listed under version under vault_id
         return self._vault_id.version
 
     @property
-    def provider(self):
-        # type: () -> Optional[str]
+    def provider(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._provider
 
@@ -1148,15 +1070,14 @@ class CertificateIssuer(object):
 
     def __init__(
         self,
-        provider,  # type: Optional[str]
-        attributes=None,  # type: Optional[models.IssuerAttributes]
-        account_id=None,  # type: Optional[str]
-        password=None,  # type: Optional[str]
-        organization_id=None,  # type: Optional[str]
-        admin_contacts=None,  # type: Optional[List[AdministratorContact]]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> None
+        provider: "Optional[str]",
+        attributes: "Optional[models.IssuerAttributes]" = None,
+        account_id: "Optional[str]" = None,
+        password: "Optional[str]" = None,
+        organization_id: "Optional[str]" = None,
+        admin_contacts: "Optional[List[AdministratorContact]]" = None,
+        **kwargs: "Any",
+    ) -> None:
         self._provider = provider
         self._attributes = attributes
         self._account_id = account_id
@@ -1166,13 +1087,11 @@ class CertificateIssuer(object):
         self._id = kwargs.pop("issuer_id", None)
         self._vault_id = parse_key_vault_id(self._id)
 
-    def __repr__(self):
-        # type () -> str
-        return "<CertificateIssuer [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<CertificateIssuer [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_issuer_bundle(cls, issuer_bundle):
-        # type: (models.IssuerBundle) -> CertificateIssuer
+    def _from_issuer_bundle(cls, issuer_bundle: models.IssuerBundle) -> "CertificateIssuer":
         """Construct a CertificateIssuer from an autorest-generated IssuerBundle"""
         admin_contacts = []
         admin_details = (
@@ -1193,24 +1112,21 @@ class CertificateIssuer(object):
         )
 
     @property
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """:rtype: str"""
         return self._id
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> "Optional[str]":
+        """:rtype: str or None"""
         # Issuer name is listed under version under vault_id.
         # This is because the id we pass to parse_key_vault_id has an extra segment, so where most cases the version of
         # the general pattern is certificates/name/version, but here we have certificates/issuers/name/version.
         # Issuers are not versioned.
-        """:rtype: str or None"""
         return self._vault_id.version
 
     @property
-    def provider(self):
-        # type: () -> Optional[str]
+    def provider(self) -> "Optional[str]":
         """The issuer provider.
 
         :rtype: str or None
@@ -1218,8 +1134,7 @@ class CertificateIssuer(object):
         return self._provider
 
     @property
-    def enabled(self):
-        # type: () -> Optional[bool]
+    def enabled(self) -> "Optional[bool]":
         """Whether the certificate is enabled or not.
 
         :rtype: bool or None
@@ -1227,8 +1142,7 @@ class CertificateIssuer(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def created_on(self):
-        # type: () -> Optional[datetime]
+    def created_on(self) -> "Optional[datetime]":
         """The datetime when the certificate is created.
 
         :rtype: ~datetime.datetime or None
@@ -1236,8 +1150,7 @@ class CertificateIssuer(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self):
-        # type: () -> Optional[datetime]
+    def updated_on(self) -> "Optional[datetime]":
         """The datetime when the certificate was last updated.
 
         :rtype: ~datetime.datetime or None
@@ -1245,8 +1158,7 @@ class CertificateIssuer(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def account_id(self):
-        # type: () -> Optional[str]
+    def account_id(self) -> "Optional[str]":
         """The username/ account name/ account id.
 
         :rtype: str or None
@@ -1254,8 +1166,7 @@ class CertificateIssuer(object):
         return self._account_id
 
     @property
-    def password(self):
-        # type: () -> Optional[str]
+    def password(self) -> "Optional[str]":
         """The password / secret / account key.
 
         :rtype: str or None
@@ -1263,14 +1174,12 @@ class CertificateIssuer(object):
         return self._password
 
     @property
-    def organization_id(self):
-        # type: () -> Optional[str]
+    def organization_id(self) -> "Optional[str]":
         """:rtype: str or None"""
         return self._organization_id
 
     @property
-    def admin_contacts(self):
-        # type: () -> Optional[List[AdministratorContact]]
+    def admin_contacts(self) -> "Optional[List[AdministratorContact]]":
         """Contact details of the organization administrator of this issuer.
 
         :rtype: list[~azure.keyvault.certificates.AdministratorContact] or None
@@ -1279,33 +1188,35 @@ class CertificateIssuer(object):
 
 
 class LifetimeAction(object):
-    """Action and its trigger that will be performed by certificate Vault over the
-    lifetime of a certificate.
+    """Action and its trigger that will be performed by certificate Vault over the lifetime of a certificate.
 
     :param action: The type of the action. For valid values, see CertificatePolicyAction
     :type action: str or ~azure.keyvault.certificates.CertificatePolicyAction
-    :param int lifetime_percentage: Percentage of lifetime at which to trigger. Value
-        should be between 1 and 99.
-    :param int days_before_expiry: Days before expiry to attempt renewal. Value should be between
-        1 and validity_in_months multiplied by 27. I.e., if validity_in_months is 36, then value
-        should be between 1 and 972 (36 * 27).
+    :param int lifetime_percentage: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+    :param int days_before_expiry: Days before expiry to attempt renewal. Value should be between 1 and
+        `validity_in_months` multiplied by 27. I.e., if validity_in_months is 36, then value should be between 1 and 972
+        (36 * 27).
     """
 
-    def __init__(self, action, lifetime_percentage=None, days_before_expiry=None):
-        # type: (Optional[CertificatePolicyAction], Optional[int], Optional[int]) -> None
+    def __init__(
+        self,
+        action: "Optional[CertificatePolicyAction]",
+        lifetime_percentage: "Optional[int]" = None,
+        days_before_expiry: "Optional[int]" = None,
+    ) -> None:
         self._lifetime_percentage = lifetime_percentage
         self._days_before_expiry = days_before_expiry
         self._action = action
 
-    def __repr__(self):
-        # type () -> str
-        return "LifetimeAction(action={}, lifetime_percentage={}, days_before_expiry={})".format(
-            self.action, self.lifetime_percentage, self.days_before_expiry
-        )[:1024]
+    def __repr__(self) -> str:
+        result = (
+            f"LifetimeAction(action={self.action}, lifetime_percentage={self.lifetime_percentage}, "
+            + f"days_before_expiry={self.days_before_expiry})"
+        )
+        return result[:1024]
 
     @property
-    def lifetime_percentage(self):
-        # type: () -> Optional[int]
+    def lifetime_percentage(self) -> "Optional[int]":
         """Percentage of lifetime at which to trigger.
 
         :rtype: int or None
@@ -1313,8 +1224,7 @@ class LifetimeAction(object):
         return self._lifetime_percentage
 
     @property
-    def days_before_expiry(self):
-        # type: () -> Optional[int]
+    def days_before_expiry(self) -> "Optional[int]":
         """Days before expiry to attempt renewal.
 
         :rtype: int or None
@@ -1322,10 +1232,8 @@ class LifetimeAction(object):
         return self._days_before_expiry
 
     @property
-    def action(self):
-        # type: () -> Optional[CertificatePolicyAction]
-        """The type of the action that will be executed.
-        Valid values are "EmailContacts" and "AutoRenew"
+    def action(self) -> "Optional[CertificatePolicyAction]":
+        """The type of the action that will be executed. Valid values are "EmailContacts" and "AutoRenew".
 
         :rtype: ~azure.keyvault.certificates.CertificatePolicyAction or None
         """
@@ -1333,39 +1241,35 @@ class LifetimeAction(object):
 
 
 class DeletedCertificate(KeyVaultCertificate):
-    """A Deleted Certificate consisting of its previous id, attributes and its
-    tags, as well as information on when it will be purged.
+    """A deleted Certificate consisting of its previous ID, attributes, tags, and information on when it will be purged.
 
     :param policy: The management policy of the deleted certificate.
     :type policy: ~azure.keyvault.certificates.CertificatePolicy
     :param bytearray cer: CER contents of the X509 certificate.
-    :param datetime deleted_on: The time when the certificate was deleted, in UTC
-    :param str recovery_id: The url of the recovery object, used to identify and
-        recover the deleted certificate.
-    :param datetime scheduled_purge_date: The time when the certificate is scheduled to
-        be purged, in UTC
+    :param datetime deleted_on: The time when the certificate was deleted, in UTC.
+    :param str recovery_id: The url of the recovery object, used to identify and recover the deleted certificate.
+    :param datetime scheduled_purge_date: The time when the certificate is scheduled to be purged, in UTC.
     """
 
     def __init__(
         self,
-        properties=None,  # type: Optional[CertificateProperties]
-        policy=None,  # type: Optional[CertificatePolicy]
-        cer=None,  # type: Optional[bytes]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> None
+        properties: "Optional[CertificateProperties]" = None,
+        policy: "Optional[CertificatePolicy]" = None,
+        cer: "Optional[bytes]" = None,
+        **kwargs: "Any",
+    ) -> None:
         super(DeletedCertificate, self).__init__(properties=properties, policy=policy, cer=cer, **kwargs)
         self._deleted_on = kwargs.get("deleted_on", None)
         self._recovery_id = kwargs.get("recovery_id", None)
         self._scheduled_purge_date = kwargs.get("scheduled_purge_date", None)
 
-    def __repr__(self):
-        # type () -> str
-        return "<DeletedCertificate [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<DeletedCertificate [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_deleted_certificate_item(cls, deleted_certificate_item):
-        # type: (models.DeletedCertificateItem) -> DeletedCertificate
+    def _from_deleted_certificate_item(
+        cls, deleted_certificate_item: models.DeletedCertificateItem
+    ) -> "DeletedCertificate":
         """Construct a DeletedCertificate from an autorest-generated DeletedCertificateItem"""
         return cls(
             properties=CertificateProperties._from_certificate_item(  # pylint: disable=protected-access
@@ -1381,8 +1285,9 @@ class DeletedCertificate(KeyVaultCertificate):
         )
 
     @classmethod
-    def _from_deleted_certificate_bundle(cls, deleted_certificate_bundle):
-        # type: (models.DeletedCertificateBundle) -> DeletedCertificate
+    def _from_deleted_certificate_bundle(
+        cls, deleted_certificate_bundle: models.DeletedCertificateBundle
+    ) -> "DeletedCertificate":
         """Construct a DeletedCertificate from an autorest-generated DeletedCertificateItem"""
         # pylint:disable=protected-access
         return cls(
@@ -1397,8 +1302,7 @@ class DeletedCertificate(KeyVaultCertificate):
         )
 
     @property
-    def deleted_on(self):
-        # type: () -> datetime
+    def deleted_on(self) -> "datetime":
         """The datetime that the certificate was deleted.
 
         :rtype: ~datetime.datetime
@@ -1406,8 +1310,7 @@ class DeletedCertificate(KeyVaultCertificate):
         return self._deleted_on
 
     @property
-    def recovery_id(self):
-        # type: () -> str
+    def recovery_id(self) -> str:
         """The url of the recovery object, used to identify and recover the deleted certificate.
 
         :rtype: str
@@ -1415,8 +1318,7 @@ class DeletedCertificate(KeyVaultCertificate):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self):
-        # type: () -> datetime
+    def scheduled_purge_date(self) -> "datetime":
         """The datetime when the certificate is scheduled to be purged.
 
         :rtype: str

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -136,7 +136,7 @@ class CertificateOperationError(object):
 class CertificateProperties(object):
     """Certificate properties consists of a certificates metadata."""
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self._attributes = kwargs.pop("attributes", None)
         self._id = kwargs.pop("cert_id", None)
         self._vault_id = KeyVaultCertificateIdentifier(self._id)
@@ -281,7 +281,7 @@ class KeyVaultCertificate(object):
         policy: "Optional[CertificatePolicy]" = None,
         properties: "Optional[CertificateProperties]" = None,
         cer: "Optional[bytes]" = None,
-        **kwargs: "Any",
+        **kwargs,
     ) -> None:
         self._properties = properties
         self._key_id = kwargs.get("key_id", None)
@@ -615,7 +615,7 @@ class CertificatePolicy(object):
     def __init__(
         self,
         issuer_name: "Optional[str]" = None,
-        **kwargs: "Any",
+        **kwargs,
     ) -> None:
         self._issuer_name = issuer_name
         self._subject = kwargs.pop("subject", None)
@@ -1025,7 +1025,7 @@ class IssuerProperties(object):
     :param str provider: The issuer provider.
     """
 
-    def __init__(self, provider: "Optional[str]" = None, **kwargs: "Any") -> None:
+    def __init__(self, provider: "Optional[str]" = None, **kwargs) -> None:
         self._id = kwargs.pop("issuer_id", None)
         self._vault_id = parse_key_vault_id(self._id)
         self._provider = provider
@@ -1076,7 +1076,7 @@ class CertificateIssuer(object):
         password: "Optional[str]" = None,
         organization_id: "Optional[str]" = None,
         admin_contacts: "Optional[List[AdministratorContact]]" = None,
-        **kwargs: "Any",
+        **kwargs,
     ) -> None:
         self._provider = provider
         self._attributes = attributes
@@ -1256,7 +1256,7 @@ class DeletedCertificate(KeyVaultCertificate):
         properties: "Optional[CertificateProperties]" = None,
         policy: "Optional[CertificatePolicy]" = None,
         cer: "Optional[bytes]" = None,
-        **kwargs: "Any",
+        **kwargs,
     ) -> None:
         super(DeletedCertificate, self).__init__(properties=properties, policy=policy, cer=cer, **kwargs)
         self._deleted_on = kwargs.get("deleted_on", None)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_sdk_moniker.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_sdk_moniker.py
@@ -4,4 +4,4 @@
 # ------------------------------------
 from ._version import VERSION
 
-SDK_MONIKER = "keyvault-certificates/{}".format(VERSION)
+SDK_MONIKER = f"keyvault-certificates/{VERSION}"

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
@@ -2,13 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    import urllib.parse as parse
-except ImportError:
-    # pylint:disable=import-error
-    import urlparse as parse  # type: ignore
-
 from typing import TYPE_CHECKING
+from urllib import parse
+
 from .challenge_auth_policy import ChallengeAuthPolicy
 from .client_base import KeyVaultClientBase
 from .http_challenge import HttpChallenge
@@ -39,32 +35,31 @@ class KeyVaultResourceId():
 
     def __init__(
         self,
-        source_id,  # type: str
-        vault_url,  # type: str
-        name,  # type: str
-        version=None  # type: Optional[str]
-    ):
+        source_id: str,
+        vault_url: str,
+        name: str,
+        version: "Optional[str]" = None,
+    ) -> None:
         self.source_id = source_id
         self.vault_url = vault_url
         self.name = name
         self.version = version
 
 
-def parse_key_vault_id(source_id):
-    # type: (str) -> KeyVaultResourceId
+def parse_key_vault_id(source_id: str) -> KeyVaultResourceId:
     try:
         parsed_uri = parse.urlparse(source_id)
     except Exception:  # pylint: disable=broad-except
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
     if not (parsed_uri.scheme and parsed_uri.hostname):
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
 
     path = list(filter(None, parsed_uri.path.split("/")))
 
     if len(path) < 2 or len(path) > 3:
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
 
-    vault_url = "{}://{}".format(parsed_uri.scheme, parsed_uri.hostname)
+    vault_url = f"{parsed_uri.scheme}://{parsed_uri.hostname}"
     if parsed_uri.port:
         vault_url += f":{parsed_uri.port}"
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
@@ -11,17 +11,12 @@ from typing import TYPE_CHECKING
 from azure.core.polling import PollingMethod, LROPoller, NoPolling
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
-try:
-    from urlparse import urlparse  # type: ignore # pylint: disable=unused-import
-except ImportError:
-    from urllib.parse import urlparse
-
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.common import with_current_context
 
 if TYPE_CHECKING:
     # pylint: disable=ungrouped-imports
-    from typing import Any, Callable, Union, List, Optional
+    from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -31,37 +26,35 @@ class KeyVaultOperationPoller(LROPoller):
     """
 
     # pylint: disable=arguments-differ
-    def __init__(self, polling_method):
-        # type: (PollingMethod) -> None
+    def __init__(self, polling_method: PollingMethod) -> None:
         super(KeyVaultOperationPoller, self).__init__(None, None, lambda *_: None, NoPolling())
         self._polling_method = polling_method
 
     # pylint: disable=arguments-differ
-    def result(self):  # type: ignore
-        # type: () -> Any
+    def result(self) -> "Any":  # type: ignore
         """Returns a representation of the final resource without waiting for the operation to complete.
 
         :returns: The deserialized resource of the long running operation
+
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """
         return self._polling_method.resource()
 
     @distributed_trace
-    def wait(self, timeout=None):
-        # type: (Optional[float]) -> None
+    def wait(self, timeout: "Optional[float]" = None) -> None:
         """Wait on the long running operation for a number of seconds.
 
         You can check if this call has ended with timeout with the "done()" method.
 
-        :param float timeout: Period of time to wait for the long running
-         operation to complete (in seconds).
+        :param float timeout: Period of time to wait for the long running operation to complete (in seconds).
+
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """
 
         if not self._polling_method.finished():
             self._done = threading.Event()
             self._thread = threading.Thread(
-                target=with_current_context(self._start), name="KeyVaultOperationPoller({})".format(uuid.uuid4())
+                target=with_current_context(self._start), name=f"KeyVaultOperationPoller({uuid.uuid4()})"
             )
             self._thread.daemon = True
             self._thread.start()
@@ -87,14 +80,13 @@ class DeleteRecoverPollingMethod(PollingMethod):
     Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
     resource; when it responds 2xx, the resource exists in the non-deleted collection, i.e. its recovery is complete.
     """
-    def __init__(self, command, final_resource, finished, interval=2):
+    def __init__(self, command: "Callable", final_resource: "Any", finished: bool, interval: int = 2) -> None:
         self._command = command
         self._resource = final_resource
         self._polling_interval = interval
         self._finished = finished
 
-    def _update_status(self):
-        # type: () -> None
+    def _update_status(self) -> None:
         try:
             self._command()
             self._finished = True
@@ -108,11 +100,10 @@ class DeleteRecoverPollingMethod(PollingMethod):
             else:
                 raise
 
-    def initialize(self, client, initial_response, deserialization_callback):
+    def initialize(self, client: "Any", initial_response: "Any", deserialization_callback: "Callable") -> None:
         pass
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         try:
             while not self.finished():
                 self._update_status()
@@ -122,14 +113,11 @@ class DeleteRecoverPollingMethod(PollingMethod):
             logger.warning(str(e))
             raise
 
-    def finished(self):
-        # type: () -> bool
+    def finished(self) -> bool:
         return self._finished
 
-    def resource(self):
-        # type: () -> Any
+    def resource(self) -> "Any":
         return self._resource
 
-    def status(self):
-        # type: () -> str
+    def status(self) -> str:
         return "finished" if self._finished else "polling"

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -50,7 +50,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 
 class AsyncKeyVaultClientBase(object):
+    # pylint:disable=protected-access
     def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -3,20 +3,20 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from typing import TYPE_CHECKING
+
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.tracing.decorator_async import distributed_trace_async
+
 from . import AsyncChallengeAuthPolicy
-from .client_base import ApiVersion, DEFAULT_VERSION
+from .client_base import ApiVersion, DEFAULT_VERSION, _format_api_version, _SERIALIZER
 from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 
 if TYPE_CHECKING:
-    try:
-        # pylint:disable=unused-import
-        from typing import Any
-        from azure.core.credentials_async import AsyncTokenCredential
-    except ImportError:
-        # AsyncTokenCredential is a typing_extensions.Protocol; we don't depend on that package
-        pass
+    # pylint:disable=unused-import
+    from typing import Any
+    from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 
 class AsyncKeyVaultClientBase(object):
@@ -60,8 +60,8 @@ class AsyncKeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=self.api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(self.api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{self.api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property
@@ -81,3 +81,25 @@ class AsyncKeyVaultClientBase(object):
         Calling this method is unnecessary when using the client as a context manager.
         """
         await self._client.close()
+
+    @distributed_trace_async
+    async def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "AsyncHttpResponse":
+        """Runs a network request using the client's existing pipeline.
+
+        The request URL can be relative to the vault URL. The service API version used for the request is the same as
+        the client's unless otherwise specified. This method does not raise if the response is an error; to raise an
+        exception, call `raise_for_status()` on the returned response object. For more information about how to send
+        custom requests with this method, see https://aka.ms/azsdk/dpcodegen/python/send_request.
+
+        :param request: The network request you want to make.
+        :type request: ~azure.core.rest.HttpRequest
+
+        :return: The response of your network call. Does not do error handling on your response.
+        :rtype: ~azure.core.rest.AsyncHttpResponse
+        """
+        request_copy = _format_api_version(request, self.api_version)
+        path_format_arguments = {
+            "vaultBaseUrl": _SERIALIZER.url("vault_base_url", self._vault_url, "str", skip_quote=True),
+        }
+        request_copy.url = self._client._client.format_url(request_copy.url, **path_format_arguments)
+        return await self._client._client.send_request(request_copy, **kwargs)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -84,7 +84,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    async def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "AsyncHttpResponse":
+    async def send_request(self, request: "HttpRequest", **kwargs) -> "AsyncHttpResponse":
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -35,17 +35,15 @@ if TYPE_CHECKING:
     from azure.core.pipeline import PipelineResponse
 
 
-def _enforce_tls(request):
-    # type: (PipelineRequest) -> None
+def _enforce_tls(request: PipelineRequest) -> None:
     if not request.http_request.url.lower().startswith("https"):
         raise ServiceRequestError(
             "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
         )
 
 
-def _update_challenge(request, challenger):
-    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
-    """parse challenge from challenger, cache it, return it"""
+def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") -> HttpChallenge:
+    """Parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
         request.http_request.url,
@@ -57,17 +55,15 @@ def _update_challenge(request, challenger):
 
 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
-    """policy for handling HTTP authentication challenges"""
+    """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential, *scopes, **kwargs):
-        # type: (TokenCredential, *str, **Any) -> None
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    def on_request(self, request):
-        # type: (PipelineRequest) -> None
+    def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -78,7 +74,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,
@@ -90,8 +86,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
             request.http_request.set_json_body(None)
             request.http_request.headers["Content-Length"] = "0"
 
-    def on_challenge(self, request, response):
-        # type: (PipelineRequest, PipelineResponse) -> bool
+    def on_challenge(self, request: PipelineRequest, response: "PipelineResponse") -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
@@ -119,6 +114,5 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         return True
 
     @property
-    def _need_new_token(self):
-        # type: () -> bool
+    def _need_new_token(self) -> bool:
         return not self._token or self._token.expires_on - time.time() < 300

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -57,7 +57,7 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -61,6 +61,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 
 class KeyVaultClientBase(object):
+    # pylint:disable=protected-access
     def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -2,20 +2,25 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from copy import deepcopy
 from typing import TYPE_CHECKING
 from enum import Enum
+from urllib.parse import urlparse
 
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.tracing.decorator import distributed_trace
 
 from . import ChallengeAuthPolicy
 from .._generated import KeyVaultClient as _KeyVaultClient
+from .._generated._serialization import Serializer
 from .._sdk_moniker import SDK_MONIKER
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any
     from azure.core.credentials import TokenCredential
+    from azure.core.rest import HttpRequest, HttpResponse
 
 
 class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -31,10 +36,32 @@ class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
 
 DEFAULT_VERSION = ApiVersion.V7_3
 
+_SERIALIZER = Serializer()
+_SERIALIZER.client_side_validation = False
+
+
+def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpRequest":
+    """Returns a request copy that includes an api-version query parameter if one wasn't originally present."""
+    request_copy = deepcopy(request)
+    params = {"api-version": api_version}  # By default, we want to use the client's API version
+    query = urlparse(request_copy.url).query
+
+    if query:
+        request_copy.url = request_copy.url.partition("?")[0]
+        existing_params = {p[0]: p[-1] for p in [p.partition("=") for p in query.split("&")]}
+        params.update(existing_params)  # If an api-version was provided, this will overwrite our default
+
+    # Reconstruct the query parameters onto the URL
+    query_params = []
+    for k, v in params.items():
+        query_params.append("{}={}".format(k, v))
+    query = "?" + "&".join(query_params)
+    request_copy.url = request_copy.url + query
+    return request_copy
+
 
 class KeyVaultClientBase(object):
-    def __init__(self, vault_url, credential, **kwargs):
-        # type: (str, TokenCredential, **Any) -> None
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -74,28 +101,46 @@ class KeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=self.api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(self.api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{self.api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._vault_url
 
-    def __enter__(self):
-        # type: () -> KeyVaultClientBase
+    def __enter__(self) -> "KeyVaultClientBase":
         self._client.__enter__()
         return self
 
-    def __exit__(self, *args):
-        # type: (*Any) -> None
+    def __exit__(self, *args: "Any") -> None:
         self._client.__exit__(*args)
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """Close sockets opened by the client.
 
         Calling this method is unnecessary when using the client as a context manager.
         """
         self._client.close()
+
+    @distributed_trace
+    def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "HttpResponse":
+        """Runs a network request using the client's existing pipeline.
+
+        The request URL can be relative to the vault URL. The service API version used for the request is the same as
+        the client's unless otherwise specified. This method does not raise if the response is an error; to raise an
+        exception, call `raise_for_status()` on the returned response object. For more information about how to send
+        custom requests with this method, see https://aka.ms/azsdk/dpcodegen/python/send_request.
+
+        :param request: The network request you want to make.
+        :type request: ~azure.core.rest.HttpRequest
+
+        :return: The response of your network call. Does not do error handling on your response.
+        :rtype: ~azure.core.rest.HttpResponse
+        """
+        request_copy = _format_api_version(request, self.api_version)
+        path_format_arguments = {
+            "vaultBaseUrl": _SERIALIZER.url("vault_base_url", self._vault_url, "str", skip_quote=True),
+        }
+        request_copy.url = self._client._client.format_url(request_copy.url, **path_format_arguments)
+        return self._client._client.send_request(request_copy, **kwargs)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -62,7 +62,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 class KeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -125,7 +125,7 @@ class KeyVaultClientBase(object):
         self._client.close()
 
     @distributed_trace
-    def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "HttpResponse":
+    def send_request(self, request: "HttpRequest", **kwargs) -> "HttpResponse":
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
@@ -12,16 +12,15 @@ from azure.core.pipeline.policies import ContentDecodePolicy
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Optional, Type
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.rest import HttpResponse
 
 
-def _get_exception_for_key_vault_error(cls, response):
-    # type: (Type[HttpResponseError], HttpResponse) -> HttpResponseError
+def _get_exception_for_key_vault_error(cls: "Type[HttpResponseError]", response: "HttpResponse") -> HttpResponseError:
     """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
 
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])  # type: Optional[str]
+        message = f"({body['error']['code']}) {body['error']['message']}"  # type: Optional[str]
     except (DecodeError, KeyError):
         # Key Vault error response bodies should have the expected shape and be de-serializable.
         # If we somehow land here, we'll take HttpResponse's default message.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
@@ -2,18 +2,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from typing import TYPE_CHECKING
+from urllib import parse
+
+if TYPE_CHECKING:
+    from typing import Dict, MutableMapping, Optional
 
 
 class HttpChallenge(object):
-    def __init__(self, request_uri, challenge, response_headers=None):
-        """ Parses an HTTP WWW-Authentication Bearer challenge from a server. """
+    def __init__(self, request_uri: str, challenge: str, response_headers: "MutableMapping[str, str]" = None) -> None:
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
-        self._parameters = {}
+        self._parameters = {}  # type: Dict[str, str]
 
         # get the scheme of the challenge and remove from the challenge string
         trimmed_challenge = self._validate_challenge(challenge)
@@ -42,7 +43,8 @@ class HttpChallenge(object):
 
         authorization_uri = self.get_authorization_server()
         # the authorization server URI should look something like https://login.windows.net/tenant-id
-        uri_path = parse.urlparse(authorization_uri).path.lstrip("/")
+        raw_uri_path = str(parse.urlparse(authorization_uri).path)
+        uri_path = raw_uri_path.lstrip("/")
         self.tenant_id = uri_path.split("/")[0] or None
 
         # if the response headers were supplied
@@ -51,27 +53,25 @@ class HttpChallenge(object):
             self.server_signature_key = response_headers.get("x-ms-message-signing-key", None)
             self.server_encryption_key = response_headers.get("x-ms-message-encryption-key", None)
 
-    def is_bearer_challenge(self):
-        """ Tests whether the HttpChallenge a Bearer challenge.
-        rtype: bool """
+    def is_bearer_challenge(self) -> bool:
+        """Tests whether the HttpChallenge a Bearer challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "bearer"
 
-    def is_pop_challenge(self):
-        """ Tests whether the HttpChallenge is a proof of possession challenge.
-        rtype: bool """
+    def is_pop_challenge(self) -> bool:
+        """Tests whether the HttpChallenge is a proof of possession challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "pop"
 
-    def get_value(self, key):
+    def get_value(self, key: str) -> "Optional[str]":
         return self._parameters.get(key)
 
-    def get_authorization_server(self):
-        """ Returns the URI for the authorization server if present, otherwise empty string. """
+    def get_authorization_server(self) -> "Optional[str]":
+        """Returns the URI for the authorization server if present, otherwise empty string."""
         value = ""
         for key in ["authorization_uri", "authorization"]:
             value = self.get_value(key) or ""
@@ -79,41 +79,41 @@ class HttpChallenge(object):
                 break
         return value
 
-    def get_resource(self):
-        """ Returns the resource if present, otherwise empty string. """
+    def get_resource(self) -> str:
+        """Returns the resource if present, otherwise empty string."""
         return self.get_value("resource") or ""
 
-    def get_scope(self):
-        """ Returns the scope if present, otherwise empty string. """
+    def get_scope(self) -> str:
+        """Returns the scope if present, otherwise empty string."""
         return self.get_value("scope") or ""
 
-    def supports_pop(self):
-        """ Returns True if challenge supports pop token auth else False """
+    def supports_pop(self) -> bool:
+        """Returns True if challenge supports pop token auth else False."""
         return self._parameters.get("supportspop", "").lower() == "true"
 
-    def supports_message_protection(self):
-        """ Returns True if challenge vault supports message protection """
-        return self.supports_pop() and self.server_encryption_key and self.server_signature_key
+    def supports_message_protection(self) -> bool:
+        """Returns True if challenge vault supports message protection."""
+        return self.supports_pop() and self.server_encryption_key and self.server_signature_key  # type: ignore
 
     # pylint:disable=no-self-use
-    def _validate_challenge(self, challenge):
-        """ Verifies that the challenge is a valid auth challenge and returns the key=value pairs. """
+    def _validate_challenge(self, challenge: str) -> str:
+        """Verifies that the challenge is a valid auth challenge and returns the key=value pairs."""
         if not challenge:
             raise ValueError("Challenge cannot be empty")
 
         return challenge.strip()
 
     # pylint:disable=no-self-use
-    def _validate_request_uri(self, uri):
-        """ Extracts the host authority from the given URI. """
+    def _validate_request_uri(self, uri: str) -> str:
+        """Extracts the host authority from the given URI."""
         if not uri:
             raise ValueError("request_uri cannot be empty")
 
-        uri = parse.urlparse(uri)
-        if not uri.netloc:
+        parsed = parse.urlparse(uri)
+        if not parsed.netloc:
             raise ValueError("request_uri must be an absolute URI")
 
-        if uri.scheme.lower() not in ["http", "https"]:
+        if parsed.scheme.lower() not in ["http", "https"]:
             raise ValueError("request_uri must be HTTP or HTTPS")
 
-        return uri.netloc
+        return parsed.netloc

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge_cache.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge_cache.py
@@ -3,11 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import threading
-
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from urllib import parse
 
 try:
     from typing import TYPE_CHECKING
@@ -16,7 +12,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from typing import Dict
+    from typing import Dict, Optional
     from .http_challenge import HttpChallenge
 
 
@@ -24,10 +20,11 @@ _cache = {}  # type: Dict[str, HttpChallenge]
 _lock = threading.Lock()
 
 
-def get_challenge_for_url(url):
-    """ Gets the challenge for the cached URL.
-    :param url: the URL the challenge is cached for.
-    :rtype: HttpBearerChallenge """
+def get_challenge_for_url(url: str) -> "Optional[HttpChallenge]":
+    """Gets the challenge for the cached URL.
+
+    :param str url: the URL the challenge is cached for.
+    """
 
     if not url:
         raise ValueError("URL cannot be None")
@@ -38,7 +35,7 @@ def get_challenge_for_url(url):
         return _cache.get(key)
 
 
-def _get_cache_key(url):
+def _get_cache_key(url: str) -> str:
     """Use the URL's netloc as cache key except when the URL specifies the default port for its scheme. In that case
     use the netloc without the port. That is to say, https://foo.bar and https://foo.bar:443 are considered equivalent.
 
@@ -52,22 +49,27 @@ def _get_cache_key(url):
     return parsed.netloc
 
 
-def remove_challenge_for_url(url):
-    """ Removes the cached challenge for the specified URL.
-    :param url: the URL for which to remove the cached challenge """
+def remove_challenge_for_url(url: str) -> None:
+    """Removes the cached challenge for the specified URL.
+
+    :param str url: the URL for which to remove the cached challenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
-    url = parse.urlparse(url)
+    parsed = parse.urlparse(url)
 
     with _lock:
-        del _cache[url.netloc]
+        del _cache[parsed.netloc]
 
 
-def set_challenge_for_url(url, challenge):
-    """ Caches the challenge for the specified URL.
-    :param url: the URL for which to cache the challenge
-    :param challenge: the challenge to cache """
+def set_challenge_for_url(url: str, challenge: "HttpChallenge") -> None:
+    """Caches the challenge for the specified URL.
+
+    :param str url: the URL for which to cache the challenge
+    :param challenge: the challenge to cache
+    :type challenge: HttpChallenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
@@ -82,8 +84,8 @@ def set_challenge_for_url(url, challenge):
         _cache[src_url.netloc] = challenge
 
 
-def clear():
-    """ Clears the cache. """
+def clear() -> None:
+    """Clears the cache."""
 
     with _lock:
         _cache.clear()

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 # pylint:disable=too-many-lines,too-many-public-methods
 import base64
-from typing import Any, Optional, Iterable, List, Dict, Union
+from typing import Any, Optional, Iterable, List, Union
 from functools import partial
 
 from azure.core.polling import async_poller
@@ -60,23 +60,23 @@ class CertificateClient(AsyncKeyVaultClientBase):
     ) -> Union[KeyVaultCertificate, CertificateOperation]:
         """Creates a new certificate.
 
-        If this is the first version, the certificate resource is created. This
-        operation requires the certificates/create permission. The poller requires the
-        certificates/get permission, otherwise raises
-        an :class:`~azure.core.exceptions.HttpResponseError`
+        If this is the first version, the certificate resource is created. This operation requires the
+        certificates/create permission. The poller requires the certificates/get permission, otherwise raises an
+        :class:`~azure.core.exceptions.HttpResponseError`
 
         :param str certificate_name: The name of the certificate.
         :param policy: The management policy for the certificate. Either subject or one of the subject alternative
             name properties are required.
-        :type policy:
-            ~azure.keyvault.certificates.CertificatePolicy
+        :type policy: ~azure.keyvault.certificates.CertificatePolicy
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
-        :returns: A coroutine for the creation of the certificate. Awaiting the coroutine
-            returns the created KeyVaultCertificate if creation is successful, the CertificateOperation if not.
-        :rtype: ~azure.keyvault.certificates.KeyVaultCertificate or
-            ~azure.keyvault.certificates.CertificateOperation
+
+        :returns: A coroutine for the creation of the certificate. Awaiting the coroutine returns the created
+            KeyVaultCertificate if creation is successful, or the CertificateOperation if not.
+        :rtype: ~azure.keyvault.certificates.KeyVaultCertificate or ~azure.keyvault.certificates.CertificateOperation
+
         :raises:
             :class:`ValueError` if the certificate policy is invalid,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors.
@@ -135,8 +135,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         certificate, call :func:`get_certificate_version`.
 
         :param str certificate_name: The name of the certificate in the given vault.
+
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -164,13 +166,15 @@ class CertificateClient(AsyncKeyVaultClientBase):
     ) -> KeyVaultCertificate:
         """Gets a specific version of a certificate without returning its management policy.
 
-        Requires certificates/get permission. To get the latest version of the certificate,
-        or to get the certificate's policy as well, call :func:`get_certificate`.
+        Requires certificates/get permission. To get the latest version of the certificate, or to get the certificate's
+        policy as well, call :func:`get_certificate`.
 
         :param str certificate_name: The name of the certificate in the given vault.
         :param str version: The version of the certificate.
+
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -199,8 +203,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         If the vault has soft-delete enabled, deletion may take several seconds to complete.
 
         :param str certificate_name: The name of the certificate.
+
         :returns: The deleted certificate
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -236,13 +242,14 @@ class CertificateClient(AsyncKeyVaultClientBase):
     async def get_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> DeletedCertificate:
         """Get a deleted certificate. Possible only in a vault with soft-delete enabled.
 
-        Requires certificates/get permission. Retrieves the deleted certificate information
-        plus its attributes, such as retention interval, scheduled permanent deletion, and the
-        current deletion recovery level.
+        Requires certificates/get permission. Retrieves the deleted certificate information plus its attributes, such as
+        retention interval, scheduled permanent deletion, and the current deletion recovery level.
 
         :param str certificate_name: The name of the certificate.
+
         :return: The deleted certificate
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -264,17 +271,17 @@ class CertificateClient(AsyncKeyVaultClientBase):
     async def purge_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> None:
         """Permanently deletes a deleted certificate. Possible only in vaults with soft-delete enabled.
 
-        Requires certificates/purge permission.
-
-        Performs an irreversible deletion of the specified certificate, without
+        Requires certificates/purge permission. Performs an irreversible deletion of the specified certificate, without
         possibility for recovery. The operation is not available if the
         :py:attr:`~azure.keyvault.certificates.CertificateProperties.recovery_level` does not specify 'Purgeable'.
         This method is only necessary for purging a certificate before its
         :py:attr:`~azure.keyvault.certificates.DeletedCertificate.scheduled_purge_date`.
 
         :param str certificate_name: The name of the certificate
+
         :return: None
         :rtype: None
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         await self._client.purge_deleted_certificate(
@@ -290,8 +297,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         non-deleted certificate will also raise an error.
 
         :param str certificate_name: The name of the deleted certificate
+
         :returns: The recovered certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -326,13 +335,14 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         Imports an existing valid certificate, containing a private key, into Azure Key Vault. The certificate to be
         imported can be in either PFX or PEM format. If the certificate is in PEM format the PEM file must contain the
-        key as well as x509 certificates, and you must provide a ``policy``
-        with :attr:`~azure.keyvault.certificates.CertificatePolicy.content_type` of
+        key as well as x509 certificates, and you must provide a ``policy`` with
+        :attr:`~azure.keyvault.certificates.CertificatePolicy.content_type` of
         :attr:`~azure.keyvault.certificates.CertificateContentType.pem`.
 
         :param str certificate_name: The name of the certificate.
         :param bytes certificate_bytes: Bytes of the certificate object to import.
             This certificate needs to contain the private key.
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
@@ -342,8 +352,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
             with :attr:`~azure.keyvault.certificates.CertificatePolicy.content_type` set to
             :attr:`~azure.keyvault.certificates.CertificateContentType.pem`.
         :paramtype policy: ~azure.keyvault.certificates.CertificatePolicy
+
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
@@ -380,8 +392,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         Returns the specified certificate policy resources in the key vault.
 
         :param str certificate_name: The name of the certificate in a given key vault.
+
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.get_certificate_policy(
@@ -400,8 +414,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str certificate_name: The name of the certificate in the given vault.
         :param policy: The policy for the certificate.
         :type policy: ~azure.keyvault.certificates.CertificatePolicy
+
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.update_certificate_policy(
@@ -421,11 +437,14 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         :param str certificate_name: The name of the certificate in the given key vault.
         :param str version: The version of the certificate.
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
+
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -462,14 +481,16 @@ class CertificateClient(AsyncKeyVaultClientBase):
     async def backup_certificate(self, certificate_name: str, **kwargs: "Any") -> bytes:
         """Back up a certificate in a protected form useable only by Azure Key Vault.
 
-        Requires certificates/backup permission. This is intended to allow copying a certificate
-        from one vault to another. Both vaults must be owned by the same Azure subscription.
-        Also, backup / restore cannot be performed across geopolitical boundaries. For example, a backup
-        from a vault in a USA region cannot be restored to a vault in an EU region.
+        Requires certificates/backup permission. This is intended to allow copying a certificate from one vault to
+        another. Both vaults must be owned by the same Azure subscription. Also, backup / restore cannot be performed
+        across geopolitical boundaries. For example, a backup from a vault in a USA region cannot be restored to a vault
+        in an EU region.
 
         :param str certificate_name: The name of the certificate.
+
         :return: The backup blob containing the backed up certificate.
         :rtype: bytes
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -491,13 +512,15 @@ class CertificateClient(AsyncKeyVaultClientBase):
     async def restore_certificate_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultCertificate:
         """Restore a certificate backup to the vault. Requires certificates/restore permission.
 
-        This restores all versions of the certificate, with its name, attributes, and access control policies.
-        If the certificate's name is already in use, restoring it will fail. Also, the target vault must
-        be owned by the same Microsoft Azure subscription as the source vault.
+        This restores all versions of the certificate, with its name, attributes, and access control policies. If the
+        certificate's name is already in use, restoring it will fail. Also, the target vault must be owned by the same
+        Microsoft Azure subscription as the source vault.
 
         :param bytes backup: The backup blob associated with a certificate bundle.
+
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -520,15 +543,15 @@ class CertificateClient(AsyncKeyVaultClientBase):
     def list_deleted_certificates(self, **kwargs: "Any") -> AsyncItemPaged[DeletedCertificate]:
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
-        Requires certificates/get/list permission. Retrieves the certificates in the current vault which
-        are in a deleted state and ready for recovery or purging. This operation includes
-        deletion-specific information.
+        Requires certificates/get/list permission. Retrieves the certificates in the current vault which are in a
+        deleted state and ready for recovery or purging. This operation includes deletion-specific information.
 
-        :keyword bool include_pending: Specifies whether to include certificates which are
-         not completely deleted. Only available for API versions v7.0 and up
-        :return: An iterator like instance of DeletedCertificate
-        :rtype:
-         ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
+        :keyword bool include_pending: Specifies whether to include certificates which are not completely deleted.
+            Only available for API versions v7.0 and up.
+
+        :return: An iterator-like instance of DeletedCertificate
+        :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -559,11 +582,12 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         Requires certificates/list permission.
 
-        :keyword bool include_pending: Specifies whether to include certificates which are not
-         completely provisioned. Only available for API versions v7.0 and up
-        :returns: An iterator like instance of CertificateProperties
-        :rtype:
-         ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+        :keyword bool include_pending: Specifies whether to include certificates which are not completely provisioned.
+            Only available for API versions v7.0 and up.
+
+        :returns: An iterator-like instance of CertificateProperties
+        :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -597,9 +621,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         Requires certificates/list permission.
 
         :param str certificate_name: The name of the certificate.
-        :returns: An iterator like instance of CertificateProperties
-        :rtype:
-         ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+
+        :returns: An iterator-like instance of CertificateProperties
+        :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -621,16 +646,14 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def set_contacts(self, contacts: Iterable[CertificateContact], **kwargs: "Any") -> List[CertificateContact]:
-        # pylint:disable=unsubscriptable-object
-
-        # disabled unsubscriptable-object because of pylint bug referenced here:
-        # https://github.com/PyCQA/pylint/issues/2377
         """Sets the certificate contacts for the key vault. Requires certificates/managecontacts permission.
 
         :param contacts: The contact list for the vault certificates.
         :type contacts: list[~azure.keyvault.certificates.CertificateContact]
+
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -653,14 +676,11 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_contacts(self, **kwargs: "Any") -> List[CertificateContact]:
-        # pylint:disable=unsubscriptable-object
-
-        # disabled unsubscriptable-object because of pylint bug referenced here:
-        # https://github.com/PyCQA/pylint/issues/2377
         """Gets the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The certificate contacts for the key vault.
         :rtype: list[azure.keyvault.certificates.CertificateContact]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -678,14 +698,11 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_contacts(self, **kwargs: "Any") -> List[CertificateContact]:
-        # pylint:disable=unsubscriptable-object
-
-        # disabled unsubscriptable-object because of pylint bug referenced here:
-        # https://github.com/PyCQA/pylint/issues/2377
         """Deletes the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -706,8 +723,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         """Gets the creation operation of a certificate. Requires the certificates/get permission.
 
         :param str certificate_name: The name of the certificate.
+
         :returns: The created CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -725,8 +744,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
+
         :return: The deleted CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the operation doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -741,8 +762,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         """Cancels an in-progress certificate operation. Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
+
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.update_certificate_operation(
@@ -760,20 +783,22 @@ class CertificateClient(AsyncKeyVaultClientBase):
     ) -> KeyVaultCertificate:
         """Merges a certificate or a certificate chain with a key pair existing on the server.
 
-        Requires the certificates/create permission. Performs the merging of a certificate or
-        certificate chain with a key pair currently available in the service.
-        Make sure when creating the certificate to merge using :func:`create_certificate` that you set
-        its issuer to 'Unknown'. This way Key Vault knows that the certificate will not be signed
-        by an issuer known to it.
+        Requires the certificates/create permission. Performs the merging of a certificate or certificate chain with a
+        key pair currently available in the service. Make sure when creating the certificate to merge using
+        :func:`begin_create_certificate` that you set its issuer to 'Unknown'. This way Key Vault knows that the
+        certificate will not be signed by an issuer known to it.
 
         :param str certificate_name: The name of the certificate
         :param x509_certificates: The certificate or the certificate chain to merge.
         :type x509_certificates: list[bytes]
+
         :keyword bool enabled: Whether the certificate is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
+
         :return: The merged certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
@@ -802,8 +827,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         """Gets the specified certificate issuer. Requires certificates/manageissuers/getissuers permission.
 
         :param str issuer_name: The name of the issuer.
+
         :return: The specified certificate issuer.
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -827,6 +854,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         :param str issuer_name: The name of the issuer.
         :param str provider: The issuer provider.
+
         :keyword bool enabled: Whether the issuer is enabled for use.
         :keyword str account_id: The user name/account name/account id.
         :keyword str password: The password/secret/account key.
@@ -834,8 +862,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :keyword admin_contacts: Contact details of the organization administrators of the
          certificate issuer.
         :paramtype admin_contacts: list[~azure.keyvault.certificates.AdministratorContact]
+
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -895,6 +925,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         """Updates the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
+
         :keyword bool enabled: Whether the issuer is enabled for use.
         :keyword str provider: The issuer provider
         :keyword str account_id: The user name/account name/account id.
@@ -903,8 +934,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :keyword admin_contacts: Contact details of the organization administrators of
          the certificate issuer
         :paramtype admin_contacts: list[~azure.keyvault.certificates.AdministratorContact]
+
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
@@ -958,8 +991,10 @@ class CertificateClient(AsyncKeyVaultClientBase):
         Requires certificates/manageissuers/deleteissuers permission.
 
         :param str issuer_name: The name of the issuer.
+
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -981,8 +1016,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         Requires the certificates/manageissuers/getissuers permission.
 
-        :return: An iterator like instance of Issuers
+        :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -56,7 +56,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
     @distributed_trace_async
     async def create_certificate(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs: "Any"
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs
     ) -> Union[KeyVaultCertificate, CertificateOperation]:
         """Creates a new certificate.
 
@@ -128,7 +128,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return await async_poller(command, create_certificate_operation, None, create_certificate_polling)
 
     @distributed_trace_async
-    async def get_certificate(self, certificate_name: str, **kwargs: "Any") -> KeyVaultCertificate:
+    async def get_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:
         """Gets a certificate with its management policy attached. Requires certificates/get permission.
 
         Does not accept the version of the certificate as a parameter. To get a specific version of the
@@ -162,7 +162,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_certificate_version(
-        self, certificate_name: str, version: str, **kwargs: "Any"
+        self, certificate_name: str, version: str, **kwargs
     ) -> KeyVaultCertificate:
         """Gets a specific version of a certificate without returning its management policy.
 
@@ -197,7 +197,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def delete_certificate(self, certificate_name: str, **kwargs: "Any") -> DeletedCertificate:
+    async def delete_certificate(self, certificate_name: str, **kwargs) -> DeletedCertificate:
         """Delete all versions of a certificate. Requires certificates/delete permission.
 
         If the vault has soft-delete enabled, deletion may take several seconds to complete.
@@ -239,7 +239,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> DeletedCertificate:
+    async def get_deleted_certificate(self, certificate_name: str, **kwargs) -> DeletedCertificate:
         """Get a deleted certificate. Possible only in a vault with soft-delete enabled.
 
         Requires certificates/get permission. Retrieves the deleted certificate information plus its attributes, such as
@@ -268,7 +268,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def purge_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> None:
+    async def purge_deleted_certificate(self, certificate_name: str, **kwargs) -> None:
         """Permanently deletes a deleted certificate. Possible only in vaults with soft-delete enabled.
 
         Requires certificates/purge permission. Performs an irreversible deletion of the specified certificate, without
@@ -289,7 +289,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def recover_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> KeyVaultCertificate:
+    async def recover_deleted_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:
         """Recover a deleted certificate to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires certificates/recover permission. If the vault does not have soft-delete enabled,
@@ -329,7 +329,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def import_certificate(
-        self, certificate_name: str, certificate_bytes: bytes, **kwargs: "Any"
+        self, certificate_name: str, certificate_bytes: bytes, **kwargs
     ) -> KeyVaultCertificate:
         """Import a certificate created externally. Requires certificates/import permission.
 
@@ -386,7 +386,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def get_certificate_policy(self, certificate_name: str, **kwargs: "Any") -> CertificatePolicy:
+    async def get_certificate_policy(self, certificate_name: str, **kwargs) -> CertificatePolicy:
         """Gets the policy for a certificate. Requires certificates/get permission.
 
         Returns the specified certificate policy resources in the key vault.
@@ -405,7 +405,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_certificate_policy(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs: "Any"
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs
     ) -> CertificatePolicy:
         """Updates the policy for a certificate. Requires certificates/update permission.
 
@@ -431,7 +431,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_certificate_properties(
-        self, certificate_name: str, version: Optional[str] = None, **kwargs: "Any"
+        self, certificate_name: str, version: Optional[str] = None, **kwargs
     ) -> KeyVaultCertificate:
         """Change a certificate's properties. Requires certificates/update permission.
 
@@ -478,7 +478,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def backup_certificate(self, certificate_name: str, **kwargs: "Any") -> bytes:
+    async def backup_certificate(self, certificate_name: str, **kwargs) -> bytes:
         """Back up a certificate in a protected form useable only by Azure Key Vault.
 
         Requires certificates/backup permission. This is intended to allow copying a certificate from one vault to
@@ -509,7 +509,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_certificate_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultCertificate:
+    async def restore_certificate_backup(self, backup: bytes, **kwargs) -> KeyVaultCertificate:
         """Restore a certificate backup to the vault. Requires certificates/restore permission.
 
         This restores all versions of the certificate, with its name, attributes, and access control policies. If the
@@ -540,7 +540,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def list_deleted_certificates(self, **kwargs: "Any") -> AsyncItemPaged[DeletedCertificate]:
+    def list_deleted_certificates(self, **kwargs) -> AsyncItemPaged[DeletedCertificate]:
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
         Requires certificates/get/list permission. Retrieves the certificates in the current vault which are in a
@@ -577,7 +577,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_certificates(self, **kwargs: "Any") -> AsyncItemPaged[CertificateProperties]:
+    def list_properties_of_certificates(self, **kwargs) -> AsyncItemPaged[CertificateProperties]:
         """List identifiers and properties of all certificates in the vault.
 
         Requires certificates/list permission.
@@ -614,7 +614,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_properties_of_certificate_versions(
-        self, certificate_name: str, **kwargs: "Any"
+        self, certificate_name: str, **kwargs
     ) -> AsyncItemPaged[CertificateProperties]:
         """List the identifiers and properties of a certificate's versions.
 
@@ -645,7 +645,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def set_contacts(self, contacts: Iterable[CertificateContact], **kwargs: "Any") -> List[CertificateContact]:
+    async def set_contacts(self, contacts: Iterable[CertificateContact], **kwargs) -> List[CertificateContact]:
         """Sets the certificate contacts for the key vault. Requires certificates/managecontacts permission.
 
         :param contacts: The contact list for the vault certificates.
@@ -675,7 +675,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         ]
 
     @distributed_trace_async
-    async def get_contacts(self, **kwargs: "Any") -> List[CertificateContact]:
+    async def get_contacts(self, **kwargs) -> List[CertificateContact]:
         """Gets the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The certificate contacts for the key vault.
@@ -697,7 +697,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace_async
-    async def delete_contacts(self, **kwargs: "Any") -> List[CertificateContact]:
+    async def delete_contacts(self, **kwargs) -> List[CertificateContact]:
         """Deletes the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The deleted contacts for the key vault.
@@ -719,7 +719,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace_async
-    async def get_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
+    async def get_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
         """Gets the creation operation of a certificate. Requires the certificates/get permission.
 
         :param str certificate_name: The name of the certificate.
@@ -738,7 +738,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace_async
-    async def delete_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
+    async def delete_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
         """Deletes and stops the creation operation for a specific certificate.
 
         Requires the certificates/update permission.
@@ -758,7 +758,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace_async
-    async def cancel_certificate_operation(self, certificate_name: str, **kwargs: "Any") -> CertificateOperation:
+    async def cancel_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
         """Cancels an in-progress certificate operation. Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
@@ -779,7 +779,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def merge_certificate(
-        self, certificate_name: str, x509_certificates: Iterable[bytes], **kwargs: "Any"
+        self, certificate_name: str, x509_certificates: Iterable[bytes], **kwargs
     ) -> KeyVaultCertificate:
         """Merges a certificate or a certificate chain with a key pair existing on the server.
 
@@ -823,7 +823,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def get_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
+    async def get_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
         """Gets the specified certificate issuer. Requires certificates/manageissuers/getissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -849,7 +849,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace_async
-    async def create_issuer(self, issuer_name: str, provider: str, **kwargs: "Any") -> CertificateIssuer:
+    async def create_issuer(self, issuer_name: str, provider: str, **kwargs) -> CertificateIssuer:
         """Sets the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -921,7 +921,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace_async
-    async def update_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
+    async def update_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
         """Updates the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -985,7 +985,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace_async
-    async def delete_issuer(self, issuer_name: str, **kwargs: "Any") -> CertificateIssuer:
+    async def delete_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
         """Deletes the specified certificate issuer.
 
         Requires certificates/manageissuers/deleteissuers permission.
@@ -1011,7 +1011,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def list_properties_of_issuers(self, **kwargs: "Any") -> AsyncItemPaged[IssuerProperties]:
+    def list_properties_of_issuers(self, **kwargs) -> AsyncItemPaged[IssuerProperties]:
         """Lists properties of the certificate issuers for the key vault.
 
         Requires the certificates/manageissuers/getissuers permission.

--- a/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations.py
@@ -49,19 +49,19 @@ create_certificate_poller = client.begin_create_certificate(
 # The result call awaits the completion of the create certificate operation and returns the final result.
 # It will return a certificate if creation is successful, and will return the CertificateOperation if not.
 certificate = create_certificate_poller.result()
-print("Certificate with name '{0}' created.".format(cert_name))
+print(f"Certificate with name '{cert_name}' created.")
 
 # Backups are good to have, if in case certificates gets deleted accidentally.
 # For long term storage, it is ideal to write the backup to a file.
 print("\n.. Create a backup for an existing certificate")
 certificate_backup = client.backup_certificate(cert_name)
-print("Backup created for certificate with name '{0}'.".format(cert_name))
+print(f"Backup created for certificate with name '{cert_name}'.")
 
 # The storage account certificate is no longer in use, so you can delete it.
 print("\n.. Delete the certificate")
 delete_operation = client.begin_delete_certificate(cert_name)
 deleted_certificate = delete_operation.result()
-print("Deleted certificate with name '{0}'".format(deleted_certificate.name))
+print(f"Deleted certificate with name '{deleted_certificate.name}'")
 
 # Wait for the deletion to complete before purging the certificate.
 # The purge will take some time, so wait before restoring the backup to avoid a conflict.
@@ -69,11 +69,11 @@ delete_operation.wait()
 print("\n.. Purge the certificate")
 client.purge_deleted_certificate(deleted_certificate.name)
 time.sleep(60)
-print("Purged certificate with name '{0}'".format(deleted_certificate.name))
+print(f"Purged certificate with name '{deleted_certificate.name}'")
 
 # In the future, if the certificate is required again, we can use the backup value to restore it in the Key Vault.
 print("\n.. Restore the certificate from the backup")
 certificate = client.restore_certificate_backup(certificate_backup)
-print("Restored certificate with name '{0}'".format(certificate.name))
+print(f"Restored certificate with name '{certificate.name}'")
 
 print("\nrun_sample done")

--- a/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations_async.py
@@ -49,30 +49,30 @@ async def run_sample():
         certificate_name=cert_name, policy=CertificatePolicy.get_default()
     )
 
-    print("Certificate with name '{0}' created.".format(certificate.name))
+    print(f"Certificate with name '{certificate.name}' created.")
 
     # Backups are good to have, if in case certificates gets deleted accidentally.
     # For long term storage, it is ideal to write the backup to a file.
     print("\n.. Create a backup for an existing certificate")
     certificate_backup = await client.backup_certificate(cert_name)
-    print("Backup created for certificate with name '{0}'.".format(cert_name))
+    print(f"Backup created for certificate with name '{cert_name}'.")
 
     # The storage account certificate is no longer in use, so you can delete it.
     print("\n.. Delete the certificate")
     await client.delete_certificate(cert_name)
-    print("Deleted certificate with name '{0}'".format(cert_name))
+    print(f"Deleted certificate with name '{cert_name}'")
 
     # Purge the deleted certificate.
     # The purge will take some time, so wait before restoring the backup to avoid a conflict.
     print("\n.. Purge the certificate")
     await client.purge_deleted_certificate(cert_name)
     await asyncio.sleep(60)
-    print("Purged certificate with name '{0}'".format(cert_name))
+    print(f"Purged certificate with name '{cert_name}'")
 
     # In the future, if the certificate is required again, we can use the backup value to restore it in the Key Vault.
     print("\n.. Restore the certificate using the backed up certificate bytes")
     certificate = await client.restore_certificate_backup(certificate_backup)
-    print("Restored certificate with name '{0}'".format(certificate.name))
+    print(f"Restored certificate with name '{certificate.name}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-certificates/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/hello_world.py
@@ -63,12 +63,12 @@ cert_name = "HelloWorldCertificate"
 certificate = client.begin_create_certificate(
     certificate_name=cert_name, policy=cert_policy
 ).result()
-print("Certificate with name '{0}' created".format(certificate.name))
+print(f"Certificate with name '{certificate.name}' created")
 
 # Let's get the bank certificate using its name
 print("\n.. Get a certificate by name")
 bank_certificate = client.get_certificate(cert_name)
-print("Certificate with name '{0}' was found'.".format(bank_certificate.name))
+print(f"Certificate with name '{bank_certificate.name}' was found'.")
 
 # After one year, the bank account is still active, and we have decided to update the tags.
 print("\n.. Update a certificate by name")
@@ -77,19 +77,15 @@ updated_certificate = client.update_certificate_properties(
     certificate_name=bank_certificate.name, tags=tags
 )
 print(
-    "Certificate with name '{0}' was updated on date '{1}'".format(
-        bank_certificate.name, updated_certificate.properties.updated_on
-    )
+    f"Certificate with name '{bank_certificate.name}' was updated on date '{updated_certificate.properties.updated_on}'"
 )
 print(
-    "Certificate with name '{0}' was updated with tags '{1}'".format(
-        bank_certificate.name, updated_certificate.properties.tags
-    )
+    f"Certificate with name '{bank_certificate.name}' was updated with tags '{updated_certificate.properties.tags}'"
 )
 
 # The bank account was closed, need to delete its credentials from the Key Vault.
 print("\n.. Delete certificate")
 deleted_certificate = client.begin_delete_certificate(bank_certificate.name).result()
-print("Certificate with name '{0}' was deleted.".format(deleted_certificate.name))
+print(f"Certificate with name '{deleted_certificate.name}' was deleted.")
 
 print("\nrun_sample done")

--- a/sdk/keyvault/azure-keyvault-certificates/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/hello_world_async.py
@@ -64,12 +64,12 @@ async def run_sample():
     # Awaiting create_certificate will return the certificate as a KeyVaultCertificate
     # if creation is successful, and the CertificateOperation if not.
     certificate = await client.create_certificate(certificate_name=cert_name, policy=cert_policy)
-    print("Certificate with name '{0}' created".format(certificate.name))
+    print(f"Certificate with name '{certificate.name}' created")
 
     # Let's get the bank certificate using its name
     print("\n.. Get a certificate by name")
     bank_certificate = await client.get_certificate(cert_name)
-    print("Certificate with name '{0}' was found.".format(bank_certificate.name))
+    print(f"Certificate with name '{bank_certificate.name}' was found.")
 
     # After one year, the bank account is still active, and we have decided to update the tags.
     print("\n.. Update a certificate by name")
@@ -78,21 +78,18 @@ async def run_sample():
         certificate_name=bank_certificate.name, tags=tags
     )
     print(
-        "Certificate with name '{0}' was updated on date '{1}'".format(
-            bank_certificate.name, updated_certificate.properties.updated_on
-        )
+        f"Certificate with name '{bank_certificate.name}' was updated on date "
+        f"'{updated_certificate.properties.updated_on}'"
     )
     print(
-        "Certificate with name '{0}' was updated with tags '{1}'".format(
-            bank_certificate.name, updated_certificate.properties.tags
-        )
+        f"Certificate with name '{bank_certificate.name}' was updated with tags '{updated_certificate.properties.tags}'"
     )
 
     # The bank account was closed, need to delete its credentials from the Key Vault.
     print("\n.. Delete certificate")
     deleted_certificate = await client.delete_certificate(bank_certificate.name)
     print("Deleting certificate..")
-    print("Certificate with name '{0}' was deleted.".format(deleted_certificate.name))
+    print(f"Certificate with name '{deleted_certificate.name}' was deleted.")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-certificates/samples/import_certificate.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/import_certificate.py
@@ -48,7 +48,7 @@ pfx_cert_name = "pfxCert"
 with open(os.environ["PFX_CERT_PATH"], "rb") as f:
     pfx_cert_bytes = f.read()
 imported_pfx_cert = client.import_certificate(certificate_name=pfx_cert_name, certificate_bytes=pfx_cert_bytes)
-print("PFX certificate '{}' imported successfully.".format(imported_pfx_cert.name))
+print(f"PFX certificate '{imported_pfx_cert.name}' imported successfully.")
 
 # Now let's import a PEM-formatted certificate.
 # To import a PEM-formatted certificate, you must provide a CertificatePolicy that sets the content_type to
@@ -60,4 +60,4 @@ pem_cert_policy = CertificatePolicy(issuer_name=WellKnownIssuerNames.self, conte
 imported_pem_cert = client.import_certificate(
     certificate_name=pem_cert_name, certificate_bytes=pem_cert_bytes, policy=pem_cert_policy
 )
-print("PEM-formatted certificate '{}' imported successfully.".format(imported_pem_cert.name))
+print(f"PEM-formatted certificate '{imported_pem_cert.name}' imported successfully.")

--- a/sdk/keyvault/azure-keyvault-certificates/samples/import_certificate_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/import_certificate_async.py
@@ -48,7 +48,7 @@ async def run_sample():
     imported_pfx_cert = await client.import_certificate(
         certificate_name=pfx_cert_name, certificate_bytes=pfx_cert_bytes
     )
-    print("PFX certificate '{}' imported successfully.".format(imported_pfx_cert.name))
+    print(f"PFX certificate '{imported_pfx_cert.name}' imported successfully.")
 
     # Now let's import a PEM-formatted certificate.
     # To import a PEM-formatted certificate, you must provide a CertificatePolicy that sets the content_type to
@@ -60,7 +60,7 @@ async def run_sample():
     imported_pem_cert = await client.import_certificate(
         certificate_name=pem_cert_name, certificate_bytes=pem_cert_bytes, policy=pem_cert_policy
     )
-    print("PEM-formatted certificate '{}' imported successfully.".format(imported_pem_cert.name))
+    print(f"PEM-formatted certificate '{imported_pem_cert.name}' imported successfully.")
 
     await credential.close()
     await client.close()

--- a/sdk/keyvault/azure-keyvault-certificates/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/list_operations.py
@@ -53,14 +53,14 @@ storage_certificate_poller = client.begin_create_certificate(
 bank_certificate = bank_certificate_poller.result()
 storage_certificate = storage_certificate_poller.result()
 
-print("Certificate with name '{0}' was created.".format(bank_certificate.name))
-print("Certificate with name '{0}' was created.".format(storage_certificate.name))
+print(f"Certificate with name '{bank_certificate.name}' was created.")
+print(f"Certificate with name '{storage_certificate.name}' was created.")
 
 # Let's list the certificates.
 print("\n.. List certificates from the Key Vault")
 certificates = client.list_properties_of_certificates()
 for certificate in certificates:
-    print("Certificate with name '{0}' was found.".format(certificate.name))
+    print(f"Certificate with name '{certificate.name}' was found.")
 
 # You've decided to add tags to the certificate you created. Calling begin_create_certificate on an existing
 # certificate creates a new version of the certificate in the Key Vault with the new value.
@@ -71,9 +71,7 @@ bank_certificate_poller = client.begin_create_certificate(
 )
 bank_certificate = bank_certificate_poller.result()
 print(
-    "Certificate with name '{0}' was created again with tags '{1}'".format(
-        bank_certificate.name, bank_certificate.properties.tags
-    )
+    f"Certificate with name '{bank_certificate.name}' was created again with tags '{bank_certificate.properties.tags}'"
 )
 
 # You need to check all the different tags your bank account certificate had previously. Let's print
@@ -82,9 +80,8 @@ print("\n.. List versions of the certificate using its name")
 certificate_versions = client.list_properties_of_certificate_versions(bank_cert_name)
 for certificate_version in certificate_versions:
     print(
-        "Bank Certificate with name '{0}' with version '{1}' has tags: '{2}'.".format(
-            certificate_version.name, certificate_version.version, certificate_version.tags
-        )
+        f"Bank Certificate with name '{certificate_version.name}' with version '{certificate_version.version}' "
+        f"has tags: '{certificate_version.tags}'."
     )
 
 # The bank account and storage accounts got closed. Let's delete bank and storage accounts certificates.
@@ -97,10 +94,6 @@ client.begin_delete_certificate(storage_cert_name).wait()
 print("\n.. List deleted certificates from the Key Vault")
 deleted_certificates = client.list_deleted_certificates()
 for deleted_certificate in deleted_certificates:
-    print(
-        "Certificate with name '{0}' has recovery id '{1}'".format(
-            deleted_certificate.name, deleted_certificate.recovery_id
-        )
-    )
+    print(f"Certificate with name '{deleted_certificate.name}' has recovery id '{deleted_certificate.recovery_id}'")
 
 print("\nrun_sample done")

--- a/sdk/keyvault/azure-keyvault-certificates/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/list_operations_async.py
@@ -52,14 +52,14 @@ async def run_sample():
         certificate_name=storage_cert_name, policy=CertificatePolicy.get_default()
     )
 
-    print("Certificate with name '{0}' was created.".format(bank_certificate.name))
-    print("Certificate with name '{0}' was created.".format(storage_certificate.name))
+    print(f"Certificate with name '{bank_certificate.name}' was created.")
+    print(f"Certificate with name '{storage_certificate.name}' was created.")
 
     # Let's list the certificates.
     print("\n.. List certificates from the Key Vault")
     certificates = client.list_properties_of_certificates()
     async for certificate in certificates:
-        print("Certificate with name '{0}' was found.".format(certificate.name))
+        print(f"Certificate with name '{certificate.name}' was found.")
 
     # You've decided to add tags to the certificate you created. Calling create_certificate on an existing
     # certificate creates a new version of the certificate in the Key Vault with the new value.
@@ -70,9 +70,8 @@ async def run_sample():
         certificate_name=bank_cert_name, policy=CertificatePolicy.get_default(), tags=tags
     )
     print(
-        "Certificate with name '{0}' was created again with tags '{1}'".format(
-            bank_certificate.name, bank_certificate.properties.tags
-        )
+        f"Certificate with name '{bank_certificate.name}' was created again with tags "
+        f"'{bank_certificate.properties.tags}'"
     )
 
     # You need to check all the different tags your bank account certificate had previously. Lets print all the versions of this certificate.
@@ -80,9 +79,8 @@ async def run_sample():
     certificate_versions = client.list_properties_of_certificate_versions(bank_cert_name)
     async for certificate_version in certificate_versions:
         print(
-            "Bank Certificate with name '{0}' with version '{1}' has tags: '{2}'.".format(
-                certificate_version.name, certificate_version.version, certificate_version.tags
-            )
+            f"Bank Certificate with name '{certificate_version.name}' with version '{certificate_version.version}' "
+            f"has tags: '{certificate_version.tags}'."
         )
 
     # The bank account and storage accounts got closed. Let's delete bank and storage accounts certificates.
@@ -93,11 +91,7 @@ async def run_sample():
     print("\n.. List deleted certificates from the Key Vault")
     deleted_certificates = client.list_deleted_certificates()
     async for deleted_certificate in deleted_certificates:
-        print(
-            "Certificate with name '{0}' has recovery id '{1}'".format(
-                deleted_certificate.name, deleted_certificate.recovery_id
-            )
-        )
+        print(f"Certificate with name '{deleted_certificate.name}' has recovery id '{deleted_certificate.recovery_id}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate.py
@@ -60,14 +60,14 @@ cert_policy = CertificatePolicy.get_default()
 created_certificate = certificate_client.begin_create_certificate(
     certificate_name=cert_name, policy=cert_policy
 ).result()
-print("Certificate with name '{}' was created".format(created_certificate.name))
+print(f"Certificate with name '{created_certificate.name}' was created")
 
 # Key Vault also creates a secret with the same name as the created certificate.
 # This secret contains the certificate's bytes, which include the private key if the certificate's
 # policy indicates that the key is exportable.
 print("\n.. Get a secret by name")
 certificate_secret = secret_client.get_secret(name=cert_name)
-print("Certificate secret with name '{}' was found.".format(certificate_secret.name))
+print(f"Certificate secret with name '{certificate_secret.name}' was found.")
 
 # Now we can extract the private key and public certificate from the secret using the cryptography
 # package. `additional_certificates` will be empty since the secret only contains one certificate.
@@ -79,7 +79,7 @@ private_key, public_certificate, additional_certificates = pkcs12.load_key_and_c
     data=cert_bytes,
     password=None
 )
-print("Certificate with name '{}' was parsed.".format(certificate_secret.name))
+print(f"Certificate with name '{certificate_secret.name}' was parsed.")
 
 # Now we can clean up the vault by deleting, then purging, the certificate.
 print("\n.. Delete certificate")
@@ -88,9 +88,9 @@ delete_operation_poller = certificate_client.begin_delete_certificate(
 )
 deleted_certificate = delete_operation_poller.result()
 delete_operation_poller.wait()
-print("Certificate with name '{}' was deleted.".format(deleted_certificate.name))
+print(f"Certificate with name '{deleted_certificate.name}' was deleted.")
 
 certificate_client.purge_deleted_certificate(certificate_name=deleted_certificate.name)
-print("Certificate with name '{}' is being purged.".format(deleted_certificate.name))
+print(f"Certificate with name '{deleted_certificate.name}' is being purged.")
 
 print("\nrun_sample done")

--- a/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate_async.py
@@ -62,13 +62,13 @@ async def run_sample():
     created_certificate = await certificate_client.create_certificate(
         certificate_name=cert_name, policy=cert_policy
     )
-    print("Certificate with name '{}' was created".format(created_certificate.name))
+    print(f"Certificate with name '{created_certificate.name}' was created")
 
     # Key Vault also creates a secret with the same name as the created certificate.
     # This secret contains protected information about the certificate, such as its private key.
     print("\n.. Get a secret by name")
     certificate_secret = await secret_client.get_secret(name=cert_name)
-    print("Certificate secret with name '{}' was found.".format(certificate_secret.name))
+    print(f"Certificate secret with name '{certificate_secret.name}' was found.")
 
     # Now we can extract the private key and public certificate from the secret using the cryptography
     # package. `additional_certificates` will be empty since the secret only contains one certificate.
@@ -80,15 +80,15 @@ async def run_sample():
         data=cert_bytes,
         password=None
     )
-    print("Certificate with name '{}' was parsed.".format(certificate_secret.name))
+    print(f"Certificate with name '{certificate_secret.name}' was parsed.")
 
     # Now we can clean up the vault by deleting, then purging, the certificate.
     print("\n.. Delete certificate")
     deleted_certificate = await certificate_client.delete_certificate(certificate_name=cert_name)
-    print("Certificate with name '{}' was deleted.".format(deleted_certificate.name))
+    print(f"Certificate with name '{deleted_certificate.name}' was deleted.")
 
     await certificate_client.purge_deleted_certificate(certificate_name=deleted_certificate.name)
-    print("Certificate with name '{}' is being purged.".format(deleted_certificate.name))
+    print(f"Certificate with name '{deleted_certificate.name}' is being purged.")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations.py
@@ -51,8 +51,8 @@ storage_certificate_poller = client.begin_create_certificate(
 
 bank_certificate = bank_certificate_poller.result()
 storage_certificate = storage_certificate_poller.result()
-print("Certificate with name '{0}' was created.".format(bank_certificate.name))
-print("Certificate with name '{0}' was created.".format(storage_certificate.name))
+print(f"Certificate with name '{bank_certificate.name}' was created.")
+print(f"Certificate with name '{storage_certificate.name}' was created.")
 
 # The storage account was closed, need to delete its credentials from the Key Vault.
 print("\n.. Delete a Certificate")
@@ -62,9 +62,8 @@ deleted_bank_certificate = deleted_bank_poller.result()
 deleted_bank_poller.wait()
 
 print(
-    "Certificate with name '{0}' was deleted on date {1}.".format(
-        deleted_bank_certificate.name, deleted_bank_certificate.deleted_on
-    )
+    f"Certificate with name '{deleted_bank_certificate.name}' was deleted on date "
+    f"{deleted_bank_certificate.deleted_on}."
 )
 
 # We accidentally deleted the bank account certificate. Let's recover it.
@@ -74,7 +73,7 @@ recovered_bank_poller = client.begin_recover_deleted_certificate(deleted_bank_ce
 recovered_bank_certificate = recovered_bank_poller.result()
 # To ensure certificate is recovered on the server side.
 recovered_bank_poller.wait()
-print("Recovered Certificate with name '{0}'.".format(recovered_bank_certificate.name))
+print(f"Recovered Certificate with name '{recovered_bank_certificate.name}'.")
 
 # Let's delete the storage certificate now.
 # If the keyvault is soft-delete enabled, then for permanent deletion deleted certificate needs to be purged.

--- a/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations_async.py
@@ -50,8 +50,8 @@ async def run_sample():
         certificate_name=storage_cert_name, policy=CertificatePolicy.get_default()
     )
 
-    print("Certificate with name '{0}' was created.".format(bank_certificate.name))
-    print("Certificate with name '{0}' was created.".format(storage_certificate.name))
+    print(f"Certificate with name '{bank_certificate.name}' was created.")
+    print(f"Certificate with name '{storage_certificate.name}' was created.")
 
     # The storage account was closed, need to delete its credentials from the Key Vault.
     print("\n.. Delete a Certificate")
@@ -60,16 +60,15 @@ async def run_sample():
     await asyncio.sleep(30)
 
     print(
-        "Certificate with name '{0}' was deleted on date {1}.".format(
-            deleted_bank_certificate.name, deleted_bank_certificate.deleted_on
-        )
+        f"Certificate with name '{deleted_bank_certificate.name}' was deleted on date "
+        f"{deleted_bank_certificate.deleted_on}."
     )
 
     # We accidentally deleted the bank account certificate. Let's recover it.
     # A deleted certificate can only be recovered if the Key Vault is soft-delete enabled.
     print("\n.. Recover Deleted Certificate")
     recovered_bank_certificate = await client.recover_deleted_certificate(deleted_bank_certificate.name)
-    print("Recovered Certificate with name '{0}'.".format(recovered_bank_certificate.name))
+    print(f"Recovered Certificate with name '{recovered_bank_certificate.name}'.")
 
     # Let's delete storage account now.
     # If the keyvault is soft-delete enabled, then for permanent deletion deleted certificate needs to be purged.

--- a/sdk/keyvault/azure-keyvault-certificates/setup.py
+++ b/sdk/keyvault/azure-keyvault-certificates/setup.py
@@ -36,7 +36,7 @@ setup(
     name=PACKAGE_NAME,
     version=VERSION,
     include_package_data=True,
-    description="Microsoft Azure {} Client Library for Python".format(PACKAGE_PPRINT_NAME),
+    description=f"Microsoft Azure {PACKAGE_PPRINT_NAME} Client Library for Python",
     long_description=README + "\n\n" + CHANGELOG,
     long_description_content_type="text/markdown",
     license="MIT License",

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -256,7 +256,7 @@ class TestCertificateClient(KeyVaultTestCase):
 
         # import some certificates
         for x in range(max_certificates):
-            cert_name = self.get_resource_name("cert{}".format(x))
+            cert_name = self.get_resource_name(f"cert{x}")
             error_count = 0
             try:
                 cert_bundle = self._import_common_certificate(client=client, cert_name=cert_name)
@@ -343,12 +343,12 @@ class TestCertificateClient(KeyVaultTestCase):
         certs = {}
         # create certificates to recover
         for i in range(LIST_TEST_SIZE):
-            cert_name = self.get_resource_name("certrec{}".format(str(i)))
+            cert_name = self.get_resource_name(f"certrec{str(i)}")
             certs[cert_name] = self._import_common_certificate(client=client, cert_name=cert_name)
 
         # create certificates to purge
         for i in range(LIST_TEST_SIZE):
-            cert_name = self.get_resource_name("certprg{}".format(str(i)))
+            cert_name = self.get_resource_name(f"certprg{str(i)}")
             certs[cert_name] = self._import_common_certificate(client=client, cert_name=cert_name)
 
         # delete all certificates

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
@@ -258,7 +258,7 @@ class TestCertificateClient(KeyVaultTestCase):
 
         # import some certificates
         for x in range(max_certificates):
-            cert_name = self.get_resource_name("cert{}".format(x))
+            cert_name = self.get_resource_name(f"cert{x}")
             error_count = 0
             try:
                 cert_bundle = await self._import_common_certificate(client=client, cert_name=cert_name)
@@ -351,12 +351,12 @@ class TestCertificateClient(KeyVaultTestCase):
         certs = {}
         # create certificates to recover
         for i in range(LIST_TEST_SIZE):
-            cert_name = self.get_resource_name("certrec{}".format(str(i)))
+            cert_name = self.get_resource_name(f"certrec{str(i)}")
             certs[cert_name] = await self._import_common_certificate(client=client, cert_name=cert_name)
 
         # create certificates to purge
         for i in range(LIST_TEST_SIZE):
-            cert_name = self.get_resource_name("certprg{}".format(str(i)))
+            cert_name = self.get_resource_name(f"certprg{str(i)}")
             certs[cert_name] = await self._import_common_certificate(client=client, cert_name=cert_name)
 
         # delete all certificates

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -72,7 +72,7 @@ class KeyClient(KeyVaultClientBase):
             )
         return None
 
-    def get_cryptography_client(self, key_name: str, **kwargs: "Any") -> CryptographyClient:
+    def get_cryptography_client(self, key_name: str, **kwargs) -> CryptographyClient:
         """Gets a :class:`~azure.keyvault.keys.crypto.CryptographyClient` for the given key.
 
         :param str key_name: The name of the key used to perform cryptographic operations.
@@ -91,7 +91,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs: "Any") -> KeyVaultKey:
+    def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs) -> KeyVaultKey:
         """Create a key or, if ``name`` is already in use, create a new version of the key.
 
         Requires keys/create permission.
@@ -160,7 +160,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def create_rsa_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    def create_rsa_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new RSA key or, if ``name`` is already in use, create a new version of the key
 
         Requires the keys/create permission.
@@ -199,7 +199,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="RSA-HSM" if hsm else "RSA", **kwargs)
 
     @distributed_trace
-    def create_ec_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    def create_ec_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new elliptic curve key or, if ``name`` is already in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -238,7 +238,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace
-    def create_oct_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    def create_oct_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new octet sequence (symmetric) key or, if ``name`` is in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -275,7 +275,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="oct-HSM" if hsm else "oct", **kwargs)
 
     @distributed_trace
-    def create_okp_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    def create_okp_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new octet key pair or, if ``name`` is in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -314,7 +314,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="OKP-HSM" if hsm else "OKP", **kwargs)
 
     @distributed_trace
-    def begin_delete_key(self, name: str, **kwargs: "Any") -> "LROPoller[DeletedKey]":
+    def begin_delete_key(self, name: str, **kwargs) -> "LROPoller[DeletedKey]":
         """Delete all versions of a key and its cryptographic material.
 
         Requires keys/delete permission. When this method returns Key Vault has begun deleting the key. Deletion may
@@ -360,7 +360,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_key(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultKey:
+    def get_key(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultKey:
         """Get a key's attributes and, if it's an asymmetric key, its public material.
 
         Requires keys/get permission.
@@ -387,7 +387,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def get_deleted_key(self, name: str, **kwargs: "Any") -> DeletedKey:
+    def get_deleted_key(self, name: str, **kwargs) -> DeletedKey:
         """Get a deleted key. Possible only in a vault with soft-delete enabled.
 
         Requires keys/get permission.
@@ -413,7 +413,7 @@ class KeyClient(KeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_keys(self, **kwargs: "Any") -> "ItemPaged[DeletedKey]":
+    def list_deleted_keys(self, **kwargs) -> "ItemPaged[DeletedKey]":
         """List all deleted keys, including the public part of each. Possible only in a vault with soft-delete enabled.
 
         Requires keys/list permission.
@@ -438,7 +438,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_keys(self, **kwargs: "Any") -> "ItemPaged[KeyProperties]":
+    def list_properties_of_keys(self, **kwargs) -> "ItemPaged[KeyProperties]":
         """List identifiers and properties of all keys in the vault.
 
         Requires keys/list permission.
@@ -463,7 +463,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_key_versions(self, name: str, **kwargs: "Any") -> "ItemPaged[KeyProperties]":
+    def list_properties_of_key_versions(self, name: str, **kwargs) -> "ItemPaged[KeyProperties]":
         """List the identifiers and properties of a key's versions.
 
         Requires keys/list permission.
@@ -491,7 +491,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def purge_deleted_key(self, name: str, **kwargs: "Any") -> None:
+    def purge_deleted_key(self, name: str, **kwargs) -> None:
         """Permanently deletes a deleted key. Only possible in a vault with soft-delete enabled.
 
         Performs an irreversible deletion of the specified key, without possibility for recovery. The operation is not
@@ -518,7 +518,7 @@ class KeyClient(KeyVaultClientBase):
         self._client.purge_deleted_key(vault_base_url=self.vault_url, key_name=name, error_map=_error_map, **kwargs)
 
     @distributed_trace
-    def begin_recover_deleted_key(self, name: str, **kwargs: "Any") -> "LROPoller[KeyVaultKey]":
+    def begin_recover_deleted_key(self, name: str, **kwargs) -> "LROPoller[KeyVaultKey]":
         """Recover a deleted key to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires keys/recover permission.
@@ -563,7 +563,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def update_key_properties(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultKey:
+    def update_key_properties(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultKey:
         """Change a key's properties (not its cryptographic material).
 
         Requires keys/update permission.
@@ -619,7 +619,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def backup_key(self, name: str, **kwargs: "Any") -> bytes:
+    def backup_key(self, name: str, **kwargs) -> bytes:
         """Back up a key in a protected form useable only by Azure Key Vault.
 
         Requires keys/backup permission.
@@ -648,7 +648,7 @@ class KeyClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_key_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultKey:
+    def restore_key_backup(self, backup: bytes, **kwargs) -> KeyVaultKey:
         """Restore a key backup to the vault.
 
         Requires keys/restore permission.
@@ -683,7 +683,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def import_key(self, name: str, key: "JsonWebKey", **kwargs: "Any") -> KeyVaultKey:
+    def import_key(self, name: str, key: "JsonWebKey", **kwargs) -> KeyVaultKey:
         """Import a key created externally.
 
         Requires keys/import permission. If ``name`` is already in use, the key will be imported as a new version.
@@ -732,7 +732,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def release_key(self, name: str, target_attestation_token: str, **kwargs: "Any") -> ReleaseKeyResult:
+    def release_key(self, name: str, target_attestation_token: str, **kwargs) -> ReleaseKeyResult:
         """Releases a key.
 
         The release key operation is applicable to all key types. The target key must be marked
@@ -766,7 +766,7 @@ class KeyClient(KeyVaultClientBase):
         return ReleaseKeyResult(result.value)
 
     @distributed_trace
-    def get_random_bytes(self, count: int, **kwargs: "Any") -> bytes:
+    def get_random_bytes(self, count: int, **kwargs) -> bytes:
         """Get the requested number of random bytes from a managed HSM.
 
         :param int count: The requested number of random bytes.
@@ -792,7 +792,7 @@ class KeyClient(KeyVaultClientBase):
         return result.value
 
     @distributed_trace
-    def get_key_rotation_policy(self, key_name: str, **kwargs: "Any") -> KeyRotationPolicy:
+    def get_key_rotation_policy(self, key_name: str, **kwargs) -> KeyRotationPolicy:
         """Get the rotation policy of a Key Vault key.
 
         :param str key_name: The name of the key.
@@ -806,7 +806,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyRotationPolicy._from_generated(policy)
 
     @distributed_trace
-    def rotate_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    def rotate_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Rotate the key based on the key policy by generating a new version of the key.
 
         This operation requires the keys/rotate permission.
@@ -823,7 +823,7 @@ class KeyClient(KeyVaultClientBase):
 
     @distributed_trace
     def update_key_rotation_policy(
-        self, key_name: str, policy: KeyRotationPolicy, **kwargs: "Any"
+        self, key_name: str, policy: KeyRotationPolicy, **kwargs
     ) -> KeyRotationPolicy:
         """Updates the rotation policy of a Key Vault key.
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -18,15 +18,17 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
+    from datetime import datetime
     from typing import Any, Optional, Union
     from azure.core.paging import ItemPaged
     from azure.core.polling import LROPoller
-    from ._models import JsonWebKey
     from ._enums import KeyType
+    from ._generated_models import KeyAttributes
+    from ._models import JsonWebKey
 
 
 def _get_key_id(vault_url, key_name, version=None):
-    without_version = "{}/keys/{}".format(vault_url, key_name)
+    without_version = f"{vault_url}/keys/{key_name}"
     return without_version + "/" + version if version else without_version
 
 
@@ -56,7 +58,13 @@ class KeyClient(KeyVaultClientBase):
 
     # pylint:disable=protected-access, too-many-public-methods
 
-    def _get_attributes(self, enabled, not_before, expires_on, exportable=None):
+    def _get_attributes(
+        self,
+        enabled: "Optional[bool]",
+        not_before: "Optional[datetime]",
+        expires_on: "Optional[datetime]",
+        exportable: "Optional[bool]" = None,
+    ) -> "Optional[KeyAttributes]":
         """Return a KeyAttributes object if none-None attributes are provided, or None otherwise"""
         if enabled is not None or not_before is not None or expires_on is not None or exportable is not None:
             return self._models.KeyAttributes(
@@ -64,8 +72,7 @@ class KeyClient(KeyVaultClientBase):
             )
         return None
 
-    def get_cryptography_client(self, key_name, **kwargs):
-        # type: (str, **Any) -> CryptographyClient
+    def get_cryptography_client(self, key_name: str, **kwargs: "Any") -> CryptographyClient:
         """Gets a :class:`~azure.keyvault.keys.crypto.CryptographyClient` for the given key.
 
         :param str key_name: The name of the key used to perform cryptographic operations.
@@ -84,8 +91,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def create_key(self, name, key_type, **kwargs):
-        # type: (str, Union[str, KeyType], **Any) -> KeyVaultKey
+    def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs: "Any") -> KeyVaultKey:
         """Create a key or, if ``name`` is already in use, create a new version of the key.
 
         Requires keys/create permission.
@@ -95,9 +101,9 @@ class KeyClient(KeyVaultClientBase):
         :type key_type: ~azure.keyvault.keys.KeyType or str
 
         :keyword int size: Key size in bits. Applies only to RSA and symmetric keys. Consider using
-         :func:`create_rsa_key` or :func:`create_oct_key` instead.
+            :func:`create_rsa_key` or :func:`create_oct_key` instead.
         :keyword curve: Elliptic curve name. Applies only to elliptic curve keys. Defaults to the NIST P-256
-         elliptic curve. To create an elliptic curve key, consider using :func:`create_ec_key` instead.
+            elliptic curve. To create an elliptic curve key, consider using :func:`create_ec_key` instead.
         :paramtype curve: ~azure.keyvault.keys.KeyCurveName or str
         :keyword int public_exponent: The RSA public exponent to use. Applies only to RSA keys created in a Managed HSM.
         :keyword key_operations: Allowed key operations
@@ -113,6 +119,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -153,8 +160,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def create_rsa_key(self, name, **kwargs):
-        # type: (str, **Any) -> KeyVaultKey
+    def create_rsa_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
         """Create a new RSA key or, if ``name`` is already in use, create a new version of the key
 
         Requires the keys/create permission.
@@ -178,6 +184,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -192,8 +199,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="RSA-HSM" if hsm else "RSA", **kwargs)
 
     @distributed_trace
-    def create_ec_key(self, name, **kwargs):
-        # type: (str, **Any) -> KeyVaultKey
+    def create_ec_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
         """Create a new elliptic curve key or, if ``name`` is already in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -205,7 +211,7 @@ class KeyClient(KeyVaultClientBase):
         :keyword key_operations: Allowed key operations
         :paramtype key_operations: list[~azure.keyvault.keys.KeyOperation or str]
         :keyword bool hardware_protected: Whether the key should be created in a hardware security module.
-         Defaults to ``False``.
+            Defaults to ``False``.
         :keyword bool enabled: Whether the key is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
@@ -217,6 +223,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -231,8 +238,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace
-    def create_oct_key(self, name, **kwargs):
-        # type: (str, **Any) -> KeyVaultKey
+    def create_oct_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
         """Create a new octet sequence (symmetric) key or, if ``name`` is in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -243,7 +249,7 @@ class KeyClient(KeyVaultClientBase):
         :keyword key_operations: Allowed key operations.
         :paramtype key_operations: list[~azure.keyvault.keys.KeyOperation or str]
         :keyword bool hardware_protected: Whether the key should be created in a hardware security module.
-         Defaults to ``False``.
+            Defaults to ``False``.
         :keyword bool enabled: Whether the key is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
@@ -293,6 +299,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -307,8 +314,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="OKP-HSM" if hsm else "OKP", **kwargs)
 
     @distributed_trace
-    def begin_delete_key(self, name, **kwargs):
-        # type: (str, **Any) -> LROPoller
+    def begin_delete_key(self, name: str, **kwargs: "Any") -> "LROPoller[DeletedKey]":
         """Delete all versions of a key and its cryptographic material.
 
         Requires keys/delete permission. When this method returns Key Vault has begun deleting the key. Deletion may
@@ -318,11 +324,12 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key to delete.
 
         :returns: A poller for the delete key operation. The poller's `result` method returns the
-         :class:`~azure.keyvault.keys.DeletedKey` without waiting for deletion to complete. If the vault has
-         soft-delete enabled and you want to permanently delete the key with :func:`purge_deleted_key`, call the
-         poller's `wait` method first. It will block until the deletion is complete. The `wait` method requires
-         keys/get permission.
+            :class:`~azure.keyvault.keys.DeletedKey` without waiting for deletion to complete. If the vault has
+            soft-delete enabled and you want to permanently delete the key with :func:`purge_deleted_key`, call the
+            poller's `wait` method first. It will block until the deletion is complete. The `wait` method requires
+            keys/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.keys.DeletedKey]
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -353,8 +360,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_key(self, name, version=None, **kwargs):
-        # type: (str, Optional[str], **Any) -> KeyVaultKey
+    def get_key(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultKey:
         """Get a key's attributes and, if it's an asymmetric key, its public material.
 
         Requires keys/get permission.
@@ -364,6 +370,7 @@ class KeyClient(KeyVaultClientBase):
             of the key.
 
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -380,8 +387,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def get_deleted_key(self, name, **kwargs):
-        # type: (str, **Any) -> DeletedKey
+    def get_deleted_key(self, name: str, **kwargs: "Any") -> DeletedKey:
         """Get a deleted key. Possible only in a vault with soft-delete enabled.
 
         Requires keys/get permission.
@@ -390,6 +396,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.DeletedKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -406,8 +413,7 @@ class KeyClient(KeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_keys(self, **kwargs):
-        # type: (**Any) -> ItemPaged[DeletedKey]
+    def list_deleted_keys(self, **kwargs: "Any") -> "ItemPaged[DeletedKey]":
         """List all deleted keys, including the public part of each. Possible only in a vault with soft-delete enabled.
 
         Requires keys/list permission.
@@ -432,8 +438,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_keys(self, **kwargs):
-        # type: (**Any) -> ItemPaged[KeyProperties]
+    def list_properties_of_keys(self, **kwargs: "Any") -> "ItemPaged[KeyProperties]":
         """List identifiers and properties of all keys in the vault.
 
         Requires keys/list permission.
@@ -458,8 +463,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_key_versions(self, name, **kwargs):
-        # type: (str, **Any) -> ItemPaged[KeyProperties]
+    def list_properties_of_key_versions(self, name: str, **kwargs: "Any") -> "ItemPaged[KeyProperties]":
         """List the identifiers and properties of a key's versions.
 
         Requires keys/list permission.
@@ -487,13 +491,11 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def purge_deleted_key(self, name, **kwargs):
-        # type: (str, **Any) -> None
+    def purge_deleted_key(self, name: str, **kwargs: "Any") -> None:
         """Permanently deletes a deleted key. Only possible in a vault with soft-delete enabled.
 
-        Performs an irreversible deletion of the specified key, without
-        possibility for recovery. The operation is not available if the
-        :py:attr:`~azure.keyvault.keys.KeyProperties.recovery_level` does not specify 'Purgeable'.
+        Performs an irreversible deletion of the specified key, without possibility for recovery. The operation is not
+        available if the :py:attr:`~azure.keyvault.keys.KeyProperties.recovery_level` does not specify 'Purgeable'.
         This method is only necessary for purging a key before its
         :py:attr:`~azure.keyvault.keys.DeletedKey.scheduled_purge_date`.
 
@@ -502,6 +504,7 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the deleted key to purge
 
         :returns: None
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -515,8 +518,7 @@ class KeyClient(KeyVaultClientBase):
         self._client.purge_deleted_key(vault_base_url=self.vault_url, key_name=name, error_map=_error_map, **kwargs)
 
     @distributed_trace
-    def begin_recover_deleted_key(self, name, **kwargs):
-        # type: (str, **Any) -> LROPoller
+    def begin_recover_deleted_key(self, name: str, **kwargs: "Any") -> "LROPoller[KeyVaultKey]":
         """Recover a deleted key to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires keys/recover permission.
@@ -561,8 +563,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def update_key_properties(self, name, version=None, **kwargs):
-        # type: (str, Optional[str], **Any) -> KeyVaultKey
+    def update_key_properties(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultKey:
         """Change a key's properties (not its cryptographic material).
 
         Requires keys/update permission.
@@ -582,6 +583,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -617,8 +619,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def backup_key(self, name, **kwargs):
-        # type: (str, **Any) -> bytes
+    def backup_key(self, name: str, **kwargs: "Any") -> bytes:
         """Back up a key in a protected form useable only by Azure Key Vault.
 
         Requires keys/backup permission.
@@ -630,6 +631,7 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key to back up
 
         :rtype: bytes
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -646,8 +648,7 @@ class KeyClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_key_backup(self, backup, **kwargs):
-        # type: (bytes, **Any) -> KeyVaultKey
+    def restore_key_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultKey:
         """Restore a key backup to the vault.
 
         Requires keys/restore permission.
@@ -660,6 +661,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -681,8 +683,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def import_key(self, name, key, **kwargs):
-        # type: (str, JsonWebKey, **Any) -> KeyVaultKey
+    def import_key(self, name: str, key: "JsonWebKey", **kwargs: "Any") -> KeyVaultKey:
         """Import a key created externally.
 
         Requires keys/import permission. If ``name`` is already in use, the key will be imported as a new version.
@@ -703,6 +704,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         enabled = kwargs.pop("enabled", None)
@@ -730,8 +732,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def release_key(self, name, target_attestation_token, **kwargs):
-        # type: (str, str, **Any) -> ReleaseKeyResult
+    def release_key(self, name: str, target_attestation_token: str, **kwargs: "Any") -> ReleaseKeyResult:
         """Releases a key.
 
         The release key operation is applicable to all key types. The target key must be marked
@@ -747,6 +748,7 @@ class KeyClient(KeyVaultClientBase):
 
         :return: The result of the key release.
         :rtype: ~azure.keyvault.keys.ReleaseKeyResult
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         version = kwargs.pop("version", "")
@@ -764,8 +766,7 @@ class KeyClient(KeyVaultClientBase):
         return ReleaseKeyResult(result.value)
 
     @distributed_trace
-    def get_random_bytes(self, count, **kwargs):
-        # type: (int, **Any) -> bytes
+    def get_random_bytes(self, count: int, **kwargs: "Any") -> bytes:
         """Get the requested number of random bytes from a managed HSM.
 
         :param int count: The requested number of random bytes.
@@ -791,22 +792,21 @@ class KeyClient(KeyVaultClientBase):
         return result.value
 
     @distributed_trace
-    def get_key_rotation_policy(self, key_name, **kwargs):
-        # type: (str, **Any) -> KeyRotationPolicy
+    def get_key_rotation_policy(self, key_name: str, **kwargs: "Any") -> KeyRotationPolicy:
         """Get the rotation policy of a Key Vault key.
 
         :param str key_name: The name of the key.
 
         :return: The key rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
+
         :raises: :class: `~azure.core.exceptions.HttpResponseError`
         """
         policy = self._client.get_key_rotation_policy(vault_base_url=self._vault_url, key_name=key_name, **kwargs)
         return KeyRotationPolicy._from_generated(policy)
 
     @distributed_trace
-    def rotate_key(self, name, **kwargs):
-        # type: (str, **Any) -> KeyVaultKey
+    def rotate_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
         """Rotate the key based on the key policy by generating a new version of the key.
 
         This operation requires the keys/rotate permission.
@@ -815,14 +815,16 @@ class KeyClient(KeyVaultClientBase):
 
         :return: The new version of the rotated key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.rotate_key(vault_base_url=self._vault_url, key_name=name, **kwargs)
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def update_key_rotation_policy(self, key_name, policy, **kwargs):
-        # type: (str, KeyRotationPolicy, **Any) -> KeyRotationPolicy
+    def update_key_rotation_policy(
+        self, key_name: str, policy: KeyRotationPolicy, **kwargs: "Any"
+    ) -> KeyRotationPolicy:
         """Updates the rotation policy of a Key Vault key.
 
         This operation requires the keys/update permission.
@@ -841,6 +843,7 @@ class KeyClient(KeyVaultClientBase):
 
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         lifetime_actions = kwargs.pop("lifetime_actions", policy.lifetime_actions)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -48,13 +48,11 @@ class JsonWebKey(object):
 
     _FIELDS = ("kid", "kty", "key_ops", "n", "e", "d", "dp", "dq", "qi", "p", "q", "k", "t", "crv", "x", "y")
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: "Any") -> None:
         for field in self._FIELDS:
             setattr(self, field, kwargs.get(field))
 
-    def _to_generated_model(self):
-        # type: () -> _JsonWebKey
+    def _to_generated_model(self) -> _JsonWebKey:
         jwk = _JsonWebKey()
         for field in self._FIELDS:
             setattr(jwk, field, getattr(self, field))
@@ -64,8 +62,7 @@ class JsonWebKey(object):
 class KeyProperties(object):
     """A key's id and attributes."""
 
-    def __init__(self, key_id, attributes=None, **kwargs):
-        # type: (str, Optional[_models.KeyAttributes], **Any) -> None
+    def __init__(self, key_id: str, attributes: "Optional[_models.KeyAttributes]" = None, **kwargs: "Any") -> None:
         self._attributes = attributes
         self._id = key_id
         self._vault_id = KeyVaultKeyIdentifier(key_id)
@@ -73,13 +70,11 @@ class KeyProperties(object):
         self._tags = kwargs.get("tags", None)
         self._release_policy = kwargs.pop("release_policy", None)
 
-    def __repr__(self):
-        # type () -> str
-        return "<KeyProperties [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<KeyProperties [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_key_bundle(cls, key_bundle):
-        # type: (_models.KeyBundle) -> KeyProperties
+    def _from_key_bundle(cls, key_bundle: "_models.KeyBundle") -> "KeyProperties":
         """Construct a KeyProperties from an autorest-generated KeyBundle"""
         # pylint:disable=line-too-long
         # release_policy was added in 7.3-preview
@@ -102,8 +97,7 @@ class KeyProperties(object):
         )
 
     @classmethod
-    def _from_key_item(cls, key_item):
-        # type: (_models.KeyItem) -> KeyProperties
+    def _from_key_item(cls, key_item: "_models.KeyItem") -> "KeyProperties":
         """Construct a KeyProperties from an autorest-generated KeyItem"""
         return cls(
             key_id=key_item.kid,  # type: ignore
@@ -113,8 +107,7 @@ class KeyProperties(object):
         )
 
     @property
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """The key's id
 
         :rtype: str
@@ -122,8 +115,7 @@ class KeyProperties(object):
         return self._id
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         """The key's name
 
         :rtype: str
@@ -131,8 +123,7 @@ class KeyProperties(object):
         return self._vault_id.name
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> "Optional[str]":
         """The key's version
 
         :rtype: str or None
@@ -140,8 +131,7 @@ class KeyProperties(object):
         return self._vault_id.version
 
     @property
-    def enabled(self):
-        # type: () -> Optional[bool]
+    def enabled(self) -> "Optional[bool]":
         """Whether the key is enabled for use
 
         :rtype: bool or None
@@ -149,8 +139,7 @@ class KeyProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self):
-        # type: () -> Optional[datetime]
+    def not_before(self) -> "Optional[datetime]":
         """The time before which the key can not be used, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -158,8 +147,7 @@ class KeyProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self):
-        # type: () -> Optional[datetime]
+    def expires_on(self) -> "Optional[datetime]":
         """When the key will expire, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -167,8 +155,7 @@ class KeyProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self):
-        # type: () -> Optional[datetime]
+    def created_on(self) -> "Optional[datetime]":
         """When the key was created, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -176,8 +163,7 @@ class KeyProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self):
-        # type: () -> Optional[datetime]
+    def updated_on(self) -> "Optional[datetime]":
         """When the key was last updated, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -185,8 +171,7 @@ class KeyProperties(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         """URL of the vault containing the key
 
         :rtype: str
@@ -194,8 +179,7 @@ class KeyProperties(object):
         return self._vault_id.vault_url
 
     @property
-    def recoverable_days(self):
-        # type: () -> Optional[int]
+    def recoverable_days(self) -> "Optional[int]":
         """The number of days the key is retained before being deleted from a soft-delete enabled Key Vault.
 
         :rtype: int or None
@@ -206,8 +190,7 @@ class KeyProperties(object):
         return None
 
     @property
-    def recovery_level(self):
-        # type: () -> Optional[str]
+    def recovery_level(self) -> "Optional[str]":
         """The vault's deletion recovery level for keys
 
         :rtype: str or None
@@ -215,8 +198,7 @@ class KeyProperties(object):
         return self._attributes.recovery_level if self._attributes else None
 
     @property
-    def tags(self):
-        # type: () -> Dict[str, str]
+    def tags(self) -> "Dict[str, str]":
         """Application specific metadata in the form of key-value pairs
 
         :rtype: dict[str, str]
@@ -224,8 +206,7 @@ class KeyProperties(object):
         return self._tags
 
     @property
-    def managed(self):
-        # type: () -> Optional[bool]
+    def managed(self) -> "Optional[bool]":
         """Whether the key's lifetime is managed by Key Vault. If the key backs a certificate, this will be true.
 
         :rtype: bool or None
@@ -233,8 +214,7 @@ class KeyProperties(object):
         return self._managed
 
     @property
-    def exportable(self):
-        # type: () -> Optional[bool]
+    def exportable(self) -> "Optional[bool]":
         """Whether the private key can be exported
 
         :rtype: bool or None
@@ -245,8 +225,7 @@ class KeyProperties(object):
         return None
 
     @property
-    def release_policy(self):
-        # type: () -> Optional[KeyReleasePolicy]
+    def release_policy(self) -> "Optional[KeyReleasePolicy]":
         """The :class:`~azure.keyvault.keys.KeyReleasePolicy` specifying the rules under which the key can be exported.
 
         :rtype: ~azure.keyvault.keys.KeyReleasePolicy or None
@@ -267,8 +246,7 @@ class KeyReleasePolicy(object):
         updated after being marked immutable. Release policies are mutable by default.
     """
 
-    def __init__(self, encoded_policy, **kwargs):
-        # type: (bytes, **Any) -> None
+    def __init__(self, encoded_policy: bytes, **kwargs: "Any") -> None:
         self.encoded_policy = encoded_policy
         self.content_type = kwargs.get("content_type", None)
         self.immutable = kwargs.get("immutable", None)
@@ -280,8 +258,7 @@ class ReleaseKeyResult(object):
     :ivar str value: A signed token containing the released key.
     """
 
-    def __init__(self, value):
-        # type: (str) -> None
+    def __init__(self, value: str) -> None:
         self.value = value
 
 
@@ -301,21 +278,22 @@ class KeyRotationLifetimeAction(object):
     :paramtype time_before_expiry: Optional[str]
     """
 
-    def __init__(self, action, **kwargs):
-        # type: (KeyRotationPolicyAction, **Any) -> None
+    def __init__(self, action: "Union[KeyRotationPolicyAction, str]", **kwargs: "Any") -> None:
         self.action = action
-        self.time_after_create = kwargs.get("time_after_create", None)
-        self.time_before_expiry = kwargs.get("time_before_expiry", None)
+        self.time_after_create = kwargs.get("time_after_create", None)  # type: Optional[str]
+        self.time_before_expiry = kwargs.get("time_before_expiry", None)  # type: Optional[str]
 
     @classmethod
-    def _from_generated(cls, lifetime_action):
-        if lifetime_action.trigger:
-            return cls(
-                action=lifetime_action.action.type,
-                time_after_create=lifetime_action.trigger.time_after_create,
-                time_before_expiry=lifetime_action.trigger.time_before_expiry,
-            )
-        return cls(action=lifetime_action.action)
+    def _from_generated(cls, lifetime_action: "_models.LifetimeActions") -> "KeyRotationLifetimeAction":
+        if lifetime_action.action:
+            if lifetime_action.trigger:
+                return cls(
+                    action=lifetime_action.action.type,  # type: ignore
+                    time_after_create=lifetime_action.trigger.time_after_create,
+                    time_before_expiry=lifetime_action.trigger.time_before_expiry,
+                )
+            return cls(action=lifetime_action.action)  # type: ignore
+        raise ValueError("Provided LifetimeActions model is missing a required lifetime action property.")
 
 
 class KeyRotationPolicy(object):
@@ -335,16 +313,15 @@ class KeyRotationPolicy(object):
     :vartype updated_on: Optional[~datetime.datetime]
     """
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: "Any") -> None:
         self.id = kwargs.get("policy_id", None)
-        self.lifetime_actions = kwargs.get("lifetime_actions", [])
+        self.lifetime_actions = kwargs.get("lifetime_actions", [])  # type: List[KeyRotationLifetimeAction]
         self.expires_in = kwargs.get("expires_in", None)
         self.created_on = kwargs.get("created_on", None)
         self.updated_on = kwargs.get("updated_on", None)
 
     @classmethod
-    def _from_generated(cls, policy):
+    def _from_generated(cls, policy: "_models.KeyRotationPolicy") -> "KeyRotationPolicy":
         lifetime_actions = (
             []
             if policy.lifetime_actions is None
@@ -364,11 +341,12 @@ class KeyRotationPolicy(object):
 class KeyVaultKey(object):
     """A key's attributes and cryptographic material.
 
-    :param str key_id:
-        Key Vault's identifier for the key. Typically a URI, e.g. https://myvault.vault.azure.net/keys/my-key/version
-    :param jwk:
-        The key's cryptographic material as a JSON Web Key (https://tools.ietf.org/html/rfc7517). This may be provided
-        as a dictionary or keyword arguments. See :class:`~azure.keyvault.keys.models.JsonWebKey` for field names.
+    :param str key_id: Key Vault's identifier for the key. Typically a URI, e.g.
+        https://myvault.vault.azure.net/keys/my-key/version
+    :param jwk: The key's cryptographic material as a JSON Web Key (https://tools.ietf.org/html/rfc7517). This may be
+        provided as a dictionary or keyword arguments. See :class:`~azure.keyvault.keys.models.JsonWebKey` for field
+        names.
+    :type jwk: Dict[str, Any]
 
     Providing cryptographic material as keyword arguments:
 
@@ -393,9 +371,8 @@ class KeyVaultKey(object):
 
     """
 
-    def __init__(self, key_id, jwk=None, **kwargs):
-        # type: (str, Optional[dict], **Any) -> None
-        self._properties = kwargs.pop("properties", None) or KeyProperties(key_id, **kwargs)
+    def __init__(self, key_id: str, jwk: "Optional[Dict[str, Any]]" = None, **kwargs: "Any") -> None:
+        self._properties = kwargs.pop("properties", None) or KeyProperties(key_id, **kwargs)  # type: KeyProperties
         if isinstance(jwk, dict):
             if any(field in kwargs for field in JsonWebKey._FIELDS):  # pylint:disable=protected-access
                 raise ValueError(
@@ -405,13 +382,11 @@ class KeyVaultKey(object):
         else:
             self._key_material = JsonWebKey(**kwargs)
 
-    def __repr__(self):
-        # type () -> str
-        return "<KeyVaultKey [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<KeyVaultKey [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_key_bundle(cls, key_bundle):
-        # type: (_models.KeyBundle) -> KeyVaultKey
+    def _from_key_bundle(cls, key_bundle: "_models.KeyBundle") -> "KeyVaultKey":
         """Construct a KeyVaultKey from an autorest-generated KeyBundle"""
         # pylint:disable=protected-access
         return cls(
@@ -421,8 +396,7 @@ class KeyVaultKey(object):
         )
 
     @property
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """The key's id
 
         :rtype: str
@@ -430,8 +404,7 @@ class KeyVaultKey(object):
         return self._properties.id
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         """The key's name
 
         :rtype: str
@@ -439,8 +412,7 @@ class KeyVaultKey(object):
         return self._properties.name
 
     @property
-    def properties(self):
-        # type: () -> KeyProperties
+    def properties(self) -> KeyProperties:
         """The key's properties
 
         :rtype: ~azure.keyvault.keys.KeyProperties
@@ -448,8 +420,7 @@ class KeyVaultKey(object):
         return self._properties
 
     @property
-    def key(self):
-        # type: () -> JsonWebKey
+    def key(self) -> JsonWebKey:
         """The JSON web key
 
         :rtype: ~azure.keyvault.keys.JsonWebKey
@@ -457,8 +428,7 @@ class KeyVaultKey(object):
         return self._key_material
 
     @property
-    def key_type(self):
-        # type: () -> Union[str, KeyType]
+    def key_type(self) -> "Union[str, KeyType]":
         """The key's type. See :class:`~azure.keyvault.keys.KeyType` for possible values.
 
         :rtype: ~azure.keyvault.keys.KeyType or str
@@ -467,8 +437,7 @@ class KeyVaultKey(object):
         return self._key_material.kty  # type: ignore[attr-defined]
 
     @property
-    def key_operations(self):
-        # type: () -> List[Union[str, KeyOperation]]
+    def key_operations(self) -> "List[Union[str, KeyOperation]]":
         """Permitted operations. See :class:`~azure.keyvault.keys.KeyOperation` for possible values.
 
         :rtype: List[~azure.keyvault.keys.KeyOperation or str]
@@ -480,8 +449,10 @@ class KeyVaultKey(object):
 class KeyVaultKeyIdentifier(object):
     """Information about a KeyVaultKey parsed from a key ID.
 
-    :param str source_id: the full original identifier of a key
+    :param str source_id: The full original identifier of a key
+
     :raises ValueError: if the key ID is improperly formatted
+
     Example:
         .. literalinclude:: ../tests/test_parse_id.py
             :start-after: [START parse_key_vault_key_id]
@@ -491,56 +462,50 @@ class KeyVaultKeyIdentifier(object):
             :dedent: 8
     """
 
-    def __init__(self, source_id):
-        # type: (str) -> None
+    def __init__(self, source_id: str) -> None:
         self._resource_id = parse_key_vault_id(source_id)
 
     @property
-    def source_id(self):
-        # type: () -> str
+    def source_id(self) -> str:
         return self._resource_id.source_id
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._resource_id.vault_url
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         return self._resource_id.name
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> "Optional[str]":
         return self._resource_id.version
 
 
 class DeletedKey(KeyVaultKey):
-    """A deleted key's properties, cryptographic material and its deletion information. If soft-delete
-    is enabled, returns information about its recovery as well."""
+    """A deleted key's properties, cryptographic material and its deletion information.
+
+    If soft-delete is enabled, returns information about its recovery as well.
+    """
 
     def __init__(
         self,
-        properties,  # type: KeyProperties
-        deleted_date=None,  # type: Optional[datetime]
-        recovery_id=None,  # type: Optional[str]
-        scheduled_purge_date=None,  # type: Optional[datetime]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> None
+        properties: KeyProperties,
+        deleted_date: "Optional[datetime]" = None,
+        recovery_id: "Optional[str]" = None,
+        scheduled_purge_date: "Optional[datetime]" = None,
+        **kwargs: "Any",
+    ) -> None:
         super(DeletedKey, self).__init__(properties=properties, **kwargs)
         self._deleted_date = deleted_date
         self._recovery_id = recovery_id
         self._scheduled_purge_date = scheduled_purge_date
 
-    def __repr__(self):
-        # type () -> str
-        return "<DeletedKey [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<DeletedKey [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_deleted_key_bundle(cls, deleted_key_bundle):
-        # type: (_models.DeletedKeyBundle) -> DeletedKey
+    def _from_deleted_key_bundle(cls, deleted_key_bundle: "_models.DeletedKeyBundle") -> "DeletedKey":
         """Construct a DeletedKey from an autorest-generated DeletedKeyBundle"""
         # pylint:disable=protected-access
         return cls(
@@ -553,8 +518,7 @@ class DeletedKey(KeyVaultKey):
         )
 
     @classmethod
-    def _from_deleted_key_item(cls, deleted_key_item):
-        # type: (_models.DeletedKeyItem) -> DeletedKey
+    def _from_deleted_key_item(cls, deleted_key_item: "_models.DeletedKeyItem") -> "DeletedKey":
         """Construct a DeletedKey from an autorest-generated DeletedKeyItem"""
         return cls(
             properties=KeyProperties._from_key_item(deleted_key_item),  # pylint: disable=protected-access
@@ -565,8 +529,7 @@ class DeletedKey(KeyVaultKey):
         )
 
     @property
-    def deleted_date(self):
-        # type: () -> Optional[datetime]
+    def deleted_date(self) -> "Optional[datetime]":
         """When the key was deleted, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -574,8 +537,7 @@ class DeletedKey(KeyVaultKey):
         return self._deleted_date
 
     @property
-    def recovery_id(self):
-        # type: () -> Optional[str]
+    def recovery_id(self) -> "Optional[str]":
         """An identifier used to recover the deleted key. Returns ``None`` if soft-delete is disabled.
 
         :rtype: str or None
@@ -583,8 +545,7 @@ class DeletedKey(KeyVaultKey):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self):
-        # type: () -> Optional[datetime]
+    def scheduled_purge_date(self) -> "Optional[datetime]":
         """When the key is scheduled to be purged, in UTC. Returns ``None`` if soft-delete is disabled.
 
         :rtype: ~datetime.datetime or None

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -48,7 +48,7 @@ class JsonWebKey(object):
 
     _FIELDS = ("kid", "kty", "key_ops", "n", "e", "d", "dp", "dq", "qi", "p", "q", "k", "t", "crv", "x", "y")
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         for field in self._FIELDS:
             setattr(self, field, kwargs.get(field))
 
@@ -62,7 +62,7 @@ class JsonWebKey(object):
 class KeyProperties(object):
     """A key's id and attributes."""
 
-    def __init__(self, key_id: str, attributes: "Optional[_models.KeyAttributes]" = None, **kwargs: "Any") -> None:
+    def __init__(self, key_id: str, attributes: "Optional[_models.KeyAttributes]" = None, **kwargs) -> None:
         self._attributes = attributes
         self._id = key_id
         self._vault_id = KeyVaultKeyIdentifier(key_id)
@@ -246,7 +246,7 @@ class KeyReleasePolicy(object):
         updated after being marked immutable. Release policies are mutable by default.
     """
 
-    def __init__(self, encoded_policy: bytes, **kwargs: "Any") -> None:
+    def __init__(self, encoded_policy: bytes, **kwargs) -> None:
         self.encoded_policy = encoded_policy
         self.content_type = kwargs.get("content_type", None)
         self.immutable = kwargs.get("immutable", None)
@@ -278,7 +278,7 @@ class KeyRotationLifetimeAction(object):
     :paramtype time_before_expiry: Optional[str]
     """
 
-    def __init__(self, action: "Union[KeyRotationPolicyAction, str]", **kwargs: "Any") -> None:
+    def __init__(self, action: "Union[KeyRotationPolicyAction, str]", **kwargs) -> None:
         self.action = action
         self.time_after_create = kwargs.get("time_after_create", None)  # type: Optional[str]
         self.time_before_expiry = kwargs.get("time_before_expiry", None)  # type: Optional[str]
@@ -313,7 +313,7 @@ class KeyRotationPolicy(object):
     :vartype updated_on: Optional[~datetime.datetime]
     """
 
-    def __init__(self, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs) -> None:
         self.id = kwargs.get("policy_id", None)
         self.lifetime_actions = kwargs.get("lifetime_actions", [])  # type: List[KeyRotationLifetimeAction]
         self.expires_in = kwargs.get("expires_in", None)
@@ -371,7 +371,7 @@ class KeyVaultKey(object):
 
     """
 
-    def __init__(self, key_id: str, jwk: "Optional[Dict[str, Any]]" = None, **kwargs: "Any") -> None:
+    def __init__(self, key_id: str, jwk: "Optional[Dict[str, Any]]" = None, **kwargs) -> None:
         self._properties = kwargs.pop("properties", None) or KeyProperties(key_id, **kwargs)  # type: KeyProperties
         if isinstance(jwk, dict):
             if any(field in kwargs for field in JsonWebKey._FIELDS):  # pylint:disable=protected-access
@@ -494,7 +494,7 @@ class DeletedKey(KeyVaultKey):
         deleted_date: "Optional[datetime]" = None,
         recovery_id: "Optional[str]" = None,
         scheduled_purge_date: "Optional[datetime]" = None,
-        **kwargs: "Any",
+        **kwargs,
     ) -> None:
         super(DeletedKey, self).__init__(properties=properties, **kwargs)
         self._deleted_date = deleted_date

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_sdk_moniker.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_sdk_moniker.py
@@ -4,4 +4,4 @@
 # ------------------------------------
 from ._version import VERSION
 
-SDK_MONIKER = "keyvault-keys/{}".format(VERSION)
+SDK_MONIKER = f"keyvault-keys/{VERSION}"

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
@@ -2,13 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    import urllib.parse as parse
-except ImportError:
-    # pylint:disable=import-error
-    import urlparse as parse  # type: ignore
-
 from typing import TYPE_CHECKING
+from urllib import parse
+
 from .challenge_auth_policy import ChallengeAuthPolicy
 from .client_base import KeyVaultClientBase
 from .http_challenge import HttpChallenge
@@ -39,32 +35,31 @@ class KeyVaultResourceId():
 
     def __init__(
         self,
-        source_id,  # type: str
-        vault_url,  # type: str
-        name,  # type: str
-        version=None  # type: Optional[str]
-    ):
+        source_id: str,
+        vault_url: str,
+        name: str,
+        version: "Optional[str]" = None,
+    ) -> None:
         self.source_id = source_id
         self.vault_url = vault_url
         self.name = name
         self.version = version
 
 
-def parse_key_vault_id(source_id):
-    # type: (str) -> KeyVaultResourceId
+def parse_key_vault_id(source_id: str) -> KeyVaultResourceId:
     try:
         parsed_uri = parse.urlparse(source_id)
     except Exception:  # pylint: disable=broad-except
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
     if not (parsed_uri.scheme and parsed_uri.hostname):
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
 
     path = list(filter(None, parsed_uri.path.split("/")))
 
     if len(path) < 2 or len(path) > 3:
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
 
-    vault_url = "{}://{}".format(parsed_uri.scheme, parsed_uri.hostname)
+    vault_url = f"{parsed_uri.scheme}://{parsed_uri.hostname}"
     if parsed_uri.port:
         vault_url += f":{parsed_uri.port}"
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
@@ -11,17 +11,12 @@ from typing import TYPE_CHECKING
 from azure.core.polling import PollingMethod, LROPoller, NoPolling
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
-try:
-    from urlparse import urlparse  # type: ignore # pylint: disable=unused-import
-except ImportError:
-    from urllib.parse import urlparse
-
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.common import with_current_context
 
 if TYPE_CHECKING:
     # pylint: disable=ungrouped-imports
-    from typing import Any, Callable, Union, List, Optional
+    from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -31,37 +26,35 @@ class KeyVaultOperationPoller(LROPoller):
     """
 
     # pylint: disable=arguments-differ
-    def __init__(self, polling_method):
-        # type: (PollingMethod) -> None
+    def __init__(self, polling_method: PollingMethod) -> None:
         super(KeyVaultOperationPoller, self).__init__(None, None, lambda *_: None, NoPolling())
         self._polling_method = polling_method
 
     # pylint: disable=arguments-differ
-    def result(self):  # type: ignore
-        # type: () -> Any
+    def result(self) -> "Any":  # type: ignore
         """Returns a representation of the final resource without waiting for the operation to complete.
 
         :returns: The deserialized resource of the long running operation
+
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """
         return self._polling_method.resource()
 
     @distributed_trace
-    def wait(self, timeout=None):
-        # type: (Optional[float]) -> None
+    def wait(self, timeout: "Optional[float]" = None) -> None:
         """Wait on the long running operation for a number of seconds.
 
         You can check if this call has ended with timeout with the "done()" method.
 
-        :param float timeout: Period of time to wait for the long running
-         operation to complete (in seconds).
+        :param float timeout: Period of time to wait for the long running operation to complete (in seconds).
+
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """
 
         if not self._polling_method.finished():
             self._done = threading.Event()
             self._thread = threading.Thread(
-                target=with_current_context(self._start), name="KeyVaultOperationPoller({})".format(uuid.uuid4())
+                target=with_current_context(self._start), name=f"KeyVaultOperationPoller({uuid.uuid4()})"
             )
             self._thread.daemon = True
             self._thread.start()
@@ -87,14 +80,13 @@ class DeleteRecoverPollingMethod(PollingMethod):
     Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
     resource; when it responds 2xx, the resource exists in the non-deleted collection, i.e. its recovery is complete.
     """
-    def __init__(self, command, final_resource, finished, interval=2):
+    def __init__(self, command: "Callable", final_resource: "Any", finished: bool, interval: int = 2) -> None:
         self._command = command
         self._resource = final_resource
         self._polling_interval = interval
         self._finished = finished
 
-    def _update_status(self):
-        # type: () -> None
+    def _update_status(self) -> None:
         try:
             self._command()
             self._finished = True
@@ -108,11 +100,10 @@ class DeleteRecoverPollingMethod(PollingMethod):
             else:
                 raise
 
-    def initialize(self, client, initial_response, deserialization_callback):
+    def initialize(self, client: "Any", initial_response: "Any", deserialization_callback: "Callable") -> None:
         pass
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         try:
             while not self.finished():
                 self._update_status()
@@ -122,14 +113,11 @@ class DeleteRecoverPollingMethod(PollingMethod):
             logger.warning(str(e))
             raise
 
-    def finished(self):
-        # type: () -> bool
+    def finished(self) -> bool:
         return self._finished
 
-    def resource(self):
-        # type: () -> Any
+    def resource(self) -> "Any":
         return self._resource
 
-    def status(self):
-        # type: () -> str
+    def status(self) -> str:
         return "finished" if self._finished else "polling"

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -50,7 +50,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -13,14 +13,10 @@ from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 
 if TYPE_CHECKING:
-    try:
-        # pylint:disable=unused-import
-        from typing import Any
-        from azure.core.credentials_async import AsyncTokenCredential
-        from azure.core.rest import AsyncHttpResponse, HttpRequest
-    except ImportError:
-        # AsyncTokenCredential is a typing_extensions.Protocol; we don't depend on that package
-        pass
+    # pylint:disable=unused-import
+    from typing import Any
+    from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 
 class AsyncKeyVaultClientBase(object):
@@ -65,8 +61,8 @@ class AsyncKeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=self.api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(self.api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{self.api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -88,9 +88,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    async def send_request(
-        self, request: "HttpRequest", *, stream: bool = False, **kwargs: "Any"
-    ) -> "AsyncHttpResponse":
+    async def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "AsyncHttpResponse":
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as
@@ -109,4 +107,4 @@ class AsyncKeyVaultClientBase(object):
             "vaultBaseUrl": _SERIALIZER.url("vault_base_url", self._vault_url, "str", skip_quote=True),
         }
         request_copy.url = self._client._client.format_url(request_copy.url, **path_format_arguments)
-        return await self._client._client.send_request(request_copy, stream=stream, **kwargs)
+        return await self._client._client.send_request(request_copy, **kwargs)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -84,7 +84,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    async def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "AsyncHttpResponse":
+    async def send_request(self, request: "HttpRequest", **kwargs) -> "AsyncHttpResponse":
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -35,17 +35,15 @@ if TYPE_CHECKING:
     from azure.core.pipeline import PipelineResponse
 
 
-def _enforce_tls(request):
-    # type: (PipelineRequest) -> None
+def _enforce_tls(request: PipelineRequest) -> None:
     if not request.http_request.url.lower().startswith("https"):
         raise ServiceRequestError(
             "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
         )
 
 
-def _update_challenge(request, challenger):
-    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
-    """parse challenge from challenger, cache it, return it"""
+def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") -> HttpChallenge:
+    """Parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
         request.http_request.url,
@@ -57,17 +55,15 @@ def _update_challenge(request, challenger):
 
 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
-    """policy for handling HTTP authentication challenges"""
+    """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential, *scopes, **kwargs):
-        # type: (TokenCredential, *str, **Any) -> None
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    def on_request(self, request):
-        # type: (PipelineRequest) -> None
+    def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -78,7 +74,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,
@@ -90,8 +86,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
             request.http_request.set_json_body(None)
             request.http_request.headers["Content-Length"] = "0"
 
-    def on_challenge(self, request, response):
-        # type: (PipelineRequest, PipelineResponse) -> bool
+    def on_challenge(self, request: PipelineRequest, response: "PipelineResponse") -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
@@ -119,6 +114,5 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         return True
 
     @property
-    def _need_new_token(self):
-        # type: () -> bool
+    def _need_new_token(self) -> bool:
         return not self._token or self._token.expires_on - time.time() < 300

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -57,7 +57,7 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -62,6 +62,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 
 class KeyVaultClientBase(object):
+    # pylint:disable=protected-access
     def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -63,7 +63,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 class KeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -126,7 +126,7 @@ class KeyVaultClientBase(object):
         self._client.close()
 
     @distributed_trace
-    def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "HttpResponse":
+    def send_request(self, request: "HttpRequest", **kwargs) -> "HttpResponse":
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -62,9 +62,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 
 class KeyVaultClientBase(object):
-    # pylint:disable=protected-access
-    def __init__(self, vault_url, credential, **kwargs):
-        # type: (str, TokenCredential, **Any) -> None
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -104,26 +102,22 @@ class KeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=self.api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(self.api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{self.api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._vault_url
 
-    def __enter__(self):
-        # type: () -> KeyVaultClientBase
+    def __enter__(self) -> "KeyVaultClientBase":
         self._client.__enter__()
         return self
 
-    def __exit__(self, *args):
-        # type: (*Any) -> None
+    def __exit__(self, *args: "Any") -> None:
         self._client.__exit__(*args)
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """Close sockets opened by the client.
 
         Calling this method is unnecessary when using the client as a context manager.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
@@ -12,16 +12,15 @@ from azure.core.pipeline.policies import ContentDecodePolicy
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Optional, Type
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.rest import HttpResponse
 
 
-def _get_exception_for_key_vault_error(cls, response):
-    # type: (Type[HttpResponseError], HttpResponse) -> HttpResponseError
+def _get_exception_for_key_vault_error(cls: "Type[HttpResponseError]", response: "HttpResponse") -> HttpResponseError:
     """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
 
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])  # type: Optional[str]
+        message = f"({body['error']['code']}) {body['error']['message']}"  # type: Optional[str]
     except (DecodeError, KeyError):
         # Key Vault error response bodies should have the expected shape and be de-serializable.
         # If we somehow land here, we'll take HttpResponse's default message.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge.py
@@ -2,18 +2,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from typing import TYPE_CHECKING
+from urllib import parse
+
+if TYPE_CHECKING:
+    from typing import Dict, MutableMapping, Optional
 
 
 class HttpChallenge(object):
-    def __init__(self, request_uri, challenge, response_headers=None):
-        """ Parses an HTTP WWW-Authentication Bearer challenge from a server. """
+    def __init__(self, request_uri: str, challenge: str, response_headers: "MutableMapping[str, str]" = None) -> None:
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
-        self._parameters = {}
+        self._parameters = {}  # type: Dict[str, str]
 
         # get the scheme of the challenge and remove from the challenge string
         trimmed_challenge = self._validate_challenge(challenge)
@@ -42,7 +43,8 @@ class HttpChallenge(object):
 
         authorization_uri = self.get_authorization_server()
         # the authorization server URI should look something like https://login.windows.net/tenant-id
-        uri_path = parse.urlparse(authorization_uri).path.lstrip("/")
+        raw_uri_path = str(parse.urlparse(authorization_uri).path)
+        uri_path = raw_uri_path.lstrip("/")
         self.tenant_id = uri_path.split("/")[0] or None
 
         # if the response headers were supplied
@@ -51,27 +53,25 @@ class HttpChallenge(object):
             self.server_signature_key = response_headers.get("x-ms-message-signing-key", None)
             self.server_encryption_key = response_headers.get("x-ms-message-encryption-key", None)
 
-    def is_bearer_challenge(self):
-        """ Tests whether the HttpChallenge a Bearer challenge.
-        rtype: bool """
+    def is_bearer_challenge(self) -> bool:
+        """Tests whether the HttpChallenge a Bearer challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "bearer"
 
-    def is_pop_challenge(self):
-        """ Tests whether the HttpChallenge is a proof of possession challenge.
-        rtype: bool """
+    def is_pop_challenge(self) -> bool:
+        """Tests whether the HttpChallenge is a proof of possession challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "pop"
 
-    def get_value(self, key):
+    def get_value(self, key: str) -> "Optional[str]":
         return self._parameters.get(key)
 
-    def get_authorization_server(self):
-        """ Returns the URI for the authorization server if present, otherwise empty string. """
+    def get_authorization_server(self) -> "Optional[str]":
+        """Returns the URI for the authorization server if present, otherwise empty string."""
         value = ""
         for key in ["authorization_uri", "authorization"]:
             value = self.get_value(key) or ""
@@ -79,41 +79,41 @@ class HttpChallenge(object):
                 break
         return value
 
-    def get_resource(self):
-        """ Returns the resource if present, otherwise empty string. """
+    def get_resource(self) -> str:
+        """Returns the resource if present, otherwise empty string."""
         return self.get_value("resource") or ""
 
-    def get_scope(self):
-        """ Returns the scope if present, otherwise empty string. """
+    def get_scope(self) -> str:
+        """Returns the scope if present, otherwise empty string."""
         return self.get_value("scope") or ""
 
-    def supports_pop(self):
-        """ Returns True if challenge supports pop token auth else False """
+    def supports_pop(self) -> bool:
+        """Returns True if challenge supports pop token auth else False."""
         return self._parameters.get("supportspop", "").lower() == "true"
 
-    def supports_message_protection(self):
-        """ Returns True if challenge vault supports message protection """
-        return self.supports_pop() and self.server_encryption_key and self.server_signature_key
+    def supports_message_protection(self) -> bool:
+        """Returns True if challenge vault supports message protection."""
+        return self.supports_pop() and self.server_encryption_key and self.server_signature_key  # type: ignore
 
     # pylint:disable=no-self-use
-    def _validate_challenge(self, challenge):
-        """ Verifies that the challenge is a valid auth challenge and returns the key=value pairs. """
+    def _validate_challenge(self, challenge: str) -> str:
+        """Verifies that the challenge is a valid auth challenge and returns the key=value pairs."""
         if not challenge:
             raise ValueError("Challenge cannot be empty")
 
         return challenge.strip()
 
     # pylint:disable=no-self-use
-    def _validate_request_uri(self, uri):
-        """ Extracts the host authority from the given URI. """
+    def _validate_request_uri(self, uri: str) -> str:
+        """Extracts the host authority from the given URI."""
         if not uri:
             raise ValueError("request_uri cannot be empty")
 
-        uri = parse.urlparse(uri)
-        if not uri.netloc:
+        parsed = parse.urlparse(uri)
+        if not parsed.netloc:
             raise ValueError("request_uri must be an absolute URI")
 
-        if uri.scheme.lower() not in ["http", "https"]:
+        if parsed.scheme.lower() not in ["http", "https"]:
             raise ValueError("request_uri must be HTTP or HTTPS")
 
-        return uri.netloc
+        return parsed.netloc

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge_cache.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/http_challenge_cache.py
@@ -3,11 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import threading
-
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from urllib import parse
 
 try:
     from typing import TYPE_CHECKING
@@ -16,7 +12,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from typing import Dict
+    from typing import Dict, Optional
     from .http_challenge import HttpChallenge
 
 
@@ -24,10 +20,11 @@ _cache = {}  # type: Dict[str, HttpChallenge]
 _lock = threading.Lock()
 
 
-def get_challenge_for_url(url):
-    """ Gets the challenge for the cached URL.
-    :param url: the URL the challenge is cached for.
-    :rtype: HttpBearerChallenge """
+def get_challenge_for_url(url: str) -> "Optional[HttpChallenge]":
+    """Gets the challenge for the cached URL.
+
+    :param str url: the URL the challenge is cached for.
+    """
 
     if not url:
         raise ValueError("URL cannot be None")
@@ -38,7 +35,7 @@ def get_challenge_for_url(url):
         return _cache.get(key)
 
 
-def _get_cache_key(url):
+def _get_cache_key(url: str) -> str:
     """Use the URL's netloc as cache key except when the URL specifies the default port for its scheme. In that case
     use the netloc without the port. That is to say, https://foo.bar and https://foo.bar:443 are considered equivalent.
 
@@ -52,22 +49,27 @@ def _get_cache_key(url):
     return parsed.netloc
 
 
-def remove_challenge_for_url(url):
-    """ Removes the cached challenge for the specified URL.
-    :param url: the URL for which to remove the cached challenge """
+def remove_challenge_for_url(url: str) -> None:
+    """Removes the cached challenge for the specified URL.
+
+    :param str url: the URL for which to remove the cached challenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
-    url = parse.urlparse(url)
+    parsed = parse.urlparse(url)
 
     with _lock:
-        del _cache[url.netloc]
+        del _cache[parsed.netloc]
 
 
-def set_challenge_for_url(url, challenge):
-    """ Caches the challenge for the specified URL.
-    :param url: the URL for which to cache the challenge
-    :param challenge: the challenge to cache """
+def set_challenge_for_url(url: str, challenge: "HttpChallenge") -> None:
+    """Caches the challenge for the specified URL.
+
+    :param str url: the URL for which to cache the challenge
+    :param challenge: the challenge to cache
+    :type challenge: HttpChallenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
@@ -82,8 +84,8 @@ def set_challenge_for_url(url, challenge):
         _cache[src_url.netloc] = challenge
 
 
-def clear():
-    """ Clears the cache. """
+def clear() -> None:
+    """Clears the cache."""
 
     with _lock:
         _cache.clear()

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -24,9 +24,11 @@ from .. import (
 
 if TYPE_CHECKING:
     # pylint:disable=ungrouped-imports
-    from azure.core.async_paging import AsyncItemPaged
+    from datetime import datetime
     from typing import Any, Optional, Union
+    from azure.core.async_paging import AsyncItemPaged
     from .. import KeyType
+    from .._generated_models import KeyAttributes
 
 
 class KeyClient(AsyncKeyVaultClientBase):
@@ -55,7 +57,13 @@ class KeyClient(AsyncKeyVaultClientBase):
 
     # pylint:disable=protected-access, too-many-public-methods
 
-    def _get_attributes(self, enabled, not_before, expires_on, exportable=None):
+    def _get_attributes(
+        self,
+        enabled: "Optional[bool]",
+        not_before: "Optional[datetime]",
+        expires_on: "Optional[datetime]",
+        exportable: "Optional[bool]" = None,
+    ) -> "Optional[KeyAttributes]":
         """Return a KeyAttributes object if none-None attributes are provided, or None otherwise"""
         if enabled is not None or not_before is not None or expires_on is not None or exportable is not None:
             return self._models.KeyAttributes(
@@ -63,8 +71,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             )
         return None
 
-    def get_cryptography_client(self, key_name, **kwargs):
-        # type: (str, **Any) -> CryptographyClient
+    def get_cryptography_client(self, key_name: str, **kwargs: "Any") -> CryptographyClient:
         """Gets a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` for the given key.
 
         :param str key_name: The name of the key used to perform cryptographic operations.
@@ -93,9 +100,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         :type key_type: ~azure.keyvault.keys.KeyType or str
 
         :keyword int size: Key size in bits. Applies only to RSA and symmetric keys. Consider using
-         :func:`create_rsa_key` or :func:`create_oct_key` instead.
+            :func:`create_rsa_key` or :func:`create_oct_key` instead.
         :keyword curve: Elliptic curve name. Applies only to elliptic curve keys. Defaults to the NIST P-256
-         elliptic curve. To create an elliptic curve key, consider using :func:`create_ec_key` instead.
+            elliptic curve. To create an elliptic curve key, consider using :func:`create_ec_key` instead.
         :paramtype curve: ~azure.keyvault.keys.KeyCurveName or str
         :keyword int public_exponent: The RSA public exponent to use. Applies only to RSA keys created in a Managed HSM.
         :keyword key_operations: Allowed key operations
@@ -111,6 +118,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -179,6 +187,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -205,7 +214,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :keyword key_operations: Allowed key operations
         :paramtype key_operations: list[~azure.keyvault.keys.KeyOperation or str]
         :keyword bool hardware_protected: Whether the key should be created in a hardware security module.
-         Defaults to ``False``.
+            Defaults to ``False``.
         :keyword bool enabled: Whether the key is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
@@ -217,6 +226,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -242,7 +252,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :keyword key_operations: Allowed key operations.
         :paramtype key_operations: list[~azure.keyvault.keys.KeyOperation or str]
         :keyword bool hardware_protected: Whether the key should be created in a hardware security module.
-         Defaults to ``False``.
+            Defaults to ``False``.
         :keyword bool enabled: Whether the key is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
         :paramtype tags: dict[str, str]
@@ -254,6 +264,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -292,6 +303,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -316,6 +328,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.DeletedKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -357,6 +370,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             of the key.
 
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -385,6 +399,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.DeletedKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -482,9 +497,8 @@ class KeyClient(AsyncKeyVaultClientBase):
     async def purge_deleted_key(self, name: str, **kwargs: "Any") -> None:
         """Permanently deletes a deleted key. Only possible in a vault with soft-delete enabled.
 
-        Performs an irreversible deletion of the specified key, without
-        possibility for recovery. The operation is not available if the
-        :py:attr:`~azure.keyvault.keys.KeyProperties.recovery_level` does not specify 'Purgeable'.
+        Performs an irreversible deletion of the specified key, without possibility for recovery. The operation is not
+        available if the :py:attr:`~azure.keyvault.keys.KeyProperties.recovery_level` does not specify 'Purgeable'.
         This method is only necessary for purging a key before its
         :py:attr:`~azure.keyvault.keys.DeletedKey.scheduled_purge_date`.
 
@@ -493,6 +507,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str name: The name of the deleted key to purge
 
         :returns: None
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -517,6 +532,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The recovered key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -563,6 +579,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -606,15 +623,14 @@ class KeyClient(AsyncKeyVaultClientBase):
     async def backup_key(self, name: str, **kwargs: "Any") -> bytes:
         """Back up a key in a protected form useable only by Azure Key Vault.
 
-        Requires key/backup permission.
-
-        This is intended to allow copying a key from one vault to another. Both vaults must be owned by the same Azure
-        subscription. Also, backup / restore cannot be performed across geopolitical boundaries. For example, a backup
-        from a vault in a USA region cannot be restored to a vault in an EU region.
+        Requires key/backup permission. This is intended to allow copying a key from one vault to another. Both vaults
+        must be owned by the same Azure subscription. Also, backup / restore cannot be performed across geopolitical
+        boundaries. For example, a backup from a vault in a USA region cannot be restored to a vault in an EU region.
 
         :param str name: The name of the key to back up
 
         :rtype: bytes
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -634,16 +650,15 @@ class KeyClient(AsyncKeyVaultClientBase):
     async def restore_key_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultKey:
         """Restore a key backup to the vault.
 
-        Requires keys/restore permission.
-
-        This imports all versions of the key, with its name, attributes, and access control policies. If the key's name
-        is already in use, restoring it will fail. Also, the target vault must be owned by the same Microsoft Azure
-        subscription as the source vault.
+        Requires keys/restore permission. This imports all versions of the key, with its name, attributes, and access
+        control policies. If the key's name is already in use, restoring it will fail. Also, the target vault must be
+        owned by the same Microsoft Azure subscription as the source vault.
 
         :param bytes backup: A key backup as returned by :func:`backup_key`
 
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises:
             :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -686,6 +701,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         enabled = kwargs.pop("enabled", None)
@@ -731,6 +747,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :return: The result of the key release.
         :rtype: ~azure.keyvault.keys.ReleaseKeyResult
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         version = kwargs.pop("version", "")
@@ -755,6 +772,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :return: The random bytes.
         :rtype: bytes
+
         :raises:
             :class:`ValueError` if less than one random byte is requested,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -781,6 +799,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :return: The key rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         policy = await self._client.get_key_rotation_policy(vault_base_url=self._vault_url, key_name=key_name, **kwargs)
@@ -796,6 +815,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :return: The new version of the rotated key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.rotate_key(vault_base_url=self._vault_url, key_name=name, **kwargs)
@@ -823,6 +843,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         lifetime_actions = kwargs.pop("lifetime_actions", policy.lifetime_actions)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -71,7 +71,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             )
         return None
 
-    def get_cryptography_client(self, key_name: str, **kwargs: "Any") -> CryptographyClient:
+    def get_cryptography_client(self, key_name: str, **kwargs) -> CryptographyClient:
         """Gets a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` for the given key.
 
         :param str key_name: The name of the key used to perform cryptographic operations.
@@ -90,7 +90,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs: "Any") -> KeyVaultKey:
+    async def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs) -> KeyVaultKey:
         """Create a key or, if ``name`` is already in use, create a new version of the key.
 
         Requires keys/create permission.
@@ -163,7 +163,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def create_rsa_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    async def create_rsa_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new RSA key or, if ``name`` is already in use, create a new version of the key
 
         Requires the keys/create permission.
@@ -202,7 +202,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="RSA-HSM" if hsm else "RSA", **kwargs)
 
     @distributed_trace_async
-    async def create_ec_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    async def create_ec_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new elliptic curve key or, if ``name`` is already in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -241,7 +241,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace_async
-    async def create_oct_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    async def create_oct_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new octet sequence (symmetric) key or, if ``name`` is in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -279,7 +279,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="oct-HSM" if hsm else "oct", **kwargs)
 
     @distributed_trace_async
-    async def create_okp_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    async def create_okp_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Create a new octet key pair or, if ``name`` is in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -318,7 +318,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="OKP-HSM" if hsm else "OKP", **kwargs)
 
     @distributed_trace_async
-    async def delete_key(self, name: str, **kwargs: "Any") -> DeletedKey:
+    async def delete_key(self, name: str, **kwargs) -> DeletedKey:
         """Delete all versions of a key and its cryptographic material.
 
         Requires keys/delete permission. If the vault has soft-delete enabled, deletion may take several seconds to
@@ -360,7 +360,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_key(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultKey:
+    async def get_key(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultKey:
         """Get a key's attributes and, if it's an asymmetric key, its public material.
 
         Requires keys/get permission.
@@ -390,7 +390,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def get_deleted_key(self, name: str, **kwargs: "Any") -> DeletedKey:
+    async def get_deleted_key(self, name: str, **kwargs) -> DeletedKey:
         """Get a deleted key. Possible only in a vault with soft-delete enabled.
 
         Requires keys/get permission.
@@ -416,7 +416,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_keys(self, **kwargs: "Any") -> "AsyncItemPaged[DeletedKey]":
+    def list_deleted_keys(self, **kwargs) -> "AsyncItemPaged[DeletedKey]":
         """List all deleted keys, including the public part of each. Possible only in a vault with soft-delete enabled.
 
         Requires keys/list permission.
@@ -441,7 +441,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_keys(self, **kwargs: "Any") -> "AsyncItemPaged[KeyProperties]":
+    def list_properties_of_keys(self, **kwargs) -> "AsyncItemPaged[KeyProperties]":
         """List identifiers and properties of all keys in the vault.
 
         Requires keys/list permission.
@@ -466,7 +466,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_key_versions(self, name: str, **kwargs: "Any") -> "AsyncItemPaged[KeyProperties]":
+    def list_properties_of_key_versions(self, name: str, **kwargs) -> "AsyncItemPaged[KeyProperties]":
         """List the identifiers and properties of a key's versions.
 
         Requires keys/list permission.
@@ -494,7 +494,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def purge_deleted_key(self, name: str, **kwargs: "Any") -> None:
+    async def purge_deleted_key(self, name: str, **kwargs) -> None:
         """Permanently deletes a deleted key. Only possible in a vault with soft-delete enabled.
 
         Performs an irreversible deletion of the specified key, without possibility for recovery. The operation is not
@@ -521,7 +521,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         await self._client.purge_deleted_key(self.vault_url, name, error_map=_error_map, **kwargs)
 
     @distributed_trace_async
-    async def recover_deleted_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    async def recover_deleted_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Recover a deleted key to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires keys/recover permission. If the vault does not have soft-delete enabled, :func:`delete_key` is
@@ -559,7 +559,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def update_key_properties(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultKey:
+    async def update_key_properties(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultKey:
         """Change a key's properties (not its cryptographic material).
 
         Requires keys/update permission.
@@ -620,7 +620,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def backup_key(self, name: str, **kwargs: "Any") -> bytes:
+    async def backup_key(self, name: str, **kwargs) -> bytes:
         """Back up a key in a protected form useable only by Azure Key Vault.
 
         Requires key/backup permission. This is intended to allow copying a key from one vault to another. Both vaults
@@ -647,7 +647,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_key_backup(self, backup: bytes, **kwargs: "Any") -> KeyVaultKey:
+    async def restore_key_backup(self, backup: bytes, **kwargs) -> KeyVaultKey:
         """Restore a key backup to the vault.
 
         Requires keys/restore permission. This imports all versions of the key, with its name, attributes, and access
@@ -680,7 +680,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def import_key(self, name: str, key: JsonWebKey, **kwargs: "Any") -> KeyVaultKey:
+    async def import_key(self, name: str, key: JsonWebKey, **kwargs) -> KeyVaultKey:
         """Import a key created externally.
 
         Requires keys/import permission. If ``name`` is already in use, the key will be imported as a new version.
@@ -731,7 +731,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def release_key(self, name: str, target_attestation_token: str, **kwargs: "Any") -> ReleaseKeyResult:
+    async def release_key(self, name: str, target_attestation_token: str, **kwargs) -> ReleaseKeyResult:
         """Releases a key.
 
         The release key operation is applicable to all key types. The target key must be marked
@@ -765,7 +765,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return ReleaseKeyResult(result.value)
 
     @distributed_trace_async
-    async def get_random_bytes(self, count: int, **kwargs: "Any") -> bytes:
+    async def get_random_bytes(self, count: int, **kwargs) -> bytes:
         """Get the requested number of random bytes from a managed HSM.
 
         :param int count: The requested number of random bytes.
@@ -792,7 +792,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return result.value
 
     @distributed_trace_async
-    async def get_key_rotation_policy(self, key_name: str, **kwargs: "Any") -> "KeyRotationPolicy":
+    async def get_key_rotation_policy(self, key_name: str, **kwargs) -> "KeyRotationPolicy":
         """Get the rotation policy of a Key Vault key.
 
         :param str key_name: The name of the key.
@@ -806,7 +806,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyRotationPolicy._from_generated(policy)
 
     @distributed_trace_async
-    async def rotate_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
+    async def rotate_key(self, name: str, **kwargs) -> KeyVaultKey:
         """Rotate the key based on the key policy by generating a new version of the key.
 
         This operation requires the keys/rotate permission.
@@ -823,7 +823,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_key_rotation_policy(
-        self, key_name: str, policy: KeyRotationPolicy, **kwargs: "Any"
+        self, key_name: str, policy: KeyRotationPolicy, **kwargs
     ) -> KeyRotationPolicy:
         """Updates the rotation policy of a Key Vault key.
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -18,7 +18,7 @@ from .._shared import KeyVaultClientBase, parse_key_vault_id
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from datetime import datetime
-    from typing import Any, Optional, Union
+    from typing import Any, Dict, Optional, Union
     from azure.core.credentials import TokenCredential
     from . import KeyWrapAlgorithm, SignatureAlgorithm
     from .._shared import KeyVaultResourceId
@@ -26,15 +26,16 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _validate_arguments(operation, algorithm, **kwargs):
-    # type: (KeyOperation, EncryptionAlgorithm, **Any) -> None
+def _validate_arguments(operation: KeyOperation, algorithm: EncryptionAlgorithm, **kwargs: "Any") -> None:
     """Validates the arguments passed to perform an operation with a provided algorithm.
 
     :param KeyOperation operation: the type of operation being requested
     :param EncryptionAlgorithm algorithm: the encryption algorithm to use for the operation
+
     :keyword bytes iv: initialization vector
     :keyword bytes authentication_tag: authentication tag returned from an encryption
     :keyword bytes additional_authenticated_data: data that is authenticated but not encrypted
+
     :raises ValueError: if parameters that are incompatible with the specified algorithm are provided.
     """
     iv = kwargs.pop("iv", None)
@@ -44,35 +45,33 @@ def _validate_arguments(operation, algorithm, **kwargs):
     if operation == KeyOperation.encrypt:
         if iv and "CBC" not in algorithm:
             raise ValueError(
-                "iv should only be provided with AES-CBC algorithms; {} does not accept an iv".format(algorithm)
+                f"iv should only be provided with AES-CBC algorithms; {algorithm} does not accept an iv"
             )
         if iv is None and "CBC" in algorithm:
             raise ValueError("iv is a required parameter for encryption with AES-CBC algorithms.")
         if aad and not ("CBC" in algorithm or "GCM" in algorithm):
             raise ValueError(
-                "additional_authenticated_data should only be provided with AES algorithms; {} does not accept "
-                "additional authenticated data".format(algorithm)
+                f"additional_authenticated_data should only be provided with AES algorithms; {algorithm} does not "
+                "accept additional authenticated data"
             )
 
     if operation == KeyOperation.decrypt:
         if iv and not ("CBC" in algorithm or "GCM" in algorithm):
             raise ValueError(
-                "iv should only be provided with AES algorithms; {} does not accept an iv".format(algorithm)
+                f"iv should only be provided with AES algorithms; {algorithm} does not accept an iv"
             )
         if iv is None and ("CBC" in algorithm or "GCM" in algorithm):
             raise ValueError("iv is a required parameter for decryption with AES algorithms.")
         if tag and "GCM" not in algorithm:
             raise ValueError(
-                "authentication_tag should only be provided with AES-GCM algorithms; {} does not accept a tag".format(
-                    algorithm
-                )
+                f"authentication_tag should only be provided with AES-GCM algorithms; {algorithm} does not accept a tag"
             )
         if tag is None and "GCM" in algorithm:
             raise ValueError("authentication_tag is a required parameter for AES-GCM decryption.")
         if aad and not ("CBC" in algorithm or "GCM" in algorithm):
             raise ValueError(
-                "additional_authenticated_data should only be provided with AES algorithms; {} does not accept "
-                "additional authenticated data".format(algorithm)
+                f"additional_authenticated_data should only be provided with AES algorithms; {algorithm} does not "
+                "accept additional authenticated data"
             )
 
 
@@ -83,8 +82,7 @@ class CryptographyClient(KeyVaultClientBase):
     that material from Key Vault. When the required key material is unavailable, cryptographic operations are performed
     by the Key Vault service.
 
-    :param key:
-        Either a :class:`~azure.keyvault.keys.KeyVaultKey` instance as returned by
+    :param key: Either a :class:`~azure.keyvault.keys.KeyVaultKey` instance as returned by
         :func:`~azure.keyvault.keys.KeyClient.get_key`, or a string.
         If a string, the value must be the identifier of an Azure Key Vault key. Including a version is recommended.
     :type key: str or :class:`~azure.keyvault.keys.KeyVaultKey`
@@ -107,8 +105,7 @@ class CryptographyClient(KeyVaultClientBase):
 
     # pylint:disable=protected-access
 
-    def __init__(self, key, credential, **kwargs):
-        # type: (Union[KeyVaultKey, str], TokenCredential, **Any) -> None
+    def __init__(self, key: "Union[KeyVaultKey, str]", credential: "TokenCredential", **kwargs: "Any") -> None:
         self._jwk = kwargs.pop("_jwk", False)
         self._not_before = None  # type: Optional[datetime]
         self._expires_on = None  # type: Optional[datetime]
@@ -147,8 +144,7 @@ class CryptographyClient(KeyVaultClientBase):
         )
 
     @property
-    def key_id(self):
-        # type: () -> Optional[str]
+    def key_id(self) -> "Optional[str]":
         """The full identifier of the client's key.
 
         This property may be None when a client is constructed with :func:`from_jwk`.
@@ -160,8 +156,7 @@ class CryptographyClient(KeyVaultClientBase):
         return cast(JsonWebKey, self._key).kid  # type: ignore[attr-defined]
 
     @property
-    def vault_url(self):  # type: ignore
-        # type: () -> Optional[str]
+    def vault_url(self) -> "Optional[str]":  # type: ignore
         """The base vault URL of the client's key.
 
         This property may be None when a client is constructed with :func:`from_jwk`.
@@ -171,12 +166,12 @@ class CryptographyClient(KeyVaultClientBase):
         return self._vault_url
 
     @classmethod
-    def from_jwk(cls, jwk):
-        # type: (Union[JsonWebKey, dict]) -> CryptographyClient
+    def from_jwk(cls, jwk: "Union[JsonWebKey, Dict[str, Any]]") -> "CryptographyClient":
         """Creates a client that can only perform cryptographic operations locally.
 
         :param jwk: the key's cryptographic material, as a JsonWebKey or dictionary.
-        :type jwk: JsonWebKey or dict
+        :type jwk: JsonWebKey or Dict[str, Any]
+
         :rtype: CryptographyClient
         """
         if not isinstance(jwk, JsonWebKey):
@@ -184,8 +179,7 @@ class CryptographyClient(KeyVaultClientBase):
         return cls(jwk, object(), _jwk=True)  # type: ignore
 
     @distributed_trace
-    def _initialize(self, **kwargs):
-        # type: (**Any) -> None
+    def _initialize(self, **kwargs: "Any") -> None:
         if self._initialized:
             return
 
@@ -215,8 +209,7 @@ class CryptographyClient(KeyVaultClientBase):
             self._initialized = self._keys_get_forbidden
 
     @distributed_trace
-    def encrypt(self, algorithm, plaintext, **kwargs):
-        # type: (EncryptionAlgorithm, bytes, **Any) -> EncryptResult
+    def encrypt(self, algorithm: "EncryptionAlgorithm", plaintext: bytes, **kwargs: "Any") -> EncryptResult:
         """Encrypt bytes using the client's key.
 
         Requires the keys/encrypt permission. This method encrypts only a single block of data, whose size depends on
@@ -225,13 +218,16 @@ class CryptographyClient(KeyVaultClientBase):
         :param algorithm: Encryption algorithm to use
         :type algorithm: :class:`~azure.keyvault.keys.crypto.EncryptionAlgorithm`
         :param bytes plaintext: Bytes to encrypt
+
         :keyword bytes iv: Initialization vector. Required for only AES-CBC(PAD) encryption. If you pass your own IV,
             make sure you use a cryptographically random, non-repeating IV. If omitted, an attempt will be made to
             generate an IV via `os.urandom <https://docs.python.org/library/os.html#os.urandom>`_ for local
             cryptography; for remote cryptography, Key Vault will generate an IV.
         :keyword bytes additional_authenticated_data: Optional data that is authenticated but not encrypted. For use
             with AES-GCM encryption.
+
         :rtype: :class:`~azure.keyvault.keys.crypto.EncryptResult`
+
         :raises ValueError: if parameters that are incompatible with the specified algorithm are provided, or if
             generating an IV fails on the current platform.
 
@@ -286,8 +282,7 @@ class CryptographyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def decrypt(self, algorithm, ciphertext, **kwargs):
-        # type: (EncryptionAlgorithm, bytes, **Any) -> DecryptResult
+    def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
         """Decrypt a single block of encrypted data using the client's key.
 
         Requires the keys/decrypt permission. This method decrypts only a single block of data, whose size depends on
@@ -298,12 +293,15 @@ class CryptographyClient(KeyVaultClientBase):
         :param bytes ciphertext: Encrypted bytes to decrypt. Microsoft recommends you not use CBC without first ensuring
             the integrity of the ciphertext using, for example, an HMAC. See
             https://docs.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode for more information.
+
         :keyword bytes iv: The initialization vector used during encryption. Required for AES decryption.
         :keyword bytes authentication_tag: The authentication tag generated during encryption. Required for only AES-GCM
             decryption.
         :keyword bytes additional_authenticated_data: Optional data that is authenticated but not encrypted. For use
             with AES-GCM decryption.
+
         :rtype: :class:`~azure.keyvault.keys.crypto.DecryptResult`
+
         :raises ValueError: If parameters that are incompatible with the specified algorithm are provided.
 
         .. literalinclude:: ../tests/test_examples_crypto.py
@@ -344,8 +342,7 @@ class CryptographyClient(KeyVaultClientBase):
         return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=operation_result.result)
 
     @distributed_trace
-    def wrap_key(self, algorithm, key, **kwargs):
-        # type: (KeyWrapAlgorithm, bytes, **Any) -> WrapResult
+    def wrap_key(self, algorithm: "KeyWrapAlgorithm", key: bytes, **kwargs: "Any") -> WrapResult:
         """Wrap a key with the client's key.
 
         Requires the keys/wrapKey permission.
@@ -353,6 +350,7 @@ class CryptographyClient(KeyVaultClientBase):
         :param algorithm: wrapping algorithm to use
         :type algorithm: :class:`~azure.keyvault.keys.crypto.KeyWrapAlgorithm`
         :param bytes key: key to wrap
+
         :rtype: :class:`~azure.keyvault.keys.crypto.WrapResult`
 
         .. literalinclude:: ../tests/test_examples_crypto.py
@@ -387,8 +385,7 @@ class CryptographyClient(KeyVaultClientBase):
         return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=operation_result.result)
 
     @distributed_trace
-    def unwrap_key(self, algorithm, encrypted_key, **kwargs):
-        # type: (KeyWrapAlgorithm, bytes, **Any) -> UnwrapResult
+    def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs: "Any") -> UnwrapResult:
         """Unwrap a key previously wrapped with the client's key.
 
         Requires the keys/unwrapKey permission.
@@ -396,6 +393,7 @@ class CryptographyClient(KeyVaultClientBase):
         :param algorithm: wrapping algorithm to use
         :type algorithm: :class:`~azure.keyvault.keys.crypto.KeyWrapAlgorithm`
         :param bytes encrypted_key: the wrapped key
+
         :rtype: :class:`~azure.keyvault.keys.crypto.UnwrapResult`
 
         .. literalinclude:: ../tests/test_examples_crypto.py
@@ -428,8 +426,7 @@ class CryptographyClient(KeyVaultClientBase):
         return UnwrapResult(key_id=self.key_id, algorithm=algorithm, key=operation_result.result)
 
     @distributed_trace
-    def sign(self, algorithm, digest, **kwargs):
-        # type: (SignatureAlgorithm, bytes, **Any) -> SignResult
+    def sign(self, algorithm: "SignatureAlgorithm", digest: bytes, **kwargs: "Any") -> SignResult:
         """Create a signature from a digest using the client's key.
 
         Requires the keys/sign permission.
@@ -437,6 +434,7 @@ class CryptographyClient(KeyVaultClientBase):
         :param algorithm: signing algorithm
         :type algorithm: :class:`~azure.keyvault.keys.crypto.SignatureAlgorithm`
         :param bytes digest: hashed bytes to sign
+
         :rtype: :class:`~azure.keyvault.keys.crypto.SignResult`
 
         .. literalinclude:: ../tests/test_examples_crypto.py
@@ -471,8 +469,7 @@ class CryptographyClient(KeyVaultClientBase):
         return SignResult(key_id=self.key_id, algorithm=algorithm, signature=operation_result.result)
 
     @distributed_trace
-    def verify(self, algorithm, digest, signature, **kwargs):
-        # type: (SignatureAlgorithm, bytes, bytes, **Any) -> VerifyResult
+    def verify(self, algorithm: "SignatureAlgorithm", digest: bytes, signature: bytes, **kwargs: "Any") -> VerifyResult:
         """Verify a signature using the client's key.
 
         Requires the keys/verify permission.
@@ -480,8 +477,9 @@ class CryptographyClient(KeyVaultClientBase):
         :param algorithm: verification algorithm
         :type algorithm: :class:`~azure.keyvault.keys.crypto.SignatureAlgorithm`
         :param bytes digest: Pre-hashed digest corresponding to **signature**. The hash algorithm used must be
-          compatible with **algorithm**.
+            compatible with ``algorithm``.
         :param bytes signature: signature to verify
+
         :rtype: :class:`~azure.keyvault.keys.crypto.VerifyResult`
 
         .. literalinclude:: ../tests/test_examples_crypto.py

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _validate_arguments(operation: KeyOperation, algorithm: EncryptionAlgorithm, **kwargs: "Any") -> None:
+def _validate_arguments(operation: KeyOperation, algorithm: EncryptionAlgorithm, **kwargs) -> None:
     """Validates the arguments passed to perform an operation with a provided algorithm.
 
     :param KeyOperation operation: the type of operation being requested
@@ -105,7 +105,7 @@ class CryptographyClient(KeyVaultClientBase):
 
     # pylint:disable=protected-access
 
-    def __init__(self, key: "Union[KeyVaultKey, str]", credential: "TokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, key: "Union[KeyVaultKey, str]", credential: "TokenCredential", **kwargs) -> None:
         self._jwk = kwargs.pop("_jwk", False)
         self._not_before = None  # type: Optional[datetime]
         self._expires_on = None  # type: Optional[datetime]
@@ -179,7 +179,7 @@ class CryptographyClient(KeyVaultClientBase):
         return cls(jwk, object(), _jwk=True)  # type: ignore
 
     @distributed_trace
-    def _initialize(self, **kwargs: "Any") -> None:
+    def _initialize(self, **kwargs) -> None:
         if self._initialized:
             return
 
@@ -209,7 +209,7 @@ class CryptographyClient(KeyVaultClientBase):
             self._initialized = self._keys_get_forbidden
 
     @distributed_trace
-    def encrypt(self, algorithm: "EncryptionAlgorithm", plaintext: bytes, **kwargs: "Any") -> EncryptResult:
+    def encrypt(self, algorithm: "EncryptionAlgorithm", plaintext: bytes, **kwargs) -> EncryptResult:
         """Encrypt bytes using the client's key.
 
         Requires the keys/encrypt permission. This method encrypts only a single block of data, whose size depends on
@@ -282,7 +282,7 @@ class CryptographyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
+    def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs) -> DecryptResult:
         """Decrypt a single block of encrypted data using the client's key.
 
         Requires the keys/decrypt permission. This method decrypts only a single block of data, whose size depends on
@@ -342,7 +342,7 @@ class CryptographyClient(KeyVaultClientBase):
         return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=operation_result.result)
 
     @distributed_trace
-    def wrap_key(self, algorithm: "KeyWrapAlgorithm", key: bytes, **kwargs: "Any") -> WrapResult:
+    def wrap_key(self, algorithm: "KeyWrapAlgorithm", key: bytes, **kwargs) -> WrapResult:
         """Wrap a key with the client's key.
 
         Requires the keys/wrapKey permission.
@@ -385,7 +385,7 @@ class CryptographyClient(KeyVaultClientBase):
         return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=operation_result.result)
 
     @distributed_trace
-    def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs: "Any") -> UnwrapResult:
+    def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs) -> UnwrapResult:
         """Unwrap a key previously wrapped with the client's key.
 
         Requires the keys/unwrapKey permission.
@@ -426,7 +426,7 @@ class CryptographyClient(KeyVaultClientBase):
         return UnwrapResult(key_id=self.key_id, algorithm=algorithm, key=operation_result.result)
 
     @distributed_trace
-    def sign(self, algorithm: "SignatureAlgorithm", digest: bytes, **kwargs: "Any") -> SignResult:
+    def sign(self, algorithm: "SignatureAlgorithm", digest: bytes, **kwargs) -> SignResult:
         """Create a signature from a digest using the client's key.
 
         Requires the keys/sign permission.
@@ -469,7 +469,7 @@ class CryptographyClient(KeyVaultClientBase):
         return SignResult(key_id=self.key_id, algorithm=algorithm, signature=operation_result.result)
 
     @distributed_trace
-    def verify(self, algorithm: "SignatureAlgorithm", digest: bytes, signature: bytes, **kwargs: "Any") -> VerifyResult:
+    def verify(self, algorithm: "SignatureAlgorithm", digest: bytes, signature: bytes, **kwargs) -> VerifyResult:
         """Verify a signature using the client's key.
 
         Requires the keys/verify permission.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/_internal.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/_internal.py
@@ -72,7 +72,7 @@ def _int_to_fixed_length_bigendian_bytes(i, length):
     b = _int_to_bytes(i)
 
     if len(b) > length:
-        raise ValueError("{} is too large to be represented by {} bytes".format(i, length))
+        raise ValueError(f"{i} is too large to be represented by {length} bytes")
 
     if len(b) < length:
         b = (b"\0" * (length - len(b))) + b

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
@@ -85,12 +85,12 @@ class _AesCbc(SymmetricEncryptionAlgorithm):
         if not key:
             raise ValueError("A key is required for AES-CBC and AES-CBCPAD encryption and decryption")
         if len(key) < self.key_size_in_bytes():
-            raise ValueError("key must be at least %d bits" % self.key_size)
+            raise ValueError(f"key must be at least {self.key_size} bits")
 
         if not iv:
             raise ValueError("A 16-byte iv is required for AES-CBC and AES-CBCPAD encryption and decryption")
         if not len(iv) == self.block_size_in_bytes():
-            raise ValueError("iv must be %d bits" % self.block_size)
+            raise ValueError(f"iv must be {self.block_size} bits")
 
         return key[: self.key_size_in_bytes()], iv
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_kw.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_kw.py
@@ -43,7 +43,7 @@ class _AesKeyWrap(AsymmetricEncryptionAlgorithm):
         if not key:
             raise ValueError("key")
         if len(key) < self.key_size_in_bytes:
-            raise ValueError("key must be at least %d bits" % self.key_size)
+            raise ValueError(f"key must be at least {self.key_size} bits")
 
         return key[: self.key_size_in_bytes]
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/ec_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/ec_key.py
@@ -62,7 +62,7 @@ class EllipticCurveKey(Key):
 
     @classmethod
     def from_jwk(cls, jwk):
-        if jwk.kty != "EC" and jwk.kty != "EC-HSM":
+        if jwk.kty not in ("EC", "EC-HSM"):
             raise ValueError("The specified key must be of type 'EC' or 'EC-HSM'")
 
         if not jwk.x or not jwk.y:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/key.py
@@ -95,6 +95,6 @@ class Key(object, metaclass=ABCMeta):
             algorithm = Algorithm.resolve(algorithm)
 
         if not algorithm or not supported_algorithms or algorithm.name() not in supported_algorithms:
-            raise ValueError("unsupported algorithm '{}'".format(algorithm))
+            raise ValueError(f"unsupported algorithm '{algorithm}'")
 
         return algorithm

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/rsa_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/rsa_key.py
@@ -99,7 +99,7 @@ class RsaKey(Key):  # pylint:disable=too-many-public-methods
 
     @classmethod
     def from_jwk(cls, jwk):
-        if jwk.kty != "RSA" and jwk.kty != "RSA-HSM":
+        if jwk.kty not in ("RSA", "RSA-HSM"):
             raise ValueError('The specified jwk must have a key type of "RSA" or "RSA-HSM"')
 
         if not jwk.n or not jwk.e:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_key_validity.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_key_validity.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,30 +10,11 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-class _UTC_TZ(tzinfo):
-    """from https://docs.python.org/2/library/datetime.html#tzinfo-objects"""
-
-    ZERO = timedelta(0)
-
-    def utcoffset(self, dt):
-        return self.__class__.ZERO
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return self.__class__.ZERO
-
-
-_UTC = _UTC_TZ()
-
-
-def raise_if_time_invalid(not_before, expires_on):
-    # type: (Optional[datetime], Optional[datetime]) -> None
-    now = datetime.now(_UTC)
+def raise_if_time_invalid(not_before: "Optional[datetime]", expires_on: "Optional[datetime]") -> None:
+    now = datetime.now(timezone.utc)
     if (not_before and expires_on) and not not_before <= now <= expires_on:
-        raise ValueError("This client's key is useable only between {} and {} (UTC)".format(not_before, expires_on))
+        raise ValueError(f"This client's key is useable only between {not_before} and {expires_on} (UTC)")
     if not_before and not_before > now:
-        raise ValueError("This client's key is not useable until {} (UTC)".format(not_before))
+        raise ValueError(f"This client's key is not useable until {not_before} (UTC)")
     if expires_on and expires_on <= now:
-        raise ValueError("This client's key expired at {} (UTC)".format(expires_on))
+        raise ValueError(f"This client's key expired at {expires_on} (UTC)")

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -40,7 +40,7 @@ class EncryptResult:
     """
 
     def __init__(
-        self, key_id: "Optional[str]", algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any"
+        self, key_id: "Optional[str]", algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs
     ) -> None:
         self.key_id = key_id
         self.algorithm = algorithm

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -18,8 +18,7 @@ class DecryptResult:
     :param bytes plaintext: The decrypted bytes
     """
 
-    def __init__(self, key_id, algorithm, plaintext):
-        # type: (Optional[str], EncryptionAlgorithm, bytes) -> None
+    def __init__(self, key_id: "Optional[str]", algorithm: "EncryptionAlgorithm", plaintext: bytes) -> None:
         self.key_id = key_id
         self.algorithm = algorithm
         self.plaintext = plaintext
@@ -32,6 +31,7 @@ class EncryptResult:
     :param algorithm: The encryption algorithm used
     :type algorithm: ~azure.keyvault.keys.crypto.EncryptionAlgorithm
     :param bytes ciphertext: The encrypted bytes
+
     :keyword bytes iv: Initialization vector for symmetric algorithms
     :keyword bytes authentication_tag: The tag to authenticate when performing decryption with an authenticated
         algorithm
@@ -39,8 +39,9 @@ class EncryptResult:
         authenticated algorithm
     """
 
-    def __init__(self, key_id, algorithm, ciphertext, **kwargs):
-        # type: (Optional[str], EncryptionAlgorithm, bytes, **Any) -> None
+    def __init__(
+        self, key_id: "Optional[str]", algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any"
+    ) -> None:
         self.key_id = key_id
         self.algorithm = algorithm
         self.ciphertext = ciphertext
@@ -58,8 +59,7 @@ class SignResult:
     :param bytes signature:
     """
 
-    def __init__(self, key_id, algorithm, signature):
-        # type: (Optional[str], SignatureAlgorithm, bytes) -> None
+    def __init__(self, key_id: "Optional[str]", algorithm: "SignatureAlgorithm", signature: bytes) -> None:
         self.key_id = key_id
         self.algorithm = algorithm
         self.signature = signature
@@ -74,8 +74,7 @@ class VerifyResult:
     :type algorithm: ~azure.keyvault.keys.crypto.SignatureAlgorithm
     """
 
-    def __init__(self, key_id, is_valid, algorithm):
-        # type: (Optional[str], bool, SignatureAlgorithm) -> None
+    def __init__(self, key_id: "Optional[str]", is_valid: bool, algorithm: "SignatureAlgorithm") -> None:
         self.key_id = key_id
         self.is_valid = is_valid
         self.algorithm = algorithm
@@ -90,8 +89,7 @@ class UnwrapResult:
     :param bytes key: The unwrapped key
     """
 
-    def __init__(self, key_id, algorithm, key):
-        # type: (Optional[str], KeyWrapAlgorithm, bytes) -> None
+    def __init__(self, key_id: "Optional[str]", algorithm: "KeyWrapAlgorithm", key: bytes) -> None:
         self.key_id = key_id
         self.algorithm = algorithm
         self.key = key
@@ -106,8 +104,7 @@ class WrapResult:
     :param bytes encrypted_key: The encrypted key bytes
     """
 
-    def __init__(self, key_id, algorithm, encrypted_key):
-        # type: (Optional[str], KeyWrapAlgorithm, bytes) -> None
+    def __init__(self, key_id: "Optional[str]", algorithm: "KeyWrapAlgorithm", encrypted_key: bytes) -> None:
         self.key_id = key_id
         self.algorithm = algorithm
         self.encrypted_key = encrypted_key

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/__init__.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
     from ... import JsonWebKey
 
 
-def get_local_cryptography_provider(key):
-    # type: (JsonWebKey) -> LocalCryptographyProvider
+def get_local_cryptography_provider(key: "JsonWebKey") -> LocalCryptographyProvider:
     if key.kty in (KeyType.ec, KeyType.ec_hsm):  # type: ignore[attr-defined]
         return EllipticCurveCryptographyProvider(key)
     if key.kty in (KeyType.rsa, KeyType.rsa_hsm):  # type: ignore[attr-defined]
@@ -25,7 +24,7 @@ def get_local_cryptography_provider(key):
     if key.kty in (KeyType.okp, KeyType.okp_hsm):  # type: ignore[attr-defined]
         return NoLocalCryptography()
 
-    raise ValueError('Unsupported key type "{}"'.format(key.kty))  # type: ignore[attr-defined]
+    raise ValueError(f'Unsupported key type "{key.kty}"')  # type: ignore[attr-defined]
 
 
 class NoLocalCryptography(LocalCryptographyProvider):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/ec.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/ec.py
@@ -18,14 +18,12 @@ _PRIVATE_KEY_OPERATIONS = frozenset((KeyOperation.decrypt, KeyOperation.sign, Ke
 
 
 class EllipticCurveCryptographyProvider(LocalCryptographyProvider):
-    def _get_internal_key(self, key):
-        # type: (JsonWebKey) -> Key
+    def _get_internal_key(self, key: "JsonWebKey") -> "Key":
         if key.kty not in (KeyType.ec, KeyType.ec_hsm):  # type: ignore[attr-defined]
             raise ValueError('"key" must be an EC or EC-HSM key')
         return EllipticCurveKey.from_jwk(key)
 
-    def supports(self, operation, algorithm):
-        # type: (KeyOperation, Algorithm) -> bool
+    def supports(self, operation: KeyOperation, algorithm: "Algorithm") -> bool:
         if operation in _PRIVATE_KEY_OPERATIONS and not self._internal_key.is_private_key():
             return False
         if operation in (KeyOperation.decrypt, KeyOperation.encrypt):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/rsa.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/rsa.py
@@ -18,14 +18,12 @@ _PRIVATE_KEY_OPERATIONS = frozenset((KeyOperation.decrypt, KeyOperation.sign, Ke
 
 
 class RsaCryptographyProvider(LocalCryptographyProvider):
-    def _get_internal_key(self, key):
-        # type: (JsonWebKey) -> Key
+    def _get_internal_key(self, key: "JsonWebKey") -> "Key":
         if key.kty not in (KeyType.rsa, KeyType.rsa_hsm):  # type: ignore[attr-defined]
             raise ValueError('"key" must be an RSA or RSA-HSM key')
         return RsaKey.from_jwk(key)
 
-    def supports(self, operation, algorithm):
-        # type: (KeyOperation, Algorithm) -> bool
+    def supports(self, operation: KeyOperation, algorithm: "Algorithm") -> bool:
         if operation in _PRIVATE_KEY_OPERATIONS and not self._internal_key.is_private_key():
             return False
         if operation in (KeyOperation.decrypt, KeyOperation.encrypt):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/symmetric.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/symmetric.py
@@ -16,14 +16,12 @@ if TYPE_CHECKING:
 
 
 class SymmetricCryptographyProvider(LocalCryptographyProvider):
-    def _get_internal_key(self, key):
-        # type: (JsonWebKey) -> Key
+    def _get_internal_key(self, key: "JsonWebKey") -> "Key":
         if key.kty not in (KeyType.oct, KeyType.oct_hsm):  # type: ignore[attr-defined]
             raise ValueError('"key" must be an oct or oct-HSM (symmetric) key')
         return SymmetricKey.from_jwk(key)
 
-    def supports(self, operation, algorithm):
-        # type: (KeyOperation, Algorithm) -> bool
+    def supports(self, operation: KeyOperation, algorithm: "Algorithm") -> bool:
         if operation in (KeyOperation.decrypt, KeyOperation.encrypt):
             return algorithm in self._internal_key.supported_encryption_algorithms
         if operation in (KeyOperation.unwrap_key, KeyOperation.wrap_key):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -57,7 +57,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
     # pylint:disable=protected-access
 
-    def __init__(self, key: "Union[KeyVaultKey, str]", credential: "AsyncTokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, key: "Union[KeyVaultKey, str]", credential: "AsyncTokenCredential", **kwargs) -> None:
         self._jwk = kwargs.pop("_jwk", False)
         self._not_before = None  # type: Optional[datetime]
         self._expires_on = None  # type: Optional[datetime]
@@ -129,7 +129,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return cls(jwk, object(), _jwk=True)  # type: ignore
 
     @distributed_trace_async
-    async def _initialize(self, **kwargs: "Any") -> None:
+    async def _initialize(self, **kwargs) -> None:
         if self._initialized:
             return
 
@@ -159,7 +159,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             self._initialized = self._keys_get_forbidden
 
     @distributed_trace_async
-    async def encrypt(self, algorithm: EncryptionAlgorithm, plaintext: bytes, **kwargs: "Any") -> EncryptResult:
+    async def encrypt(self, algorithm: EncryptionAlgorithm, plaintext: bytes, **kwargs) -> EncryptResult:
         """Encrypt bytes using the client's key.
 
         Requires the keys/encrypt permission. This method encrypts only a single block of data, whose size depends on
@@ -232,7 +232,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def decrypt(self, algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
+    async def decrypt(self, algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs) -> DecryptResult:
         """Decrypt a single block of encrypted data using the client's key.
 
         Requires the keys/decrypt permission. This method decrypts only a single block of data, whose size depends on
@@ -292,7 +292,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=operation_result.result)
 
     @distributed_trace_async
-    async def wrap_key(self, algorithm: "KeyWrapAlgorithm", key: bytes, **kwargs: "Any") -> WrapResult:
+    async def wrap_key(self, algorithm: "KeyWrapAlgorithm", key: bytes, **kwargs) -> WrapResult:
         """Wrap a key with the client's key.
 
         Requires the keys/wrapKey permission.
@@ -335,7 +335,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=operation_result.result)
 
     @distributed_trace_async
-    async def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs: "Any") -> UnwrapResult:
+    async def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs) -> UnwrapResult:
         """Unwrap a key previously wrapped with the client's key.
 
         Requires the keys/unwrapKey permission.
@@ -377,7 +377,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return UnwrapResult(key_id=self.key_id, algorithm=algorithm, key=operation_result.result)
 
     @distributed_trace_async
-    async def sign(self, algorithm: "SignatureAlgorithm", digest: bytes, **kwargs: "Any") -> SignResult:
+    async def sign(self, algorithm: "SignatureAlgorithm", digest: bytes, **kwargs) -> SignResult:
         """Create a signature from a digest using the client's key.
 
         Requires the keys/sign permission.
@@ -421,7 +421,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def verify(
-        self, algorithm: "SignatureAlgorithm", digest: bytes, signature: bytes, **kwargs: "Any"
+        self, algorithm: "SignatureAlgorithm", digest: bytes, signature: bytes, **kwargs
     ) -> VerifyResult:
         """Verify a signature using the client's key.
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -19,7 +19,7 @@ from ..._shared import AsyncKeyVaultClientBase, parse_key_vault_id
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from datetime import datetime
-    from typing import Any, Optional, Union
+    from typing import Any, Dict, Optional, Union
     from azure.core.credentials_async import AsyncTokenCredential
     from .. import KeyWrapAlgorithm, SignatureAlgorithm
     from ..._shared import KeyVaultResourceId
@@ -34,8 +34,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
     that material from Key Vault. When the required key material is unavailable, cryptographic operations are performed
     by the Key Vault service.
 
-    :param key:
-        Either a :class:`~azure.keyvault.keys.KeyVaultKey` instance as returned by
+    :param key: Either a :class:`~azure.keyvault.keys.KeyVaultKey` instance as returned by
         :func:`~azure.keyvault.keys.aio.KeyClient.get_key`, or a string.
         If a string, the value must be the identifier of an Azure Key Vault key. Including a version is recommended.
     :type key: str or :class:`~azure.keyvault.keys.KeyVaultKey`
@@ -117,11 +116,12 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return self._vault_url
 
     @classmethod
-    def from_jwk(cls, jwk: "Union[JsonWebKey, dict]") -> "CryptographyClient":
+    def from_jwk(cls, jwk: "Union[JsonWebKey, Dict[str, Any]]") -> "CryptographyClient":
         """Creates a client that can only perform cryptographic operations locally.
 
         :param jwk: the key's cryptographic material, as a JsonWebKey or dictionary.
-        :type jwk: JsonWebKey or dict
+        :type jwk: JsonWebKey or Dict[str, Any]
+
         :rtype: CryptographyClient
         """
         if not isinstance(jwk, JsonWebKey):
@@ -129,8 +129,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return cls(jwk, object(), _jwk=True)  # type: ignore
 
     @distributed_trace_async
-    async def _initialize(self, **kwargs):
-        # type: (**Any) -> None
+    async def _initialize(self, **kwargs: "Any") -> None:
         if self._initialized:
             return
 
@@ -160,7 +159,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             self._initialized = self._keys_get_forbidden
 
     @distributed_trace_async
-    async def encrypt(self, algorithm: "EncryptionAlgorithm", plaintext: bytes, **kwargs: "Any") -> EncryptResult:
+    async def encrypt(self, algorithm: EncryptionAlgorithm, plaintext: bytes, **kwargs: "Any") -> EncryptResult:
         """Encrypt bytes using the client's key.
 
         Requires the keys/encrypt permission. This method encrypts only a single block of data, whose size depends on
@@ -169,13 +168,16 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :param algorithm: Encryption algorithm to use
         :type algorithm: :class:`~azure.keyvault.keys.crypto.EncryptionAlgorithm`
         :param bytes plaintext: Bytes to encrypt
+
         :keyword bytes iv: Initialization vector. Required for only AES-CBC(PAD) encryption. If you pass your own IV,
             make sure you use a cryptographically random, non-repeating IV. If omitted, an attempt will be made to
             generate an IV via `os.urandom <https://docs.python.org/library/os.html#os.urandom>`_ for local
             cryptography; for remote cryptography, Key Vault will generate an IV.
         :keyword bytes additional_authenticated_data: Optional data that is authenticated but not encrypted. For use
             with AES-GCM encryption.
+
         :rtype: :class:`~azure.keyvault.keys.crypto.EncryptResult`
+
         :raises ValueError: if parameters that are incompatible with the specified algorithm are provided, or if
             generating an IV fails on the current platform.
 
@@ -230,7 +232,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
+    async def decrypt(self, algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
         """Decrypt a single block of encrypted data using the client's key.
 
         Requires the keys/decrypt permission. This method decrypts only a single block of data, whose size depends on
@@ -241,12 +243,15 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :param bytes ciphertext: Encrypted bytes to decrypt. Microsoft recommends you not use CBC without first ensuring
             the integrity of the ciphertext using, for example, an HMAC. See
             https://docs.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode for more information.
+
         :keyword bytes iv: The initialization vector used during encryption. Required for AES decryption.
         :keyword bytes authentication_tag: The authentication tag generated during encryption. Required for only AES-GCM
             decryption.
         :keyword bytes additional_authenticated_data: Optional data that is authenticated but not encrypted. For use
             with AES-GCM decryption.
+
         :rtype: :class:`~azure.keyvault.keys.crypto.DecryptResult`
+
         :raises ValueError: If parameters that are incompatible with the specified algorithm are provided.
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
@@ -295,6 +300,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :param algorithm: wrapping algorithm to use
         :type algorithm: :class:`~azure.keyvault.keys.crypto.KeyWrapAlgorithm`
         :param bytes key: key to wrap
+
         :rtype: :class:`~azure.keyvault.keys.crypto.WrapResult`
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
@@ -337,6 +343,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :param algorithm: wrapping algorithm to use
         :type algorithm: :class:`~azure.keyvault.keys.crypto.KeyWrapAlgorithm`
         :param bytes encrypted_key: the wrapped key
+
         :rtype: :class:`~azure.keyvault.keys.crypto.UnwrapResult`
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
@@ -378,6 +385,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :param algorithm: signing algorithm
         :type algorithm: :class:`~azure.keyvault.keys.crypto.SignatureAlgorithm`
         :param bytes digest: hashed bytes to sign
+
         :rtype: :class:`~azure.keyvault.keys.crypto.SignResult`
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
@@ -422,8 +430,9 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :param algorithm: verification algorithm
         :type algorithm: :class:`~azure.keyvault.keys.crypto.SignatureAlgorithm`
         :param bytes digest: Pre-hashed digest corresponding to **signature**. The hash algorithm used must be
-          compatible with **algorithm**.
+            compatible with ``algorithm``.
         :param bytes signature: signature to verify
+
         :rtype: :class:`~azure.keyvault.keys.crypto.VerifyResult`
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py

--- a/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations.py
@@ -44,19 +44,19 @@ client = KeyClient(vault_url=VAULT_URL, credential=credential)
 # if the key already exists in the Key Vault, then a new version of the key is created.
 print("\n.. Create Key")
 key = client.create_key("keyName", "RSA")
-print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key_type))
+print(f"Key with name '{key.name}' created with key type '{key.key_type}'")
 
 # Backups are good to have, if in case keys gets deleted accidentally.
 # For long term storage, it is ideal to write the backup to a file.
 print("\n.. Create a backup for an existing Key")
 key_backup = client.backup_key(key.name)
-print("Backup created for key with name '{0}'.".format(key.name))
+print(f"Backup created for key with name '{key.name}'.")
 
 # The rsa key is no longer in use, so you delete it.
 print("\n.. Delete the key")
 delete_operation = client.begin_delete_key(key.name)
 deleted_key = delete_operation.result()
-print("Deleted key with name '{0}'".format(deleted_key.name))
+print(f"Deleted key with name '{deleted_key.name}'")
 
 # Wait for the deletion to complete before purging the key.
 # The purge will take some time, so wait before restoring the backup to avoid a conflict.
@@ -64,9 +64,9 @@ delete_operation.wait()
 print("\n.. Purge the key")
 client.purge_deleted_key(key.name)
 time.sleep(60)
-print("Purged key with name '{0}'".format(deleted_key.name))
+print(f"Purged key with name '{deleted_key.name}'")
 
 # In the future, if the key is required again, we can use the backup value to restore it in the Key Vault.
 print("\n.. Restore the key using the backed up key bytes")
 key = client.restore_key_backup(key_backup)
-print("Restored key with name '{0}'".format(key.name))
+print(f"Restored key with name '{key.name}'")

--- a/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
@@ -45,29 +45,29 @@ async def run_sample():
     # if the key already exists in the Key Vault, then a new version of the key is created.
     print("\n.. Create Key")
     key = await client.create_key("keyNameAsync", "RSA")
-    print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key_type))
+    print(f"Key with name '{key.name}' created with key type '{key.key_type}'")
 
     # Backups are good to have, if in case keys gets deleted accidentally.
     # For long term storage, it is ideal to write the backup to a file.
     print("\n.. Create a backup for an existing Key")
     key_backup = await client.backup_key(key.name)
-    print("Backup created for key with name '{0}'.".format(key.name))
+    print(f"Backup created for key with name '{key.name}'.")
 
     # The rsa key is no longer in use, so you delete it.
     deleted_key = await client.delete_key(key.name)
-    print("Deleted key with name '{0}'".format(deleted_key.name))
+    print(f"Deleted key with name '{deleted_key.name}'")
 
     # Purge the deleted key.
     # The purge will take some time, so wait before restoring the backup to avoid a conflict.
     print("\n.. Purge the key")
     await client.purge_deleted_key(key.name)
     await asyncio.sleep(60)
-    print("Purged key with name '{0}'".format(deleted_key.name))
+    print(f"Purged key with name '{deleted_key.name}'")
 
     # In the future, if the key is required again, we can use the backup value to restore it in the Key Vault.
     print("\n.. Restore the key using the backed up key bytes")
     key = await client.restore_key_backup(key_backup)
-    print("Restored key with name '{0}'".format(key.name))
+    print(f"Restored key with name '{key.name}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
@@ -47,7 +47,7 @@ key_size = 2048
 key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
 key_name = "rsaKeyName"
 rsa_key = client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
-print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
+print(f"RSA Key with name '{rsa_key.name}' created of type '{rsa_key.key_type}'.")
 
 # Let's create an Elliptic Curve key with algorithm curve type P-256.
 # if the key already exists in the Key Vault, then a new version of the key is created.
@@ -55,12 +55,12 @@ print("\n.. Create an EC Key")
 key_curve = "P-256"
 key_name = "ECKeyName"
 ec_key = client.create_ec_key(key_name, curve=key_curve)
-print("EC Key with name '{0}' created of type '{1}'.".format(ec_key.name, ec_key.key_type))
+print(f"EC Key with name '{ec_key.name}' created of type '{ec_key.key_type}'.")
 
 # Let's get the rsa key details using its name
 print("\n.. Get a Key by its name")
 rsa_key = client.get_key(rsa_key.name)
-print("Key with name '{0}' was found.".format(rsa_key.name))
+print(f"Key with name '{rsa_key.name}' was found.")
 
 # Let's say we want to update the expiration time for the EC key and disable the key to be usable
 # for cryptographic operations. The update method allows the user to modify the metadata (key attributes)
@@ -70,18 +70,12 @@ expires = datetime.datetime.utcnow() + datetime.timedelta(days=365)
 updated_ec_key = client.update_key_properties(
     ec_key.name, ec_key.properties.version, expires_on=expires, enabled=False
 )
-print(
-    "Key with name '{0}' was updated on date '{1}'".format(updated_ec_key.name, updated_ec_key.properties.updated_on)
-)
-print(
-    "Key with name '{0}' was updated to expire on '{1}'".format(
-        updated_ec_key.name, updated_ec_key.properties.expires_on
-    )
-)
+print(f"Key with name '{updated_ec_key.name}' was updated on date '{updated_ec_key.properties.updated_on}'")
+print(f"Key with name '{updated_ec_key.name}' was updated to expire on '{updated_ec_key.properties.expires_on}'")
 
 # The RSA key is no longer used, need to delete it from the Key Vault.
 print("\n.. Delete Keys")
 client.begin_delete_key(ec_key.name)
 client.begin_delete_key(rsa_key.name)
-print("Deleted key '{0}'".format(ec_key.name))
-print("Deleted key '{0}'".format(rsa_key.name))
+print(f"Deleted key '{ec_key.name}'")
+print(f"Deleted key '{rsa_key.name}'")

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
@@ -49,7 +49,7 @@ async def run_sample():
     key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
     key_name = "rsaKeyNameAsync"
     rsa_key = await client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
-    print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
+    print(f"RSA Key with name '{rsa_key.name}' created of type '{rsa_key.key_type}'.")
 
     # Let's create an Elliptic Curve key with algorithm curve type P-256.
     # if the key already exists in the Key Vault, then a new version of the key is created.
@@ -57,12 +57,12 @@ async def run_sample():
     key_curve = "P-256"
     key_name = "ECKeyNameAsync"
     ec_key = await client.create_ec_key(key_name, curve=key_curve)
-    print("EC Key with name '{0}' created of type {1}.".format(ec_key.name, ec_key.key_type))
+    print(f"EC Key with name '{ec_key.name}' created of type {ec_key.key_type}.")
 
     # Let's get the rsa key details using its name
     print("\n.. Get a Key using it's name")
     rsa_key = await client.get_key(rsa_key.name)
-    print("Key with name '{0}' was found.".format(rsa_key.name))
+    print(f"Key with name '{rsa_key.name}' was found.")
 
     # Let's say we want to update the expiration time for the EC key and disable the key to be usable
     # for cryptographic operations. The update method allows the user to modify the metadata (key attributes)
@@ -72,22 +72,14 @@ async def run_sample():
     updated_ec_key = await client.update_key_properties(
         ec_key.name, version=ec_key.properties.version, expires_on=expires_on, enabled=False
     )
-    print(
-        "Key with name '{0}' was updated on date '{1}'".format(
-            updated_ec_key.name, updated_ec_key.properties.updated_on
-        )
-    )
-    print(
-        "Key with name '{0}' was updated to expire on '{1}'".format(
-            updated_ec_key.name, updated_ec_key.properties.expires_on
-        )
-    )
+    print(f"Key with name '{updated_ec_key.name}' was updated on date '{updated_ec_key.properties.updated_on}'")
+    print(f"Key with name '{updated_ec_key.name}' was updated to expire on '{updated_ec_key.properties.expires_on}'")
 
     # The keys are no longer used, let's delete them
     print("\n.. Deleting keys")
     for key_name in (ec_key.name, rsa_key.name):
         deleted_key = await client.delete_key(key_name)
-        print("\nDeleted '{}'".format(deleted_key.name))
+        print(f"\nDeleted '{deleted_key.name}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
@@ -42,7 +42,7 @@ client = KeyClient(vault_url=VAULT_URL, credential=credential)
 # First, create a key
 key_name = "rotation-sample-key"
 key = client.create_rsa_key(key_name)
-print("\nCreated a key; new version is {}".format(key.properties.version))
+print(f"\nCreated a key; new version is {key.properties.version}")
 
 # Set the key's automated rotation policy to rotate the key two months after the key was created.
 # If you pass an empty KeyRotationPolicy() as the `policy` parameter, the rotation policy will be set to the
@@ -61,7 +61,7 @@ for i in range(len(updated_policy.lifetime_actions)):
 assert policy_action, "The specified action should exist in the key rotation policy"
 assert policy_action.time_after_create == "P2M", "The action should have the specified time_after_create"
 assert policy_action.time_before_expiry is None, "The action shouldn't have a time_before_expiry"
-print("\nCreated a new key rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
+print(f"\nCreated a new key rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
 # Get the key's current rotation policy
 current_policy = client.get_key_rotation_policy(key_name)
@@ -69,7 +69,7 @@ policy_action = None
 for i in range(len(current_policy.lifetime_actions)):
     if current_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
         policy_action = current_policy.lifetime_actions[i]
-print("\nCurrent rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
+print(f"\nCurrent rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
 # Update the key's automated rotation policy to notify 10 days before the key expires
 new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P10D")]
@@ -88,11 +88,11 @@ for i in range(len(new_policy.lifetime_actions)):
 assert notify_action, "The specified action should exist in the key rotation policy"
 assert notify_action.time_after_create is None, "The action shouldn't have a time_after_create"
 assert notify_action.time_before_expiry == "P10D", "The action should have the specified time_before_expiry"
-print("\nNew policy action: {} {} before expiry".format(notify_action.action, notify_action.time_before_expiry))
+print(f"\nNew policy action: {notify_action.action} {notify_action.time_before_expiry} before expiry")
 
 # Finally, you can rotate a key on-demand by creating a new version of the key
 rotated_key = client.rotate_key(key_name)
-print("\nRotated the key on-demand; new version is {}".format(rotated_key.properties.version))
+print(f"\nRotated the key on-demand; new version is {rotated_key.properties.version}")
 
 # To clean up, delete the key
 client.begin_delete_key(key_name)

--- a/sdk/keyvault/azure-keyvault-keys/samples/key_rotation_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/key_rotation_async.py
@@ -45,7 +45,7 @@ async def run_sample():
     # First, create a key
     key_name = "rotation-sample-key-async"
     key = await client.create_rsa_key(key_name)
-    print("\nCreated a key; new version is {}".format(key.properties.version))
+    print(f"\nCreated a key; new version is {key.properties.version}")
 
     # Set the key's automated rotation policy to rotate the key two months after the key was created.
     # If you pass an empty KeyRotationPolicy() as the `policy` parameter, the rotation policy will be set to the
@@ -64,9 +64,7 @@ async def run_sample():
     assert policy_action, "The specified action should exist in the key rotation policy"
     assert policy_action.time_after_create == "P2M", "The action should have the specified time_after_create"
     assert policy_action.time_before_expiry is None, "The action shouldn't have a time_before_expiry"
-    print(
-        "\nCreated a new key rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create)
-    )
+    print(f"\nCreated a new key rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
     # Get the key's current rotation policy
     current_policy = await client.get_key_rotation_policy(key_name)
@@ -74,7 +72,7 @@ async def run_sample():
     for i in range(len(current_policy.lifetime_actions)):
         if current_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
             policy_action = current_policy.lifetime_actions[i]
-    print("\nCurrent rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
+    print(f"\nCurrent rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
     # Update the key's automated rotation policy to notify 10 days before the key expires
     new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P10D")]
@@ -93,11 +91,11 @@ async def run_sample():
     assert notify_action, "The specified action should exist in the key rotation policy"
     assert notify_action.time_after_create is None, "The action shouldn't have a time_after_create"
     assert notify_action.time_before_expiry == "P10D", "The action should have the specified time_before_expiry"
-    print("\nNew policy action: {} {} before expiry".format(notify_action.action, notify_action.time_before_expiry))
+    print(f"\nNew policy action: {notify_action.action} {notify_action.time_before_expiry} before expiry")
 
     # Finally, you can rotate a key on-demand by creating a new version of the key
     rotated_key = await client.rotate_key(key_name)
-    print("\nRotated the key on-demand; new version is {}".format(rotated_key.properties.version))
+    print(f"\nRotated the key on-demand; new version is {rotated_key.properties.version}")
 
     # To clean up, delete the key
     await client.delete_key(key_name)

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
@@ -45,8 +45,8 @@ client = KeyClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create Key")
 rsa_key = client.create_rsa_key("rsaKeyName")
 ec_key = client.create_ec_key("ecKeyName")
-print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
-print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_type))
+print(f"Key with name '{rsa_key.name}' was created of type '{rsa_key.key_type}'.")
+print(f"Key with name '{ec_key.name}' was created of type '{ec_key.key_type}'.")
 
 # You need to check the type of all the keys in the vault.
 # Let's list the keys and print their key types.
@@ -56,21 +56,19 @@ print("\n.. List keys from the Key Vault")
 keys = client.list_properties_of_keys()
 for key in keys:
     retrieved_key = client.get_key(key.name)
-    print(
-        "Key with name '{0}' with type '{1}' was found.".format(retrieved_key.name, retrieved_key.key_type)
-    )
+    print(f"Key with name '{retrieved_key.name}' with type '{retrieved_key.key_type}' was found.")
 
 # The rsa key size now should now be 3072, default - 2048. So you want to update the key in Key Vault to ensure
 # it reflects the new key size. Calling create_rsa_key on an existing key creates a new version of the key in
 # the Key Vault with the new key size.
 new_key = client.create_rsa_key(rsa_key.name, size=3072)
-print("New version was created for Key with name '{0}' with the updated size.".format(new_key.name))
+print(f"New version was created for Key with name '{new_key.name}' with the updated size.")
 
 # You should have more than one version of the rsa key at this time. Lets print all the versions of this key.
 print("\n.. List versions of a key using its name")
 key_versions = client.list_properties_of_key_versions(rsa_key.name)
 for key in key_versions:
-    print("Key '{0}' has version: '{1}'".format(key.name, key.version))
+    print(f"Key '{key.name}' has version: '{key.version}'")
 
 # Both the rsa key and ec key are not needed anymore. Let's delete those keys.
 print("\n.. Delete the created keys...")
@@ -81,4 +79,4 @@ for key_name in (ec_key.name, rsa_key.name):
 print("\n.. List deleted keys from the Key Vault (requires soft-delete)")
 deleted_keys = client.list_deleted_keys()
 for deleted_key in deleted_keys:
-    print("Key with name '{0}' has recovery id '{1}'".format(deleted_key.name, deleted_key.recovery_id))
+    print(f"Key with name '{deleted_key.name}' has recovery id '{deleted_key.recovery_id}'")

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
@@ -47,8 +47,8 @@ async def run_sample():
     print("\n.. Create Key")
     rsa_key = await client.create_rsa_key("rsaKeyNameAsync")
     ec_key = await client.create_ec_key("ecKeyNameAsync")
-    print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
-    print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_type))
+    print(f"Key with name '{rsa_key.name}' was created of type '{rsa_key.key_type}'.")
+    print(f"Key with name '{ec_key.name}' was created of type '{ec_key.key_type}'.")
 
     # You need to check the type of all the keys in the vault.
     # Let's list the keys and print their key types.
@@ -58,23 +58,19 @@ async def run_sample():
     keys = client.list_properties_of_keys()
     async for key in keys:
         retrieved_key = await client.get_key(key.name)
-        print(
-            "Key with name '{0}' with type '{1}' was found.".format(
-                retrieved_key.name, retrieved_key.key_type
-            )
-        )
+        print(f"Key with name '{retrieved_key.name}' with type '{retrieved_key.key_type}' was found.")
 
     # The rsa key size now should now be 3072, default - 2048. So you want to update the key in Key Vault to ensure
     # it reflects the new key size. Calling create_rsa_key on an existing key creates a new version of the key in
     # the Key Vault with the new key size.
     new_key = await client.create_rsa_key(rsa_key.name, size=3072)
-    print("New version was created for Key with name '{0}' with the updated size.".format(new_key.name))
+    print(f"New version was created for Key with name '{new_key.name}' with the updated size.")
 
     # You should have more than one version of the rsa key at this time. Lets print all the versions of this key.
     print("\n.. List versions of the key using its name")
     key_versions = client.list_properties_of_key_versions(rsa_key.name)
     async for key in key_versions:
-        print("RSA Key with name '{0}' has version: '{1}'".format(key.name, key.version))
+        print(f"RSA Key with name '{key.name}' has version: '{key.version}'")
 
     # Both the rsa key and ec key are not needed anymore. Let's delete those keys.
     print("\n..Deleting keys...")
@@ -85,7 +81,7 @@ async def run_sample():
     print("\n.. List deleted keys from the Key Vault")
     deleted_keys = client.list_deleted_keys()
     async for deleted_key in deleted_keys:
-        print("Key with name '{0}' has recovery id '{1}'".format(deleted_key.name, deleted_key.recovery_id))
+        print(f"Key with name '{deleted_key.name}' has recovery id '{deleted_key.recovery_id}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
@@ -40,13 +40,13 @@ client = KeyClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create keys")
 rsa_key = client.create_rsa_key("rsaKeyName")
 ec_key = client.create_ec_key("ecKeyName")
-print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
-print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_type))
+print(f"Created key '{rsa_key.name}' of type '{rsa_key.key_type}'.")
+print(f"Created key '{ec_key.name}' of type '{ec_key.key_type}'.")
 
 print("\n.. Delete the keys")
 for key_name in (ec_key.name, rsa_key.name):
     client.begin_delete_key(key_name).wait()
-    print("Deleted key '{0}'".format(key_name))
+    print(f"Deleted key '{key_name}'")
 
 # A deleted key can only be recovered if the Key Vault is soft-delete enabled.
 print("\n.. Recover a deleted key")
@@ -55,7 +55,7 @@ recovered_key = recover_key_poller.result()
 
 # This wait is just to ensure recovery is complete before we delete the key again
 recover_key_poller.wait()
-print("Recovered key '{0}'".format(recovered_key.name))
+print(f"Recovered key '{recovered_key.name}'")
 
 # To permanently delete the key, the deleted key needs to be purged.
 # Calling result() on the method will immediately return the `DeletedKey`, but calling wait() blocks
@@ -67,4 +67,4 @@ client.begin_delete_key(recovered_key.name).wait()
 print("\n.. Purge keys")
 for key_name in (ec_key.name, rsa_key.name):
     client.purge_deleted_key(key_name)
-    print("Purged '{}'".format(key_name))
+    print(f"Purged '{key_name}'")

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
@@ -41,18 +41,18 @@ async def run_sample():
     print("\n.. Create keys")
     rsa_key = await client.create_rsa_key("rsaKeyNameAsync")
     ec_key = await client.create_ec_key("ecKeyNameAsync")
-    print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
-    print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_type))
+    print(f"Created key '{rsa_key.name}' of type '{rsa_key.key_type}'.")
+    print(f"Created key '{ec_key.name}' of type '{ec_key.key_type}'.")
 
     print("\n.. Delete the keys")
     for key_name in (ec_key.name, rsa_key.name):
         deleted_key = await client.delete_key(key_name)
-        print("Deleted key '{0}'".format(deleted_key.name))
+        print(f"Deleted key '{deleted_key.name}'")
 
     # A deleted key can only be recovered if the Key Vault is soft-delete enabled.
     print("\n.. Recover a deleted key")
     recovered_key = await client.recover_deleted_key(rsa_key.name)
-    print("Recovered key '{0}'".format(recovered_key.name))
+    print(f"Recovered key '{recovered_key.name}'")
 
     # To permanently delete the key, the deleted key needs to be purged.
     await client.delete_key(recovered_key.name)
@@ -62,7 +62,7 @@ async def run_sample():
     print("\n.. Purge keys")
     for key_name in (ec_key.name, rsa_key.name):
         await client.purge_deleted_key(key_name)
-        print("Purged '{}'".format(key_name))
+        print(f"Purged '{key_name}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-keys/setup.py
+++ b/sdk/keyvault/azure-keyvault-keys/setup.py
@@ -36,7 +36,7 @@ setup(
     name=PACKAGE_NAME,
     version=VERSION,
     include_package_data=True,
-    description="Microsoft Azure {} Client Library for Python".format(PACKAGE_PPRINT_NAME),
+    description=f"Microsoft Azure {PACKAGE_PPRINT_NAME} Client Library for Python",
     long_description=README + "\n\n" + CHANGELOG,
     long_description_content_type="text/markdown",
     license="MIT License",

--- a/sdk/keyvault/azure-keyvault-keys/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_async_test_case.py
@@ -14,7 +14,7 @@ from devtools_testutils import AzureRecordedTestCase
 
 
 async def get_attestation_token(attestation_uri):
-    request = HttpRequest("GET", "{}/generate-test-token".format(attestation_uri))
+    request = HttpRequest("GET", f"{attestation_uri}/generate-test-token")
     async with AsyncPipeline(transport=AioHttpTransport()) as pipeline:
         response = await pipeline.run(request)
         return json.loads(response.http_response.text())["token"]

--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -14,7 +14,7 @@ from devtools_testutils import AzureRecordedTestCase
 
 
 def get_attestation_token(attestation_uri):
-    request = HttpRequest("GET", "{}/generate-test-token".format(attestation_uri))
+    request = HttpRequest("GET", f"{attestation_uri}/generate-test-token")
     with Pipeline(transport=RequestsTransport()) as pipeline:
         response = pipeline.run(request)
         return json.loads(response.http_response.text())["token"]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -85,7 +85,7 @@ def empty_challenge_cache(fn):
 def get_random_url():
     """The challenge cache is keyed on URLs. Random URLs defend against tests interfering with each other."""
 
-    return "https://{}.vault.azure.net/{}".format(uuid4(), uuid4()).replace("-", "")
+    return f"https://{uuid4()}.vault.azure.net/{uuid4()}".replace("-", "")
 
 
 def add_url_port(url: str):
@@ -126,10 +126,10 @@ def test_challenge_cache():
 
 def test_challenge_parsing():
     tenant = "tenant"
-    authority = "https://login.authority.net/{}".format(tenant)
+    authority = f"https://login.authority.net/{tenant}"
     resource = "https://challenge.resource"
     challenge = HttpChallenge(
-        "https://request.uri", challenge="Bearer authorization={}, resource={}".format(authority, resource)
+        "https://request.uri", challenge=f"Bearer authorization={authority}, resource={resource}"
     )
 
     assert challenge.get_authorization_server() == authority
@@ -185,11 +185,11 @@ def test_scope():
 
     challenge_with_resource = Mock(
         status_code=401,
-        headers={"WWW-Authenticate": 'Bearer authorization="{}", resource={}'.format(endpoint, resource)},
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource={resource}'},
     )
 
     challenge_with_scope = Mock(
-        status_code=401, headers={"WWW-Authenticate": 'Bearer authorization="{}", scope={}'.format(endpoint, scope)}
+        status_code=401, headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", scope={scope}'}
     )
 
     test_with_challenge(challenge_with_resource, scope)
@@ -236,7 +236,7 @@ def test_tenant():
         assert credential.get_token.call_count == 1
 
     tenant = "tenant-id"
-    endpoint = "https://authority.net/{}".format(tenant)
+    endpoint = f"https://authority.net/{tenant}"
     resource = "https://vault.azure.net"
 
     challenge = Mock(
@@ -258,7 +258,7 @@ def test_policy_updates_cache():
     first_token = "first-scope-token"
     second_scope = "https://vault.azure.net/second-scope"
     second_token = "second-scope-token"
-    challenge_fmt = 'Bearer authorization="https://login.authority.net/tenant", resource={}'
+    challenge_fmt = 'Bearer authorization="https://login.authority.net/tenant", resource='
 
     # mocking a tenant change:
     # 1. first request -> respond with challenge
@@ -270,17 +270,17 @@ def test_policy_updates_cache():
     transport = validating_transport(
         requests=(
             Request(url),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(first_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(first_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(first_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(second_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(second_token)}),
+            Request(url, required_headers={"Authorization": f"Bearer {first_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {first_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {first_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {second_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {second_token}"}),
         ),
         responses=(
-            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt.format(first_scope)}),
+            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt + first_scope}),
             mock_response(status_code=200),
             mock_response(status_code=200),
-            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt.format(second_scope)}),
+            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt + second_scope}),
             mock_response(status_code=200),
             mock_response(status_code=200),
         ),

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -133,11 +133,11 @@ async def test_scope():
 
     challenge_with_resource = Mock(
         status_code=401,
-        headers={"WWW-Authenticate": 'Bearer authorization="{}", resource={}'.format(endpoint, resource)},
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource={resource}'},
     )
 
     challenge_with_scope = Mock(
-        status_code=401, headers={"WWW-Authenticate": 'Bearer authorization="{}", scope={}'.format(endpoint, scope)}
+        status_code=401, headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", scope={scope}'}
     )
 
     await test_with_challenge(challenge_with_resource, scope)
@@ -187,7 +187,7 @@ async def test_tenant():
         assert credential.get_token.call_count == 1
 
     tenant = "tenant-id"
-    endpoint = "https://authority.net/{}".format(tenant)
+    endpoint = f"https://authority.net/{tenant}"
     resource = "https://vault.azure.net"
 
     challenge = Mock(
@@ -211,7 +211,7 @@ async def test_policy_updates_cache():
     first_token = "first-scope-token"
     second_scope = "https://vault.azure.net/second-scope"
     second_token = "second-scope-token"
-    challenge_fmt = 'Bearer authorization="https://login.authority.net/tenant", resource={}'
+    challenge_fmt = 'Bearer authorization="https://login.authority.net/tenant", resource='
 
     # mocking a tenant change:
     # 1. first request -> respond with challenge
@@ -223,17 +223,17 @@ async def test_policy_updates_cache():
     transport = async_validating_transport(
         requests=(
             Request(url),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(first_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(first_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(first_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(second_token)}),
-            Request(url, required_headers={"Authorization": "Bearer {}".format(second_token)}),
+            Request(url, required_headers={"Authorization": f"Bearer {first_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {first_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {first_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {second_token}"}),
+            Request(url, required_headers={"Authorization": f"Bearer {second_token}"}),
         ),
         responses=(
-            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt.format(first_scope)}),
+            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt + first_scope}),
             mock_response(status_code=200),
             mock_response(status_code=200),
-            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt.format(second_scope)}),
+            mock_response(status_code=401, headers={"WWW-Authenticate": challenge_fmt + second_scope}),
             mock_response(status_code=200),
             mock_response(status_code=200),
         ),

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -82,10 +82,10 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
         key = key_attributes.key
         kid = key_attributes.id
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key.n and key.e, "Bad RSA public material."
-        assert sorted(key_ops) == sorted(key.key_ops), "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops)
+        assert sorted(key_ops) == sorted(key.key_ops), f"keyOps should be '{key_ops}', but is '{key.key_ops}'"
         
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on, "Missing required date attributes."
         
@@ -95,14 +95,14 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         key = key_attributes.key
         kid = key_attributes.id
         assert key_curve == key.crv
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on,"Missing required date attributes."
 
     def _import_test_key(self, client, name, hardware_protected=False):
         def _to_bytes(hex):
             if len(hex) % 2:
-                hex = "0{}".format(hex)
+                hex = f"0{hex}"
             return codecs.decode(hex, "hex_codec")
 
         key = JsonWebKey(
@@ -465,7 +465,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     def test_rsa_verify_local(self, key_client, is_hsm, **kwargs):
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
-            key_name = self.get_resource_name("rsa-verify-{}".format(size))
+            key_name = self.get_resource_name(f"rsa-verify-{size}")
             key = self._create_rsa_key(key_client, key_name, size=size, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, api_version=key_client.api_version)
             for signature_algorithm, hash_function in (
@@ -490,7 +490,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     def test_rsa_verify_local_from_jwk(self, key_client, is_hsm, **kwargs):
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
-            key_name = self.get_resource_name("rsa-verify-{}".format(size))
+            key_name = self.get_resource_name(f"rsa-verify-{size}")
             key = self._create_rsa_key(key_client, key_name, size=size, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, api_version=key_client.api_version)
             local_client = CryptographyClient.from_jwk(key.key)
@@ -523,7 +523,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         }
 
         for curve, (signature_algorithm, hash_function) in sorted(matrix.items()):
-            key_name = self.get_resource_name("ec-verify-{}".format(curve.value))
+            key_name = self.get_resource_name(f"ec-verify-{curve.value}")
             key = self._create_ec_key(key_client, key_name, curve=curve, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, api_version=key_client.api_version)
 
@@ -548,7 +548,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         }
 
         for curve, (signature_algorithm, hash_function) in sorted(matrix.items()):
-            key_name = self.get_resource_name("ec-verify-{}".format(curve.value))
+            key_name = self.get_resource_name(f"ec-verify-{curve.value}")
             key = self._create_ec_key(key_client, key_name, curve=curve, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, api_version=key_client.api_version)
             local_client = CryptographyClient.from_jwk(key.key)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -6,7 +6,7 @@ import codecs
 import hashlib
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
 
@@ -32,7 +32,6 @@ from azure.keyvault.keys.crypto import (
     KeyWrapAlgorithm,
     SignatureAlgorithm,
 )
-from azure.keyvault.keys.crypto._key_validity import _UTC
 from azure.keyvault.keys.crypto._providers import NoLocalCryptography, get_local_cryptography_provider
 from azure.keyvault.keys._generated._serialization import Deserializer, Serializer
 from azure.keyvault.keys._generated_models import KeySignParameters
@@ -580,7 +579,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
                     assert substring in str(ex.value)
 
         # operations should not succeed with a key whose nbf is in the future
-        the_year_3000 = datetime(3000, 1, 1, tzinfo=_UTC)
+        the_year_3000 = datetime(3000, 1, 1, tzinfo=timezone.utc)
 
         rsa_wrap_algorithms = [algorithm for algorithm in KeyWrapAlgorithm if algorithm.startswith("RSA")]
         rsa_encryption_algorithms = [algorithm for algorithm in EncryptionAlgorithm if algorithm.startswith("RSA")]
@@ -591,14 +590,14 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         test_operations(not_yet_valid_key, [str(the_year_3000)], rsa_encryption_algorithms, rsa_wrap_algorithms)
 
         # nor should they succeed with a key whose exp has passed
-        the_year_2000 = datetime(2000, 1, 1, tzinfo=_UTC)
+        the_year_2000 = datetime(2000, 1, 1, tzinfo=timezone.utc)
 
         key_name = self.get_resource_name("rsa-expired")
         expired_key = self._create_rsa_key(key_client, key_name, expires_on=the_year_2000, hardware_protected=is_hsm)
         test_operations(expired_key, [str(the_year_2000)], rsa_encryption_algorithms, rsa_wrap_algorithms)
 
         # when exp and nbf are set, error messages should contain both
-        the_year_3001 = datetime(3001, 1, 1, tzinfo=_UTC)
+        the_year_3001 = datetime(3001, 1, 1, tzinfo=timezone.utc)
 
         key_name = self.get_resource_name("rsa-valid")
         valid_key = self._create_rsa_key(
@@ -833,7 +832,7 @@ def test_prefers_local_provider():
         spec=KeyVaultKey,
         id="https://localhost/fake/key/version",
         properties=mock.Mock(
-            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+            not_before=datetime(2000, 1, 1, tzinfo=timezone.utc), expires_on=datetime(3000, 1, 1, tzinfo=timezone.utc)
         ),
     )
     client = CryptographyClient(key, mock.Mock())
@@ -901,7 +900,7 @@ def test_encrypt_argument_validation():
         spec=KeyVaultKey,
         id="https://localhost/fake/key/version",
         properties=mock.Mock(
-            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+            not_before=datetime(2000, 1, 1, tzinfo=timezone.utc), expires_on=datetime(3000, 1, 1, tzinfo=timezone.utc)
         ),
     )
     client = CryptographyClient(key, mock.Mock())
@@ -924,7 +923,7 @@ def test_decrypt_argument_validation():
         spec=KeyVaultKey,
         id="https://localhost/fake/key/version",
         properties=mock.Mock(
-            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+            not_before=datetime(2000, 1, 1, tzinfo=timezone.utc), expires_on=datetime(3000, 1, 1, tzinfo=timezone.utc)
         ),
     )
     client = CryptographyClient(key, mock.Mock())

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -6,7 +6,7 @@ import asyncio
 import codecs
 import hashlib
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -20,7 +20,6 @@ from azure.keyvault.keys import (
     KeyOperation,
     KeyVaultKey,
 )
-from azure.keyvault.keys.crypto._key_validity import _UTC
 from azure.keyvault.keys.crypto._providers import NoLocalCryptography, get_local_cryptography_provider
 from azure.keyvault.keys.crypto.aio import (
     CryptographyClient,
@@ -594,7 +593,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
                     assert substring in str(ex.value)
 
         # operations should not succeed with a key whose nbf is in the future
-        the_year_3000 = datetime(3000, 1, 1, tzinfo=_UTC)
+        the_year_3000 = datetime(3000, 1, 1, tzinfo=timezone.utc)
 
         rsa_wrap_algorithms = [algorithm for algorithm in KeyWrapAlgorithm if algorithm.startswith("RSA")]
         rsa_encryption_algorithms = [algorithm for algorithm in EncryptionAlgorithm if algorithm.startswith("RSA")]
@@ -605,7 +604,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         await test_operations(not_yet_valid_key, [str(the_year_3000)], rsa_encryption_algorithms, rsa_wrap_algorithms)
 
         # nor should they succeed with a key whose exp has passed
-        the_year_2000 = datetime(2000, 1, 1, tzinfo=_UTC)
+        the_year_2000 = datetime(2000, 1, 1, tzinfo=timezone.utc)
 
         key_name = self.get_resource_name("rsa-expired")
         expired_key = await self._create_rsa_key(
@@ -614,7 +613,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         await test_operations(expired_key, [str(the_year_2000)], rsa_encryption_algorithms, rsa_wrap_algorithms)
 
         # when exp and nbf are set, error messages should contain both
-        the_year_3001 = datetime(3001, 1, 1, tzinfo=_UTC)
+        the_year_3001 = datetime(3001, 1, 1, tzinfo=timezone.utc)
 
         key_name = self.get_resource_name("rsa-valid")
         valid_key = await self._create_rsa_key(
@@ -880,7 +879,7 @@ async def test_prefers_local_provider():
         spec=KeyVaultKey,
         id="https://localhost/fake/key/version",
         properties=mock.Mock(
-            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+            not_before=datetime(2000, 1, 1, tzinfo=timezone.utc), expires_on=datetime(3000, 1, 1, tzinfo=timezone.utc)
         ),
     )
     client = CryptographyClient(key, mock.Mock())
@@ -951,7 +950,7 @@ async def test_encrypt_argument_validation():
         spec=KeyVaultKey,
         id="https://localhost/fake/key/version",
         properties=mock.Mock(
-            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+            not_before=datetime(2000, 1, 1, tzinfo=timezone.utc), expires_on=datetime(3000, 1, 1, tzinfo=timezone.utc)
         ),
     )
     client = CryptographyClient(key, mock.Mock())
@@ -975,7 +974,7 @@ async def test_decrypt_argument_validation():
         spec=KeyVaultKey,
         id="https://localhost/fake/key/version",
         properties=mock.Mock(
-            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+            not_before=datetime(2000, 1, 1, tzinfo=timezone.utc), expires_on=datetime(3000, 1, 1, tzinfo=timezone.utc)
         ),
     )
     client = CryptographyClient(key, mock.Mock())

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -79,10 +79,10 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
         key = key_attributes.key
         kid = key_attributes.id
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key.n and key.e, "Bad RSA public material."
-        assert sorted(key_ops) == sorted(key.key_ops), "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops)
+        assert sorted(key_ops) == sorted(key.key_ops), f"keyOps should be '{key_ops}', but is '{key.key_ops}'"
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on,"Missing required date attributes."
         
 
@@ -91,14 +91,14 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         key = key_attributes.key
         kid = key_attributes.id
         assert key_curve == key.crv
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on,"Missing required date attributes."
 
     async def _import_test_key(self, client, name, hardware_protected=False):
         def _to_bytes(hex):
             if len(hex) % 2:
-                hex = "0{}".format(hex)
+                hex = f"0{hex}"
             return codecs.decode(hex, "hex_codec")
 
         key = JsonWebKey(
@@ -475,7 +475,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     async def test_rsa_verify_local(self, key_client, is_hsm, **kwargs):
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
-            key_name = self.get_resource_name("rsa-verify-{}".format(size))
+            key_name = self.get_resource_name(f"rsa-verify-{size}")
             key = await self._create_rsa_key(key_client, key_name, size=size, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, is_async=True, api_version=key_client.api_version)
             for signature_algorithm, hash_function in (
@@ -501,7 +501,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
     async def test_rsa_verify_local_from_jwk(self, key_client, is_hsm, **kwargs):
         """Sign with Key Vault, verify locally"""
         for size in (2048, 3072, 4096):
-            key_name = self.get_resource_name("rsa-verify-{}".format(size))
+            key_name = self.get_resource_name(f"rsa-verify-{size}")
             key = await self._create_rsa_key(key_client, key_name, size=size, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, is_async=True, api_version=key_client.api_version)
             local_client = CryptographyClient.from_jwk(key.key)
@@ -535,7 +535,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         }
 
         for curve, (signature_algorithm, hash_function) in sorted(matrix.items()):
-            key_name = self.get_resource_name("ec-verify-{}".format(curve.value))
+            key_name = self.get_resource_name(f"ec-verify-{curve.value}")
             key = await self._create_ec_key(key_client, key_name, curve=curve, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, is_async=True, api_version=key_client.api_version)
 
@@ -561,7 +561,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         }
 
         for curve, (signature_algorithm, hash_function) in sorted(matrix.items()):
-            key_name = self.get_resource_name("ec-verify-{}".format(curve.value))
+            key_name = self.get_resource_name(f"ec-verify-{curve.value}")
             key = await self._create_ec_key(key_client, key_name, curve=curve, hardware_protected=is_hsm)
             crypto_client = self.create_crypto_client(key, is_async=True, api_version=key_client.api_version)
             local_client = CryptographyClient.from_jwk(key.key)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -110,8 +110,8 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         key = key_attributes.key
         kid = key_attributes.id
         assert key_curve == key.crv
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on,"Missing required date attributes."
         
 
@@ -119,10 +119,10 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
         key = key_attributes.key
         kid = key_attributes.id
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key.n and key.e, "Bad RSA public material."
-        assert sorted(key_ops) == sorted(key.key_ops), "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops)
+        assert sorted(key_ops) == sorted(key.key_ops), f"keyOps should be '{key_ops}', but is '{key.key_ops}'"
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on, "Missing required date attributes."
 
     def _update_key_properties(self, client, key, release_policy=None):
@@ -148,7 +148,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
     def _import_test_key(self, client, name, hardware_protected=False, **kwargs):
         def _to_bytes(hex):
             if len(hex) % 2:
-                hex = "0{}".format(hex)
+                hex = f"0{hex}"
             return codecs.decode(hex, "hex_codec")
 
         key = JsonWebKey(
@@ -299,7 +299,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
 
         # create many keys
         for x in range(max_keys):
-            key_name = self.get_resource_name("key{}".format(x))
+            key_name = self.get_resource_name(f"key{x}")
             key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
             expected[key.name] = key
 
@@ -348,7 +348,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
 
         # create keys
         for i in range(LIST_TEST_SIZE):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             expected[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
         # delete them
@@ -378,7 +378,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         # create keys
         keys = {}
         for i in range(LIST_TEST_SIZE):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             keys[key_name] = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
         # delete them
@@ -403,7 +403,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         assert client is not None
 
         # create keys
-        key_names = [self.get_resource_name("key{}".format(i)) for i in range(LIST_TEST_SIZE)]
+        key_names = [self.get_resource_name(f"key{i}") for i in range(LIST_TEST_SIZE)]
         for name in key_names:
             self._create_rsa_key(client, name, hardware_protected=is_hsm)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -98,18 +98,18 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         key = key_attributes.key
         kid = key_attributes.id
         assert key_curve == key.crv
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on,"Missing required date attributes."
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
         key = key_attributes.key
         kid = key_attributes.id
-        assert kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid)
-        assert key.kty == kty, "kty should by '{}', but is '{}'".format(key, key.kty)
+        assert kid.index(prefix) == 0, f"Key Id should start with '{prefix}', but value is '{kid}'"
+        assert key.kty == kty, f"kty should by '{key}', but is '{key.kty}'"
         assert key.n and key.e, "Bad RSA public material."
-        assert sorted(key_ops) == sorted(key.key_ops), "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops)
+        assert sorted(key_ops) == sorted(key.key_ops), f"keyOps should be '{key_ops}', but is '{key.key_ops}'"
         assert key_attributes.properties.created_on and key_attributes.properties.updated_on,"Missing required date attributes."
 
     async def _update_key_properties(self, client, key, release_policy=None):
@@ -142,7 +142,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
     async def _import_test_key(self, client, name, hardware_protected=False, **kwargs):
         def _to_bytes(hex):
             if len(hex) % 2:
-                hex = "0{}".format(hex)
+                hex = f"0{hex}"
             return codecs.decode(hex, "hex_codec")
 
         key = JsonWebKey(
@@ -295,7 +295,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
 
         # create many keys
         for x in range(max_keys):
-            key_name = self.get_resource_name("key{}".format(x))
+            key_name = self.get_resource_name(f"key{x}")
             key = await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
             expected[key.name] = key
 
@@ -345,7 +345,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
 
         # create keys to delete
         for i in range(LIST_TEST_SIZE):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             expected[key_name] = await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
         # delete all keys
@@ -376,7 +376,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         # create keys
         keys = {}
         for i in range(LIST_TEST_SIZE):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             keys[key_name] = await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
         # delete them
@@ -405,7 +405,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         assert client is not None
 
         # create keys
-        key_names = [self.get_resource_name("key{}".format(i)) for i in range(LIST_TEST_SIZE)]
+        key_names = [self.get_resource_name(f"key{i}") for i in range(LIST_TEST_SIZE)]
         for key_name in key_names:
             await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -166,10 +166,10 @@ class TestExamplesKeyVault(KeyVaultTestCase, KeysTestCase):
     @recorded_by_proxy
     def test_example_key_list_operations(self, key_client, **kwargs):
         for i in range(4):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             key_client.create_ec_key(key_name)
         for i in range(4):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             key_client.create_rsa_key(key_name)
 
         # [START list_keys]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -167,10 +167,10 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @recorded_by_proxy_async
     async def test_example_key_list_operations(self, key_client, **kwargs):
         for i in range(4):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             await key_client.create_ec_key(key_name)
         for i in range(4):
-            key_name = self.get_resource_name("key{}".format(i))
+            key_name = self.get_resource_name(f"key{i}")
             await key_client.create_rsa_key(key_name)
 
         # [START list_keys]

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -49,7 +49,7 @@ class SecretClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_secret(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultSecret:
+    def get_secret(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultSecret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -79,7 +79,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def set_secret(self, name: str, value: str, **kwargs: "Any") -> KeyVaultSecret:
+    def set_secret(self, name: str, value: str, **kwargs) -> KeyVaultSecret:
         """Set a secret value. If `name` is in use, create a new version of the secret. If not, create a new secret.
 
         Requires secrets/set permission.
@@ -135,7 +135,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def update_secret_properties(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> SecretProperties:
+    def update_secret_properties(self, name: str, version: "Optional[str]" = None, **kwargs) -> SecretProperties:
         """Update properties of a secret other than its value. Requires secrets/set permission.
 
         This method updates properties of the secret, such as whether it's enabled, but can't change the secret's
@@ -194,7 +194,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_properties_of_secrets(self, **kwargs: "Any") -> "ItemPaged[SecretProperties]":
+    def list_properties_of_secrets(self, **kwargs) -> "ItemPaged[SecretProperties]":
         """List identifiers and attributes of all secrets in the vault. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -220,7 +220,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_secret_versions(self, name: str, **kwargs: "Any") -> "ItemPaged[SecretProperties]":
+    def list_properties_of_secret_versions(self, name: str, **kwargs) -> "ItemPaged[SecretProperties]":
         """List properties of all versions of a secret, excluding their values. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -249,7 +249,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def backup_secret(self, name: str, **kwargs: "Any") -> bytes:
+    def backup_secret(self, name: str, **kwargs) -> bytes:
         """Back up a secret in a protected form useable only by Azure Key Vault. Requires secrets/backup permission.
 
         :param str name: Name of the secret to back up
@@ -273,7 +273,7 @@ class SecretClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_secret_backup(self, backup: bytes, **kwargs: "Any") -> SecretProperties:
+    def restore_secret_backup(self, backup: bytes, **kwargs) -> SecretProperties:
         """Restore a backed up secret. Requires the secrets/restore permission.
 
         :param bytes backup: A secret backup as returned by :func:`backup_secret`
@@ -303,7 +303,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace
-    def begin_delete_secret(self, name: str, **kwargs: "Any") -> "LROPoller[DeletedSecret]":
+    def begin_delete_secret(self, name: str, **kwargs) -> "LROPoller[DeletedSecret]":
         """Delete all versions of a secret. Requires secrets/delete permission.
 
         When this method returns Key Vault has begun deleting the secret. Deletion may take several seconds in a vault
@@ -349,7 +349,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_deleted_secret(self, name: str, **kwargs: "Any") -> DeletedSecret:
+    def get_deleted_secret(self, name: str, **kwargs) -> DeletedSecret:
         """Get a deleted secret. Possible only in vaults with soft-delete enabled. Requires secrets/get permission.
 
         :param str name: Name of the deleted secret
@@ -373,7 +373,7 @@ class SecretClient(KeyVaultClientBase):
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_secrets(self, **kwargs: "Any") -> "ItemPaged[DeletedSecret]":
+    def list_deleted_secrets(self, **kwargs) -> "ItemPaged[DeletedSecret]":
         """Lists all deleted secrets. Possible only in vaults with soft-delete enabled.
 
         Requires secrets/list permission.
@@ -399,7 +399,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def purge_deleted_secret(self, name: str, **kwargs: "Any") -> None:
+    def purge_deleted_secret(self, name: str, **kwargs) -> None:
         """Permanently deletes a deleted secret. Possible only in vaults with soft-delete enabled.
 
         Performs an irreversible deletion of the specified secret, without possibility for recovery. The operation is
@@ -426,7 +426,7 @@ class SecretClient(KeyVaultClientBase):
         self._client.purge_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
 
     @distributed_trace
-    def begin_recover_deleted_secret(self, name: str, **kwargs: "Any") -> "LROPoller[SecretProperties]":
+    def begin_recover_deleted_secret(self, name: str, **kwargs) -> "LROPoller[SecretProperties]":
         """Recover a deleted secret to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires the secrets/recover permission. If the vault does not have soft-delete enabled,

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -4,7 +4,6 @@
 # ------------------------------------
 from functools import partial
 from azure.core.tracing.decorator import distributed_trace
-from azure.core.polling import LROPoller
 
 from ._models import KeyVaultSecret, DeletedSecret, SecretProperties
 from ._shared import KeyVaultClientBase
@@ -18,9 +17,9 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, Dict, Optional
-    from datetime import datetime
+    from typing import Any, Optional
     from azure.core.paging import ItemPaged
+    from azure.core.polling import LROPoller
 
 
 class SecretClient(KeyVaultClientBase):
@@ -50,13 +49,14 @@ class SecretClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_secret(self, name, version=None, **kwargs):
-        # type: (str, str, **Any) -> KeyVaultSecret
+    def get_secret(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> KeyVaultSecret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
         :param str version: (optional) Version of the secret to get. If unspecified, gets the latest version.
+
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -79,21 +79,23 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def set_secret(self, name, value, **kwargs):
-        # type: (str, str, **Any) -> KeyVaultSecret
+    def set_secret(self, name: str, value: str, **kwargs: "Any") -> KeyVaultSecret:
         """Set a secret value. If `name` is in use, create a new version of the secret. If not, create a new secret.
 
         Requires secrets/set permission.
 
         :param str name: The name of the secret
         :param str value: The value of the secret
+
         :keyword bool enabled: Whether the secret is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
-        :paramtype tags: dict[str, str]
+        :paramtype tags: Dict[str, str]
         :keyword str content_type: An arbitrary string indicating the type of the secret, e.g. 'password'
         :keyword ~datetime.datetime not_before: Not before date of the secret in UTC
         :keyword ~datetime.datetime expires_on: Expiry date of the secret in UTC
+
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -133,8 +135,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def update_secret_properties(self, name, version=None, **kwargs):
-        # type: (str, Optional[str], **Any) -> SecretProperties
+    def update_secret_properties(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> SecretProperties:
         """Update properties of a secret other than its value. Requires secrets/set permission.
 
         This method updates properties of the secret, such as whether it's enabled, but can't change the secret's
@@ -142,13 +143,16 @@ class SecretClient(KeyVaultClientBase):
 
         :param str name: Name of the secret
         :param str version: (optional) Version of the secret to update. If unspecified, the latest version is updated.
+
         :keyword bool enabled: Whether the secret is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
-        :paramtype tags: dict[str, str]
+        :paramtype tags: Dict[str, str]
         :keyword str content_type: An arbitrary string indicating the type of the secret, e.g. 'password'
         :keyword ~datetime.datetime not_before: Not before date of the secret in UTC
         :keyword ~datetime.datetime expires_on: Expiry date of the secret in UTC
+
         :rtype: ~azure.keyvault.secrets.SecretProperties
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -190,8 +194,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_properties_of_secrets(self, **kwargs):
-        # type: (**Any) -> ItemPaged[SecretProperties]
+    def list_properties_of_secrets(self, **kwargs: "Any") -> "ItemPaged[SecretProperties]":
         """List identifiers and attributes of all secrets in the vault. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -217,13 +220,13 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_secret_versions(self, name, **kwargs):
-        # type: (str, **Any) -> ItemPaged[SecretProperties]
+    def list_properties_of_secret_versions(self, name: str, **kwargs: "Any") -> "ItemPaged[SecretProperties]":
         """List properties of all versions of a secret, excluding their values. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
 
         :param str name: Name of the secret
+
         :returns: An iterator of secrets, excluding their values
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.secrets.SecretProperties]
 
@@ -246,12 +249,13 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def backup_secret(self, name, **kwargs):
-        # type: (str, **Any) -> bytes
+    def backup_secret(self, name: str, **kwargs: "Any") -> bytes:
         """Back up a secret in a protected form useable only by Azure Key Vault. Requires secrets/backup permission.
 
         :param str name: Name of the secret to back up
+
         :rtype: bytes
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -269,13 +273,14 @@ class SecretClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_secret_backup(self, backup, **kwargs):
-        # type: (bytes, **Any) -> SecretProperties
+    def restore_secret_backup(self, backup: bytes, **kwargs: "Any") -> SecretProperties:
         """Restore a backed up secret. Requires the secrets/restore permission.
 
         :param bytes backup: A secret backup as returned by :func:`backup_secret`
+
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.SecretProperties
+
         :raises:
             :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -298,20 +303,21 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace
-    def begin_delete_secret(self, name, **kwargs):
-        # type: (str, **Any) -> LROPoller
+    def begin_delete_secret(self, name: str, **kwargs: "Any") -> "LROPoller[DeletedSecret]":
         """Delete all versions of a secret. Requires secrets/delete permission.
 
         When this method returns Key Vault has begun deleting the secret. Deletion may take several seconds in a vault
         with soft-delete enabled. This method therefore returns a poller enabling you to wait for deletion to complete.
 
         :param str name: Name of the secret to delete.
+
         :returns: A poller for the delete operation. The poller's `result` method returns the
-         :class:`~azure.keyvault.secrets.DeletedSecret` without waiting for deletion to complete. If the vault has
-         soft-delete enabled and you want to permanently delete the secret with :func:`purge_deleted_secret`, call the
-         poller's `wait` method first. It will block until the deletion is complete. The `wait` method requires
-         secrets/get permission.
+            :class:`~azure.keyvault.secrets.DeletedSecret` without waiting for deletion to complete. If the vault has
+            soft-delete enabled and you want to permanently delete the secret with :func:`purge_deleted_secret`, call
+            the poller's `wait` method first. It will block until the deletion is complete. The `wait` method requires
+            secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.DeletedSecret]
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -343,12 +349,13 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_deleted_secret(self, name, **kwargs):
-        # type: (str, **Any) -> DeletedSecret
+    def get_deleted_secret(self, name: str, **kwargs: "Any") -> DeletedSecret:
         """Get a deleted secret. Possible only in vaults with soft-delete enabled. Requires secrets/get permission.
 
         :param str name: Name of the deleted secret
+
         :rtype: ~azure.keyvault.secrets.DeletedSecret
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -366,8 +373,7 @@ class SecretClient(KeyVaultClientBase):
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_secrets(self, **kwargs):
-        # type: (**Any) -> ItemPaged[DeletedSecret]
+    def list_deleted_secrets(self, **kwargs: "Any") -> "ItemPaged[DeletedSecret]":
         """Lists all deleted secrets. Possible only in vaults with soft-delete enabled.
 
         Requires secrets/list permission.
@@ -393,20 +399,20 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def purge_deleted_secret(self, name, **kwargs):
-        # type: (str, **Any) -> None
+    def purge_deleted_secret(self, name: str, **kwargs: "Any") -> None:
         """Permanently deletes a deleted secret. Possible only in vaults with soft-delete enabled.
 
-        Performs an irreversible deletion of the specified secret, without
-        possibility for recovery. The operation is not available if the
-        :py:attr:`~azure.keyvault.secrets.SecretProperties.recovery_level` does not specify 'Purgeable'.
-        This method is only necessary for purging a secret before its
+        Performs an irreversible deletion of the specified secret, without possibility for recovery. The operation is
+        not available if the :py:attr:`~azure.keyvault.secrets.SecretProperties.recovery_level` does not specify
+        'Purgeable'. This method is only necessary for purging a secret before its
         :py:attr:`~azure.keyvault.secrets.DeletedSecret.scheduled_purge_date`.
 
         Requires secrets/purge permission.
 
-        :param str name: Name of the secret to purge
+        :param str name: Name of the deleted secret to purge
+
         :returns: None
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -420,25 +426,24 @@ class SecretClient(KeyVaultClientBase):
         self._client.purge_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
 
     @distributed_trace
-    def begin_recover_deleted_secret(self, name, **kwargs):
-        # type: (str, **Any) -> LROPoller
+    def begin_recover_deleted_secret(self, name: str, **kwargs: "Any") -> "LROPoller[SecretProperties]":
         """Recover a deleted secret to its latest version. Possible only in a vault with soft-delete enabled.
 
-        If the vault does not have soft-delete enabled, :func:`begin_delete_secret` is permanent, and this method will
-        return an error. Attempting to recover a non-deleted secret will also return an error.
-
-        When this method returns Key Vault has begun recovering the secret. Recovery may take several seconds. This
-        method therefore returns a poller enabling you to wait for recovery to complete. Waiting is only necessary when
-        you want to use the recovered secret in another operation immediately.
-
-        Requires the secrets/recover permission.
+        Requires the secrets/recover permission. If the vault does not have soft-delete enabled,
+        :func:`begin_delete_secret` is permanent, and this method will return an error. Attempting to recover a
+        non-deleted secret will also return an error. When this method returns Key Vault has begun recovering the
+        secret. Recovery may take several seconds. This method therefore returns a poller enabling you to wait for
+        recovery to complete. Waiting is only necessary when you want to use the recovered secret in another operation
+        immediately.
 
         :param str name: Name of the deleted secret to recover
-        :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
-         :class:`~azure.keyvault.secrets.Secret` without waiting for recovery to complete. If you want to use the
-         recovered secret immediately, call the poller's `wait` method, which blocks until the secret is ready to use.
-         The `wait` method requires secrets/get permission.
+
+        :returns: A poller for the recovery operation. The poller's `result` method returns the recovered secret's
+            :class:`~azure.keyvault.secrets.SecretProperties` without waiting for recovery to complete. If you want to
+            use the recovered secret immediately, call the poller's `wait` method, which blocks until the secret is
+            ready to use. The `wait` method requires secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.SecretProperties]
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
@@ -20,7 +20,7 @@ class SecretProperties(object):
     """A secret's id and attributes."""
 
     def __init__(
-        self, attributes: "Optional[_models.SecretAttributes]", vault_id: "Optional[str]", **kwargs: "Any"
+        self, attributes: "Optional[_models.SecretAttributes]", vault_id: "Optional[str]", **kwargs
     ) -> None:
         self._attributes = attributes
         self._id = vault_id

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
@@ -19,8 +19,9 @@ if TYPE_CHECKING:
 class SecretProperties(object):
     """A secret's id and attributes."""
 
-    def __init__(self, attributes, vault_id, **kwargs):
-        # type: (Optional[_models.SecretAttributes], Optional[str], **Any) -> None
+    def __init__(
+        self, attributes: "Optional[_models.SecretAttributes]", vault_id: "Optional[str]", **kwargs: "Any"
+    ) -> None:
         self._attributes = attributes
         self._id = vault_id
         self._vault_id = KeyVaultSecretIdentifier(vault_id) if vault_id else None
@@ -29,13 +30,11 @@ class SecretProperties(object):
         self._managed = kwargs.get("managed", None)
         self._tags = kwargs.get("tags", None)
 
-    def __repr__(self):
-        # type () -> str
-        return "<SecretProperties [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<SecretProperties [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_secret_bundle(cls, secret_bundle):
-        # type: (_models.SecretBundle) -> SecretProperties
+    def _from_secret_bundle(cls, secret_bundle: "_models.SecretBundle") -> "SecretProperties":
         """Construct a SecretProperties from an autorest-generated SecretBundle"""
         return cls(
             secret_bundle.attributes,
@@ -47,8 +46,7 @@ class SecretProperties(object):
         )
 
     @classmethod
-    def _from_secret_item(cls, secret_item):
-        # type: (_models.SecretItem) -> SecretProperties
+    def _from_secret_item(cls, secret_item: "_models.SecretItem") -> "SecretProperties":
         """Construct a SecretProperties from an autorest-generated SecretItem"""
         return cls(
             secret_item.attributes,
@@ -59,8 +57,7 @@ class SecretProperties(object):
         )
 
     @property
-    def content_type(self):
-        # type: () -> Optional[str]
+    def content_type(self) -> "Optional[str]":
         """An arbitrary string indicating the type of the secret
 
         :rtype: str or None
@@ -68,8 +65,7 @@ class SecretProperties(object):
         return self._content_type
 
     @property
-    def id(self):
-        # type: () -> Optional[str]
+    def id(self) -> "Optional[str]":
         """The secret's id
 
         :rtype: str or None
@@ -77,8 +73,7 @@ class SecretProperties(object):
         return self._id
 
     @property
-    def key_id(self):
-        # type: () -> Optional[str]
+    def key_id(self) -> "Optional[str]":
         """If this secret backs a certificate, this property is the identifier of the corresponding key.
 
         :rtype: str or None
@@ -86,8 +81,7 @@ class SecretProperties(object):
         return self._key_id
 
     @property
-    def enabled(self):
-        # type: () -> Optional[bool]
+    def enabled(self) -> "Optional[bool]":
         """Whether the secret is enabled for use
 
         :rtype: bool or None
@@ -95,8 +89,7 @@ class SecretProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self):
-        # type: () -> Optional[datetime]
+    def not_before(self) -> "Optional[datetime]":
         """The time before which the secret can not be used, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -104,8 +97,7 @@ class SecretProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self):
-        # type: () -> Optional[datetime]
+    def expires_on(self) -> "Optional[datetime]":
         """When the secret expires, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -113,8 +105,7 @@ class SecretProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self):
-        # type: () -> Optional[datetime]
+    def created_on(self) -> "Optional[datetime]":
         """When the secret was created, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -122,8 +113,7 @@ class SecretProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self):
-        # type: () -> Optional[datetime]
+    def updated_on(self) -> "Optional[datetime]":
         """When the secret was last updated, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -131,8 +121,7 @@ class SecretProperties(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def recoverable_days(self):
-        # type: () -> Optional[int]
+    def recoverable_days(self) -> "Optional[int]":
         """The number of days the key is retained before being deleted from a soft-delete enabled Key Vault.
 
         :rtype: int or None
@@ -143,8 +132,7 @@ class SecretProperties(object):
         return None
 
     @property
-    def recovery_level(self):
-        # type: () -> Optional[str]
+    def recovery_level(self) -> "Optional[str]":
         """The vault's deletion recovery level for secrets
 
         :rtype: str or None
@@ -152,8 +140,7 @@ class SecretProperties(object):
         return self._attributes.recovery_level if self._attributes else None
 
     @property
-    def vault_url(self):
-        # type: () -> Optional[str]
+    def vault_url(self) -> "Optional[str]":
         """URL of the vault containing the secret
 
         :rtype: str or None
@@ -161,8 +148,7 @@ class SecretProperties(object):
         return self._vault_id.vault_url if self._vault_id else None
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> "Optional[str]":
         """The secret's name
 
         :rtype: str or None
@@ -170,8 +156,7 @@ class SecretProperties(object):
         return self._vault_id.name if self._vault_id else None
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> "Optional[str]":
         """The secret's version
 
         :rtype: str or None
@@ -179,8 +164,7 @@ class SecretProperties(object):
         return self._vault_id.version if self._vault_id else None
 
     @property
-    def tags(self):
-        # type: () -> Optional[Dict[str, str]]
+    def tags(self) -> "Optional[Dict[str, str]]":
         """Application specific metadata in the form of key-value pairs
 
         :rtype: dict or None
@@ -188,8 +172,7 @@ class SecretProperties(object):
         return self._tags
 
     @property
-    def managed(self):
-        # type: () -> Optional[bool]
+    def managed(self) -> "Optional[bool]":
         """Whether the secret's lifetime is managed by Key Vault. If the secret backs a certificate, this will be true.
 
         :rtype: bool or None
@@ -200,18 +183,15 @@ class SecretProperties(object):
 class KeyVaultSecret(object):
     """All of a secret's properties, and its value."""
 
-    def __init__(self, properties, value):
-        # type: (SecretProperties, Optional[str]) -> None
+    def __init__(self, properties: SecretProperties, value: "Optional[str]") -> None:
         self._properties = properties
         self._value = value
 
-    def __repr__(self):
-        # type: () -> str
-        return "<KeyVaultSecret [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<KeyVaultSecret [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_secret_bundle(cls, secret_bundle):
-        # type: (_models.SecretBundle) -> KeyVaultSecret
+    def _from_secret_bundle(cls, secret_bundle: "_models.SecretBundle") -> "KeyVaultSecret":
         """Construct a KeyVaultSecret from an autorest-generated SecretBundle"""
         return cls(
             properties=SecretProperties._from_secret_bundle(secret_bundle),  # pylint: disable=protected-access
@@ -219,8 +199,7 @@ class KeyVaultSecret(object):
         )
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> "Optional[str]":
         """The secret's name
 
         :rtype: str or None
@@ -228,8 +207,7 @@ class KeyVaultSecret(object):
         return self._properties.name
 
     @property
-    def id(self):
-        # type: () -> Optional[str]
+    def id(self) -> "Optional[str]":
         """The secret's id
 
         :rtype: str or None
@@ -237,8 +215,7 @@ class KeyVaultSecret(object):
         return self._properties.id
 
     @property
-    def properties(self):
-        # type: () -> SecretProperties
+    def properties(self) -> SecretProperties:
         """The secret's properties
 
         :rtype: ~azure.keyvault.secrets.SecretProperties
@@ -246,8 +223,7 @@ class KeyVaultSecret(object):
         return self._properties
 
     @property
-    def value(self):
-        # type: () -> Optional[str]
+    def value(self) -> "Optional[str]":
         """The secret's value
 
         :rtype: str or None
@@ -259,7 +235,9 @@ class KeyVaultSecretIdentifier(object):
     """Information about a KeyVaultSecret parsed from a secret ID.
 
     :param str source_id: the full original identifier of a secret
+
     :raises ValueError: if the secret ID is improperly formatted
+
     Example:
         .. literalinclude:: ../tests/test_parse_id.py
             :start-after: [START parse_key_vault_secret_id]
@@ -269,28 +247,23 @@ class KeyVaultSecretIdentifier(object):
             :dedent: 8
     """
 
-    def __init__(self, source_id):
-        # type: (str) -> None
+    def __init__(self, source_id: str) -> None:
         self._resource_id = parse_key_vault_id(source_id)
 
     @property
-    def source_id(self):
-        # type: () -> str
+    def source_id(self) -> str:
         return self._resource_id.source_id
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._resource_id.vault_url
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         return self._resource_id.name
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> "Optional[str]":
         return self._resource_id.version
 
 
@@ -300,24 +273,21 @@ class DeletedSecret(object):
 
     def __init__(
         self,
-        properties,  # type: SecretProperties
-        deleted_date=None,  # type: Optional[datetime]
-        recovery_id=None,  # type: Optional[str]
-        scheduled_purge_date=None,  # type: Optional[datetime]
-    ):
-        # type: (...) -> None
+        properties: SecretProperties,
+        deleted_date: "Optional[datetime]" = None,
+        recovery_id: "Optional[str]" = None,
+        scheduled_purge_date: "Optional[datetime]" = None,
+    ) -> None:
         self._properties = properties
         self._deleted_date = deleted_date
         self._recovery_id = recovery_id
         self._scheduled_purge_date = scheduled_purge_date
 
-    def __repr__(self):
-        # type: () -> str
-        return "<DeletedSecret [{}]>".format(self.id)[:1024]
+    def __repr__(self) -> str:
+        return f"<DeletedSecret [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_deleted_secret_bundle(cls, deleted_secret_bundle):
-        # type: (_models.DeletedSecretBundle) -> DeletedSecret
+    def _from_deleted_secret_bundle(cls, deleted_secret_bundle: "_models.DeletedSecretBundle") -> "DeletedSecret":
         """Construct a DeletedSecret from an autorest-generated DeletedSecretBundle"""
         return cls(
             properties=SecretProperties._from_secret_bundle(deleted_secret_bundle),  # pylint: disable=protected-access
@@ -327,8 +297,7 @@ class DeletedSecret(object):
         )
 
     @classmethod
-    def _from_deleted_secret_item(cls, deleted_secret_item):
-        # type: (_models.DeletedSecretItem) -> DeletedSecret
+    def _from_deleted_secret_item(cls, deleted_secret_item: "_models.DeletedSecretItem") -> "DeletedSecret":
         """Construct a DeletedSecret from an autorest-generated DeletedSecretItem"""
         return cls(
             properties=SecretProperties._from_secret_item(deleted_secret_item),  # pylint: disable=protected-access
@@ -338,8 +307,7 @@ class DeletedSecret(object):
         )
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> "Optional[str]":
         """The secret's name
 
         :rtype: str or None
@@ -347,8 +315,7 @@ class DeletedSecret(object):
         return self._properties.name
 
     @property
-    def id(self):
-        # type: () -> Optional[str]
+    def id(self) -> "Optional[str]":
         """The secret's id
 
         :rtype: str or None
@@ -356,8 +323,7 @@ class DeletedSecret(object):
         return self._properties.id
 
     @property
-    def properties(self):
-        # type: () -> SecretProperties
+    def properties(self) -> SecretProperties:
         """The properties of the deleted secret
 
         :rtype: ~azure.keyvault.secrets.SecretProperties
@@ -365,8 +331,7 @@ class DeletedSecret(object):
         return self._properties
 
     @property
-    def deleted_date(self):
-        # type: () -> Optional[datetime]
+    def deleted_date(self) -> "Optional[datetime]":
         """When the secret was deleted, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -374,8 +339,7 @@ class DeletedSecret(object):
         return self._deleted_date
 
     @property
-    def recovery_id(self):
-        # type: () -> Optional[str]
+    def recovery_id(self) -> "Optional[str]":
         """An identifier used to recover the deleted secret. Returns ``None`` if soft-delete is disabled.
 
         :rtype: str or None
@@ -383,8 +347,7 @@ class DeletedSecret(object):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self):
-        # type: () -> Optional[datetime]
+    def scheduled_purge_date(self) -> "Optional[datetime]":
         """When the secret is scheduled to be purged, in UTC. Returns ``None`` if soft-delete is disabled.
 
         :rtype: ~datetime.datetime or None

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_sdk_moniker.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_sdk_moniker.py
@@ -4,4 +4,4 @@
 # ------------------------------------
 from ._version import VERSION
 
-SDK_MONIKER = "keyvault-secrets/{}".format(VERSION)
+SDK_MONIKER = f"keyvault-secrets/{VERSION}"

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
@@ -2,13 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    import urllib.parse as parse
-except ImportError:
-    # pylint:disable=import-error
-    import urlparse as parse  # type: ignore
-
 from typing import TYPE_CHECKING
+from urllib import parse
+
 from .challenge_auth_policy import ChallengeAuthPolicy
 from .client_base import KeyVaultClientBase
 from .http_challenge import HttpChallenge
@@ -39,32 +35,31 @@ class KeyVaultResourceId():
 
     def __init__(
         self,
-        source_id,  # type: str
-        vault_url,  # type: str
-        name,  # type: str
-        version=None  # type: Optional[str]
-    ):
+        source_id: str,
+        vault_url: str,
+        name: str,
+        version: "Optional[str]" = None,
+    ) -> None:
         self.source_id = source_id
         self.vault_url = vault_url
         self.name = name
         self.version = version
 
 
-def parse_key_vault_id(source_id):
-    # type: (str) -> KeyVaultResourceId
+def parse_key_vault_id(source_id: str) -> KeyVaultResourceId:
     try:
         parsed_uri = parse.urlparse(source_id)
     except Exception:  # pylint: disable=broad-except
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
     if not (parsed_uri.scheme and parsed_uri.hostname):
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
 
     path = list(filter(None, parsed_uri.path.split("/")))
 
     if len(path) < 2 or len(path) > 3:
-        raise ValueError("'{}' is not a valid ID".format(source_id))
+        raise ValueError(f"'{source_id}' is not a valid ID")
 
-    vault_url = "{}://{}".format(parsed_uri.scheme, parsed_uri.hostname)
+    vault_url = f"{parsed_uri.scheme}://{parsed_uri.hostname}"
     if parsed_uri.port:
         vault_url += f":{parsed_uri.port}"
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
@@ -11,17 +11,12 @@ from typing import TYPE_CHECKING
 from azure.core.polling import PollingMethod, LROPoller, NoPolling
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
-try:
-    from urlparse import urlparse  # type: ignore # pylint: disable=unused-import
-except ImportError:
-    from urllib.parse import urlparse
-
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.common import with_current_context
 
 if TYPE_CHECKING:
     # pylint: disable=ungrouped-imports
-    from typing import Any, Callable, Union, List, Optional
+    from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -31,37 +26,35 @@ class KeyVaultOperationPoller(LROPoller):
     """
 
     # pylint: disable=arguments-differ
-    def __init__(self, polling_method):
-        # type: (PollingMethod) -> None
+    def __init__(self, polling_method: PollingMethod) -> None:
         super(KeyVaultOperationPoller, self).__init__(None, None, lambda *_: None, NoPolling())
         self._polling_method = polling_method
 
     # pylint: disable=arguments-differ
-    def result(self):  # type: ignore
-        # type: () -> Any
+    def result(self) -> "Any":  # type: ignore
         """Returns a representation of the final resource without waiting for the operation to complete.
 
         :returns: The deserialized resource of the long running operation
+
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """
         return self._polling_method.resource()
 
     @distributed_trace
-    def wait(self, timeout=None):
-        # type: (Optional[float]) -> None
+    def wait(self, timeout: "Optional[float]" = None) -> None:
         """Wait on the long running operation for a number of seconds.
 
         You can check if this call has ended with timeout with the "done()" method.
 
-        :param float timeout: Period of time to wait for the long running
-         operation to complete (in seconds).
+        :param float timeout: Period of time to wait for the long running operation to complete (in seconds).
+
         :raises ~azure.core.exceptions.HttpResponseError: Server problem with the query.
         """
 
         if not self._polling_method.finished():
             self._done = threading.Event()
             self._thread = threading.Thread(
-                target=with_current_context(self._start), name="KeyVaultOperationPoller({})".format(uuid.uuid4())
+                target=with_current_context(self._start), name=f"KeyVaultOperationPoller({uuid.uuid4()})"
             )
             self._thread.daemon = True
             self._thread.start()
@@ -87,14 +80,13 @@ class DeleteRecoverPollingMethod(PollingMethod):
     Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
     resource; when it responds 2xx, the resource exists in the non-deleted collection, i.e. its recovery is complete.
     """
-    def __init__(self, command, final_resource, finished, interval=2):
+    def __init__(self, command: "Callable", final_resource: "Any", finished: bool, interval: int = 2) -> None:
         self._command = command
         self._resource = final_resource
         self._polling_interval = interval
         self._finished = finished
 
-    def _update_status(self):
-        # type: () -> None
+    def _update_status(self) -> None:
         try:
             self._command()
             self._finished = True
@@ -108,11 +100,10 @@ class DeleteRecoverPollingMethod(PollingMethod):
             else:
                 raise
 
-    def initialize(self, client, initial_response, deserialization_callback):
+    def initialize(self, client: "Any", initial_response: "Any", deserialization_callback: "Callable") -> None:
         pass
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         try:
             while not self.finished():
                 self._update_status()
@@ -122,14 +113,11 @@ class DeleteRecoverPollingMethod(PollingMethod):
             logger.warning(str(e))
             raise
 
-    def finished(self):
-        # type: () -> bool
+    def finished(self) -> bool:
         return self._finished
 
-    def resource(self):
-        # type: () -> Any
+    def resource(self) -> "Any":
         return self._resource
 
-    def status(self):
-        # type: () -> str
+    def status(self) -> str:
         return "finished" if self._finished else "polling"

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -50,7 +50,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
                 self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 
 class AsyncKeyVaultClientBase(object):
+    # pylint:disable=protected-access
     def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -3,20 +3,20 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from typing import TYPE_CHECKING
+
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.tracing.decorator_async import distributed_trace_async
+
 from . import AsyncChallengeAuthPolicy
-from .client_base import ApiVersion, DEFAULT_VERSION
+from .client_base import ApiVersion, DEFAULT_VERSION, _format_api_version, _SERIALIZER
 from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 
 if TYPE_CHECKING:
-    try:
-        # pylint:disable=unused-import
-        from typing import Any
-        from azure.core.credentials_async import AsyncTokenCredential
-    except ImportError:
-        # AsyncTokenCredential is a typing_extensions.Protocol; we don't depend on that package
-        pass
+    # pylint:disable=unused-import
+    from typing import Any
+    from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 
 class AsyncKeyVaultClientBase(object):
@@ -60,8 +60,8 @@ class AsyncKeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=self.api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(self.api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{self.api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property
@@ -81,3 +81,25 @@ class AsyncKeyVaultClientBase(object):
         Calling this method is unnecessary when using the client as a context manager.
         """
         await self._client.close()
+
+    @distributed_trace_async
+    async def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "AsyncHttpResponse":
+        """Runs a network request using the client's existing pipeline.
+
+        The request URL can be relative to the vault URL. The service API version used for the request is the same as
+        the client's unless otherwise specified. This method does not raise if the response is an error; to raise an
+        exception, call `raise_for_status()` on the returned response object. For more information about how to send
+        custom requests with this method, see https://aka.ms/azsdk/dpcodegen/python/send_request.
+
+        :param request: The network request you want to make.
+        :type request: ~azure.core.rest.HttpRequest
+
+        :return: The response of your network call. Does not do error handling on your response.
+        :rtype: ~azure.core.rest.AsyncHttpResponse
+        """
+        request_copy = _format_api_version(request, self.api_version)
+        path_format_arguments = {
+            "vaultBaseUrl": _SERIALIZER.url("vault_base_url", self._vault_url, "str", skip_quote=True),
+        }
+        request_copy.url = self._client._client.format_url(request_copy.url, **path_format_arguments)
+        return await self._client._client.send_request(request_copy, **kwargs)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -84,7 +84,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    async def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "AsyncHttpResponse":
+    async def send_request(self, request: "HttpRequest", **kwargs) -> "AsyncHttpResponse":
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -35,17 +35,15 @@ if TYPE_CHECKING:
     from azure.core.pipeline import PipelineResponse
 
 
-def _enforce_tls(request):
-    # type: (PipelineRequest) -> None
+def _enforce_tls(request: PipelineRequest) -> None:
     if not request.http_request.url.lower().startswith("https"):
         raise ServiceRequestError(
             "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
         )
 
 
-def _update_challenge(request, challenger):
-    # type: (PipelineRequest, PipelineResponse) -> HttpChallenge
-    """parse challenge from challenger, cache it, return it"""
+def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") -> HttpChallenge:
+    """Parse challenge from challenger, cache it, return it"""
 
     challenge = HttpChallenge(
         request.http_request.url,
@@ -57,17 +55,15 @@ def _update_challenge(request, challenger):
 
 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
-    """policy for handling HTTP authentication challenges"""
+    """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential, *scopes, **kwargs):
-        # type: (TokenCredential, *str, **Any) -> None
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    def on_request(self, request):
-        # type: (PipelineRequest) -> None
+    def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -78,7 +74,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
                 self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
-            request.http_request.headers["Authorization"] = "Bearer {}".format(self._token.token)  # type: ignore
+            request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore
             return
 
         # else: discover authentication information by eliciting a challenge from Key Vault. Remove any request data,
@@ -90,8 +86,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
             request.http_request.set_json_body(None)
             request.http_request.headers["Content-Length"] = "0"
 
-    def on_challenge(self, request, response):
-        # type: (PipelineRequest, PipelineResponse) -> bool
+    def on_challenge(self, request: PipelineRequest, response: "PipelineResponse") -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
@@ -119,6 +114,5 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
         return True
 
     @property
-    def _need_new_token(self):
-        # type: () -> bool
+    def _need_new_token(self) -> bool:
         return not self._token or self._token.expires_on - time.time() < 300

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -57,7 +57,7 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
 class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges"""
 
-    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: "Any") -> None:
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token = None  # type: Optional[AccessToken]

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -61,6 +61,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 
 class KeyVaultClientBase(object):
+    # pylint:disable=protected-access
     def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -2,20 +2,25 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from copy import deepcopy
 from typing import TYPE_CHECKING
 from enum import Enum
+from urllib.parse import urlparse
 
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.tracing.decorator import distributed_trace
 
 from . import ChallengeAuthPolicy
 from .._generated import KeyVaultClient as _KeyVaultClient
+from .._generated._serialization import Serializer
 from .._sdk_moniker import SDK_MONIKER
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any
     from azure.core.credentials import TokenCredential
+    from azure.core.rest import HttpRequest, HttpResponse
 
 
 class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -31,10 +36,32 @@ class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
 
 DEFAULT_VERSION = ApiVersion.V7_3
 
+_SERIALIZER = Serializer()
+_SERIALIZER.client_side_validation = False
+
+
+def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpRequest":
+    """Returns a request copy that includes an api-version query parameter if one wasn't originally present."""
+    request_copy = deepcopy(request)
+    params = {"api-version": api_version}  # By default, we want to use the client's API version
+    query = urlparse(request_copy.url).query
+
+    if query:
+        request_copy.url = request_copy.url.partition("?")[0]
+        existing_params = {p[0]: p[-1] for p in [p.partition("=") for p in query.split("&")]}
+        params.update(existing_params)  # If an api-version was provided, this will overwrite our default
+
+    # Reconstruct the query parameters onto the URL
+    query_params = []
+    for k, v in params.items():
+        query_params.append("{}={}".format(k, v))
+    query = "?" + "&".join(query_params)
+    request_copy.url = request_copy.url + query
+    return request_copy
+
 
 class KeyVaultClientBase(object):
-    def __init__(self, vault_url, credential, **kwargs):
-        # type: (str, TokenCredential, **Any) -> None
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -74,28 +101,46 @@ class KeyVaultClientBase(object):
             self._models = _KeyVaultClient.models(api_version=self.api_version)
         except ValueError:
             raise NotImplementedError(
-                "This package doesn't support API version '{}'. ".format(self.api_version)
-                + "Supported versions: {}".format(", ".join(v.value for v in ApiVersion))
+                f"This package doesn't support API version '{self.api_version}'. "
+                + f"Supported versions: {', '.join(v.value for v in ApiVersion)}"
             )
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._vault_url
 
-    def __enter__(self):
-        # type: () -> KeyVaultClientBase
+    def __enter__(self) -> "KeyVaultClientBase":
         self._client.__enter__()
         return self
 
-    def __exit__(self, *args):
-        # type: (*Any) -> None
+    def __exit__(self, *args: "Any") -> None:
         self._client.__exit__(*args)
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """Close sockets opened by the client.
 
         Calling this method is unnecessary when using the client as a context manager.
         """
         self._client.close()
+
+    @distributed_trace
+    def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "HttpResponse":
+        """Runs a network request using the client's existing pipeline.
+
+        The request URL can be relative to the vault URL. The service API version used for the request is the same as
+        the client's unless otherwise specified. This method does not raise if the response is an error; to raise an
+        exception, call `raise_for_status()` on the returned response object. For more information about how to send
+        custom requests with this method, see https://aka.ms/azsdk/dpcodegen/python/send_request.
+
+        :param request: The network request you want to make.
+        :type request: ~azure.core.rest.HttpRequest
+
+        :return: The response of your network call. Does not do error handling on your response.
+        :rtype: ~azure.core.rest.HttpResponse
+        """
+        request_copy = _format_api_version(request, self.api_version)
+        path_format_arguments = {
+            "vaultBaseUrl": _SERIALIZER.url("vault_base_url", self._vault_url, "str", skip_quote=True),
+        }
+        request_copy.url = self._client._client.format_url(request_copy.url, **path_format_arguments)
+        return self._client._client.send_request(request_copy, **kwargs)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -62,7 +62,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 class KeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs: "Any") -> None:
+    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -125,7 +125,7 @@ class KeyVaultClientBase(object):
         self._client.close()
 
     @distributed_trace
-    def send_request(self, request: "HttpRequest", **kwargs: "Any") -> "HttpResponse":
+    def send_request(self, request: "HttpRequest", **kwargs) -> "HttpResponse":
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
@@ -12,16 +12,15 @@ from azure.core.pipeline.policies import ContentDecodePolicy
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Optional, Type
-    from azure.core.pipeline.transport import HttpResponse
+    from azure.core.rest import HttpResponse
 
 
-def _get_exception_for_key_vault_error(cls, response):
-    # type: (Type[HttpResponseError], HttpResponse) -> HttpResponseError
+def _get_exception_for_key_vault_error(cls: "Type[HttpResponseError]", response: "HttpResponse") -> HttpResponseError:
     """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
 
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])  # type: Optional[str]
+        message = f"({body['error']['code']}) {body['error']['message']}"  # type: Optional[str]
     except (DecodeError, KeyError):
         # Key Vault error response bodies should have the expected shape and be de-serializable.
         # If we somehow land here, we'll take HttpResponse's default message.

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge.py
@@ -2,18 +2,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from typing import TYPE_CHECKING
+from urllib import parse
+
+if TYPE_CHECKING:
+    from typing import Dict, MutableMapping, Optional
 
 
 class HttpChallenge(object):
-    def __init__(self, request_uri, challenge, response_headers=None):
-        """ Parses an HTTP WWW-Authentication Bearer challenge from a server. """
+    def __init__(self, request_uri: str, challenge: str, response_headers: "MutableMapping[str, str]" = None) -> None:
+        """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
-        self._parameters = {}
+        self._parameters = {}  # type: Dict[str, str]
 
         # get the scheme of the challenge and remove from the challenge string
         trimmed_challenge = self._validate_challenge(challenge)
@@ -42,7 +43,8 @@ class HttpChallenge(object):
 
         authorization_uri = self.get_authorization_server()
         # the authorization server URI should look something like https://login.windows.net/tenant-id
-        uri_path = parse.urlparse(authorization_uri).path.lstrip("/")
+        raw_uri_path = str(parse.urlparse(authorization_uri).path)
+        uri_path = raw_uri_path.lstrip("/")
         self.tenant_id = uri_path.split("/")[0] or None
 
         # if the response headers were supplied
@@ -51,27 +53,25 @@ class HttpChallenge(object):
             self.server_signature_key = response_headers.get("x-ms-message-signing-key", None)
             self.server_encryption_key = response_headers.get("x-ms-message-encryption-key", None)
 
-    def is_bearer_challenge(self):
-        """ Tests whether the HttpChallenge a Bearer challenge.
-        rtype: bool """
+    def is_bearer_challenge(self) -> bool:
+        """Tests whether the HttpChallenge a Bearer challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "bearer"
 
-    def is_pop_challenge(self):
-        """ Tests whether the HttpChallenge is a proof of possession challenge.
-        rtype: bool """
+    def is_pop_challenge(self) -> bool:
+        """Tests whether the HttpChallenge is a proof of possession challenge."""
         if not self.scheme:
             return False
 
         return self.scheme.lower() == "pop"
 
-    def get_value(self, key):
+    def get_value(self, key: str) -> "Optional[str]":
         return self._parameters.get(key)
 
-    def get_authorization_server(self):
-        """ Returns the URI for the authorization server if present, otherwise empty string. """
+    def get_authorization_server(self) -> "Optional[str]":
+        """Returns the URI for the authorization server if present, otherwise empty string."""
         value = ""
         for key in ["authorization_uri", "authorization"]:
             value = self.get_value(key) or ""
@@ -79,41 +79,41 @@ class HttpChallenge(object):
                 break
         return value
 
-    def get_resource(self):
-        """ Returns the resource if present, otherwise empty string. """
+    def get_resource(self) -> str:
+        """Returns the resource if present, otherwise empty string."""
         return self.get_value("resource") or ""
 
-    def get_scope(self):
-        """ Returns the scope if present, otherwise empty string. """
+    def get_scope(self) -> str:
+        """Returns the scope if present, otherwise empty string."""
         return self.get_value("scope") or ""
 
-    def supports_pop(self):
-        """ Returns True if challenge supports pop token auth else False """
+    def supports_pop(self) -> bool:
+        """Returns True if challenge supports pop token auth else False."""
         return self._parameters.get("supportspop", "").lower() == "true"
 
-    def supports_message_protection(self):
-        """ Returns True if challenge vault supports message protection """
-        return self.supports_pop() and self.server_encryption_key and self.server_signature_key
+    def supports_message_protection(self) -> bool:
+        """Returns True if challenge vault supports message protection."""
+        return self.supports_pop() and self.server_encryption_key and self.server_signature_key  # type: ignore
 
     # pylint:disable=no-self-use
-    def _validate_challenge(self, challenge):
-        """ Verifies that the challenge is a valid auth challenge and returns the key=value pairs. """
+    def _validate_challenge(self, challenge: str) -> str:
+        """Verifies that the challenge is a valid auth challenge and returns the key=value pairs."""
         if not challenge:
             raise ValueError("Challenge cannot be empty")
 
         return challenge.strip()
 
     # pylint:disable=no-self-use
-    def _validate_request_uri(self, uri):
-        """ Extracts the host authority from the given URI. """
+    def _validate_request_uri(self, uri: str) -> str:
+        """Extracts the host authority from the given URI."""
         if not uri:
             raise ValueError("request_uri cannot be empty")
 
-        uri = parse.urlparse(uri)
-        if not uri.netloc:
+        parsed = parse.urlparse(uri)
+        if not parsed.netloc:
             raise ValueError("request_uri must be an absolute URI")
 
-        if uri.scheme.lower() not in ["http", "https"]:
+        if parsed.scheme.lower() not in ["http", "https"]:
             raise ValueError("request_uri must be HTTP or HTTPS")
 
-        return uri.netloc
+        return parsed.netloc

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge_cache.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/http_challenge_cache.py
@@ -3,11 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import threading
-
-try:
-    import urllib.parse as parse
-except ImportError:
-    import urlparse as parse  # type: ignore
+from urllib import parse
 
 try:
     from typing import TYPE_CHECKING
@@ -16,7 +12,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from typing import Dict
+    from typing import Dict, Optional
     from .http_challenge import HttpChallenge
 
 
@@ -24,10 +20,11 @@ _cache = {}  # type: Dict[str, HttpChallenge]
 _lock = threading.Lock()
 
 
-def get_challenge_for_url(url):
-    """ Gets the challenge for the cached URL.
-    :param url: the URL the challenge is cached for.
-    :rtype: HttpBearerChallenge """
+def get_challenge_for_url(url: str) -> "Optional[HttpChallenge]":
+    """Gets the challenge for the cached URL.
+
+    :param str url: the URL the challenge is cached for.
+    """
 
     if not url:
         raise ValueError("URL cannot be None")
@@ -38,7 +35,7 @@ def get_challenge_for_url(url):
         return _cache.get(key)
 
 
-def _get_cache_key(url):
+def _get_cache_key(url: str) -> str:
     """Use the URL's netloc as cache key except when the URL specifies the default port for its scheme. In that case
     use the netloc without the port. That is to say, https://foo.bar and https://foo.bar:443 are considered equivalent.
 
@@ -52,22 +49,27 @@ def _get_cache_key(url):
     return parsed.netloc
 
 
-def remove_challenge_for_url(url):
-    """ Removes the cached challenge for the specified URL.
-    :param url: the URL for which to remove the cached challenge """
+def remove_challenge_for_url(url: str) -> None:
+    """Removes the cached challenge for the specified URL.
+
+    :param str url: the URL for which to remove the cached challenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
-    url = parse.urlparse(url)
+    parsed = parse.urlparse(url)
 
     with _lock:
-        del _cache[url.netloc]
+        del _cache[parsed.netloc]
 
 
-def set_challenge_for_url(url, challenge):
-    """ Caches the challenge for the specified URL.
-    :param url: the URL for which to cache the challenge
-    :param challenge: the challenge to cache """
+def set_challenge_for_url(url: str, challenge: "HttpChallenge") -> None:
+    """Caches the challenge for the specified URL.
+
+    :param str url: the URL for which to cache the challenge
+    :param challenge: the challenge to cache
+    :type challenge: HttpChallenge
+    """
     if not url:
         raise ValueError("URL cannot be empty")
 
@@ -82,8 +84,8 @@ def set_challenge_for_url(url, challenge):
         _cache[src_url.netloc] = challenge
 
 
-def clear():
-    """ Clears the cache. """
+def clear() -> None:
+    """Clears the cache."""
 
     with _lock:
         _cache.clear()

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any, Optional, Dict
+from typing import Any, Optional
 from functools import partial
 
 from azure.core.tracing.decorator import distributed_trace
@@ -42,12 +42,14 @@ class SecretClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace_async
-    async def get_secret(self, name: str, version: Optional[str] = None, **kwargs: "Any") -> KeyVaultSecret:
+    async def get_secret(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultSecret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
         :param str version: (optional) Version of the secret to get. If unspecified, gets the latest version.
+
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -64,20 +66,23 @@ class SecretClient(AsyncKeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace_async
-    async def set_secret(self, name: str, value: str, **kwargs: "Any") -> KeyVaultSecret:
+    async def set_secret(self, name: str, value: str, **kwargs: Any) -> KeyVaultSecret:
         """Set a secret value. If `name` is in use, create a new version of the secret. If not, create a new secret.
 
         Requires secrets/set permission.
 
         :param str name: The name of the secret
         :param str value: The value of the secret
+
         :keyword bool enabled: Whether the secret is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
-        :paramtype tags: dict[str, str]
+        :paramtype tags: Dict[str, str]
         :keyword str content_type: An arbitrary string indicating the type of the secret, e.g. 'password'
         :keyword ~datetime.datetime not_before: Not before date of the secret in UTC
         :keyword ~datetime.datetime expires_on: Expiry date of the secret in UTC
+
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -115,7 +120,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_secret_properties(
-        self, name: str, version: "Optional[str]" = None, **kwargs: "Any"
+        self, name: str, version: Optional[str] = None, **kwargs: Any
     ) -> SecretProperties:
         """Update properties of a secret other than its value. Requires secrets/set permission.
 
@@ -124,13 +129,16 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :param str name: Name of the secret
         :param str version: (optional) Version of the secret to update. If unspecified, the latest version is updated.
+
         :keyword bool enabled: Whether the secret is enabled for use.
         :keyword tags: Application specific metadata in the form of key-value pairs.
-        :paramtype tags: dict[str, str]
+        :paramtype tags: Dict[str, str]
         :keyword str content_type: An arbitrary string indicating the type of the secret, e.g. 'password'
         :keyword ~datetime.datetime not_before: Not before date of the secret in UTC
         :keyword ~datetime.datetime expires_on: Expiry date of the secret in UTC
+
         :rtype: ~azure.keyvault.secrets.SecretProperties
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -169,7 +177,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_properties_of_secrets(self, **kwargs: "Any") -> AsyncItemPaged[SecretProperties]:
+    def list_properties_of_secrets(self, **kwargs: Any) -> AsyncItemPaged[SecretProperties]:
         """List identifiers and attributes of all secrets in the vault. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -193,12 +201,13 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_secret_versions(self, name: str, **kwargs: "Any") -> AsyncItemPaged[SecretProperties]:
+    def list_properties_of_secret_versions(self, name: str, **kwargs: Any) -> AsyncItemPaged[SecretProperties]:
         """List properties of all versions of a secret, excluding their values. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
 
         :param str name: Name of the secret
+
         :returns: An iterator of secrets, excluding their values
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.secrets.SecretProperties]
 
@@ -219,11 +228,13 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def backup_secret(self, name: str, **kwargs: "Any") -> bytes:
+    async def backup_secret(self, name: str, **kwargs: Any) -> bytes:
         """Back up a secret in a protected form useable only by Azure Key Vault. Requires secrets/backup permission.
 
-        :param str name: Name of the secret
+        :param str name: Name of the secret to back up
+
         :rtype: bytes
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -240,12 +251,14 @@ class SecretClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_secret_backup(self, backup: bytes, **kwargs: "Any") -> SecretProperties:
+    async def restore_secret_backup(self, backup: bytes, **kwargs: Any) -> SecretProperties:
         """Restore a backed up secret. Requires the secrets/restore permission.
 
         :param bytes backup: A secret backup as returned by :func:`backup_secret`
+
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.SecretProperties
+
         :raises:
             :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -267,12 +280,15 @@ class SecretClient(AsyncKeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace_async
-    async def delete_secret(self, name: str, **kwargs: "Any") -> DeletedSecret:
+    async def delete_secret(self, name: str, **kwargs: Any) -> DeletedSecret:
         """Delete all versions of a secret. Requires secrets/delete permission.
 
         If the vault has soft-delete enabled, deletion may take several seconds to complete.
 
+        :param str name: Name of the secret to delete.
+
         :rtype: ~azure.keyvault.secrets.DeletedSecret
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -304,11 +320,13 @@ class SecretClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_deleted_secret(self, name: str, **kwargs: "Any") -> DeletedSecret:
+    async def get_deleted_secret(self, name: str, **kwargs: Any) -> DeletedSecret:
         """Get a deleted secret. Possible only in vaults with soft-delete enabled. Requires secrets/get permission.
 
         :param str name: Name of the deleted secret
+
         :rtype: ~azure.keyvault.secrets.DeletedSecret
+
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
@@ -325,7 +343,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_secrets(self, **kwargs: "Any") -> AsyncItemPaged[DeletedSecret]:
+    def list_deleted_secrets(self, **kwargs: Any) -> AsyncItemPaged[DeletedSecret]:
         """Lists all deleted secrets. Possible only in vaults with soft-delete enabled.
 
         Requires secrets/list permission.
@@ -349,19 +367,20 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def purge_deleted_secret(self, name: str, **kwargs: "Any") -> None:
+    async def purge_deleted_secret(self, name: str, **kwargs: Any) -> None:
         """Permanently delete a deleted secret. Possible only in vaults with soft-delete enabled.
 
-        Performs an irreversible deletion of the specified secret, without
-        possibility for recovery. The operation is not available if the
-        :py:attr:`~azure.keyvault.secrets.SecretProperties.recovery_level` does not specify 'Purgeable'.
-        This method is only necessary for purging a secret before its
+        Performs an irreversible deletion of the specified secret, without possibility for recovery. The operation is
+        not available if the :py:attr:`~azure.keyvault.secrets.SecretProperties.recovery_level` does not specify
+        'Purgeable'. This method is only necessary for purging a secret before its
         :py:attr:`~azure.keyvault.secrets.DeletedSecret.scheduled_purge_date`.
 
         Requires secrets/purge permission.
 
         :param str name: Name of the deleted secret to purge
+
         :returns: None
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
@@ -375,16 +394,17 @@ class SecretClient(AsyncKeyVaultClientBase):
         await self._client.purge_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
 
     @distributed_trace_async
-    async def recover_deleted_secret(self, name: str, **kwargs: "Any") -> SecretProperties:
+    async def recover_deleted_secret(self, name: str, **kwargs: Any) -> SecretProperties:
         """Recover a deleted secret to its latest version. This is possible only in vaults with soft-delete enabled.
 
-        If the vault does not have soft-delete enabled, :func:`delete_secret` is permanent, and this method will raise
-        an error. Attempting to recover a non-deleted secret will also raise an error.
-
-        Requires the secrets/recover permission.
+        Requires the secrets/recover permission. If the vault does not have soft-delete enabled, :func:`delete_secret`
+        is permanent, and this method will raise an error. Attempting to recover a non-deleted secret will also raise an
+        error.
 
         :param str name: Name of the deleted secret to recover
+
         :rtype: ~azure.keyvault.secrets.SecretProperties
+
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -42,7 +42,7 @@ class SecretClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace_async
-    async def get_secret(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultSecret:
+    async def get_secret(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultSecret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -66,7 +66,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace_async
-    async def set_secret(self, name: str, value: str, **kwargs: Any) -> KeyVaultSecret:
+    async def set_secret(self, name: str, value: str, **kwargs) -> KeyVaultSecret:
         """Set a secret value. If `name` is in use, create a new version of the secret. If not, create a new secret.
 
         Requires secrets/set permission.
@@ -120,7 +120,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_secret_properties(
-        self, name: str, version: Optional[str] = None, **kwargs: Any
+        self, name: str, version: Optional[str] = None, **kwargs
     ) -> SecretProperties:
         """Update properties of a secret other than its value. Requires secrets/set permission.
 
@@ -177,7 +177,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_properties_of_secrets(self, **kwargs: Any) -> AsyncItemPaged[SecretProperties]:
+    def list_properties_of_secrets(self, **kwargs) -> AsyncItemPaged[SecretProperties]:
         """List identifiers and attributes of all secrets in the vault. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -201,7 +201,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_secret_versions(self, name: str, **kwargs: Any) -> AsyncItemPaged[SecretProperties]:
+    def list_properties_of_secret_versions(self, name: str, **kwargs) -> AsyncItemPaged[SecretProperties]:
         """List properties of all versions of a secret, excluding their values. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -228,7 +228,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def backup_secret(self, name: str, **kwargs: Any) -> bytes:
+    async def backup_secret(self, name: str, **kwargs) -> bytes:
         """Back up a secret in a protected form useable only by Azure Key Vault. Requires secrets/backup permission.
 
         :param str name: Name of the secret to back up
@@ -251,7 +251,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_secret_backup(self, backup: bytes, **kwargs: Any) -> SecretProperties:
+    async def restore_secret_backup(self, backup: bytes, **kwargs) -> SecretProperties:
         """Restore a backed up secret. Requires the secrets/restore permission.
 
         :param bytes backup: A secret backup as returned by :func:`backup_secret`
@@ -280,7 +280,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace_async
-    async def delete_secret(self, name: str, **kwargs: Any) -> DeletedSecret:
+    async def delete_secret(self, name: str, **kwargs) -> DeletedSecret:
         """Delete all versions of a secret. Requires secrets/delete permission.
 
         If the vault has soft-delete enabled, deletion may take several seconds to complete.
@@ -320,7 +320,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_deleted_secret(self, name: str, **kwargs: Any) -> DeletedSecret:
+    async def get_deleted_secret(self, name: str, **kwargs) -> DeletedSecret:
         """Get a deleted secret. Possible only in vaults with soft-delete enabled. Requires secrets/get permission.
 
         :param str name: Name of the deleted secret
@@ -343,7 +343,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_secrets(self, **kwargs: Any) -> AsyncItemPaged[DeletedSecret]:
+    def list_deleted_secrets(self, **kwargs) -> AsyncItemPaged[DeletedSecret]:
         """Lists all deleted secrets. Possible only in vaults with soft-delete enabled.
 
         Requires secrets/list permission.
@@ -367,7 +367,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def purge_deleted_secret(self, name: str, **kwargs: Any) -> None:
+    async def purge_deleted_secret(self, name: str, **kwargs) -> None:
         """Permanently delete a deleted secret. Possible only in vaults with soft-delete enabled.
 
         Performs an irreversible deletion of the specified secret, without possibility for recovery. The operation is
@@ -394,7 +394,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         await self._client.purge_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
 
     @distributed_trace_async
-    async def recover_deleted_secret(self, name: str, **kwargs: Any) -> SecretProperties:
+    async def recover_deleted_secret(self, name: str, **kwargs) -> SecretProperties:
         """Recover a deleted secret to its latest version. This is possible only in vaults with soft-delete enabled.
 
         Requires the secrets/recover permission. If the vault does not have soft-delete enabled, :func:`delete_secret`

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any, Optional
+from typing import Optional
 from functools import partial
 
 from azure.core.tracing.decorator import distributed_trace

--- a/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
@@ -40,19 +40,19 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 # if the secret already exists in the Key Vault, then a new version of the secret is created.
 print("\n.. Create Secret")
 secret = client.set_secret("backupRestoreSecretName", "backupRestoreSecretValue")
-print("Secret with name '{0}' created with value '{1}'".format(secret.name, secret.value))
+print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
 
 # Backups are good to have, if in case secrets gets deleted accidentally.
 # For long term storage, it is ideal to write the backup to a file.
 print("\n.. Create a backup for an existing Secret")
 secret_backup = client.backup_secret(secret.name)
-print("Backup created for secret with name '{0}'.".format(secret.name))
+print(f"Backup created for secret with name '{secret.name}'.")
 
 # The storage account secret is no longer in use, so you delete it.
 print("\n.. Deleting secret...")
 delete_operation = client.begin_delete_secret(secret.name)
 deleted_secret = delete_operation.result()
-print("Deleted secret with name '{0}'".format(deleted_secret.name))
+print(f"Deleted secret with name '{deleted_secret.name}'")
 
 # Wait for the deletion to complete before purging the secret.
 # The purge will take some time, so wait before restoring the backup to avoid a conflict.
@@ -60,9 +60,9 @@ delete_operation.wait()
 print("\n.. Purge the secret")
 client.purge_deleted_secret(deleted_secret.name)
 time.sleep(60)
-print("Purged secret with name '{0}'".format(deleted_secret.name))
+print(f"Purged secret with name '{deleted_secret.name}'")
 
 # In the future, if the secret is required again, we can use the backup value to restore it in the Key Vault.
 print("\n.. Restore the secret using the backed up secret bytes")
 secret = client.restore_secret_backup(secret_backup)
-print("Restored secret with name '{0}'".format(secret.name))
+print(f"Restored secret with name '{secret.name}'")

--- a/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
@@ -41,30 +41,30 @@ async def run_sample():
     # if the secret already exists in the Key Vault, then a new version of the secret is created.
     print("\n.. Create Secret")
     secret = await client.set_secret("backupRestoreSecretNameAsync", "backupRestoreSecretValue")
-    print("Secret with name '{0}' created with value '{1}'".format(secret.name, secret.value))
+    print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
 
     # Backups are good to have, if in case secrets gets deleted accidentally.
     # For long term storage, it is ideal to write the backup to a file.
     print("\n.. Create a backup for an existing Secret")
     secret_backup = await client.backup_secret(secret.name)
-    print("Backup created for secret with name '{0}'.".format(secret.name))
+    print(f"Backup created for secret with name '{secret.name}'.")
 
     # The storage account secret is no longer in use, so you delete it.
     print("\n.. Deleting secret...")
     await client.delete_secret(secret.name)
-    print("Deleted secret with name '{0}'".format(secret.name))
+    print(f"Deleted secret with name '{secret.name}'")
 
     # Purge the deleted secret.
     # The purge will take some time, so wait before restoring the backup to avoid a conflict.
     print("\n.. Purge the secret")
     await client.purge_deleted_secret(secret.name)
     await asyncio.sleep(60)
-    print("Purged secret with name '{0}'".format(secret.name))
+    print(f"Purged secret with name '{secret.name}'")
 
     # In the future, if the secret is required again, we can use the backup value to restore it in the Key Vault.
     print("\n.. Restore the secret using the backed up secret bytes")
     secret = await client.restore_secret_backup(secret_backup)
-    print("Restored secret with name '{0}'".format(secret.name))
+    print(f"Restored secret with name '{secret.name}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
@@ -41,13 +41,13 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create Secret")
 expires = datetime.datetime.utcnow() + datetime.timedelta(days=365)
 secret = client.set_secret("helloWorldSecretName", "helloWorldSecretValue", expires_on=expires)
-print("Secret with name '{0}' created with value '{1}'".format(secret.name, secret.value))
-print("Secret with name '{0}' expires on '{1}'".format(secret.name, secret.properties.expires_on))
+print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
+print(f"Secret with name '{secret.name}' expires on '{secret.properties.expires_on}'")
 
 # Let's get the bank secret using its name
 print("\n.. Get a Secret by name")
 bank_secret = client.get_secret(secret.name)
-print("Secret with name '{0}' was found with value '{1}'.".format(bank_secret.name, bank_secret.value))
+print(f"Secret with name '{bank_secret.name}' was found with value '{bank_secret.value}'.")
 
 # After one year, the bank account is still active, we need to update the expiry time of the secret.
 # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
@@ -55,20 +55,16 @@ print("Secret with name '{0}' was found with value '{1}'.".format(bank_secret.na
 print("\n.. Update a Secret by name")
 expires = bank_secret.properties.expires_on + datetime.timedelta(days=365)
 updated_secret_properties = client.update_secret_properties(secret.name, expires_on=expires)
-print("Secret with name '{0}' was updated on date '{1}'".format(secret.name, updated_secret_properties.updated_on))
-print(
-    "Secret with name '{0}' was updated to expire on '{1}'".format(
-        secret.name, updated_secret_properties.expires_on
-    )
-)
+print(f"Secret with name '{secret.name}' was updated on date '{updated_secret_properties.updated_on}'")
+print(f"Secret with name '{secret.name}' was updated to expire on '{updated_secret_properties.expires_on}'")
 
 # Bank forced a password update for security purposes. Let's change the value of the secret in the Key Vault.
 # To achieve this, we need to create a new version of the secret in the Key Vault. The update operation cannot
 # change the value of the secret.
 secret = client.set_secret(secret.name, "newSecretValue")
-print("Secret with name '{0}' created with value '{1}'".format(secret.name, secret.value))
+print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
 
 # The bank account was closed, need to delete its credentials from the Key Vault.
 print("\n.. Deleting Secret...")
 client.begin_delete_secret(secret.name)
-print("Secret with name '{0}' was deleted.".format(secret.name))
+print(f"Secret with name '{secret.name}' was deleted.")

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
@@ -41,13 +41,13 @@ async def run_sample():
     print("\n.. Create Secret")
     expires_on = datetime.datetime.utcnow() + datetime.timedelta(days=365)
     secret = await client.set_secret("helloWorldSecretNameAsync", "helloWorldSecretValue", expires_on=expires_on)
-    print("Secret with name '{0}' created with value '{1}'".format(secret.name, secret.value))
-    print("Secret with name '{0}' expires on '{1}'".format(secret.name, secret.properties.expires_on))
+    print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
+    print(f"Secret with name '{secret.name}' expires on '{secret.properties.expires_on}'")
 
     # Let's get the bank secret using its name
     print("\n.. Get a Secret by name")
     bank_secret = await client.get_secret(secret.name)
-    print("Secret with name '{0}' was found with value '{1}'.".format(bank_secret.name, bank_secret.value))
+    print(f"Secret with name '{bank_secret.name}' was found with value '{bank_secret.value}'.")
 
     # After one year, the bank account is still active, we need to update the expiry time of the secret.
     # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
@@ -56,26 +56,24 @@ async def run_sample():
     expires_on = bank_secret.properties.expires_on + datetime.timedelta(days=365)
     updated_secret_properties = await client.update_secret_properties(secret.name, expires_on=expires_on)
     print(
-        "Secret with name '{0}' was updated on date '{1}'".format(
-            updated_secret_properties.name, updated_secret_properties.updated_on
-        )
+        f"Secret with name '{updated_secret_properties.name}' was updated on date "
+        f"'{updated_secret_properties.updated_on}'"
     )
     print(
-        "Secret with name '{0}' was updated to expire on '{1}'".format(
-            updated_secret_properties.name, updated_secret_properties.expires_on
-        )
+        f"Secret with name '{updated_secret_properties.name}' was updated to expire on "
+        f"'{updated_secret_properties.expires_on}'"
     )
 
     # Bank forced a password update for security purposes. Let's change the value of the secret in the key vault.
     # To achieve this, we need to create a new version of the secret in the key vault. The update operation cannot
     # change the value of the secret.
     new_secret = await client.set_secret(secret.name, "newSecretValueAsync")
-    print("Secret with name '{0}' created with value '{1}'".format(new_secret.name, new_secret.value))
+    print(f"Secret with name '{new_secret.name}' created with value '{new_secret.value}'")
 
     # The bank account was closed, need to delete its credentials from the Key Vault.
     print("\n.. Deleting Secret...")
     deleted_secret = await client.delete_secret(secret.name)
-    print("Secret with name '{0}' was deleted.".format(deleted_secret.name))
+    print(f"Secret with name '{deleted_secret.name}' was deleted.")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
@@ -43,8 +43,8 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create Secret")
 bank_secret = client.set_secret("listOpsBankSecretName", "listOpsSecretValue1")
 storage_secret = client.set_secret("listOpsStorageSecretName", "listOpsSecretValue2")
-print("Secret with name '{0}' was created.".format(bank_secret.name))
-print("Secret with name '{0}' was created.".format(storage_secret.name))
+print(f"Secret with name '{bank_secret.name}' was created.")
+print(f"Secret with name '{storage_secret.name}' was created.")
 
 # You need to check if any of the secrets are sharing same values.
 # Let's list the secrets and print their values.
@@ -55,7 +55,7 @@ secrets = client.list_properties_of_secrets()
 for secret in secrets:
     retrieved_secret = client.get_secret(secret.name)
     print(
-        "Secret with name '{0}' and value {1} was found.".format(retrieved_secret.name, retrieved_secret.name)
+        f"Secret with name '{retrieved_secret.name}' and value {retrieved_secret.name} was found."
     )
 
 # The bank account password got updated, so you want to update the secret in Key Vault to ensure it reflects the
@@ -63,7 +63,7 @@ for secret in secrets:
 # with the new value.
 updated_secret = client.set_secret(bank_secret.name, "newSecretValue")
 print(
-    "Secret with name '{0}' was updated with new value '{1}'".format(updated_secret.name, updated_secret.value)
+    f"Secret with name '{updated_secret.name}' was updated with new value '{updated_secret.value}'"
 )
 
 # You need to check all the different values your bank account password secret had previously. Lets print all
@@ -71,11 +71,7 @@ print(
 print("\n.. List versions of the secret using its name")
 secret_versions = client.list_properties_of_secret_versions(bank_secret.name)
 for secret_version in secret_versions:
-    print(
-        "Bank Secret with name '{0}' has version: '{1}'.".format(
-            secret_version.name, secret_version.version
-        )
-    )
+    print(f"Bank Secret with name '{secret_version.name}' has version: '{secret_version.version}'.")
 
 # The bank account and storage accounts got closed. Let's delete bank and storage accounts secrets.
 # Calling result() on the method will immediately return the `DeletedSecret`, but calling wait() blocks
@@ -90,5 +86,5 @@ print("\n.. List deleted secrets from the Key Vault")
 deleted_secrets = client.list_deleted_secrets()
 for deleted_secret in deleted_secrets:
     print(
-        "Secret with name '{0}' has recovery id '{1}'".format(deleted_secret.name, deleted_secret.recovery_id)
+        f"Secret with name '{deleted_secret.name}' has recovery id '{deleted_secret.recovery_id}'"
     )

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
@@ -43,8 +43,8 @@ async def run_sample():
     print("\n.. Create Secret")
     bank_secret = await client.set_secret("listOpsBankSecretNameAsync", "listOpsSecretValue1")
     storage_secret = await client.set_secret("listOpsStorageSecretNameAsync", "listOpsSecretValue2")
-    print("Secret with name '{0}' was created.".format(bank_secret.name))
-    print("Secret with name '{0}' was created.".format(storage_secret.name))
+    print(f"Secret with name '{bank_secret.name}' was created.")
+    print(f"Secret with name '{storage_secret.name}' was created.")
 
     # You need to check if any of the secrets are sharing same values.
     # Let's list the secrets and print their values.
@@ -54,18 +54,14 @@ async def run_sample():
     secrets = client.list_properties_of_secrets()
     async for secret in secrets:
         retrieved_secret = await client.get_secret(secret.name)
-        print(
-            "Secret with name '{0}' with value '{1}' was found.".format(
-                retrieved_secret.name, retrieved_secret.value
-            )
-        )
+        print(f"Secret with name '{retrieved_secret.name}' with value '{retrieved_secret.value}' was found.")
 
     # The bank account password got updated, so you want to update the secret in Key Vault to ensure it reflects the
     # new password. Calling set_secret on an existing secret creates a new version of the secret in the Key Vault
     # with the new value.
     updated_secret = await client.set_secret(bank_secret.name, "newSecretValue")
     print(
-        "Secret with name '{0}' was updated with new value '{1}'".format(updated_secret.name, updated_secret.value)
+        f"Secret with name '{updated_secret.name}' was updated with new value '{updated_secret.value}'"
     )
 
     # You need to check all the different values your bank account password secret had previously. Lets print all
@@ -73,7 +69,7 @@ async def run_sample():
     print("\n.. List versions of the secret using its name")
     secret_versions = client.list_properties_of_secret_versions(bank_secret.name)
     async for secret in secret_versions:
-        print("Bank Secret with name '{0}' has version: '{1}'".format(secret.name, secret.version))
+        print(f"Bank Secret with name '{secret.name}' has version: '{secret.version}'")
 
     # The bank account and storage accounts got closed. Let's delete bank and storage accounts secrets.
     print("\n.. Deleting secrets...")
@@ -85,7 +81,7 @@ async def run_sample():
     deleted_secrets = client.list_deleted_secrets()
     async for deleted_secret in deleted_secrets:
         print(
-            "Secret with name '{0}' has recovery id '{1}'".format(deleted_secret.name, deleted_secret.recovery_id)
+            f"Secret with name '{deleted_secret.name}' has recovery id '{deleted_secret.recovery_id}'"
         )
 
     print("\nrun_sample done")

--- a/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations.py
@@ -40,15 +40,15 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create Secret")
 bank_secret = client.set_secret("recoverPurgeBankSecretName", "recoverPurgeSecretValue1")
 storage_secret = client.set_secret("recoverPurgeStorageSecretName", "recoverPurgeSecretValue2")
-print("Secret with name '{0}' was created.".format(bank_secret.name))
-print("Secret with name '{0}' was created.".format(storage_secret.name))
+print(f"Secret with name '{bank_secret.name}' was created.")
+print(f"Secret with name '{storage_secret.name}' was created.")
 
 # The storage account was closed, so we need to delete its credentials from the Key Vault.
 print("\n.. Delete a Secret")
 delete_secret_poller = client.begin_delete_secret(bank_secret.name)
 secret = delete_secret_poller.result()
 delete_secret_poller.wait()
-print("Secret with name '{0}' was deleted on date {1}.".format(secret.name, secret.deleted_date))
+print(f"Secret with name '{secret.name}' was deleted on date {secret.deleted_date}.")
 
 # We accidentally deleted the bank account secret. Let's recover it.
 # A deleted secret can only be recovered if the Key Vault is soft-delete enabled.
@@ -58,7 +58,7 @@ recovered_secret = recover_secret_poller.result()
 
 # This wait is just to ensure recovery is complete before we delete the secret again
 recover_secret_poller.wait()
-print("Recovered Secret with name '{0}'.".format(recovered_secret.name))
+print(f"Recovered Secret with name '{recovered_secret.name}'.")
 
 # Let's delete the storage secret now.
 # If the keyvault is soft-delete enabled, then for permanent deletion, the deleted secret needs to be purged.

--- a/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations_async.py
@@ -41,19 +41,19 @@ async def run_sample():
     print("\n.. Create Secret")
     bank_secret = await client.set_secret("recoverPurgeBankSecretNameAsync", "recoverPurgeSecretValue1")
     storage_secret = await client.set_secret("recoverPurgeStorageSecretNameAsync", "recoverPurgeSecretValue2")
-    print("Secret with name '{0}' was created.".format(bank_secret.name))
-    print("Secret with name '{0}' was created.".format(storage_secret.name))
+    print(f"Secret with name '{bank_secret.name}' was created.")
+    print(f"Secret with name '{storage_secret.name}' was created.")
 
     # The storage account was closed, need to delete its credentials from the Key Vault.
     print("\n.. Delete a Secret")
     secret = await client.delete_secret(bank_secret.name)
-    print("Secret with name '{0}' was deleted on date {1}.".format(secret.name, secret.deleted_date))
+    print(f"Secret with name '{secret.name}' was deleted on date {secret.deleted_date}.")
 
     # We accidentally deleted the bank account secret. Let's recover it.
     # A deleted secret can only be recovered if the Key Vault is soft-delete enabled.
     print("\n.. Recover Deleted Secret")
     recovered_secret = await client.recover_deleted_secret(bank_secret.name)
-    print("Recovered Secret with name '{0}'.".format(recovered_secret.name))
+    print(f"Recovered Secret with name '{recovered_secret.name}'.")
 
     # Let's delete storage account now.
     # If the keyvault is soft-delete enabled, then for permanent deletion, the deleted secret needs to be purged.

--- a/sdk/keyvault/azure-keyvault-secrets/setup.py
+++ b/sdk/keyvault/azure-keyvault-secrets/setup.py
@@ -36,7 +36,7 @@ setup(
     name=PACKAGE_NAME,
     version=VERSION,
     include_package_data=True,
-    description="Microsoft Azure {} Client Library for Python".format(PACKAGE_PPRINT_NAME),
+    description=f"Microsoft Azure {PACKAGE_PPRINT_NAME} Client Library for Python",
     long_description=README + "\n\n" + CHANGELOG,
     long_description_content_type="text/markdown",
     license="MIT License",

--- a/sdk/keyvault/azure-keyvault-secrets/tests/perfstress_tests/list_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/perfstress_tests/list_secrets.py
@@ -23,7 +23,7 @@ class ListSecretsTest(PerfStressTest):
         vault_url = self.get_from_env("AZURE_KEYVAULT_URL")
         self.client = SecretClient(vault_url, self.credential, **self._client_kwargs)
         self.async_client = AsyncSecretClient(vault_url, self.async_credential, **self._client_kwargs)
-        self.secret_names = ["livekvtestlistperfsecret{}".format(i) for i in range(self.args.count)]
+        self.secret_names = [f"livekvtestlistperfsecret{i}" for i in range(self.args.count)]
 
     async def global_setup(self):
         """The global setup is run only once."""

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -105,8 +105,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         secret_client = client
 
         for i in range(7):
-            secret_name = self.get_resource_name("secret{}".format(i))
-            secret_client.set_secret(secret_name, "value{}".format(i))
+            secret_name = self.get_resource_name(f"secret{i}")
+            secret_client.set_secret(secret_name, f"value{i}")
 
         # [START list_secrets]
         # list secrets

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -114,8 +114,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         secret_client = client
         async with secret_client:
             for i in range(7):
-                secret_name = self.get_resource_name("secret{}".format(i))
-                await secret_client.set_secret(secret_name, "value{}".format(i))
+                secret_name = self.get_resource_name(f"secret{i}")
+                await secret_client.set_secret(secret_name, f"value{i}")
 
             # [START list_secrets]
             # gets a list of secrets in the vault

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -144,8 +144,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
 
         # create many secrets
         for x in range(0, max_secrets):
-            secret_name = self.get_resource_name("sec{}".format(x))
-            secret_value = "secVal{}".format(x)
+            secret_name = self.get_resource_name(f"sec{x}")
+            secret_value = f"secVal{x}"
             secret = None
             while not secret:
                 secret = await client.set_secret(secret_name, secret_value)
@@ -165,8 +165,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
         async with client:
             # create secrets
             for i in range(list_test_size):
-                secret_name = self.get_resource_name("secret{}".format(i))
-                secret_value = "value{}".format(i)
+                secret_name = self.get_resource_name(f"secret{i}")
+                secret_value = f"value{i}"
                 expected[secret_name] = await client.set_secret(secret_name, secret_value)
 
             # delete them
@@ -251,8 +251,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
         async with client:
             # create secrets to recover
             for i in range(list_test_size):
-                secret_name = self.get_resource_name("secret{}".format(i))
-                secret_value = "value{}".format(i)
+                secret_name = self.get_resource_name(f"secret{i}")
+                secret_value = f"value{i}"
                 secrets[secret_name] = await client.set_secret(secret_name, secret_value)
 
             # delete all secrets
@@ -283,8 +283,8 @@ class TestKeyVaultSecret(KeyVaultTestCase):
         async with client:
             # create secrets to purge
             for i in range(list_test_size):
-                secret_name = self.get_resource_name("secret{}".format(i))
-                secret_value = "value{}".format(i)
+                secret_name = self.get_resource_name(f"secret{i}")
+                secret_value = f"value{i}"
                 secrets[secret_name] = await client.set_secret(secret_name, secret_value)
 
             # delete all secrets

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -147,8 +147,8 @@ class TestSecretClient(KeyVaultTestCase):
 
         # create many secrets
         for x in range(0, max_secrets):
-            secret_name = self.get_resource_name("sec{}".format(x))
-            secret_value = "secVal{}".format(x)
+            secret_name = self.get_resource_name(f"sec{x}")
+            secret_value = f"secVal{x}"
             secret = None
             while not secret:
                 secret = client.set_secret(secret_name, secret_value)
@@ -194,8 +194,8 @@ class TestSecretClient(KeyVaultTestCase):
 
         # create secrets
         for i in range(list_test_size):
-            secret_name = self.get_resource_name("secret{}".format(i))
-            secret_value = "value{}".format(i)
+            secret_name = self.get_resource_name(f"secret{i}")
+            secret_value = f"value{i}"
             expected[secret_name] = client.set_secret(secret_name, secret_value)
 
         # delete them
@@ -246,8 +246,8 @@ class TestSecretClient(KeyVaultTestCase):
 
         # create secrets to recover
         for i in range(list_test_size):
-            secret_name = self.get_resource_name("secret{}".format(i))
-            secret_value = "value{}".format(i)
+            secret_name = self.get_resource_name(f"secret{i}")
+            secret_value = f"value{i}"
             secrets[secret_name] = client.set_secret(secret_name, secret_value)
 
         # delete all secrets
@@ -276,8 +276,8 @@ class TestSecretClient(KeyVaultTestCase):
 
         # create secrets to purge
         for i in range(list_test_size):
-            secret_name = self.get_resource_name("secret{}".format(i))
-            secret_value = "value{}".format(i)
+            secret_name = self.get_resource_name(f"secret{i}")
+            secret_value = f"value{i}"
             secrets[secret_name] = client.set_secret(secret_name, secret_value)
 
         # delete all secrets


### PR DESCRIPTION
# Description

This updates KV packages to use Python 3-style type hints everywhere, typing for tools like `mypy`, and formatting such as f-strings and docstrings.

This also syncs the `_shared` folders between Certs, Keys, and Secrets, which includes sharing the `send_request` method implementation between all their clients (this method was initially just in `azure-keyvault-keys`).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
