### PR TITLE
Include source branch name in API review label for automatic review

### DIFF
--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -99,16 +99,18 @@ function ProcessPackage($PackageName)
                 return 1
             }
 
+            $revisionLabel = "$($pkgInfo.Version) - Source Branch:$($SourceBranch)"
             Write-Host "Version: $($version)"
             Write-Host "SDK Type: $($pkgInfo.SdkType)"
             Write-Host "Release Status: $($pkgInfo.ReleaseStatus)"
+            Write-Host "Label: $($revisionLabel)"
 
             # Run create review step only if build is triggered from main branch or if version is GA.
             # This is to avoid invalidating review status by a build triggered from feature branch
             if ( ($SourceBranch -eq $DefaultBranch) -or (-not $version.IsPrerelease))
             {
                 Write-Host "Submitting API Review for package $($pkg)"
-                $respCode = Submit-APIReview -reviewFileName $reviewFileName -packageArtifactname $pkg -apiLabel $($pkgInfo.Version) -releaseStatus $pkgInfo.ReleaseStatus 
+                $respCode = Submit-APIReview -reviewFileName $reviewFileName -packageArtifactname $pkg -apiLabel $revisionLabel -releaseStatus $pkgInfo.ReleaseStatus
                 Write-Host "HTTP Response code: $($respCode)"
                 # HTTP status 200 means API is in approved status
                 if ($respCode -eq '200')

--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -99,7 +99,7 @@ function ProcessPackage($PackageName)
                 return 1
             }
 
-            $revisionLabel = "$($pkgInfo.Version) - Source Branch:$($SourceBranch)"
+            $revisionLabel = "$($pkgInfo.Version) - Source Branch:${SourceBranch}"
             Write-Host "Version: $($version)"
             Write-Host "SDK Type: $($pkgInfo.SdkType)"
             Write-Host "Release Status: $($pkgInfo.ReleaseStatus)"


### PR DESCRIPTION
API review automatic revision doesn't indicate source branch from which each revision was created from. This PR is to include source branch name in API review revision.

