### PR TITLE
Add AVNM deprecation notice of azure.mgmt.network.v2021_02_01_preview

### DIFF
--- a/sdk/network/azure-mgmt-network/README.md
+++ b/sdk/network/azure-mgmt-network/README.md
@@ -8,6 +8,9 @@ For a more complete view of Azure libraries, see the [azure sdk python release](
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
 
+_azure.mgmt.network.v2021\_02\_01\_preview is deprecated for azure virtual network manager operations. Please use [azure.mgmt.network.v2022_07_01](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/network/azure-mgmt-network/azure/mgmt/network/v2022_07_01) instead. See change log for suggested operation usage._
+
+
 # Usage
 
 


### PR DESCRIPTION
# Description

AVNM is deprecating the Api version used for azure.mgmt.network.v2021_02_01_preview, and posting the corresponding announcement in the README

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
