### PR TITLE
[ML][Pipelines] Test: try to fix breaking live tests

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
@@ -760,6 +760,7 @@ class TestComponent(AzureRecordedTestCase):
             "type": "pipeline",
         }
         assert component_dict == expected_dict
+        # below line is expected to raise KeyError in live test, it will pass after related changes deployed to canary
         jobs_dict = rest_pipeline_component._to_dict()["jobs"]
         # Assert full componentId extra azureml prefix has been removed and parsed to versioned arm id correctly.
         assert "azureml:azureml_anonymous" in jobs_dict["component_a_job"]["component"]

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -568,12 +568,7 @@ def mock_component_hash(mocker: MockFixture, request: FixtureRequest):
     Note that component hash value in playback mode can be different from the one in live mode,
     so tests that check component hash directly should be skipped if not is_live.
     """
-    # do nothing if in live mode and not recording
-    if is_live_and_not_recording():
-        yield
-        return
-
-    if is_live():
+    if is_live() and not is_live_and_not_recording():
         mocker.patch("azure.ai.ml.entities._component.component.hash_dict", side_effect=generate_component_hash)
         mocker.patch(
             "azure.ai.ml.entities._component.pipeline_component.hash_dict",

--- a/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline_with_specific_nodes.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline_with_specific_nodes.py
@@ -153,6 +153,58 @@ class TestDSLPipelineWithSpecificNodes(AzureRecordedTestCase):
 
         return pipeline_leaf
 
+    # this test should run first, or at least before those tests using same component(s);
+    # otherwise, call count assertion will break.
+    def test_dsl_pipeline_component_cache_in_resolver(self, client: MLClient) -> None:
+        input_data_path = "./tests/test_configs/data/"
+        pipeline_root = self._generate_multi_layer_pipeline_func()
+
+        _submit_and_cancel = partial(
+            submit_and_cancel_new_dsl_pipeline,
+            client=client,
+            job_in_path=Input(path=input_data_path)
+        )
+
+        def _mock_get_component_arm_id(_component: Component) -> str:
+            # the logic has no diff comparing to original function other than always using show_progress=False
+            # just to mock the function and check call information
+            if not _component.id:
+                _component._id = client.components.create_or_update(
+                    _component, is_anonymous=True, show_progress=False
+                ).id
+            return _component.id
+
+        with mock.patch.object(
+            OperationOrchestrator,
+            "_get_component_arm_id",
+            side_effect=_mock_get_component_arm_id
+        ) as mock_resolve:
+            _submit_and_cancel(pipeline_root)
+            # pipeline_leaf, pipeline_mid and 3 command components will be resolved
+            assert mock_resolve.call_count == 5
+
+        with mock.patch.object(
+            OperationOrchestrator,
+            "_get_component_arm_id",
+            side_effect=_mock_get_component_arm_id
+        ) as mock_resolve:
+            _submit_and_cancel(pipeline_root)
+            # no more requests to resolve components as local cache is hit
+            assert mock_resolve.call_count == 0
+
+        pipeline_job = pipeline_root(job_in_path=Input(path=input_data_path))
+        pipeline_job.settings.default_compute = "cpu-cluster"
+        leaf_subgraph = pipeline_job.jobs["pipeline_mid"].component.jobs["pipeline_leaf"].component
+        leaf_subgraph.jobs["another_component_name"].component.command += " & echo updated2"
+        with mock.patch.object(
+            OperationOrchestrator,
+            "_get_component_arm_id",
+            side_effect=_mock_get_component_arm_id
+        ) as mock_resolve:
+            assert_job_cancel(pipeline_job, client)
+            # updated command component and its parents (pipeline_leaf and pipeline_mid) will be resolved
+            assert mock_resolve.call_count == 3
+
     def test_dsl_pipeline_sweep_node(self, client: MLClient, randstr: Callable[[str], str]) -> None:
         yaml_file = "./tests/test_configs/components/helloworld_component.yml"
 
@@ -214,56 +266,6 @@ class TestDSLPipelineWithSpecificNodes(AzureRecordedTestCase):
         name, version = created_pipeline.jobs["sweep_job1"].trial.split(":")
         created_component = client.components.get(name, version)
         assert created_component.display_name == "sweep_job1"
-
-    def test_dsl_pipeline_component_cache_in_resolver(self, client: MLClient) -> None:
-        input_data_path = "./tests/test_configs/data/"
-        pipeline_root = self._generate_multi_layer_pipeline_func()
-
-        _submit_and_cancel = partial(
-            submit_and_cancel_new_dsl_pipeline,
-            client=client,
-            job_in_path=Input(path=input_data_path)
-        )
-
-        def _mock_get_component_arm_id(_component: Component) -> str:
-            # the logic has no diff comparing to original function other than always using show_progress=False
-            # just to mock the function and check call information
-            if not _component.id:
-                _component._id = client.components.create_or_update(
-                    _component, is_anonymous=True, show_progress=False
-                ).id
-            return _component.id
-
-        with mock.patch.object(
-            OperationOrchestrator,
-            "_get_component_arm_id",
-            side_effect=_mock_get_component_arm_id
-        ) as mock_resolve:
-            _submit_and_cancel(pipeline_root)
-            # pipeline_leaf, pipeline_mid and 3 command components will be resolved
-            assert mock_resolve.call_count == 5
-
-        with mock.patch.object(
-            OperationOrchestrator,
-            "_get_component_arm_id",
-            side_effect=_mock_get_component_arm_id
-        ) as mock_resolve:
-            _submit_and_cancel(pipeline_root)
-            # no more requests to resolve components as local cache is hit
-            assert mock_resolve.call_count == 0
-
-        pipeline_job = pipeline_root(job_in_path=Input(path=input_data_path))
-        pipeline_job.settings.default_compute = "cpu-cluster"
-        leaf_subgraph = pipeline_job.jobs["pipeline_mid"].component.jobs["pipeline_leaf"].component
-        leaf_subgraph.jobs["another_component_name"].component.command += " & echo updated2"
-        with mock.patch.object(
-            OperationOrchestrator,
-            "_get_component_arm_id",
-            side_effect=_mock_get_component_arm_id
-        ) as mock_resolve:
-            assert_job_cancel(pipeline_job, client)
-            # updated command component and its parents (pipeline_leaf and pipeline_mid) will be resolved
-            assert mock_resolve.call_count == 3
 
     def test_dsl_pipeline_concurrent_component_registration(self, client: MLClient, mocker: MockFixture) -> None:
         # disable on-disk cache to test concurrent component registration


### PR DESCRIPTION
# Description

This PR targets to refine pipelines live test:

- Add one-line comment on current breaking test `test_simple_pipeline_component_create`, which is expected to break until service change deployed to canary region.
- update pytest fixture `mock_component_hash` to apply random on-disk cache folder (later in the fixture) in **live and not recording mode** - may solve `test_dsl_pipeline_component_cache_in_resolver`, `test_on_disk_cache_share_among_users` and `test_pipeline_with_setting_node_output_mode`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
