### PR TITLE
p1 component deployment exisitng job definition

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/job_definition_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/job_definition_schema.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from marshmallow import fields, post_load
 
-from azure.ai.ml._schema import ArmVersionedStr, PatchedSchemaMeta, RegistryStr, StringTransformedEnum, UnionField
+from azure.ai.ml._schema import ArmVersionedStr, PatchedSchemaMeta, RegistryStr, StringTransformedEnum, UnionField, ArmStr
 from azure.ai.ml._schema.pipeline.pipeline_component import PipelineComponentFileRefField
 from azure.ai.ml.constants._common import AzureMLResourceType
 from azure.ai.ml.constants._job.job import JobType
@@ -21,7 +21,7 @@ class JobDefinitionSchema(metaclass=PatchedSchemaMeta):
     component_id = fields.Str()
     job = UnionField(
         [
-            RegistryStr(azureml_type=AzureMLResourceType.JOB),
+            ArmStr(azureml_type=AzureMLResourceType.JOB),
             PipelineComponentFileRefField(),
         ]
     )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/job_definition_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/job_definition_schema.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from marshmallow import fields, post_load
 
-from azure.ai.ml._schema import ArmVersionedStr, PatchedSchemaMeta, RegistryStr, StringTransformedEnum, UnionField, ArmStr
+from azure.ai.ml._schema import ArmVersionedStr, PatchedSchemaMeta, StringTransformedEnum, UnionField, ArmStr
 from azure.ai.ml._schema.pipeline.pipeline_component import PipelineComponentFileRefField
 from azure.ai.ml.constants._common import AzureMLResourceType
 from azure.ai.ml.constants._job.job import JobType

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -290,6 +290,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                 deployment.job_definition.description = component.properties.description
             if not deployment.job_definition.tags and component.properties.tags:
                 deployment.job_definition.tags = component.properties.tags
+        # pylint: disable=line-too-long
         if isinstance(deployment.job_definition.job, str) or isinstance(deployment.job_definition.component, PipelineComponent):
             deployment.job_definition.component = None
             deployment.job_definition.job = None

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -280,3 +280,22 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                 name, _ = parse_prefixed_name_version(deployment.job_definition.component)
                 deployment.job_definition.name = name
             deployment.job_definition.component_id = component_id
+        elif(deployment.job_definition.job):
+            if isinstance(deployment.job_definition.job, str):
+                component = PipelineComponent(source_job_id= deployment.job_definition.job)
+                rest_component = self._component_operations.create_or_update(
+                    name = component.name,
+                    resource_group_name=self._resource_group_name,
+                    workspace_name=self._workspace_name,
+                    body = component._to_rest_object(),
+                    version= component.version,
+                    **self._init_kwargs
+                )
+                deployment.job_definition.job = None
+                deployment.job_definition.component_id = rest_component.id
+                if not deployment.job_definition.name and rest_component.name:
+                    deployment.job_definition.name = rest_component.name
+                if not deployment.job_definition.description and rest_component.properties.description:
+                    deployment.job_definition.description = rest_component.properties.description
+                if not deployment.job_definition.tags and rest_component.properties.tags:
+                    deployment.job_definition.tags = rest_component.properties.tags

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -280,22 +280,21 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                 name, _ = parse_prefixed_name_version(deployment.job_definition.component)
                 deployment.job_definition.name = name
             deployment.job_definition.component_id = component_id
-        elif(deployment.job_definition.job):
-            if isinstance(deployment.job_definition.job, str):
-                component = PipelineComponent(source_job_id= deployment.job_definition.job)
-                rest_component = self._component_operations.create_or_update(
-                    name = component.name,
-                    resource_group_name=self._resource_group_name,
-                    workspace_name=self._workspace_name,
-                    body = component._to_rest_object(),
-                    version= component.version,
-                    **self._init_kwargs
-                )
-                deployment.job_definition.job = None
-                deployment.job_definition.component_id = rest_component.id
-                if not deployment.job_definition.name and rest_component.name:
-                    deployment.job_definition.name = rest_component.name
-                if not deployment.job_definition.description and rest_component.properties.description:
-                    deployment.job_definition.description = rest_component.properties.description
-                if not deployment.job_definition.tags and rest_component.properties.tags:
-                    deployment.job_definition.tags = rest_component.properties.tags
+        elif isinstance(deployment.job_definition.job, str):
+            component = PipelineComponent(source_job_id= deployment.job_definition.job)
+            rest_component = self._component_operations.create_or_update(
+                name = component.name,
+                resource_group_name=self._resource_group_name,
+                workspace_name=self._workspace_name,
+                body = component._to_rest_object(),
+                version= component.version,
+                **self._init_kwargs
+            )
+            deployment.job_definition.job = None
+            deployment.job_definition.component_id = rest_component.id
+            if not deployment.job_definition.name and rest_component.name:
+                deployment.job_definition.name = rest_component.name
+            if not deployment.job_definition.description and rest_component.properties.description:
+                deployment.job_definition.description = rest_component.properties.description
+            if not deployment.job_definition.tags and rest_component.properties.tags:
+                deployment.job_definition.tags = rest_component.properties.tags


### PR DESCRIPTION
# Description

Component deployment p1 scenario that allows component deployments to be created with existing job definition. 

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
Test coverage will be included in another pr

