### PR TITLE
[CredScan] Remove general string suppressions (batch #2)

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -3,8 +3,6 @@
     "suppressions": [
         {
             "placeholder": [
-                "Aa1!zyx_",
-                "Aa!1()-xyz",
                 ":code:`<pfx-file-password>`",
                 "000000000000000000000000000000000000000000000000000",
                 "fakekeyfakekeyfakekeyfakekeyfakekeyfakekeyA=",

--- a/sdk/compute/azure-mgmt-compute/tests/_aio_testcase.py
+++ b/sdk/compute/azure-mgmt-compute/tests/_aio_testcase.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 from azure.core.credentials import AccessToken
 from devtools_testutils import AzureMgmtTestCase
+from devtools_testutils.fake_credentials_async import AsyncFakeCredential
 
 class AzureMgmtAsyncTestCase(AzureMgmtTestCase):
 
@@ -18,7 +19,7 @@ class AzureMgmtAsyncTestCase(AzureMgmtTestCase):
             from azure.identity.aio import DefaultAzureCredential
             credential = DefaultAzureCredential()
         else:
-            credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
+            credential = AsyncFakeCredential()
         return client(
             credential=credential,
             subscription_id=self.settings.SUBSCRIPTION_ID

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_base_async.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_base_async.py
@@ -9,6 +9,7 @@ import unittest
 
 from azure.core.exceptions import ResourceExistsError
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 from _aio_testcase import AzureMgmtAsyncTestCase
 
@@ -126,7 +127,7 @@ class TestMgmtCompute(AzureMgmtAsyncTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vm.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vm.py
@@ -21,6 +21,7 @@ import pytest
 import azure.mgmt.compute
 from azure.core.exceptions import ResourceExistsError
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 AZURE_LOCATION = 'eastus'
 
@@ -135,7 +136,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }
@@ -332,7 +333,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }

--- a/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vmss.py
+++ b/sdk/compute/azure-mgmt-compute/tests/test_mgmt_compute_vmss.py
@@ -21,6 +21,7 @@ import pytest
 import azure.mgmt.compute
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 AZURE_LOCATION = 'eastus'
 
@@ -207,7 +208,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [
@@ -304,7 +305,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [
@@ -435,7 +436,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [
@@ -591,7 +592,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [
@@ -726,7 +727,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [
@@ -911,7 +912,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [
@@ -1027,7 +1028,7 @@ class TestMgmtCompute(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [

--- a/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor.py
@@ -407,7 +407,7 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
             "os_profile": {
               "computer_name_prefix": "testPC",
               "admin_username": "testuser",
-              "admin_password": "Aa!1()-xyz"
+              "admin_password": FAKE_LOGIN_PASSWORD
             },
             "network_profile": {
               "network_interface_configurations": [

--- a/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor.py
@@ -51,6 +51,7 @@ import azure.mgmt.monitor
 import azure.mgmt.monitor.models
 import pytest
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 AZURE_LOCATION = 'eastus'
 
@@ -344,7 +345,7 @@ class TestMgmtMonitorClient(AzureMgmtRecordedTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }

--- a/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor_async.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/disable_test_cli_mgmt_monitor_async.py
@@ -12,6 +12,7 @@ import unittest
 import azure.mgmt.monitor.aio
 import azure.mgmt.monitor.models
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 from _aio_testcase import AzureMgmtAsyncTestCase
 
@@ -261,7 +262,7 @@ class TestMgmtMonitorClient(AzureMgmtAsyncTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }

--- a/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_ddos.py
+++ b/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_ddos.py
@@ -31,6 +31,7 @@ import pytest
 
 import azure.mgmt.network
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 AZURE_LOCATION = 'eastus'
 
@@ -132,7 +133,7 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }

--- a/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_interface.py
+++ b/sdk/network/azure-mgmt-network/tests/disable_test_cli_mgmt_network_interface.py
@@ -27,6 +27,7 @@ import pytest
 
 import azure.mgmt.network
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 AZURE_LOCATION = 'eastus'
 
@@ -114,7 +115,7 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }

--- a/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_watcher.py
+++ b/sdk/network/azure-mgmt-network/tests/test_cli_mgmt_network_watcher.py
@@ -33,6 +33,7 @@ import pytest
 import azure.mgmt.network
 from azure.core.exceptions import HttpResponseError
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils.fake_credentials import FAKE_LOGIN_PASSWORD
 
 AZURE_LOCATION = 'eastus'
 
@@ -196,7 +197,7 @@ class TestMgmtNetwork(AzureMgmtRecordedTestCase):
           "os_profile": {
             "admin_username": "testuser",
             "computer_name": "myVM",
-            "admin_password": "Aa1!zyx_",
+            "admin_password": FAKE_LOGIN_PASSWORD,
             "windows_configuration": {
               "enable_automatic_updates": True  # need automatic update for reimage
             }


### PR DESCRIPTION
# Description

Part of https://github.com/Azure/azure-sdk-for-python/issues/25604, building on https://github.com/Azure/azure-sdk-for-python/pull/28151. This continues the process of consolidating our false credentials into `fake_credentials.py`, to more securely and correctly suppress CredScan false flags without obscuring potential issues.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
