### PR TITLE
Change the param to keyword since parameter following an asterisk parameter is a keyword-only-parameter

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -761,11 +761,11 @@ class MLClient(object):
 
         :param entity: The resource to create or update.
         :type entity: typing.Union[~azure.ai.ml.entities.Job,
-            ~azure.ai.ml.entities.Model, ~azure.ai.ml.entities.Environment, ~azure.ai.ml.entities.Component,
-            ~azure.ai.ml.entities.Datastore, ~azure.ai.ml.entities.WorkspaceModelReference]
+             ~azure.ai.ml.entities.Model, ~azure.ai.ml.entities.Environment, ~azure.ai.ml.entities.Component,
+             ~azure.ai.ml.entities.Datastore, ~azure.ai.ml.entities.WorkspaceModelReference]
         :return: The created or updated resource.
         :rtype: typing.Union[~azure.ai.ml.entities.Job, ~azure.ai.ml.entities.Model,
-            ~azure.ai.ml.entities.Environment, ~azure.ai.ml.entities.Component, ~azure.ai.ml.entities.Datastore]
+             ~azure.ai.ml.entities.Environment, ~azure.ai.ml.entities.Component, ~azure.ai.ml.entities.Datastore]
         """
 
         return _create_or_update(entity, self._operation_container.all_operations, **kwargs)
@@ -785,14 +785,14 @@ class MLClient(object):
 
         :param entity: The resource to create or update.
         :type entity: typing.Union[~azure.ai.ml.entities.Workspace,
-            ~azure.ai.ml.entities.Registry, ~azure.ai.ml.entities.Compute, ~azure.ai.ml.entities.OnlineDeployment,
-            ~azure.ai.ml.entities.OnlineEndpoint, ~azure.ai.ml.entities.BatchDeployment,
-            ~azure.ai.ml.entities.BatchEndpoint, ~azure.ai.ml.entities.JobSchedule]
+             ~azure.ai.ml.entities.Registry, ~azure.ai.ml.entities.Compute, ~azure.ai.ml.entities.OnlineDeployment,
+             ~azure.ai.ml.entities.OnlineEndpoint, ~azure.ai.ml.entities.BatchDeployment,
+             ~azure.ai.ml.entities.BatchEndpoint, ~azure.ai.ml.entities.JobSchedule]
         :return: The resource after create/update operation.
         :rtype: azure.core.polling.LROPoller[typing.Union[~azure.ai.ml.entities.Workspace,
-            ~azure.ai.ml.entities.Registry, ~azure.ai.ml.entities.Compute, ~azure.ai.ml.entities.OnlineDeployment,
-            ~azure.ai.ml.entities.OnlineEndpoint, ~azure.ai.ml.entities.BatchDeployment,
-            ~azure.ai.ml.entities.BatchEndpoint, ~azure.ai.ml.entities.JobSchedule]]
+             ~azure.ai.ml.entities.Registry, ~azure.ai.ml.entities.Compute, ~azure.ai.ml.entities.OnlineDeployment,
+             ~azure.ai.ml.entities.OnlineEndpoint, ~azure.ai.ml.entities.BatchDeployment,
+             ~azure.ai.ml.entities.BatchEndpoint, ~azure.ai.ml.entities.JobSchedule]]
         """
 
         return _begin_create_or_update(entity, self._operation_container.all_operations, **kwargs)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
@@ -33,28 +33,28 @@ class Deployment(Resource, RestTranslatableMixin):
 
     :param name: Name of the deployment resource, defaults to None
     :type name: typing.Optional[str]
-    :param endpoint_name: Name of the Endpoint resource, defaults to None
+    :keyword endpoint_name: Name of the Endpoint resource, defaults to None
     :type endpoint_name: typing.Optional[str]
-    :param description: Description of the deployment resource, defaults to None
+    :keyword description: Description of the deployment resource, defaults to None
     :type description: typing.Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
     :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-    :param properties: The asset property dictionary, defaults to None
+    :keyword properties: The asset property dictionary, defaults to None
     :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-    :param model: The Model entity, defaults to None
-    :type model: typing.Optional[Union[str, ~azure.ai.ml.entities.Model]]
-    :param code_configuration: Code Configuration, defaults to None
+    :keyword model: The Model entity, defaults to None
+    :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
+    :keyword code_configuration: Code Configuration, defaults to None
     :type code_configuration: typing.Optional[CodeConfiguration]
-    :param environment: The Environment entity, defaults to None
-    :type environment: typing.Optional[Union[str, ~azure.ai.ml.entities.Environment]]
-    :param environment_variables: Environment variables that will be set in deployment, defaults to None
+    :keyword environment: The Environment entity, defaults to None
+    :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
+    :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
     :type environment_variables: typing.Optional[typing.Dict[str, str]]
-    :param code_path: Folder path to local code assets. Equivalent to code_configuration.code.path
+    :keyword code_path: Folder path to local code assets. Equivalent to code_configuration.code.path
         , defaults to None
-    :type code_path: typing.Optional[Union[str, PathLike]]
-    :param scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script
+    :type code_path: typing.Optional[typing.Union[str, PathLike]]
+    :keyword scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script
         , defaults to None
-    :type scoring_script: typing.Optional[Union[str, PathLike]]
+    :type scoring_script: typing.Optional[typing.Union[str, PathLike]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Deployment cannot be successfully validated.
         Exception details will be provided in the error message.
     """
@@ -82,28 +82,28 @@ class Deployment(Resource, RestTranslatableMixin):
 
         :param name: Name of the deployment resource, defaults to None
         :type name: typing.Optional[str]
-        :param endpoint_name: Name of the Endpoint resource, defaults to None
+        :keyword endpoint_name: Name of the Endpoint resource, defaults to None
         :type endpoint_name: typing.Optional[str]
-        :param description: Description of the deployment resource, defaults to None
+        :keyword description: Description of the deployment resource, defaults to None
         :type description: typing.Optional[str]
-        :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+        :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
         :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-        :param properties: The asset property dictionary, defaults to None
+        :keyword properties: The asset property dictionary, defaults to None
         :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-        :param model: The Model entity, defaults to None
-        :type model: typing.Optional[Union[str, ~azure.ai.ml.entities.Model]]
-        :param code_configuration: Code Configuration, defaults to None
+        :keyword model: The Model entity, defaults to None
+        :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
+        :keyword code_configuration: Code Configuration, defaults to None
         :type code_configuration: typing.Optional[CodeConfiguration]
-        :param environment: The Environment entity, defaults to None
-        :type environment: typing.Optional[Union[str, ~azure.ai.ml.entities.Environment]]
-        :param environment_variables: Environment variables that will be set in deployment, defaults to None
+        :keyword environment: The Environment entity, defaults to None
+        :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
+        :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
         :type environment_variables: typing.Optional[typing.Dict[str, str]]
-        :param code_path: Folder path to local code assets. Equivalent to code_configuration.code.path
+        :keyword code_path: Folder path to local code assets. Equivalent to code_configuration.code.path
             , defaults to None
-        :type code_path: typing.Optional[Union[str, PathLike]]
-        :param scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script
+        :type code_path: typing.Optional[typing.Union[str, PathLike]]
+        :keyword scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script
             , defaults to None
-        :type scoring_script: typing.Optional[Union[str, PathLike]]
+        :type scoring_script: typing.Optional[typing.Union[str, PathLike]]
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Deployment cannot be successfully validated.
             Exception details will be provided in the error message.
         """
@@ -167,7 +167,7 @@ class Deployment(Resource, RestTranslatableMixin):
             and an exception is raised if the file exists.
             If dest is an open file, the file will be written to directly,
             and an exception will be raised if the file is not writable.
-        :type dest: typing.Union[typing.PathLike, str, typing.IO[typing.AnyStr]]
+        :type dest: typing.Union[os.PathLike, str, typing.IO[typing.AnyStr]]
         """
         path = kwargs.pop("path", None)
         yaml_serialized = self._to_dict()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/online_deployment.py
@@ -59,42 +59,42 @@ class OnlineDeployment(Deployment):
 
     :param name: Name of the deployment resource.
     :type name: str
-    :param endpoint_name: Name of the endpoint resource, defaults to None
+    :keyword endpoint_name: Name of the endpoint resource, defaults to None
     :type endpoint_name: typing.Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
     :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-    :param properties: The asset property dictionary, defaults to None
+    :keyword properties: The asset property dictionary, defaults to None
     :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-    :param description: Description of the resource, defaults to None
+    :keyword description: Description of the resource, defaults to None
     :type description: typing.Optional[str]
-    :param model: Model entity for the endpoint deployment, defaults to None
+    :keyword model: Model entity for the endpoint deployment, defaults to None
     :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
-    :param code_configuration: Code Configuration, defaults to None
+    :keyword code_configuration: Code Configuration, defaults to None
     :type code_configuration: typing.Optional[CodeConfiguration]
-    :param environment: Environment entity for the endpoint deployment, defaults to None
+    :keyword environment: Environment entity for the endpoint deployment, defaults to None
     :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
-    :param app_insights_enabled: Is appinsights enabled, defaults to False
+    :keyword app_insights_enabled: Is appinsights enabled, defaults to False
     :type app_insights_enabled: typing.Optional[bool]
-    :param scale_settings: How the online deployment will scale, defaults to None
+    :keyword scale_settings: How the online deployment will scale, defaults to None
     :type scale_settings: typing.Optional[OnlineScaleSettings]
-    :param request_settings: Online Request Settings, defaults to None
+    :keyword request_settings: Online Request Settings, defaults to None
     :type request_settings: typing.Optional[OnlineRequestSettings]
-    :param liveness_probe: Liveness probe settings, defaults to None
+    :keyword liveness_probe: Liveness probe settings, defaults to None
     :type liveness_probe: typing.Optional[ProbeSettings]
-    :param readiness_probe: Readiness probe settings, defaults to None
+    :keyword readiness_probe: Readiness probe settings, defaults to None
     :type readiness_probe: typing.Optional[ProbeSettings]
-    :param environment_variables: Environment variables that will be set in deployment, defaults to None
+    :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
     :type environment_variables: typing.Optional[typing.Dict[str, str]]
-    :param instance_count: The instance count used for this deployment, defaults to None
+    :keyword instance_count: The instance count used for this deployment, defaults to None
     :type instance_count: typing.Optional[int]
-    :param instance_type: Azure compute sku, defaults to None
+    :keyword instance_type: Azure compute sku, defaults to None
     :type instance_type: typing.Optional[str]
-    :param model_mount_path: The path to mount the model in custom container, defaults to None
+    :keyword model_mount_path: The path to mount the model in custom container, defaults to None
     :type model_mount_path: typing.Optional[str]
-    :param code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
+    :keyword code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
         , defaults to None
     :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
-    :param scoring_script: Equivalent to code_configuration.code.scoring_script.
+    :keyword scoring_script: Equivalent to code_configuration.code.scoring_script.
         Will be ignored if code_configuration is present, defaults to None
     :type scoring_script: typing.Optional[typing.Union[str, os.PathLike]]
     """
@@ -128,44 +128,44 @@ class OnlineDeployment(Deployment):
 
         Constructor for Online endpoint deployment entity
 
-        :param name: Name of the deployment resource.
+        :keyword name: Name of the deployment resource.
         :type name: str
-        :param endpoint_name: Name of the endpoint resource, defaults to None
+        :keyword endpoint_name: Name of the endpoint resource, defaults to None
         :type endpoint_name: typing.Optional[str]
-        :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+        :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
         :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-        :param properties: The asset property dictionary, defaults to None
+        :keyword properties: The asset property dictionary, defaults to None
         :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-        :param description: Description of the resource, defaults to None
+        :keyword description: Description of the resource, defaults to None
         :type description: typing.Optional[str]
-        :param model: Model entity for the endpoint deployment, defaults to None
+        :keyword model: Model entity for the endpoint deployment, defaults to None
         :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
-        :param code_configuration: Code Configuration, defaults to None
+        :keyword code_configuration: Code Configuration, defaults to None
         :type code_configuration: typing.Optional[CodeConfiguration]
-        :param environment: Environment entity for the endpoint deployment, defaults to None
+        :keyword environment: Environment entity for the endpoint deployment, defaults to None
         :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
-        :param app_insights_enabled: Is appinsights enabled, defaults to False
+        :keyword app_insights_enabled: Is appinsights enabled, defaults to False
         :type app_insights_enabled: typing.Optional[bool]
-        :param scale_settings: How the online deployment will scale, defaults to None
+        :keyword scale_settings: How the online deployment will scale, defaults to None
         :type scale_settings: typing.Optional[OnlineScaleSettings]
-        :param request_settings: Online Request Settings, defaults to None
+        :keyword request_settings: Online Request Settings, defaults to None
         :type request_settings: typing.Optional[OnlineRequestSettings]
-        :param liveness_probe: Liveness probe settings, defaults to None
+        :keyword liveness_probe: Liveness probe settings, defaults to None
         :type liveness_probe: typing.Optional[ProbeSettings]
-        :param readiness_probe: Readiness probe settings, defaults to None
+        :keyword readiness_probe: Readiness probe settings, defaults to None
         :type readiness_probe: typing.Optional[ProbeSettings]
-        :param environment_variables: Environment variables that will be set in deployment, defaults to None
+        :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
         :type environment_variables: typing.Optional[typing.Dict[str, str]]
-        :param instance_count: The instance count used for this deployment, defaults to None
+        :keyword instance_count: The instance count used for this deployment, defaults to None
         :type instance_count: typing.Optional[int]
-        :param instance_type: Azure compute sku, defaults to None
+        :keyword instance_type: Azure compute sku, defaults to None
         :type instance_type: typing.Optional[str]
-        :param model_mount_path: The path to mount the model in custom container, defaults to None
+        :keyword model_mount_path: The path to mount the model in custom container, defaults to None
         :type model_mount_path: typing.Optional[str]
-        :param code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
+        :keyword code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
             , defaults to None
         :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
-        :param scoring_script: Equivalent to code_configuration.code.scoring_script.
+        :keyword scoring_script: Equivalent to code_configuration.code.scoring_script.
             Will be ignored if code_configuration is present, defaults to None
         :type scoring_script: typing.Optional[typing.Union[str, os.PathLike]]
         """
@@ -353,46 +353,44 @@ class OnlineDeployment(Deployment):
 class KubernetesOnlineDeployment(OnlineDeployment):
     """Kubernetes Online endpoint deployment entity.
 
-    :param name: Name of the deployment resource.
+    :keyword name: Name of the deployment resource.
     :type name: str
-    :param endpoint_name: Name of the endpoint resource, defaults to None
+    :keyword endpoint_name: Name of the endpoint resource, defaults to None
     :type endpoint_name: typing.Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
     :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-    :param properties: The asset property dictionary, defaults to None
+    :keyword properties: The asset property dictionary, defaults to None
     :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-    :param description: Description of the resource, defaults to None
+    :keyword description: Description of the resource, defaults to None
     :type description: typing.Optional[str]
-    :param model: Model entity for the endpoint deployment, defaults to None
+    :keyword model: Model entity for the endpoint deployment, defaults to None
     :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
-    :param code_configuration: Code Configuration, defaults to None
+    :keyword code_configuration: Code Configuration, defaults to None
     :type code_configuration: typing.Optional[CodeConfiguration]
-    :param environment: Environment entity for the endpoint deployment, defaults to None
+    :keyword environment: Environment entity for the endpoint deployment, defaults to None
     :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
-    :param app_insights_enabled: Is appinsights enabled, defaults to False
+    :keyword app_insights_enabled: Is appinsights enabled, defaults to False
     :type app_insights_enabled: bool
-    :param scale_settings: How the online deployment will scale, defaults to None
+    :keyword scale_settings: How the online deployment will scale, defaults to None
     :type scale_settings: typing.Optional[typing.Union[DefaultScaleSettings, TargetUtilizationScaleSettings]]
-    :param request_settings: Online Request Settings, defaults to None
+    :keyword request_settings: Online Request Settings, defaults to None
     :type request_settings: typing.Optional[OnlineRequestSettings]
-    :param liveness_probe: Liveness probe settings, defaults to None
+    :keyword liveness_probe: Liveness probe settings, defaults to None
     :type liveness_probe: typing.Optional[ProbeSettings]
-    :param readiness_probe: Readiness probe settings, defaults to None
+    :keyword readiness_probe: Readiness probe settings, defaults to None
     :type readiness_probe: typing.Optional[ProbeSettings]
-    :param environment_variables: Environment variables that will be set in deployment, defaults to None
+    :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
     :type environment_variables: typing.Optional[typing.Dict[str, str]]
-    :param resources: Resource requirements settings, defaults to None
+    :keyword resources: Resource requirements settings, defaults to None
     :type resources: typing.Optional[ResourceRequirementsSettings]
-    :param instance_count: The instance count used for this deployment, defaults to None
+    :keyword instance_count: The instance count used for this deployment, defaults to None
     :type instance_count: typing.Optional[int]
-    :param instance_type: The instance type defined by K8S cluster admin, defaults to None
+    :keyword instance_type: The instance type defined by K8S cluster admin, defaults to None
     :type instance_type: typing.Optional[str]
-    :param code_path: _description_, defaults to None
-    :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
-    :param code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
+    :keyword code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
         , defaults to None
     :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
-    :param scoring_script: Equivalent to code_configuration.code.scoring_script.
+    :keyword scoring_script: Equivalent to code_configuration.code.scoring_script.
         Will be ignored if code_configuration is present, defaults to None
     :type scoring_script: typing.Optional[typing.Union[str, os.PathLike]]
     """
@@ -428,46 +426,44 @@ class KubernetesOnlineDeployment(OnlineDeployment):
 
         Constructor for Kubernetes Online endpoint deployment entity.
 
-        :param name: Name of the deployment resource.
+        :keyword name: Name of the deployment resource.
         :type name: str
-        :param endpoint_name: Name of the endpoint resource, defaults to None
+        :keyword endpoint_name: Name of the endpoint resource, defaults to None
         :type endpoint_name: typing.Optional[str]
-        :param tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
+        :keyword tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
         :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-        :param properties: The asset property dictionary, defaults to None
+        :keyword properties: The asset property dictionary, defaults to None
         :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-        :param description: Description of the resource, defaults to None
+        :keyword description: Description of the resource, defaults to None
         :type description: typing.Optional[str]
-        :param model: Model entity for the endpoint deployment, defaults to None
+        :keyword model: Model entity for the endpoint deployment, defaults to None
         :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
-        :param code_configuration: Code Configuration, defaults to None
+        :keyword code_configuration: Code Configuration, defaults to None
         :type code_configuration: typing.Optional[CodeConfiguration]
-        :param environment: Environment entity for the endpoint deployment, defaults to None
+        :keyword environment: Environment entity for the endpoint deployment, defaults to None
         :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
-        :param app_insights_enabled: Is appinsights enabled, defaults to False
+        :keyword app_insights_enabled: Is appinsights enabled, defaults to False
         :type app_insights_enabled: bool
-        :param scale_settings: How the online deployment will scale, defaults to None
+        :keyword scale_settings: How the online deployment will scale, defaults to None
         :type scale_settings: typing.Optional[typing.Union[DefaultScaleSettings, TargetUtilizationScaleSettings]]
-        :param request_settings: Online Request Settings, defaults to None
+        :keyword request_settings: Online Request Settings, defaults to None
         :type request_settings: typing.Optional[OnlineRequestSettings]
-        :param liveness_probe: Liveness probe settings, defaults to None
+        :keyword liveness_probe: Liveness probe settings, defaults to None
         :type liveness_probe: typing.Optional[ProbeSettings]
-        :param readiness_probe: Readiness probe settings, defaults to None
+        :keyword readiness_probe: Readiness probe settings, defaults to None
         :type readiness_probe: typing.Optional[ProbeSettings]
-        :param environment_variables: Environment variables that will be set in deployment, defaults to None
+        :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
         :type environment_variables: typing.Optional[typing.Dict[str, str]]
-        :param resources: Resource requirements settings, defaults to None
+        :keyword resources: Resource requirements settings, defaults to None
         :type resources: typing.Optional[ResourceRequirementsSettings]
-        :param instance_count: The instance count used for this deployment, defaults to None
+        :keyword instance_count: The instance count used for this deployment, defaults to None
         :type instance_count: typing.Optional[int]
-        :param instance_type: The instance type defined by K8S cluster admin, defaults to None
+        :keyword instance_type: The instance type defined by K8S cluster admin, defaults to None
         :type instance_type: typing.Optional[str]
-        :param code_path: _description_, defaults to None
-        :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
-        :param code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
+        :keyword code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
             , defaults to None
         :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
-        :param scoring_script: Equivalent to code_configuration.code.scoring_script.
+        :keyword scoring_script: Equivalent to code_configuration.code.scoring_script.
             Will be ignored if code_configuration is present, defaults to None
         :type scoring_script: typing.Optional[typing.Union[str, os.PathLike]]
         """
@@ -593,41 +589,42 @@ class KubernetesOnlineDeployment(OnlineDeployment):
 class ManagedOnlineDeployment(OnlineDeployment):
     """Managed Online endpoint deployment entity.
 
-    :param name: Name of the deployment resource
+    :keyword name: Name of the deployment resource
     :type name: str
-    :param endpoint_name: Name of the endpoint resource, defaults to None
+    :keyword endpoint_name: Name of the endpoint resource, defaults to None
     :type endpoint_name: typing.Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
     :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-    :param properties: The asset property dictionary, defaults to None
+    :keyword properties: The asset property dictionary, defaults to None
     :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-    :param description: Description of the resource, defaults to None
+    :keyword description: Description of the resource, defaults to None
     :type description: typing.Optional[str]
-    :param model: Model entity for the endpoint deployment, defaults to None
+    :keyword model: Model entity for the endpoint deployment, defaults to None
     :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
-    :param code_configuration: Code Configuration, defaults to None
+    :keyword code_configuration: Code Configuration, defaults to None
     :type code_configuration: typing.Optional[CodeConfiguration]
-    :param environment: Environment entity for the endpoint deployment, defaults to None
+    :keyword environment: Environment entity for the endpoint deployment, defaults to None
     :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
-    :param app_insights_enabled: Is appinsights enabled, defaults to False
+    :keyword app_insights_enabled: Is appinsights enabled, defaults to False
     :type app_insights_enabled: bool
-    :param scale_settings: How the online deployment will scale, defaults to None
+    :keyword scale_settings: How the online deployment will scale, defaults to None
     :type scale_settings: typing.Optional[typing.Union[DefaultScaleSettings, TargetUtilizationScaleSettings]]
-    :param request_settings: Online Request Settings, defaults to None
+    :keyword request_settings: Online Request Settings, defaults to None
     :type request_settings: typing.Optional[OnlineRequestSettings]
-    :param liveness_probe: Liveness probe settings, defaults to None
+    :keyword liveness_probe: Liveness probe settings, defaults to None
     :type liveness_probe: typing.Optional[ProbeSettings]
-    :param readiness_probe: Readiness probe settings, defaults to None
+    :keyword readiness_probe: Readiness probe settings, defaults to None
     :type readiness_probe: typing.Optional[ProbeSettings]
-    :param environment_variables: Environment variables that will be set in deployment, defaults to None
+    :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
     :type environment_variables: typing.Optional[typing.Dict[str, str]]
-    :param instance_type: _description_, defaults to None
+    :keyword instance_type: Azure compute sku, defaults to None
     :type instance_type: typing.Optional[str]
-    :param instance_count: _description_, defaults to None
+    :keyword instance_count: The instance count used for this deployment, defaults to None
     :type instance_count: typing.Optional[int]
-    :param egress_public_network_access: Whether to restrict communication between a deployment and the
+    :keyword egress_public_network_access: Whether to restrict communication between a deployment and the
          Azure resources used to by the deployment. Allowed values are: "enabled", "disabled", defaults to None
-    :param code_path: _description_, defaults to None
+    :keyword code_path: Equivalent to code_configuration.code, will be ignored if code_configuration is present
+        , defaults to None
     :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
     """
 
@@ -662,41 +659,42 @@ class ManagedOnlineDeployment(OnlineDeployment):
 
         Constructor for Managed Online endpoint deployment entity.
 
-        :param name: Name of the deployment resource
+        :keyword name: Name of the deployment resource
         :type name: str
-        :param endpoint_name: Name of the endpoint resource, defaults to None
+        :keyword endpoint_name: Name of the endpoint resource, defaults to None
         :type endpoint_name: typing.Optional[str]
-        :param tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
+        :keyword tags: Tag dictionary. Tags can be added, removed, and updated., defaults to None
         :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-        :param properties: The asset property dictionary, defaults to None
+        :keyword properties: The asset property dictionary, defaults to None
         :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-        :param description: Description of the resource, defaults to None
+        :keyword description: Description of the resource, defaults to None
         :type description: typing.Optional[str]
-        :param model: Model entity for the endpoint deployment, defaults to None
+        :keyword model: Model entity for the endpoint deployment, defaults to None
         :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
-        :param code_configuration: Code Configuration, defaults to None
+        :keyword code_configuration: Code Configuration, defaults to None
         :type code_configuration: typing.Optional[CodeConfiguration]
-        :param environment: Environment entity for the endpoint deployment, defaults to None
+        :keyword environment: Environment entity for the endpoint deployment, defaults to None
         :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
-        :param app_insights_enabled: Is appinsights enabled, defaults to False
+        :keyword app_insights_enabled: Is appinsights enabled, defaults to False
         :type app_insights_enabled: bool
-        :param scale_settings: How the online deployment will scale, defaults to None
+        :keyword scale_settings: How the online deployment will scale, defaults to None
         :type scale_settings: typing.Optional[typing.Union[DefaultScaleSettings, TargetUtilizationScaleSettings]]
-        :param request_settings: Online Request Settings, defaults to None
+        :keyword request_settings: Online Request Settings, defaults to None
         :type request_settings: typing.Optional[OnlineRequestSettings]
-        :param liveness_probe: Liveness probe settings, defaults to None
+        :keyword liveness_probe: Liveness probe settings, defaults to None
         :type liveness_probe: typing.Optional[ProbeSettings]
-        :param readiness_probe: Readiness probe settings, defaults to None
+        :keyword readiness_probe: Readiness probe settings, defaults to None
         :type readiness_probe: typing.Optional[ProbeSettings]
-        :param environment_variables: Environment variables that will be set in deployment, defaults to None
+        :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
         :type environment_variables: typing.Optional[typing.Dict[str, str]]
-        :param instance_type: _description_, defaults to None
+        :keyword instance_type: Azure compute sku, defaults to None
         :type instance_type: typing.Optional[str]
-        :param instance_count: _description_, defaults to None
+        :keyword instance_count: The instance count used for this deployment, defaults to None
         :type instance_count: typing.Optional[int]
-        :param egress_public_network_access: Whether to restrict communication between a deployment and the
+        :keyword egress_public_network_access: Whether to restrict communication between a deployment and the
              Azure resources used to by the deployment. Allowed values are: "enabled", "disabled", defaults to None
-        :param code_path: _description_, defaults to None
+        Equivalent to code_configuration.code, will be ignored if code_configuration is present
+            , defaults to None
         :type code_path: typing.Optional[typing.Union[str, os.PathLike]]
         """
         kwargs["type"] = EndpointComputeType.MANAGED.value

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
@@ -39,31 +39,31 @@ module_logger = logging.getLogger(__name__)
 class OnlineEndpoint(Endpoint):
     """Online endpoint entity.
 
-    :param name: Name of the resource, defaults to None
+    :keyword name: Name of the resource, defaults to None
     :type name: typing.Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated. defaults to None
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated. defaults to None
     :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-    :param properties: The asset property dictionary, defaults to None
+    :keyword properties: The asset property dictionary, defaults to None
     :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-    :param auth_mode: Possible values include: "aml_token", "key", defaults to KEY
+    :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
     :type auth_mode: typing.Optional[str]
-    :param description: Description of the inference endpoint, defaults to None
+    :keyword description: Description of the inference endpoint, defaults to None
     :type description: typing.Optional[str]
-    :param location: Location of the resource, defaults to None
+    :keyword location: Location of the resource, defaults to None
     :type location: typing.Optional[str]
-    :param traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
+    :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
     :type traffic: typing.Optional[typing.Dict[str, int]]
-    :param mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
+    :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
     :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
-    :param identity: Identity Configuration, defaults to SystemAssigned
+    :keyword identity: Identity Configuration, defaults to SystemAssigned
     :type identity: typing.Optional[IdentityConfiguration]
-    :param scoring_uri: Scoring URI, defaults to None
+    :keyword scoring_uri: Scoring URI, defaults to None
     :type scoring_uri: typing.Optional[str]
-    :param openapi_uri: OpenAPI URI, defaults to None
+    :keyword openapi_uri: OpenAPI URI, defaults to None
     :type openapi_uri: typing.Optional[str]
-    :param provisioning_state: Provisioning state of an endpoint, defaults to None
+    :keyword provisioning_state: Provisioning state of an endpoint, defaults to None
     :type provisioning_state: typing.Optional[str]
-    :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
+    :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
     :type kind: typing.Optional[str]
     """
 
@@ -90,31 +90,31 @@ class OnlineEndpoint(Endpoint):
 
         Constructor for an Online endpoint entity.
 
-        :param name: Name of the resource, defaults to None
+        :keyword name: Name of the resource, defaults to None
         :type name: typing.Optional[str]
-        :param tags: Tag dictionary. Tags can be added, removed, and updated. defaults to None
+        :keyword tags: Tag dictionary. Tags can be added, removed, and updated. defaults to None
         :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-        :param properties: The asset property dictionary, defaults to None
+        :keyword properties: The asset property dictionary, defaults to None
         :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-        :param auth_mode: Possible values include: "aml_token", "key", defaults to KEY
+        :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
         :type auth_mode: typing.Optional[str]
-        :param description: Description of the inference endpoint, defaults to None
+        :keyword description: Description of the inference endpoint, defaults to None
         :type description: typing.Optional[str]
-        :param location: Location of the resource, defaults to None
+        :keyword location: Location of the resource, defaults to None
         :type location: typing.Optional[str]
-        :param traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
+        :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
         :type traffic: typing.Optional[typing.Dict[str, int]]
-        :param mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
+        :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
         :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
-        :param identity: Identity Configuration, defaults to SystemAssigned
+        :keyword identity: Identity Configuration, defaults to SystemAssigned
         :type identity: typing.Optional[IdentityConfiguration]
-        :param scoring_uri: Scoring URI, defaults to None
+        :keyword scoring_uri: Scoring URI, defaults to None
         :type scoring_uri: typing.Optional[str]
-        :param openapi_uri: OpenAPI URI, defaults to None
+        :keyword openapi_uri: OpenAPI URI, defaults to None
         :type openapi_uri: typing.Optional[str]
-        :param provisioning_state: Provisioning state of an endpoint, defaults to None
+        :keyword provisioning_state: Provisioning state of an endpoint, defaults to None
         :type provisioning_state: typing.Optional[str]
-        :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
+        :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
         :type kind: typing.Optional[str]
         """
         self._provisioning_state = kwargs.pop("provisioning_state", None)
@@ -299,27 +299,27 @@ class OnlineEndpoint(Endpoint):
 class KubernetesOnlineEndpoint(OnlineEndpoint):
     """K8s Online endpoint entity.
 
-    :param name: Name of the resource, defaults to None
+    :keyword name: Name of the resource, defaults to None
     :type name: typing.Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
     :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-    :param properties: The asset property dictionary, defaults to None
+    :keyword properties: The asset property dictionary, defaults to None
     :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-    :param auth_mode: Possible values include: "aml_token", "key", defaults to KEY
+    :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
     :type auth_mode: typing.Optional[str]
-    :param description: Description of the inference endpoint, defaults to None
+    :keyword description: Description of the inference endpoint, defaults to None
     :type description: typing.Optional[str]
-    :param location: Location of the resource, defaults to None
+    :keyword location: Location of the resource, defaults to None
     :type location: typing.Optional[str]
-    :param traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
+    :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
     :type traffic: typing.Optional[typing.Dict[str, int]]
-    :param mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
+    :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
     :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
-    :param compute: Compute cluster id, defaults to None
+    :keyword compute: Compute cluster id, defaults to None
     :type compute: typing.Optional[str]
-    :param identity: Identity Configuration, defaults to SystemAssigned
+    :keyword identity: Identity Configuration, defaults to SystemAssigned
     :type identity: typing.Optional[IdentityConfiguration]
-    :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
+    :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
     :type kind: typing.Optional[str]
     """
 
@@ -344,27 +344,27 @@ class KubernetesOnlineEndpoint(OnlineEndpoint):
 
         Constructor for K8s Online endpoint entity.
 
-        :param name: Name of the resource, defaults to None
+        :keyword name: Name of the resource, defaults to None
         :type name: typing.Optional[str]
-        :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+        :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
         :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-        :param properties: The asset property dictionary, defaults to None
+        :keyword properties: The asset property dictionary, defaults to None
         :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-        :param auth_mode: Possible values include: "aml_token", "key", defaults to KEY
+        :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
         :type auth_mode: typing.Optional[str]
-        :param description: Description of the inference endpoint, defaults to None
+        :keyword description: Description of the inference endpoint, defaults to None
         :type description: typing.Optional[str]
-        :param location: Location of the resource, defaults to None
+        :keyword location: Location of the resource, defaults to None
         :type location: typing.Optional[str]
-        :param traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
+        :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
         :type traffic: typing.Optional[typing.Dict[str, int]]
-        :param mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
+        :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
         :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
-        :param compute: Compute cluster id, defaults to None
+        :keyword compute: Compute cluster id, defaults to None
         :type compute: typing.Optional[str]
-        :param identity: Identity Configuration, defaults to SystemAssigned
+        :keyword identity: Identity Configuration, defaults to SystemAssigned
         :type identity: typing.Optional[IdentityConfiguration]
-        :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
+        :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
         :type kind: typing.Optional[str]
         """
         super(KubernetesOnlineEndpoint, self).__init__(
@@ -422,27 +422,27 @@ class KubernetesOnlineEndpoint(OnlineEndpoint):
 class ManagedOnlineEndpoint(OnlineEndpoint):
     """Managed Online endpoint entity.
 
-    :param name: Name of the resource, defaults to None
+    :keyword name: Name of the resource, defaults to None
     :type name: typing.Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
     :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-    :param properties: The asset property dictionary, defaults to None
+    :keyword properties: The asset property dictionary, defaults to None
     :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-    :param auth_mode: Possible values include: "aml_token", "key", defaults to KEY
+    :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
     :type auth_mode: str
-    :param description: Description of the inference endpoint, defaults to None
+    :keyword description: Description of the inference endpoint, defaults to None
     :type description: typing.Optional[str]
-    :param location: Location of the resource, defaults to None
+    :keyword location: Location of the resource, defaults to None
     :type location: typing.Optional[str]
-    :param traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
+    :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
     :type traffic: typing.Optional[typing.Dict[str, int]]
-    :param mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
+    :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
     :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
-    :param identity: Identity Configuration, defaults to SystemAssigned
+    :keyword identity: Identity Configuration, defaults to SystemAssigned
     :type identity: typing.Optional[IdentityConfiguration]
-    :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
+    :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
     :type kind: typing.Optional[str]
-    :param public_network_access: Whether to allow public endpoint connectivity, defaults to None
+    :keyword public_network_access: Whether to allow public endpoint connectivity, defaults to None
         Allowed values are: "enabled", "disabled"
     :type public_network_access: typing.Optional[str]
     """
@@ -468,27 +468,27 @@ class ManagedOnlineEndpoint(OnlineEndpoint):
 
         Constructor for Managed Online endpoint entity.
 
-        :param name: Name of the resource, defaults to None
+        :keyword name: Name of the resource, defaults to None
         :type name: typing.Optional[str]
-        :param tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
+        :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
         :type tags: typing.Optional[typing.Dict[str, typing.Any]]
-        :param properties: The asset property dictionary, defaults to None
+        :keyword properties: The asset property dictionary, defaults to None
         :type properties: typing.Optional[typing.Dict[str, typing.Any]]
-        :param auth_mode: Possible values include: "aml_token", "key", defaults to KEY
+        :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
         :type auth_mode: str
-        :param description: Description of the inference endpoint, defaults to None
+        :keyword description: Description of the inference endpoint, defaults to None
         :type description: typing.Optional[str]
-        :param location: Location of the resource, defaults to None
+        :keyword location: Location of the resource, defaults to None
         :type location: typing.Optional[str]
-        :param traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
+        :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
         :type traffic: typing.Optional[typing.Dict[str, int]]
-        :param mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
+        :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
         :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
-        :param identity: Identity Configuration, defaults to SystemAssigned
+        :keyword identity: Identity Configuration, defaults to SystemAssigned
         :type identity: typing.Optional[IdentityConfiguration]
-        :param kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
+        :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
         :type kind: typing.Optional[str]
-        :param public_network_access: Whether to allow public endpoint connectivity, defaults to None
+        :keyword public_network_access: Whether to allow public endpoint connectivity, defaults to None
             Allowed values are: "enabled", "disabled"
         :type public_network_access: typing.Optional[str]
         """


### PR DESCRIPTION
# Description

Change the param to keyword since parameter following an asterisk parameter is a keyword-only-parameter.

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
