### PR TITLE
[EventHubs] add back api version + update test sr version

### DIFF
--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/schemaregistry/azure-schemaregistry-avroencoder",
-  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_5561f5215a"
+  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_de42f2c6e6"
 }

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/conftest.py
@@ -4,7 +4,6 @@ from devtools_testutils import add_general_regex_sanitizer, test_proxy, add_oaut
 # autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):
-    add_general_regex_sanitizer(regex="(?<=api-version=)[0-9]{4}-[0-9]{2}", value="xxxx-xx")
     add_general_regex_sanitizer(regex="(?<=\\/\\/)[a-z-]+(?=\\.servicebus\\.windows\\.net)", value="fake_resource_avro")
     add_oauth_response_sanitizer()
 

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/dev_requirements.txt
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/dev_requirements.txt
@@ -2,3 +2,4 @@
 -e ../../../tools/azure-sdk-tools
 -e ../../identity/azure-identity
 aiohttp>=3.0
+azure-schemaregistry<=1.2.0


### PR DESCRIPTION
as per Laurent: re-record tests to include api-version in recordings, since that's crucial info to test against.

Instead, in dev_reqs.txt, restrict azure-schemaregistry version to <=1.2.0. In release pipeline, recordings are failing on windows due to potential pip bug b/c 1.3.0b1 is being installed. Restricting in the dev requirements should allow us to bypass this issue.

Will need to remove the restriction once we release the next stable SR.