### PR TITLE
[Identity] Allow configurable process timeouts

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features Added
 
-- Added proactive refreshing feature for managed iedentity
+- Added proactive refreshing feature for managed identity
+- Credentials that are implemented via launching a subprocess to acquire tokens now have configurable timeouts using the `process_timeout` keyword argument. This addresses scenarios where these proceses can take longer than the current default timeout values. The affected credentials are `AzureCliCredential`, `AzureDeveloperCliCredential`, and `AzurePowerShellCredential`. (Note: For `DefaultAzureCredential`, the `developer_credential_timeout` keyword argument allows users to propagate this option to `AzureCliCredential`, `AzureDeveloperCliCredential`, and `AzurePowerShellCredential` in the authentication chain.) ([#28290](https://github.com/Azure/azure-sdk-for-python/pull/28290))
 
 ### Breaking Changes
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -37,7 +37,8 @@ class AzureDeveloperCliCredential:
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
-    :keyword int process_timeout: Seconds to wait for the Azure Developer CLI process to respond. Defaults to 10.
+    :keyword int process_timeout: Seconds to wait for the Azure Developer CLI process to respond. Defaults
+        to 10 seconds.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 import six
 
 from azure.core.credentials import AccessToken
@@ -37,12 +37,20 @@ class AzureDeveloperCliCredential:
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+    :keyword int process_timeout: Seconds to wait for the Azure Developer CLI process to respond. Defaults to 10.
     """
 
-    def __init__(self, *, tenant_id: str = "", additionally_allowed_tenants: Optional[List[str]] = None):
+    def __init__(
+        self,
+        *,
+        tenant_id: str = "",
+        additionally_allowed_tenants: Optional[List[str]] = None,
+        process_timeout: int = 10
+    ) -> None:
 
         self.tenant_id = tenant_id
         self._additionally_allowed_tenants = additionally_allowed_tenants or []
+        self._process_timeout = process_timeout
 
     def __enter__(self) -> "AzureDeveloperCliCredential":
         return self
@@ -83,7 +91,7 @@ class AzureDeveloperCliCredential:
         )
         if tenant:
             command += " --tenant-id " + tenant
-        output = _run_command(command)
+        output = _run_command(command, self._process_timeout)
 
         token = parse_token(output)
         if not token:
@@ -130,7 +138,7 @@ def sanitize_output(output):
     return re.sub(r"\"token\": \"(.*?)(\"|$)", "****", output)
 
 
-def _run_command(command):
+def _run_command(command: str, timeout: int) -> str:
     # Ensure executable exists in PATH first. This avoids a subprocess call that would fail anyway.
     if shutil.which(EXECUTABLE_NAME) is None:
         raise CredentialUnavailableError(message=CLI_NOT_FOUND)
@@ -142,12 +150,12 @@ def _run_command(command):
     try:
         working_directory = get_safe_working_dir()
 
-        kwargs = {
+        kwargs: Dict[str, Any] = {
             "stderr": subprocess.PIPE,
             "cwd": working_directory,
             "universal_newlines": True,
             "env": dict(os.environ, NO_COLOR="true"),
-            "timeout": 10,
+            "timeout": timeout,
         }
 
         return subprocess.check_output(args, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -36,7 +36,7 @@ class AzureCliCredential:
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
-    :keyword int process_timeout: Seconds to wait for the Azure CLI process to respond. Defaults to 10.
+    :keyword int process_timeout: Seconds to wait for the Azure CLI process to respond. Defaults to 10 seconds.
     """
     def __init__(
         self,

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Dict
 import six
 
 from azure.core.credentials import AccessToken
@@ -36,16 +36,19 @@ class AzureCliCredential:
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+    :keyword int process_timeout: Seconds to wait for the Azure CLI process to respond. Defaults to 10.
     """
     def __init__(
         self,
         *,
         tenant_id: str = "",
-        additionally_allowed_tenants: Optional[List[str]] = None
+        additionally_allowed_tenants: Optional[List[str]] = None,
+        process_timeout: int = 10
     ) -> None:
 
         self.tenant_id = tenant_id
         self._additionally_allowed_tenants = additionally_allowed_tenants or []
+        self._process_timeout = process_timeout
 
     def __enter__(self):
         return self
@@ -84,7 +87,7 @@ class AzureCliCredential:
         )
         if tenant:
             command += " --tenant " + tenant
-        output = _run_command(command)
+        output = _run_command(command, self._process_timeout)
 
         token = parse_token(output)
         if not token:
@@ -135,7 +138,7 @@ def sanitize_output(output: str) -> str:
     return re.sub(r"\"accessToken\": \"(.*?)(\"|$)", "****", output)
 
 
-def _run_command(command):
+def _run_command(command: str, timeout: int) -> str:
     # Ensure executable exists in PATH first. This avoids a subprocess call that would fail anyway.
     if shutil.which(EXECUTABLE_NAME) is None:
         raise CredentialUnavailableError(message=CLI_NOT_FOUND)
@@ -147,11 +150,11 @@ def _run_command(command):
     try:
         working_directory = get_safe_working_dir()
 
-        kwargs = {
+        kwargs: Dict[str, Any] = {
             "stderr": subprocess.PIPE,
             "cwd": working_directory,
             "universal_newlines": True,
-            "timeout": 10,
+            "timeout": timeout,
             "env": dict(os.environ, AZURE_CORE_NO_COLOR="true"),
         }
         return subprocess.check_output(args, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -4,7 +4,6 @@
 # ------------------------------------
 import base64
 import logging
-import platform
 import subprocess
 import sys
 from typing import List, Tuple, Optional, Any
@@ -51,16 +50,19 @@ class AzurePowerShellCredential:
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+    :keyword int process_timeout: Seconds to wait for the Azure PowerShell process to respond. Defaults to 10.
     """
     def __init__(
         self,
         *,
         tenant_id: str = "",
-        additionally_allowed_tenants: Optional[List[str]] = None
+        additionally_allowed_tenants: Optional[List[str]] = None,
+        process_timeout: int = 10
     ) -> None:
 
         self.tenant_id = tenant_id
         self._additionally_allowed_tenants = additionally_allowed_tenants or []
+        self._process_timeout = process_timeout
 
     def __enter__(self):
         return self
@@ -96,17 +98,15 @@ class AzurePowerShellCredential:
             **kwargs
         )
         command_line = get_command_line(scopes, tenant_id)
-        output = run_command_line(command_line)
+        output = run_command_line(command_line, self._process_timeout)
         token = parse_token(output)
         return token
 
 
-def run_command_line(command_line: List[str]) -> str:
+def run_command_line(command_line: List[str], timeout: int) -> str:
     stdout = stderr = ""
     proc = None
-    kwargs = {}
-    if platform.python_version() >= "3.3":
-        kwargs["timeout"] = 10
+    kwargs = {"timeout": timeout}
 
     try:
         proc = start_process(command_line)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -50,7 +50,7 @@ class AzurePowerShellCredential:
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
-    :keyword int process_timeout: Seconds to wait for the Azure PowerShell process to respond. Defaults to 10.
+    :keyword int process_timeout: Seconds to wait for the Azure PowerShell process to respond. Defaults to 10 seconds.
     """
     def __init__(
         self,

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -81,7 +81,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         settings or, when that setting has no value, the "organizations" tenant, which supports only Azure Active
         Directory work or school accounts.
     :keyword int developer_credential_timeout: The timeout in seconds to use for developer credentials that run
-        subprocesses (e.g. AzureCliCredential, AzurePowerShellCredential). Defaults to **10**.
+        subprocesses (e.g. AzureCliCredential, AzurePowerShellCredential). Defaults to **10** seconds.
     """
 
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=too-many-statements

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -80,6 +80,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :class:`~azure.identity.VisualStudioCodeCredential`. Defaults to the "Azure: Tenant" setting in VS Code's user
         settings or, when that setting has no value, the "organizations" tenant, which supports only Azure Active
         Directory work or school accounts.
+    :keyword int developer_credential_timeout: The timeout in seconds to use for developer credentials that run
+        subprocesses (e.g. AzureCliCredential, AzurePowerShellCredential). Defaults to **10**.
     """
 
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=too-many-statements
@@ -116,6 +118,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
             "shared_cache_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
         )
 
+        developer_credential_timeout = kwargs.pop("developer_credential_timeout", 10)
+
         exclude_environment_credential = kwargs.pop("exclude_environment_credential", False)
         exclude_managed_identity_credential = kwargs.pop("exclude_managed_identity_credential", False)
         exclude_shared_token_cache_credential = kwargs.pop("exclude_shared_token_cache_credential", False)
@@ -138,7 +142,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         if not exclude_managed_identity_credential:
             credentials.append(ManagedIdentityCredential(client_id=managed_identity_client_id, **kwargs))
         if not exclude_azd_cli_credential:
-            credentials.append(AzureDeveloperCliCredential())
+            credentials.append(AzureDeveloperCliCredential(process_timeout=developer_credential_timeout))
         if not exclude_shared_token_cache_credential and SharedTokenCacheCredential.supported():
             try:
                 # username and/or tenant_id are only required when the cache contains tokens for multiple identities
@@ -151,9 +155,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         if not exclude_visual_studio_code_credential:
             credentials.append(VisualStudioCodeCredential(**vscode_args))
         if not exclude_cli_credential:
-            credentials.append(AzureCliCredential())
+            credentials.append(AzureCliCredential(process_timeout=developer_credential_timeout))
         if not exclude_powershell_credential:
-            credentials.append(AzurePowerShellCredential())
+            credentials.append(AzurePowerShellCredential(process_timeout=developer_credential_timeout))
         if not exclude_interactive_browser_credential:
             if interactive_browser_client_id:
                 credentials.append(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -35,7 +35,8 @@ class AzureDeveloperCliCredential(AsyncContextManager):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
-    :keyword int process_timeout: Seconds to wait for the Azure Developer CLI process to respond. Defaults to 10.
+    :keyword int process_timeout: Seconds to wait for the Azure Developer CLI process to respond. Defaults
+        to 10 seconds.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -35,12 +35,20 @@ class AzureDeveloperCliCredential(AsyncContextManager):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+    :keyword int process_timeout: Seconds to wait for the Azure Developer CLI process to respond. Defaults to 10.
     """
 
-    def __init__(self, *, tenant_id: str = "", additionally_allowed_tenants: Optional[List[str]] = None):
+    def __init__(
+        self,
+        *,
+        tenant_id: str = "",
+        additionally_allowed_tenants: Optional[List[str]] = None,
+        process_timeout: int = 10
+    ) -> None:
 
         self.tenant_id = tenant_id
         self._additionally_allowed_tenants = additionally_allowed_tenants or []
+        self._process_timeout = process_timeout
 
     @log_get_token_async
     async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
@@ -73,7 +81,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
 
         if tenant:
             command += " --tenant-id " + tenant
-        output = await _run_command(command)
+        output = await _run_command(command, self._process_timeout)
 
         token = parse_token(output)
         if not token:
@@ -88,7 +96,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         """Calling this method is unnecessary"""
 
 
-async def _run_command(command: str) -> str:
+async def _run_command(command: str, timeout: int) -> str:
     # Ensure executable exists in PATH first. This avoids a subprocess call that would fail anyway.
     if shutil.which(EXECUTABLE_NAME) is None:
         raise CredentialUnavailableError(message=CLI_NOT_FOUND)
@@ -108,7 +116,7 @@ async def _run_command(command: str) -> str:
             cwd=working_directory,
             env=dict(os.environ, NO_COLOR="true")
         )
-        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), 10)
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout)
         output = stdout_b.decode()
         stderr = stderr_b.decode()
     except OSError as ex:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -35,7 +35,7 @@ class AzureCliCredential(AsyncContextManager):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
-    :keyword int process_timeout: Seconds to wait for the Azure CLI process to respond. Defaults to 10.
+    :keyword int process_timeout: Seconds to wait for the Azure CLI process to respond. Defaults to 10 seconds.
     """
     def __init__(
         self,

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -29,7 +29,7 @@ class AzurePowerShellCredential(AsyncContextManager):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
-    :keyword int process_timeout: Seconds to wait for the Azure PowerShell process to respond. Defaults to 10.
+    :keyword int process_timeout: Seconds to wait for the Azure PowerShell process to respond. Defaults to 10 seconds.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -73,7 +73,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         user settings or, when that setting has no value, the "organizations" tenant, which supports only Azure Active
         Directory work or school accounts.
     :keyword int developer_credential_timeout: The timeout in seconds to use for developer credentials that run
-        subprocesses (e.g. AzureCliCredential, AzurePowerShellCredential). Defaults to **10**.
+        subprocesses (e.g. AzureCliCredential, AzurePowerShellCredential). Defaults to **10** seconds.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
@@ -134,9 +134,14 @@ def test_timeout():
     from subprocess import TimeoutExpired
 
     with mock.patch("shutil.which", return_value="azd"):
-        with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=TimeoutExpired("", 42))):
+        with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=TimeoutExpired("", 42))) as check_output_mock:
             with pytest.raises(CredentialUnavailableError):
-                AzureDeveloperCliCredential().get_token("scope")
+                AzureDeveloperCliCredential(process_timeout=42).get_token("scope")
+
+    # Ensure custom timeout is passed to subprocess
+    _, kwargs = check_output_mock.call_args
+    assert "timeout" in kwargs
+    assert kwargs["timeout"] == 42
 
 
 def test_multitenant_authentication_class():

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -141,9 +141,14 @@ def test_timeout():
     from subprocess import TimeoutExpired
 
     with mock.patch("shutil.which", return_value="az"):
-        with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=TimeoutExpired("", 42))):
+        with mock.patch(CHECK_OUTPUT, mock.Mock(side_effect=TimeoutExpired("", 42))) as check_output_mock:
             with pytest.raises(CredentialUnavailableError):
-                AzureCliCredential().get_token("scope")
+                AzureCliCredential(process_timeout=42).get_token("scope")
+
+    # Ensure custom timeout is passed to subprocess
+    _, kwargs = check_output_mock.call_args
+    assert "timeout" in kwargs
+    assert kwargs["timeout"] == 42
 
 
 def test_multitenant_authentication_class():

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -161,7 +161,7 @@ def test_exclude_options():
 
     credential = DefaultAzureCredential(exclude_powershell_credential=True)
     assert_credentials_not_present(credential, AzurePowerShellCredential)
-    
+
     credential = DefaultAzureCredential(exclude_azd_cli_credential=True)
     assert_credentials_not_present(credential, AzureDeveloperCliCredential)
 
@@ -372,6 +372,34 @@ def test_interactive_browser_client_id():
     with patch(DefaultAzureCredential.__module__ + ".InteractiveBrowserCredential") as mock_credential:
         DefaultAzureCredential(exclude_interactive_browser_credential=False, interactive_browser_client_id=client_id)
     validate_client_id(mock_credential)
+
+
+def test_developer_credential_timeout():
+    """the credential should allow configuring a process timeout for Azure CLI and PowerShell by kwarg"""
+
+    timeout = 42
+
+    with patch(DefaultAzureCredential.__module__ + ".AzureCliCredential") as mock_cli_credential:
+        with patch(DefaultAzureCredential.__module__ + ".AzurePowerShellCredential") as mock_pwsh_credential:
+            DefaultAzureCredential(developer_credential_timeout=timeout)
+
+    for credential in (mock_cli_credential, mock_pwsh_credential):
+        _, kwargs = credential.call_args
+        assert "process_timeout" in kwargs
+        assert kwargs["process_timeout"] == timeout
+
+
+def test_developer_credential_timeout_default():
+    """the credential should allow configuring a process timeout for Azure CLI and PowerShell by kwarg"""
+
+    with patch(DefaultAzureCredential.__module__ + ".AzureCliCredential") as mock_cli_credential:
+        with patch(DefaultAzureCredential.__module__ + ".AzurePowerShellCredential") as mock_pwsh_credential:
+            DefaultAzureCredential()
+
+    for credential in (mock_cli_credential, mock_pwsh_credential):
+        _, kwargs = credential.call_args
+        assert "process_timeout" in kwargs
+        assert kwargs["process_timeout"] == 10
 
 
 def test_unexpected_kwarg():

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -93,7 +93,7 @@ def test_authority(authority):
             shared_cache.supported = lambda: False
             with patch.dict("os.environ", {}, clear=True):
                 test_initialization(mock_credential, expect_argument=False)
-                
+
     # authority should not be passed to AzureDeveloperCliCredential
     with patch(DefaultAzureCredential.__module__ + ".AzureDeveloperCliCredential") as mock_credential:
         with patch(DefaultAzureCredential.__module__ + ".SharedTokenCacheCredential") as shared_cache:
@@ -280,6 +280,33 @@ def get_credential_for_shared_cache_test(expected_refresh_token, expected_access
     # this credential uses a mock shared cache, so it works on all platforms
     with patch.object(SharedTokenCacheCredential, "supported", lambda: True):
         return DefaultAzureCredential(_cache=cache, transport=transport, **exclude_other_credentials, **kwargs)
+
+
+def test_developer_credential_timeout():
+    """the credential should allow configuring a process timeout for Azure CLI and PowerShell by kwarg"""
+
+    timeout = 42
+
+    with patch(DefaultAzureCredential.__module__ + ".AzureCliCredential") as mock_cli_credential:
+        with patch(DefaultAzureCredential.__module__ + ".AzurePowerShellCredential") as mock_pwsh_credential:
+            DefaultAzureCredential(developer_credential_timeout=timeout)
+
+    for credential in (mock_cli_credential, mock_pwsh_credential):
+        _, kwargs = credential.call_args
+        assert "process_timeout" in kwargs
+        assert kwargs["process_timeout"] == timeout
+
+def test_developer_credential_timeout():
+    """the credential should allow configuring a process timeout for Azure CLI and PowerShell by kwarg"""
+
+    with patch(DefaultAzureCredential.__module__ + ".AzureCliCredential") as mock_cli_credential:
+        with patch(DefaultAzureCredential.__module__ + ".AzurePowerShellCredential") as mock_pwsh_credential:
+            DefaultAzureCredential()
+
+    for credential in (mock_cli_credential, mock_pwsh_credential):
+        _, kwargs = credential.call_args
+        assert "process_timeout" in kwargs
+        assert kwargs["process_timeout"] == 10
 
 
 def test_unexpected_kwarg():

--- a/sdk/identity/azure-identity/tests/test_powershell_credential.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential.py
@@ -192,9 +192,13 @@ def test_timeout():
     proc = Mock(communicate=Mock(side_effect=TimeoutExpired("", 42)), returncode=None)
     with patch(POPEN, Mock(return_value=proc)):
         with pytest.raises(CredentialUnavailableError):
-            AzurePowerShellCredential().get_token("scope")
+            AzurePowerShellCredential(process_timeout=42).get_token("scope")
 
     assert proc.communicate.call_count == 1
+    # Ensure custom timeout is passed to subprocess
+    _, kwargs = proc.communicate.call_args
+    assert "timeout" in kwargs
+    assert kwargs["timeout"] == 42
 
 
 def test_unexpected_error():


### PR DESCRIPTION
AzureCliCredential, AzureDeveloperCliCredential, and AzurePowerShellCredential now allow users to pass in a custom timeout. This addresses scenarios where these proceses can take longer than the current default timeout values. DefaultAzureCredential now also has an optional keyword argument to allow users to pass in timeout values to the underlying developer credentials.

- For individual credentials, the new introduced keyword argument is `process_timeout` to indicate the timeout of the underlying CLI/powerhsell process.
- For DefaultAzureCredential, the new introduced keyword argument is `developer_credential_timeout` to better indicate that this only applies to a subset of the credentials in the authentication chain (i.e. the developer credentials).

Closes: #27509