### PR TITLE
[EventHubs] fix tracing bug

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -689,7 +689,7 @@ class EventDataBatch(object):
                     self._partition_key,
                 )
 
-        outgoing_event_data._message = trace_message(
+        outgoing_event_data._message = trace_message(   # pylint: disable=protected-access
             outgoing_event_data._message,   # pylint: disable=protected-access
             amqp_transport=self._amqp_transport
         )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -689,7 +689,10 @@ class EventDataBatch(object):
                     self._partition_key,
                 )
 
-        outgoing_event_data._message = trace_message(outgoing_event_data._message, amqp_transport=self._amqp_transport)
+        outgoing_event_data._message = trace_message(
+            outgoing_event_data._message,   # pylint: disable=protected-access
+            amqp_transport=self._amqp_transport
+        )
         event_data_size = self._amqp_transport.get_message_encoded_size(
             outgoing_event_data._message  # pylint: disable=protected-access
         )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -689,7 +689,7 @@ class EventDataBatch(object):
                     self._partition_key,
                 )
 
-        trace_message(outgoing_event_data)
+        outgoing_event_data._message = trace_message(outgoing_event_data._message, amqp_transport=self._amqp_transport)
         event_data_size = self._amqp_transport.get_message_encoded_size(
             outgoing_event_data._message  # pylint: disable=protected-access
         )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
@@ -201,7 +201,11 @@ class EventHubProducer(
                     outgoing_event_data._message, partition_key  # pylint: disable=protected-access
                 )
             wrapper_event_data = outgoing_event_data
-            wrapper_event_data._message = trace_message(wrapper_event_data._message, amqp_transport=self._amqp_transport, parent_span=span)
+            wrapper_event_data._message = trace_message(
+                wrapper_event_data._message,  # pylint: disable=protected-access
+                amqp_transport=self._amqp_transport,
+                parent_span=span
+            )
         else:
             if isinstance(
                 event_data, EventDataBatch

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
@@ -65,20 +65,6 @@ def _set_partition_key(
         yield ed
 
 
-def _trace_batch_message(
-    batch_message: Union[uamqp_BatchMessage, BatchMessage],
-    amqp_transport: AmqpTransport,
-    parent_span: Optional["AbstractSpan"] = None
-) -> None:
-    span_impl_type: Type[AbstractSpan] = settings.tracing_implementation()
-    if span_impl_type is None:
-        return
-
-    for (
-        message
-    ) in batch_message.data:  # pylint: disable=protected-access
-        trace_message(message, amqp_transport=amqp_transport, parent_span=parent_span)
-
 class EventHubProducer(
     ConsumerProducerMixin
 ):  # pylint:disable=too-many-instance-attributes

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
@@ -16,10 +16,8 @@ from typing import (
     List,
     TYPE_CHECKING,
     cast,
-    Type
-)  # pylint: disable=unused-import
+)
 
-from azure.core.settings import settings
 from ._common import EventData, EventDataBatch
 from ._client_base import ConsumerProducerMixin
 from ._utils import (
@@ -201,7 +199,7 @@ class EventHubProducer(
                     outgoing_event_data._message, partition_key  # pylint: disable=protected-access
                 )
             wrapper_event_data = outgoing_event_data
-            wrapper_event_data._message = trace_message(
+            wrapper_event_data._message = trace_message(  # pylint: disable=protected-access
                 wrapper_event_data._message,  # pylint: disable=protected-access
                 amqp_transport=self._amqp_transport,
                 parent_span=span

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer.py
@@ -38,12 +38,10 @@ if TYPE_CHECKING:
         from uamqp import SendClient as uamqp_SendClient
         from uamqp.constants import MessageSendResult as uamqp_MessageSendResult
         from uamqp.authentication import JWTTokenAuth as uamqp_JWTTokenAuth
-        from uamqp.message import BatchMessage as uamqp_BatchMessage
     except ImportError:
         uamqp_MessageSendResult = None
         uamqp_SendClient = None
         uamqp_JWTTokenAuth = None
-        uamqp_BatchMessage = None
     from ._pyamqp.client import SendClient
     from ._pyamqp.message import BatchMessage
     from ._pyamqp.authentication import JWTTokenAuth

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_base.py
@@ -57,6 +57,17 @@ class AmqpTransport(ABC):   # pylint: disable=too-many-public-methods
 
     @staticmethod
     @abstractmethod
+    def update_message_app_properties(message, key, value):
+        """
+        Adds the given key/value to the application properties of the message.
+        :param uamqp.Message or pyamqp.Message message: Message.
+        :param str key: Key to set in application properties.
+        :param str Value: Value to set for key in application properties.
+        :rtype: uamqp.Message or pyamqp.Message
+        """
+
+    @staticmethod
+    @abstractmethod
     def get_message_encoded_size(message):
         """
         Gets the message encoded size given an underlying Message.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
@@ -138,6 +138,20 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         return Message(**message_dict)
 
     @staticmethod
+    def update_message_app_properties(message, key, value):
+        """
+        Adds the given key/value to the application properties of the message.
+        :param pyamqp.Message message: Message.
+        :param str key: Key to set in application properties.
+        :param str Value: Value to set for key in application properties.
+        :rtype: pyamqp.Message
+        """
+        if not message.application_properties:
+            message = message._replace(application_properties={})
+        message.application_properties.setdefault(key, value)
+        return message
+
+    @staticmethod
     def get_batch_message_encoded_size(message):
         """
         Gets the batch message encoded size given an underlying Message.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_uamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_uamqp_transport.py
@@ -181,6 +181,20 @@ if uamqp_installed:
             )
 
         @staticmethod
+        def update_message_app_properties(message, key, value):
+            """
+            Adds the given key/value to the application properties of the message.
+            :param pyamqp.Message message: Message.
+            :param str key: Key to set in application properties.
+            :param str Value: Value to set for key in application properties.
+            :rtype: pyamqp.Message
+            """
+            if not message.application_properties:
+                message.application_properties = {}
+            message.application_properties.setdefault(key, value)
+            return message
+
+        @staticmethod
         def get_batch_message_encoded_size(message):
             """
             Gets the batch message encoded size given an underlying Message.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
@@ -45,9 +45,12 @@ if TYPE_CHECKING:
     from ._transport._base import AmqpTransport
     try:
         from uamqp import types as uamqp_types
+        from uamqp import Message as uamqp_Message
     except ImportError:
         uamqp_types = None
+        uamqp_Message = None
     from ._pyamqp import types
+    from ._pyamqp.message import Message
     from azure.core.tracing import AbstractSpan
     from azure.core.credentials import AzureSasCredential
     from ._common import EventData
@@ -155,12 +158,15 @@ def set_event_partition_key(
         raw_message.header.durable = True
 
 
-def trace_message(event, parent_span=None):
-    # type: (EventData, Optional[AbstractSpan]) -> None
-    """Add tracing information to this event.
+def trace_message(
+    message: Union[uamqp_Message, Message],
+    amqp_transport: AmqpTransport,
+    parent_span: Optional[AbstractSpan] = None
+) -> Union[uamqp_Message, Message]:
+    """Add tracing information to the message and returns the updated message.
 
     Will open and close a "Azure.EventHubs.message" span, and
-    add the "DiagnosticId" as app properties of the event.
+    add the "DiagnosticId" as app properties of the message.
     """
     try:
         span_impl_type = settings.tracing_implementation()  # type: Type[AbstractSpan]
@@ -173,13 +179,15 @@ def trace_message(event, parent_span=None):
                 name="Azure.EventHubs.message", kind=SpanKind.PRODUCER, links=[link]
             ) as message_span:
                 message_span.add_attribute("az.namespace", "Microsoft.EventHub")
-                if not event.properties:
-                    event.properties = dict()
-                event.properties.setdefault(
-                    b"Diagnostic-Id", message_span.get_trace_parent().encode("ascii")
+                message = amqp_transport.update_message_app_properties(
+                    message,
+                    b"Diagnostic-Id",
+                    message_span.get_trace_parent().encode("ascii")
                 )
     except Exception as exp:  # pylint:disable=broad-except
         _LOGGER.warning("trace_message had an exception %r", exp)
+
+    return message
 
 
 def get_event_links(events):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
@@ -11,7 +11,7 @@ from typing import Iterable, Union, Optional, Any, AnyStr, List, TYPE_CHECKING, 
 from azure.core.tracing import AbstractSpan
 
 from .._common import EventData, EventDataBatch
-from .._producer import _set_partition_key, _trace_batch_message
+from .._producer import _set_partition_key
 from .._utils import (
     create_properties,
     trace_message,
@@ -223,7 +223,6 @@ class EventHubProducer(
                 wrapper_event_data = EventDataBatch._from_batch(  # type: ignore  # pylint: disable=protected-access
                     event_data, self._amqp_transport, partition_key
                 )
-            _trace_batch_message(wrapper_event_data._message, span)
         return wrapper_event_data
 
     async def send(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
@@ -185,7 +185,7 @@ class EventHubProducer(
                 )
             wrapper_event_data = outgoing_event_data
             wrapper_event_data._message = trace_message(
-                wrapper_event_data._message,
+                wrapper_event_data._message,    # pylint: disable=protected-access
                 amqp_transport=self._amqp_transport,
                 parent_span=span
             )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_async.py
@@ -184,7 +184,7 @@ class EventHubProducer(
                     partition_key,
                 )
             wrapper_event_data = outgoing_event_data
-            wrapper_event_data._message = trace_message(
+            wrapper_event_data._message = trace_message(    # pylint: disable=protected-access
                 wrapper_event_data._message,    # pylint: disable=protected-access
                 amqp_transport=self._amqp_transport,
                 parent_span=span

--- a/sdk/eventhub/azure-eventhub/tests/conftest.py
+++ b/sdk/eventhub/azure-eventhub/tests/conftest.py
@@ -27,6 +27,7 @@ except (ModuleNotFoundError, ImportError):
     uamqp_transport_ids = ["pyamqp"]
 
 from devtools_testutils import get_region_override
+from tracing_common import FakeSpan
 
 collect_ignore = []
 PARTITION_COUNT = 2
@@ -84,6 +85,10 @@ def timeout_factor(uamqp_transport):
         return 1000
     else:
         return 1
+
+@pytest.fixture(scope="session")
+def fake_span():
+    return FakeSpan
 
 @pytest.fixture(scope="session")
 def resource_group():

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -296,6 +296,8 @@ def test_send_and_receive_small_body(connstr_receivers, payload, uamqp_transport
     assert len(root_span.children[0].children[2].children) == 1
     assert root_span.children[0].children[2].children[0].name == "Azure.EventHubs.message"
     assert root_span.children[0].children[2].children[0].kind == SpanKind.PRODUCER
+    # MUST RESET TRACING IMPLEMENTATION TO NONE, ELSE ALL OTHER TESTS ADD TRACING
+    settings.tracing_implementation.set_value(None)
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/tracing_common.py
+++ b/sdk/eventhub/azure-eventhub/tests/tracing_common.py
@@ -1,0 +1,218 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+"""Fake implementation of AbstractSpan for tests. Copied from `azure-core/tests`."""
+from contextlib import contextmanager
+from azure.core.tracing import HttpSpanMixin, SpanKind
+from typing import Union, Sequence, Optional, Dict
+AttributeValue = Union[
+    str,
+    bool,
+    int,
+    float,
+    Sequence[str],
+    Sequence[bool],
+    Sequence[int],
+    Sequence[float],
+]
+Attributes = Optional[Dict[str, AttributeValue]]
+
+class FakeSpan(HttpSpanMixin, object):
+    # Keep a fake context of the current one
+    CONTEXT = []
+
+    def __init__(self, span=None, name="span", kind=None, *, links=[]):
+        # type: (Optional[Span], Optional[str]) -> None
+        """
+        If a span is not passed in, creates a new tracer. If the instrumentation key for Azure Exporter is given, will
+        configure the azure exporter else will just create a new tracer.
+
+        :param span: The OpenTelemetry span to wrap
+        :type span: :class: OpenTelemetry.trace.Span
+        :param name: The name of the OpenTelemetry span to create if a new span is needed
+        :type name: str
+        """
+        self._span = span
+        self.name = name
+        self._kind = kind or SpanKind.UNSPECIFIED
+        self.attributes = {}
+        self.children = []
+        if self.CONTEXT:
+            self.CONTEXT[-1].children.append(self)
+        self.CONTEXT.append(self)
+        self.status = None
+        self.links = links
+
+    def __str__(self):
+        buffer = "Name: {}\n".format(self.name)
+        buffer += "Children:\n"
+        subchildren = "\n".join(str(child) for child in self.children)
+        buffer += "\n".join("\t{}".format(line) for line in subchildren.splitlines())
+        return buffer
+
+    @property
+    def span_instance(self):
+        # type: () -> Span
+        """
+        :return: The OpenTelemetry span that is being wrapped.
+        """
+        return self._span
+
+    def span(self, name="span", kind=None, links=[]):
+        # type: (Optional[str]) -> OpenCensusSpan
+        """
+        Create a child span for the current span and append it to the child spans list in the span instance.
+        :param name: Name of the child span
+        :type name: str
+        :return: The OpenCensusSpan that is wrapping the child span instance
+        """
+        return self.__class__(name=name, kind=kind, links=links)
+
+    @property
+    def kind(self):
+        # type: () -> Optional[SpanKind]
+        """Get the span kind of this span."""
+        return self._kind
+
+
+    @kind.setter
+    def kind(self, value):
+        # type: (SpanKind) -> None
+        """Set the span kind of this span."""
+        self._kind = value
+    
+    def __enter__(self):
+        """Start a span."""
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        """Finish a span."""
+        if exception_value:
+            self.status = exception_value.args[0]
+        self.CONTEXT.pop()
+
+    def start(self):
+        # type: () -> None
+        """Set the start time for a span."""
+        pass
+
+    def finish(self):
+        # type: () -> None
+        """Set the end time for a span."""
+        self.CONTEXT.pop()
+
+    def to_header(self):
+        # type: () -> Dict[str, str]
+        """
+        Returns a dictionary with the header labels and values.
+        :return: A key value pair dictionary
+        """
+        return {'traceparent': '123456789'}
+
+    def add_attribute(self, key, value):
+        # type: (str, Union[str, int]) -> None
+        """
+        Add attribute (key value pair) to the current span.
+
+        :param key: The key of the key value pair
+        :type key: str
+        :param value: The value of the key value pair
+        :type value: str
+        """
+        self.attributes[key] = value
+
+    def get_trace_parent(self):
+        """Return traceparent string as defined in W3C trace context specification.
+
+        Example:
+        Value = 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+        base16(version) = 00
+        base16(trace-id) = 4bf92f3577b34da6a3ce929d0e0e4736
+        base16(parent-id) = 00f067aa0ba902b7
+        base16(trace-flags) = 01  // sampled
+
+        :return: a traceparent string
+        :rtype: str
+        """
+        return self.to_header()['traceparent']
+
+    @classmethod
+    def link(cls, traceparent, attributes=None):
+        # type: (str, Attributes) -> None
+        """
+        Links the context to the current tracer.
+
+        :param traceparent: A complete traceparent
+        :type traceparent: str
+        """
+        cls.link_from_headers({
+            'traceparent': traceparent
+        })
+
+    @classmethod
+    def link_from_headers(cls, headers, attributes=None):
+        # type: (Dict[str, str], Attributes) -> None
+        """
+        Given a dictionary, extracts the context and links the context to the current tracer.
+
+        :param headers: A key value pair dictionary
+        :type headers: dict
+        """
+        raise NotImplementedError("This method needs to be implemented")
+
+    @classmethod
+    def get_current_span(cls):
+        # type: () -> Span
+        """
+        Get the current span from the execution context. Return None otherwise.
+        """
+        return cls.CONTEXT[-1]
+
+    @classmethod
+    def get_current_tracer(cls):
+        # type: () -> Tracer
+        """
+        Get the current tracer from the execution context. Return None otherwise.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @contextmanager
+    def change_context(cls, span):
+        # type: (Span) -> ContextManager
+        """Change the context for the life of this context manager.
+        """
+        try:
+            cls.CONTEXT.append(span)
+            yield
+        finally:
+            cls.CONTEXT.pop()
+
+    @classmethod
+    def set_current_span(cls, span):
+        # type: (Span) -> None
+        """Not supported by OpenTelemetry.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def set_current_tracer(cls, tracer):
+        # type: (Tracer) -> None
+        """
+        Set the given tracer as the current tracer in the execution context.
+        :param tracer: The tracer to set the current tracer as
+        :type tracer: :class: OpenTelemetry.trace.Tracer
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def with_current_context(cls, func):
+        # type: (Callable) -> Callable
+        """Passes the current spans to the new context the function will be run in.
+
+        :param func: The function that will be run in the new context
+        :return: The target the pass in instead of the function
+        """
+        return func

--- a/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
+++ b/sdk/eventhub/azure-eventhub/tests/unittest/test_event_data.py
@@ -200,10 +200,12 @@ def test_outgoing_amqp_message_header_properties(uamqp_transport):
     ann_message.header = AmqpMessageHeader()
     ann_message.properties = AmqpMessageProperties()
     ann_message.properties.message_id = ""
+    ann_message.application_properties = {b"key": b"val"}
     amqp_message = amqp_transport.to_outgoing_amqp_message(ann_message)
 
     assert not amqp_message.header
     assert amqp_message.properties
+    assert isinstance(amqp_message.application_properties, dict)
 
 
 def test_amqp_message_from_message(uamqp_transport):


### PR DESCRIPTION
fixes bug in: #27986

changes:
- removed duplicate tracing which was adding the `Azure.EventHubs.Message` span twice when sending a batch message/list of messages.
- adding the tracing info the uamqp/pyamqp.Message application_properties rather than event_data. Ensures that the diagnostic ID is actually being added on the outgoing Message, rather than the EventData after outgoing Message has already been created.
- Adding the FakeSpan class to `tests` folder to test telemetry.

TODO:
- follow-up issue created to address implementation so it behaves correctly in a separate PR: #28141 