### PR TITLE
Loosen instrumentation key validation strictness

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+- Loosen instrumentation key validation strictness
+    ([#26753](https://github.com/Azure/azure-sdk-for-python/pull/26753))
+
 ## 1.0.0b11 (2022-12-15)
 
 ### Features Added

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_connection_string_parser.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_connection_string_parser.py
@@ -12,8 +12,8 @@ INSTRUMENTATION_KEY = "instrumentationkey"
 uuid_regex_pattern = re.compile(
     "^[0-9a-f]{8}-"
     "[0-9a-f]{4}-"
-    "[1-5][0-9a-f]{3}-"
-    "[89ab][0-9a-f]{3}-"
+    "[0-9a-f]{4}-"
+    "[0-9a-f]{4}-"
     "[0-9a-f]{12}$"
 )
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_connection_string_parser.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_connection_string_parser.py
@@ -144,22 +144,6 @@ class TestConnectionStringParser(unittest.TestCase):
             ),
         )
 
-    def test_invalid_key_version(self):
-        self.assertRaises(
-            ValueError,
-            lambda: ConnectionStringParser(
-                connection_string="InstrumentationKey=1234abcd-5678-6efa-8abc-1234567890ab"
-            ),
-        )
-
-    def test_invalid_key_variant(self):
-        self.assertRaises(
-            ValueError,
-            lambda: ConnectionStringParser(
-                connection_string="InstrumentationKey=1234abcd-5678-4efa-2abc-1234567890ab"
-            ),
-        )
-
     def test_process_options_ikey_code_cs(self):
         os.environ[
             "APPLICATIONINSIGHTS_CONNECTION_STRING"


### PR DESCRIPTION
Ikeys are expected to be UUIDs.

Also taken from [node.js](https://github.com/microsoft/ApplicationInsights-node.js/blob/develop/Library/Config.ts#L218)