### PR TITLE
[Service Bus] Doc Updates For Message Browsing

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -782,7 +782,7 @@ class ServiceBusReceiver(
 
         Peeked messages are not removed from queue, nor are they locked. They cannot be completed,
         deferred or dead-lettered.
-        
+
         For more information about message browsing see https://aka.ms/azsdk/servicebus/message-browsing
 
         :param int max_message_count: The maximum number of messages to try and peek. The actual number of messages

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -785,8 +785,8 @@ class ServiceBusReceiver(
         
         For more information about message browsing see https://aka.ms/azsdk/servicebus/message-browsing
 
-        :param int max_message_count: The maximum number of messages to try and peek up to service limits. The default
-         value is 1.
+        :param int max_message_count: The maximum number of messages to try and peek. The actual number of messages
+         returned may be fewer and are subject to service limits. The default value is 1.
         :keyword int sequence_number: A message sequence number from which to start browsing messages.
         :keyword Optional[float] timeout: The total operation timeout in seconds including all the retries.
          The value must be greater than 0 if specified. The default value is None, meaning no timeout.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -782,8 +782,10 @@ class ServiceBusReceiver(
 
         Peeked messages are not removed from queue, nor are they locked. They cannot be completed,
         deferred or dead-lettered.
+        
+        For more information about message browsing see https://aka.ms/azsdk/servicebus/message-browsing
 
-        :param int max_message_count: The maximum number of messages to try and peek. The default
+        :param int max_message_count: The maximum number of messages to try and peek up to service limits. The default
          value is 1.
         :keyword int sequence_number: A message sequence number from which to start browsing messages.
         :keyword Optional[float] timeout: The total operation timeout in seconds including all the retries.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -770,7 +770,9 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
         Peeked messages are not removed from queue, nor are they locked. They cannot be completed,
         deferred or dead-lettered.
 
-        :param int max_message_count: The maximum number of messages to try and peek. The default
+        For more information about message browsing see https://aka.ms/azsdk/servicebus/message-browsing
+
+        :param int max_message_count: The maximum number of messages to try and peek up to service limits. The default
          value is 1.
         :keyword int sequence_number: A message sequence number from which to start browsing messages.
         :keyword Optional[float] timeout: The total operation timeout in seconds including all the retries.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -772,8 +772,8 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
 
         For more information about message browsing see https://aka.ms/azsdk/servicebus/message-browsing
 
-        :param int max_message_count: The maximum number of messages to try and peek up to service limits. The default
-         value is 1.
+        :param int max_message_count: The maximum number of messages to try and peek. The actual number of messages
+         returned may be fewer and are subject to service limits. The default value is 1.
         :keyword int sequence_number: A message sequence number from which to start browsing messages.
         :keyword Optional[float] timeout: The total operation timeout in seconds including all the retries.
          The value must be greater than 0 if specified. The default value is None, meaning no timeout.


### PR DESCRIPTION
Fixes #28183 , Fixes #26643

* Update to add a link to product doc for message browsing
* Update description of `max_message_count` to show that it will go up to service limits, which will be updated in the link added