### PR TITLE
[Storage] Adjust sleep timing on `test_lease_container_break_period`

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.pyTestStorageContainertest_lease_container_break_period.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.pyTestStorageContainertest_lease_container_break_period.json
@@ -8,22 +8,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Tue, 02 Aug 2022 20:32:50 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:16:56 GMT",
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Tue, 02 Aug 2022 20:32:50 GMT",
-        "ETag": "\u00220x8DA74C62B8EB862\u0022",
-        "Last-Modified": "Tue, 02 Aug 2022 20:32:50 GMT",
+        "Date": "Tue, 10 Jan 2023 20:16:29 GMT",
+        "ETag": "\u00220x8DAF3478F949D92\u0022",
+        "Last-Modified": "Tue, 10 Jan 2023 20:16:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
@@ -35,26 +35,26 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Tue, 02 Aug 2022 20:32:51 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:16:57 GMT",
         "x-ms-lease-action": "acquire",
         "x-ms-lease-duration": "15",
         "x-ms-proposed-lease-id": "00000000-1111-2222-3333-444444444444",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Tue, 02 Aug 2022 20:32:50 GMT",
-        "ETag": "\u00220x8DA74C62B8EB862\u0022",
-        "Last-Modified": "Tue, 02 Aug 2022 20:32:50 GMT",
+        "Date": "Tue, 10 Jan 2023 20:16:29 GMT",
+        "ETag": "\u00220x8DAF3478F949D92\u0022",
+        "Last-Modified": "Tue, 10 Jan 2023 20:16:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-lease-id": "00000000-1111-2222-3333-444444444444",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
@@ -66,25 +66,25 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Tue, 02 Aug 2022 20:32:51 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:16:57 GMT",
         "x-ms-lease-action": "break",
         "x-ms-lease-break-period": "5",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Tue, 02 Aug 2022 20:32:50 GMT",
-        "ETag": "\u00220x8DA74C62B8EB862\u0022",
-        "Last-Modified": "Tue, 02 Aug 2022 20:32:50 GMT",
+        "Date": "Tue, 10 Jan 2023 20:16:30 GMT",
+        "ETag": "\u00220x8DAF3478F949D92\u0022",
+        "Last-Modified": "Tue, 10 Jan 2023 20:16:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-lease-time": "5",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
@@ -96,28 +96,28 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Tue, 02 Aug 2022 20:32:57 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:17:05 GMT",
         "x-ms-lease-id": "00000000-1111-2222-3333-444444444444",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 412,
       "ResponseHeaders": {
         "Content-Length": "248",
         "Content-Type": "application/xml",
-        "Date": "Tue, 02 Aug 2022 20:32:56 GMT",
+        "Date": "Tue, 10 Jan 2023 20:16:38 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "LeaseLost",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ELeaseLost\u003C/Code\u003E\u003CMessage\u003EA lease ID was specified, but the lease for the container has expired.\n",
-        "RequestId:af210b02-601e-002f-55af-a6fbea000000\n",
-        "Time:2022-08-02T20:32:57.3085565Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:cb9d2af8-701e-0051-7430-25d02c000000\n",
+        "Time:2023-01-10T20:16:38.6988264Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.pyTestStorageContainerAsynctest_lease_container_break_period.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.pyTestStorageContainerAsynctest_lease_container_break_period.json
@@ -7,22 +7,22 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 08 Aug 2022 19:40:07 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:17:38 GMT",
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 08 Aug 2022 19:40:07 GMT",
-        "ETag": "\u00220x8DA7975CCA177B6\u0022",
-        "Last-Modified": "Mon, 08 Aug 2022 19:40:07 GMT",
+        "Date": "Tue, 10 Jan 2023 20:17:11 GMT",
+        "ETag": "\u00220x8DAF347A871CC34\u0022",
+        "Last-Modified": "Tue, 10 Jan 2023 20:17:12 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
@@ -33,26 +33,26 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 08 Aug 2022 19:40:07 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:17:39 GMT",
         "x-ms-lease-action": "acquire",
         "x-ms-lease-duration": "15",
         "x-ms-proposed-lease-id": "00000000-1111-2222-3333-444444444444",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 08 Aug 2022 19:40:07 GMT",
-        "ETag": "\u00220x8DA7975CCA177B6\u0022",
-        "Last-Modified": "Mon, 08 Aug 2022 19:40:07 GMT",
+        "Date": "Tue, 10 Jan 2023 20:17:11 GMT",
+        "ETag": "\u00220x8DAF347A871CC34\u0022",
+        "Last-Modified": "Tue, 10 Jan 2023 20:17:12 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-lease-id": "00000000-1111-2222-3333-444444444444",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
@@ -63,25 +63,25 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 08 Aug 2022 19:40:07 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:17:39 GMT",
         "x-ms-lease-action": "break",
         "x-ms-lease-break-period": "5",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 08 Aug 2022 19:40:07 GMT",
-        "ETag": "\u00220x8DA7975CCA177B6\u0022",
-        "Last-Modified": "Mon, 08 Aug 2022 19:40:07 GMT",
+        "Date": "Tue, 10 Jan 2023 20:17:11 GMT",
+        "ETag": "\u00220x8DAF347A871CC34\u0022",
+        "Last-Modified": "Tue, 10 Jan 2023 20:17:12 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-lease-time": "5",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
@@ -92,28 +92,28 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 08 Aug 2022 19:40:13 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 10 Jan 2023 20:17:47 GMT",
         "x-ms-lease-id": "00000000-1111-2222-3333-444444444444",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 412,
       "ResponseHeaders": {
         "Content-Length": "248",
         "Content-Type": "application/xml",
-        "Date": "Mon, 08 Aug 2022 19:40:13 GMT",
+        "Date": "Tue, 10 Jan 2023 20:17:19 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "LeaseLost",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ELeaseLost\u003C/Code\u003E\u003CMessage\u003EA lease ID was specified, but the lease for the container has expired.\n",
-        "RequestId:07156fc2-f01e-00bb-485e-ab4c83000000\n",
-        "Time:2022-08-08T19:40:14.0334611Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:d7987356-101e-0025-1830-25e4dc000000\n",
+        "Time:2023-01-10T20:17:20.4146887Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -884,7 +884,7 @@ class TestStorageContainer(StorageRecordedTestCase):
 
         # Assert
         lease.break_lease(lease_break_period=5)
-        self.sleep(6)
+        self.sleep(8)
         with pytest.raises(HttpResponseError):
             container.delete_container(lease=lease)
 

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -941,7 +941,7 @@ class TestStorageContainerAsync(AsyncStorageRecordedTestCase):
 
         # Assert
         await lease.break_lease(lease_break_period=5)
-        self.sleep(6)
+        self.sleep(8)
         with pytest.raises(HttpResponseError):
             await container.delete_container(lease=lease)
 


### PR DESCRIPTION
This PR aims to adjust the timing on `test_lease_container_break_period` to avoid running into the pipeline issues we are currently facing.

NOTE: Currently only the sync version is giving us trouble, but I adjusted both as insurance for future failures and consistency!