### PR TITLE
[EventHubs] sanitize api version from avro recordings

### DIFF
--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/schemaregistry/azure-schemaregistry-avroencoder",
-  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_b8297fb102"
+  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_5561f5215a"
 }

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
@@ -4,6 +4,7 @@ from devtools_testutils import add_general_regex_sanitizer, test_proxy, add_oaut
 # autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):
+    add_general_regex_sanitizer(regex="(?<=api-version=)[0-9]{4}-[0-9]{2}", value="xxxx-xx")
     add_general_regex_sanitizer(regex="(?<=\\/\\/)[a-z-]+(?=\\.servicebus\\.windows\\.net)", value="fake_resource_avro")
     add_oauth_response_sanitizer()
 


### PR DESCRIPTION
pipelines are failing when running non-live tests, b/c of strange pip install issues (i.e. installing diff versions of azure-schemaregistry for diff OSes). Scrubbing api-version altogether to avoid failures.