### PR TITLE
[Identity] Fix args not being propagated in DAC constructor

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where certain arguments to `DefaultAzureCredential` were not being passed to the underlying credentials (i.e. `AzureCliCredential` and `AzurePowerShellCredential`). ([#28299](https://github.com/Azure/azure-sdk-for-python/pull/28299))
+
 ### Other Changes
 
 ## 1.13.0b1 (2023-01-10)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -71,6 +71,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :class:`~azure.identity.VisualStudioCodeCredential`. Defaults to the "Azure: Tenant" setting in VS Code's user
         settings or, when that setting has no value, the "organizations" tenant, which supports only Azure Active
         Directory work or school accounts.
+    :keyword List[str] additionally_allowed_tenants: In applicable credentials, specifies tenants in addition to the
+        specified tenant ID for which the credential may acquire tokens. Add the wildcard value "*" to allow the
+        credential to acquire tokens for any tenant the application can access.
     """
 
     def __init__(self, **kwargs: Any) -> None:
@@ -104,6 +107,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
             "shared_cache_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
         )
 
+        additionally_allowed_tenants = kwargs.get("additionally_allowed_tenants", None)
+
         exclude_environment_credential = kwargs.pop("exclude_environment_credential", False)
         exclude_managed_identity_credential = kwargs.pop("exclude_managed_identity_credential", False)
         exclude_shared_token_cache_credential = kwargs.pop("exclude_shared_token_cache_credential", False)
@@ -129,9 +134,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         if not exclude_visual_studio_code_credential:
             credentials.append(VisualStudioCodeCredential(**vscode_args))
         if not exclude_cli_credential:
-            credentials.append(AzureCliCredential())
+            credentials.append(AzureCliCredential(additionally_allowed_tenants=additionally_allowed_tenants))
         if not exclude_powershell_credential:
-            credentials.append(AzurePowerShellCredential())
+            credentials.append(AzurePowerShellCredential(additionally_allowed_tenants=additionally_allowed_tenants))
         if not exclude_interactive_browser_credential:
             if interactive_browser_client_id:
                 credentials.append(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -63,6 +63,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :class:`~azure.identity.aio.VisualStudioCodeCredential`. Defaults to the "Azure: Tenant" setting in VS Code's
         user settings or, when that setting has no value, the "organizations" tenant, which supports only Azure Active
         Directory work or school accounts.
+    :keyword List[str] additionally_allowed_tenants: In applicable credentials, specifies tenants in addition to the
+        specified tenant ID for which the credential may acquire tokens. Add the wildcard value "*" to allow the
+        credential to acquire tokens for any tenant the application can access.
     """
 
     def __init__(self, **kwargs: Any) -> None:
@@ -95,6 +98,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
             "visual_studio_code_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
         )
 
+        additionally_allowed_tenants = kwargs.get("additionally_allowed_tenants", None)
+
         exclude_visual_studio_code_credential = kwargs.pop("exclude_visual_studio_code_credential", True)
         exclude_cli_credential = kwargs.pop("exclude_cli_credential", False)
         exclude_environment_credential = kwargs.pop("exclude_environment_credential", False)
@@ -119,9 +124,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         if not exclude_visual_studio_code_credential:
             credentials.append(VisualStudioCodeCredential(**vscode_args))
         if not exclude_cli_credential:
-            credentials.append(AzureCliCredential())
+            credentials.append(AzureCliCredential(additionally_allowed_tenants=additionally_allowed_tenants))
         if not exclude_powershell_credential:
-            credentials.append(AzurePowerShellCredential())
+            credentials.append(AzurePowerShellCredential(additionally_allowed_tenants=additionally_allowed_tenants))
 
         super().__init__(*credentials)
 

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -362,6 +362,23 @@ def test_interactive_browser_client_id():
     validate_client_id(mock_credential)
 
 
+def test_additionally_allowed_tenants():
+    """User-supplied additionally_allowed_tenants should be passed to applicable credentials"""
+
+    additionally_allowed_tenants = ["*"]
+    mocks = [Mock(), Mock(), Mock()]
+
+    with patch.multiple(DefaultAzureCredential.__module__, AzureCliCredential=mocks[0],
+        AzurePowerShellCredential=mocks[1], EnvironmentCredential=mocks[2]):
+
+        DefaultAzureCredential(additionally_allowed_tenants=additionally_allowed_tenants)
+
+    for mocked_credential in mocks:
+        _, kwargs = mocked_credential.call_args
+        assert "additionally_allowed_tenants" in kwargs
+        assert kwargs["additionally_allowed_tenants"] == additionally_allowed_tenants
+
+
 def test_unexpected_kwarg():
     """the credential shouldn't raise when given an unexpected keyword argument"""
     DefaultAzureCredential(foo=42)

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -272,6 +272,23 @@ def get_credential_for_shared_cache_test(expected_refresh_token, expected_access
         return DefaultAzureCredential(_cache=cache, transport=transport, **exclude_other_credentials, **kwargs)
 
 
+def test_additionally_allowed_tenants():
+    """User-supplied additionally_allowed_tenants should be passed to applicable credentials"""
+
+    additionally_allowed_tenants = ["*"]
+    mocks = [Mock(), Mock(), Mock()]
+
+    with patch.multiple(DefaultAzureCredential.__module__, AzureCliCredential=mocks[0],
+        AzurePowerShellCredential=mocks[1], EnvironmentCredential=mocks[2]):
+
+        DefaultAzureCredential(additionally_allowed_tenants=additionally_allowed_tenants)
+
+    for mocked_credential in mocks:
+        _, kwargs = mocked_credential.call_args
+        assert "additionally_allowed_tenants" in kwargs
+        assert kwargs["additionally_allowed_tenants"] == additionally_allowed_tenants
+
+
 def test_unexpected_kwarg():
     """the credential shouldn't raise when given an unexpected keyword argument"""
     DefaultAzureCredential(foo=42)


### PR DESCRIPTION
AzureCliCredential and AzurePowerShellCredential both accept some arguments inside their constructors. This commit makes sure these are passed in from the DefaultAzureCredential constructor.

Currently, this only propagates `additionally_allowed_tenants`. TBD if new keyword arguments for CLI tenant ID and PowerShell tenant ID need to be introduced.
