### PR TITLE
Help mypy in FR samples

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.1/sample_manage_custom_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.1/sample_manage_custom_models.py
@@ -50,8 +50,8 @@ class ManageCustomModelsSample(object):
         custom_models = form_training_client.list_custom_models()
 
         print("We have models with the following IDs:")
-        for custom_model in custom_models:
-            print(custom_model.model_id)
+        for model_info in custom_models:
+            print(model_info.model_id)
         # [END list_custom_models]
 
         # let's train a model to use for this sample

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.1/sample_manage_custom_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.1/sample_manage_custom_models.py
@@ -50,8 +50,8 @@ class ManageCustomModelsSample(object):
         custom_models = form_training_client.list_custom_models()
 
         print("We have models with the following IDs:")
-        for model in custom_models:
-            print(model.model_id)
+        for custom_model in custom_models:
+            print(custom_model.model_id)
         # [END list_custom_models]
 
         # let's train a model to use for this sample


### PR DESCRIPTION
Create problems with https://github.com/Azure/azure-sdk-for-python/pull/28114, because the LROPoller return type is infered correctly now, and in the sample the variable `model` is re-used in two context, once from a `list` and one from the poller, which leads to type confusion to mypy:

```
samples/v3.1/sample_manage_custom_models.py:59: error: Incompatible types in assignment (expression has type "CustomFormModel", variable has type "CustomFormModelInfo")
```

The easiest solution is to make sure variable names aren't re-used for different purposes