### PR TITLE
[Communication] - Phone Numbers - Update default API version

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/CHANGELOG.md
+++ b/sdk/communication/azure-communication-phonenumbers/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## 1.1.0b4 (Unreleased)
 
 ### Features Added
+- API version `2022-12-01` is now the default for Phone Numbers clients.
 
 ### Breaking Changes
 
 ### Bugs Fixed
+- Adds missing API version `2022-12-01` to the list of supported API versions.
 
 ### Other Changes
 

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_api_versions.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_api_versions.py
@@ -9,6 +9,7 @@ from azure.core import CaseInsensitiveEnumMeta
 
 class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     V2022_01_11_PREVIEW2 = "2022-01-11-preview2"
+    V2022_12_01 = "2022-12-01"
 
 
-DEFAULT_VERSION = ApiVersion.V2022_01_11_PREVIEW2
+DEFAULT_VERSION = ApiVersion.V2022_12_01

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_phone_numbers_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_phone_numbers_client.py
@@ -71,7 +71,7 @@ class PhoneNumbersClient(object):
 
         self._endpoint = endpoint
         self._accepted_language = accepted_language
-        self._api_version = kwargs.pop("api_version", DEFAULT_VERSION)
+        self._api_version = kwargs.pop("api_version", DEFAULT_VERSION.value)
         self._phone_number_client = PhoneNumbersClientGen(
             self._endpoint,
             api_version=self._api_version,

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/aio/_phone_numbers_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/aio/_phone_numbers_client_async.py
@@ -73,7 +73,7 @@ class PhoneNumbersClient(object):
 
         self._endpoint = endpoint
         self._accepted_language = accepted_language
-        self._api_version = kwargs.pop("api_version", DEFAULT_VERSION)
+        self._api_version = kwargs.pop("api_version", DEFAULT_VERSION.value)
         self._phone_number_client = PhoneNumbersClientGen(
             self._endpoint,
             api_version=self._api_version,

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
@@ -14,6 +14,7 @@ from azure.communication.phonenumbers import (
     PhoneNumberCapabilityType,
     PhoneNumberType,
 )
+from azure.communication.phonenumbers._api_versions import DEFAULT_VERSION
 from azure.communication.phonenumbers._generated.models import PhoneNumberOperationStatus
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 from phone_number_helper import PhoneNumberUriReplacer, PhoneNumberResponseReplacerProcessor
@@ -53,7 +54,8 @@ class TestPhoneNumbersClient(PhoneNumbersTestCase):
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=DEFAULT_VERSION
         )
 
     def _get_managed_identity_phone_number_client(self):
@@ -63,7 +65,8 @@ class TestPhoneNumbersClient(PhoneNumbersTestCase):
             endpoint,
             credential,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=DEFAULT_VERSION
         )
 
     @recorded_by_proxy

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
@@ -30,8 +30,6 @@ SKIP_UPDATE_CAPABILITIES_TESTS = os.getenv(
     "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST", "false") == "true"
 SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities are skipped."
 
-API_VERSION = "2022-12-01"
-
 
 def _get_test_phone_number():
     if SKIP_UPDATE_CAPABILITIES_TESTS:
@@ -55,8 +53,7 @@ class TestPhoneNumbersClient(PhoneNumbersTestCase):
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=API_VERSION
+            headers_policy=get_header_policy()
         )
 
     def _get_managed_identity_phone_number_client(self):
@@ -66,8 +63,7 @@ class TestPhoneNumbersClient(PhoneNumbersTestCase):
             endpoint,
             credential,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=API_VERSION
+            headers_policy=get_header_policy()
         )
 
     @recorded_by_proxy

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
@@ -14,7 +14,6 @@ from azure.communication.phonenumbers import (
     PhoneNumberCapabilityType,
     PhoneNumberType,
 )
-from azure.communication.phonenumbers._api_versions import DEFAULT_VERSION
 from azure.communication.phonenumbers._generated.models import PhoneNumberOperationStatus
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 from phone_number_helper import PhoneNumberUriReplacer, PhoneNumberResponseReplacerProcessor
@@ -54,8 +53,7 @@ class TestPhoneNumbersClient(PhoneNumbersTestCase):
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=DEFAULT_VERSION
+            headers_policy=get_header_policy()
         )
 
     def _get_managed_identity_phone_number_client(self):
@@ -65,8 +63,7 @@ class TestPhoneNumbersClient(PhoneNumbersTestCase):
             endpoint,
             credential,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=DEFAULT_VERSION
+            headers_policy=get_header_policy()
         )
 
     @recorded_by_proxy

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
@@ -14,6 +14,7 @@ from azure.communication.phonenumbers import (
     PhoneNumberCapabilityType,
     PhoneNumberType,
 )
+from azure.communication.phonenumbers._api_versions import DEFAULT_VERSION
 from azure.communication.phonenumbers._generated.models import PhoneNumberOperationStatus
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 from phone_number_helper import PhoneNumberUriReplacer, PhoneNumberResponseReplacerProcessor
@@ -54,7 +55,8 @@ class TestPhoneNumbersClientAsync(PhoneNumbersTestCase):
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=DEFAULT_VERSION
         )
 
     def _get_managed_identity_phone_number_client(self):
@@ -64,7 +66,8 @@ class TestPhoneNumbersClientAsync(PhoneNumbersTestCase):
             endpoint,
             credential,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy()
+            headers_policy=get_header_policy(),
+            api_version=DEFAULT_VERSION
         )
 
     @recorded_by_proxy_async

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
@@ -30,9 +30,6 @@ SKIP_UPDATE_CAPABILITIES_TESTS = os.getenv(
     "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST", "false") == "true"
 SKIP_UPDATE_CAPABILITIES_TESTS_REASON = "Phone number capabilities are skipped."
 
-API_VERSION = "2022-12-01"
-
-
 def _get_test_phone_number():
     if SKIP_UPDATE_CAPABILITIES_TESTS:
         return os.environ["AZURE_PHONE_NUMBER"]
@@ -57,8 +54,7 @@ class TestPhoneNumbersClientAsync(PhoneNumbersTestCase):
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=API_VERSION
+            headers_policy=get_header_policy()
         )
 
     def _get_managed_identity_phone_number_client(self):
@@ -68,8 +64,7 @@ class TestPhoneNumbersClientAsync(PhoneNumbersTestCase):
             endpoint,
             credential,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=API_VERSION
+            headers_policy=get_header_policy()
         )
 
     @recorded_by_proxy_async

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
@@ -14,7 +14,6 @@ from azure.communication.phonenumbers import (
     PhoneNumberCapabilityType,
     PhoneNumberType,
 )
-from azure.communication.phonenumbers._api_versions import DEFAULT_VERSION
 from azure.communication.phonenumbers._generated.models import PhoneNumberOperationStatus
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 from phone_number_helper import PhoneNumberUriReplacer, PhoneNumberResponseReplacerProcessor
@@ -55,8 +54,7 @@ class TestPhoneNumbersClientAsync(PhoneNumbersTestCase):
         self.phone_number_client = PhoneNumbersClient.from_connection_string(
             self.connection_str,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=DEFAULT_VERSION
+            headers_policy=get_header_policy()
         )
 
     def _get_managed_identity_phone_number_client(self):
@@ -66,8 +64,7 @@ class TestPhoneNumbersClientAsync(PhoneNumbersTestCase):
             endpoint,
             credential,
             http_logging_policy=get_http_logging_policy(),
-            headers_policy=get_header_policy(),
-            api_version=DEFAULT_VERSION
+            headers_policy=get_header_policy()
         )
 
     @recorded_by_proxy_async


### PR DESCRIPTION
Adds the missing API version `2022-12-01` to the supported API versions list for phone numbers and makes it the default.
