### PR TITLE
[EventHubs] Fix Token Decode Error

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -165,6 +165,7 @@
     "dtlksd",
     "DWORD",
     "eastus",
+    "eaup",
     "eckey",
     "ekus",
     "encryptor",

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -165,7 +165,7 @@
     "dtlksd",
     "DWORD",
     "eastus",
-    "eaup",
+    "euap",
     "eckey",
     "ekus",
     "encryptor",

--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -11,7 +11,7 @@ Version 5.11.0 is our first stable release of the Azure Event Hubs client librar
 ### Bugs Fixed
 
 - Fixed a bug that caused an error when sending batches with tracing enabled (issue #27986).
-- Fixed a bug that fixed where `EventHubSharedKeyCredential` returned an `AccessToken.token` of type `bytes` and not `str`.
+- Fixed a bug where `EventHubSharedKeyCredential` returned an `AccessToken.token` of type `bytes` and not `str`, now matching the documentation.
 
 ### Other Changes
 

--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -11,6 +11,7 @@ Version 5.11.0 is our first stable release of the Azure Event Hubs client librar
 ### Bugs Fixed
 
 - Fixed a bug that caused an error when sending batches with tracing enabled (issue #27986).
+- Fixed a bug that fixed a bug where `EventHubSharedKeyCredential` returned an `AccessToken.token` of type `bytes` and not `str`.
 
 ### Other Changes
 

--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.11.0 (2023-01-10)
+## 5.11.0 (2023-01-19)
 
 Version 5.11.0 is our first stable release of the Azure Event Hubs client library based on a pure Python implemented AMQP stack.
 
@@ -11,7 +11,7 @@ Version 5.11.0 is our first stable release of the Azure Event Hubs client librar
 ### Bugs Fixed
 
 - Fixed a bug that caused an error when sending batches with tracing enabled (issue #27986).
-- Fixed a bug that fixed a bug where `EventHubSharedKeyCredential` returned an `AccessToken.token` of type `bytes` and not `str`.
+- Fixed a bug that fixed where `EventHubSharedKeyCredential` returned an `AccessToken.token` of type `bytes` and not `str`.
 
 ### Other Changes
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -156,9 +156,8 @@ def _generate_sas_token(uri, policy, key, expiry=None):
 
     abs_expiry = int(time.time()) + expiry.seconds
 
-    token = generate_sas_token(uri, policy, key, abs_expiry).encode()
+    token = generate_sas_token(uri, policy, key, abs_expiry)
     return AccessToken(token=token, expires_on=abs_expiry)
-
 
 def _build_uri(address, entity):
     # type: (str, Optional[str]) -> str

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_cbs_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_cbs_async.py
@@ -214,9 +214,14 @@ class CBSAuthenticator(object):  # pylint:disable=too-many-instance-attributes
             self._token = access_token.token.decode()
         except AttributeError:
             self._token = access_token.token
+        try:
+            token_type = self._auth.token_type.decode()
+        except AttributeError:
+            token_type = self._auth.token_type
+
         self._token_put_time = int(utc_now().timestamp())
         await self._put_token(
-            self._token, self._auth.token_type, self._auth.audience, utc_from_timestamp(self._expires_on)
+            self._token, token_type, self._auth.audience, utc_from_timestamp(self._expires_on)
         )
 
     async def handle_token(self):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/authentication.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/authentication.py
@@ -118,7 +118,7 @@ class JWTTokenAuth(_CBSAuth):
         :type token_type: str
 
         """
-        super(JWTTokenAuth, self).__init__(uri, audience, kwargs.pop("kwargs", TOKEN_TYPE_JWT), get_token)
+        super(JWTTokenAuth, self).__init__(uri, audience, kwargs.pop("token_type", TOKEN_TYPE_JWT), get_token)
         self.get_token = get_token
 
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/cbs.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/cbs.py
@@ -248,10 +248,15 @@ class CBSAuthenticator(object):  # pylint:disable=too-many-instance-attributes
             self._token = access_token.token.decode()
         except AttributeError:
             self._token = access_token.token
+        try:
+            token_type = self._auth.token_type.decode()
+        except AttributeError:
+            token_type = self._auth.token_type
+
         self._token_put_time = int(utc_now().timestamp())
         self._put_token(
             self._token,
-            self._auth.token_type,
+            token_type,
             self._auth.audience,
             utc_from_timestamp(self._expires_on),
         )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
@@ -446,7 +446,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         if update_token:
             # update_token not actually needed by pyamqp
             # just using to detect wh
-            return JWTTokenAuth(auth_uri, auth_uri, get_token)
+            return JWTTokenAuth(auth_uri, auth_uri, get_token, token_type=token_type)
         return JWTTokenAuth(
             auth_uri,
             auth_uri,
@@ -487,7 +487,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         Return updated auth token.
         :param mgmt_auth: Auth.
         """
-        return mgmt_auth.get_token()
+        return mgmt_auth.get_token().token.decode()
 
     @staticmethod
     def mgmt_client_request(mgmt_client, mgmt_msg, **kwargs):
@@ -521,7 +521,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
             return errors.AuthenticationException(
                 errors.ErrorCondition.UnauthorizedAccess,
                 description=f"""Management authentication failed. Status code: {status_code}, """
-                    """Description: {description!r}""",
+                    f"""Description: {description!r}""",
             )
         if status_code in [404]:
             return errors.AMQPConnectionError(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_transport/_pyamqp_transport.py
@@ -487,7 +487,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         Return updated auth token.
         :param mgmt_auth: Auth.
         """
-        return mgmt_auth.get_token().token.decode()
+        return mgmt_auth.get_token().token
 
     @staticmethod
     def mgmt_client_request(mgmt_client, mgmt_msg, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -255,7 +255,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         if update_token:
             # update_token not actually needed by pyamqp
             # just using to detect wh
-            return JWTTokenAuthAsync(auth_uri, auth_uri, get_token)
+            return JWTTokenAuthAsync(auth_uri, auth_uri, get_token, token_type=token_type)
         return JWTTokenAuthAsync(
             auth_uri,
             auth_uri,
@@ -294,7 +294,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         Return updated auth token.
         :param mgmt_auth: Auth.
         """
-        return await mgmt_auth.get_token()
+        return (await mgmt_auth.get_token()).token.decode()
 
     @staticmethod
     async def mgmt_client_request_async(mgmt_client, mgmt_msg, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -294,7 +294,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         Return updated auth token.
         :param mgmt_auth: Auth.
         """
-        return (await mgmt_auth.get_token()).token.decode()
+        return await mgmt_auth.get_token()
 
     @staticmethod
     async def mgmt_client_request_async(mgmt_client, mgmt_msg, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -294,7 +294,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         Return updated auth token.
         :param mgmt_auth: Auth.
         """
-        return await mgmt_auth.get_token()
+        return (await mgmt_auth.get_token()).token
 
     @staticmethod
     async def mgmt_client_request_async(mgmt_client, mgmt_msg, **kwargs):

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/client_creation_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/client_creation_async.py
@@ -14,12 +14,9 @@ from azure.eventhub import TransportType
 from azure.eventhub.aio import EventHubProducerClient, EventHubConsumerClient, EventHubSharedKeyCredential
 
 
-CONNECTION_STRING = os.environ['EVENT_HUB_CONN_STR']
-FULLY_QUALIFIED_NAMESPACE = os.environ['EVENT_HUB_HOSTNAME']
-EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
-SAS_POLICY = os.environ['EVENT_HUB_SAS_POLICY']
-SAS_KEY = os.environ['EVENT_HUB_SAS_KEY']
-CONSUMER_GROUP = "$Default"
+CONNECTION_STRING = 'Endpoint=sb://kashifk1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=LmIpx06/gDr+B6NM3rCmRU7jpcUFvFdY6MzwF+ggnhk='
+#FULLY_QUALIFIED_NAMESPACE = os.envi
+EVENTHUB_NAME = 'test'
 
 
 async def create_producer_client():
@@ -28,74 +25,78 @@ async def create_producer_client():
     # Create producer client from connection string.
 
     producer_client = EventHubProducerClient.from_connection_string(
-        conn_str=CONNECTION_STRING  # connection string contains EventHub name.
+        conn_str=CONNECTION_STRING,  # connection string contains EventHub name.,
+        eventhub_name=EVENTHUB_NAME
     )
 
-    # Illustration of commonly used parameters.
-    producer_client = EventHubProducerClient.from_connection_string(
-        conn_str=CONNECTION_STRING,
-        eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
-        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-        retry_total=3,  # Retry up to 3 times to re-do failed operations.
-        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-    )
+    props = await producer_client.get_eventhub_properties()
+    print(props)
 
-    # Create producer client from constructor.
+    # # Illustration of commonly used parameters.
+    # producer_client = EventHubProducerClient.from_connection_string(
+    #     conn_str=CONNECTION_STRING,
+    #     eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
+    #     logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+    #     retry_total=3,  # Retry up to 3 times to re-do failed operations.
+    #     transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    # )
 
-    producer_client = EventHubProducerClient(
-        fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
-        eventhub_name=EVENTHUB_NAME,
-        credential=EventHubSharedKeyCredential(
-            policy=SAS_POLICY,
-            key=SAS_KEY
-        ),
-        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-        retry_total=3,  # Retry up to 3 times to re-do failed operations.
-        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-    )
+    # # Create producer client from constructor.
 
-    async with producer_client:
-        print("Calling producer client get eventhub properties:", await producer_client.get_eventhub_properties())
+    # producer_client = EventHubProducerClient(
+    #     fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
+    #     eventhub_name=EVENTHUB_NAME,
+    #     credential=EventHubSharedKeyCredential(
+    #         policy=SAS_POLICY,
+    #         key=SAS_KEY
+    #     ),
+    #     logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+    #     retry_total=3,  # Retry up to 3 times to re-do failed operations.
+    #     transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    #)
+
+    # async with producer_client:
+    #     print("Calling producer client get eventhub properties:", await producer_client.get_eventhub_properties())
 
 
-async def create_consumer_client():
-    print('Examples showing how to create consumer client.')
+# async def create_consumer_client():
+#     print('Examples showing how to create consumer client.')
 
-    # Create consumer client from connection string.
+#     # Create consumer client from connection string.
 
-    consumer_client = EventHubConsumerClient.from_connection_string(
-        conn_str=CONNECTION_STRING,  # connection string contains EventHub name.
-        consumer_group=CONSUMER_GROUP
-    )
+#     consumer_client = EventHubConsumerClient.from_connection_string(
+#         conn_str=CONNECTION_STRING,  # connection string contains EventHub name.
+#         consumer_group=CONSUMER_GROUP
+#     )
 
-    # Illustration of commonly used parameters.
-    consumer_client = EventHubConsumerClient.from_connection_string(
-        conn_str=CONNECTION_STRING,
-        consumer_group=CONSUMER_GROUP,
-        eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
-        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-        retry_total=3,  # Retry up to 3 times to re-do failed operations.
-        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-    )
+#     # Illustration of commonly used parameters.
+#     consumer_client = EventHubConsumerClient.from_connection_string(
+#         conn_str=CONNECTION_STRING,
+#         consumer_group=CONSUMER_GROUP,
+#         eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
+#         logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+#         retry_total=3,  # Retry up to 3 times to re-do failed operations.
+#         transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+#     )
 
-    # Create consumer client from constructor.
+#     # Create consumer client from constructor.
 
-    consumer_client = EventHubConsumerClient(
-        fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
-        eventhub_name=EVENTHUB_NAME,
-        consumer_group=CONSUMER_GROUP,
-        credential=EventHubSharedKeyCredential(
-            policy=SAS_POLICY,
-            key=SAS_KEY
-        ),
-        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-        retry_total=3,  # Retry up to 3 times to re-do failed operations.
-        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-    )
+#     consumer_client = EventHubConsumerClient(
+#         fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
+#         eventhub_name=EVENTHUB_NAME,
+#         consumer_group=CONSUMER_GROUP,
+#         credential=EventHubSharedKeyCredential(
+#             policy=SAS_POLICY,
+#             key=SAS_KEY
+#         ),
+#         logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+#         retry_total=3,  # Retry up to 3 times to re-do failed operations.
+#         transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+#     )
 
-    async with consumer_client:
-        print("Calling consumer client get eventhub properties:", await consumer_client.get_eventhub_properties())
+#     async with consumer_client:
+#         print("Calling consumer client get eventhub properties:", await consumer_client.get_eventhub_properties())
 
 
 asyncio.run(create_producer_client())
-asyncio.run(create_consumer_client())
+#asyncio.run(create_consumer_client())

--- a/sdk/eventhub/azure-eventhub/samples/async_samples/client_creation_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/client_creation_async.py
@@ -14,9 +14,12 @@ from azure.eventhub import TransportType
 from azure.eventhub.aio import EventHubProducerClient, EventHubConsumerClient, EventHubSharedKeyCredential
 
 
-CONNECTION_STRING = 'Endpoint=sb://kashifk1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=LmIpx06/gDr+B6NM3rCmRU7jpcUFvFdY6MzwF+ggnhk='
-#FULLY_QUALIFIED_NAMESPACE = os.envi
-EVENTHUB_NAME = 'test'
+CONNECTION_STRING = os.environ['EVENT_HUB_CONN_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['EVENT_HUB_HOSTNAME']
+EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
+SAS_POLICY = os.environ['EVENT_HUB_SAS_POLICY']
+SAS_KEY = os.environ['EVENT_HUB_SAS_KEY']
+CONSUMER_GROUP = "$Default"
 
 
 async def create_producer_client():
@@ -25,78 +28,74 @@ async def create_producer_client():
     # Create producer client from connection string.
 
     producer_client = EventHubProducerClient.from_connection_string(
-        conn_str=CONNECTION_STRING,  # connection string contains EventHub name.,
-        eventhub_name=EVENTHUB_NAME
+        conn_str=CONNECTION_STRING  # connection string contains EventHub name.
     )
 
-    props = await producer_client.get_eventhub_properties()
-    print(props)
+    # Illustration of commonly used parameters.
+    producer_client = EventHubProducerClient.from_connection_string(
+        conn_str=CONNECTION_STRING,
+        eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
+        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+        retry_total=3,  # Retry up to 3 times to re-do failed operations.
+        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    )
 
-    # # Illustration of commonly used parameters.
-    # producer_client = EventHubProducerClient.from_connection_string(
-    #     conn_str=CONNECTION_STRING,
-    #     eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
-    #     logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-    #     retry_total=3,  # Retry up to 3 times to re-do failed operations.
-    #     transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-    # )
+    # Create producer client from constructor.
 
-    # # Create producer client from constructor.
+    producer_client = EventHubProducerClient(
+        fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
+        eventhub_name=EVENTHUB_NAME,
+        credential=EventHubSharedKeyCredential(
+            policy=SAS_POLICY,
+            key=SAS_KEY
+        ),
+        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+        retry_total=3,  # Retry up to 3 times to re-do failed operations.
+        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    )
 
-    # producer_client = EventHubProducerClient(
-    #     fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
-    #     eventhub_name=EVENTHUB_NAME,
-    #     credential=EventHubSharedKeyCredential(
-    #         policy=SAS_POLICY,
-    #         key=SAS_KEY
-    #     ),
-    #     logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-    #     retry_total=3,  # Retry up to 3 times to re-do failed operations.
-    #     transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-    #)
-
-    # async with producer_client:
-    #     print("Calling producer client get eventhub properties:", await producer_client.get_eventhub_properties())
+    async with producer_client:
+        print("Calling producer client get eventhub properties:", await producer_client.get_eventhub_properties())
 
 
-# async def create_consumer_client():
-#     print('Examples showing how to create consumer client.')
+async def create_consumer_client():
+    print('Examples showing how to create consumer client.')
 
-#     # Create consumer client from connection string.
+    # Create consumer client from connection string.
 
-#     consumer_client = EventHubConsumerClient.from_connection_string(
-#         conn_str=CONNECTION_STRING,  # connection string contains EventHub name.
-#         consumer_group=CONSUMER_GROUP
-#     )
+    consumer_client = EventHubConsumerClient.from_connection_string(
+        conn_str=CONNECTION_STRING,  # connection string contains EventHub name.
+        consumer_group=CONSUMER_GROUP
+    )
 
-#     # Illustration of commonly used parameters.
-#     consumer_client = EventHubConsumerClient.from_connection_string(
-#         conn_str=CONNECTION_STRING,
-#         consumer_group=CONSUMER_GROUP,
-#         eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
-#         logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-#         retry_total=3,  # Retry up to 3 times to re-do failed operations.
-#         transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-#     )
+    # Illustration of commonly used parameters.
+    consumer_client = EventHubConsumerClient.from_connection_string(
+        conn_str=CONNECTION_STRING,
+        consumer_group=CONSUMER_GROUP,
+        eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
+        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+        retry_total=3,  # Retry up to 3 times to re-do failed operations.
+        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    )
 
-#     # Create consumer client from constructor.
+    # Create consumer client from constructor.
 
-#     consumer_client = EventHubConsumerClient(
-#         fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
-#         eventhub_name=EVENTHUB_NAME,
-#         consumer_group=CONSUMER_GROUP,
-#         credential=EventHubSharedKeyCredential(
-#             policy=SAS_POLICY,
-#             key=SAS_KEY
-#         ),
-#         logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-#         retry_total=3,  # Retry up to 3 times to re-do failed operations.
-#         transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-#     )
+    consumer_client = EventHubConsumerClient(
+        fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
+        eventhub_name=EVENTHUB_NAME,
+        consumer_group=CONSUMER_GROUP,
+        credential=EventHubSharedKeyCredential(
+            policy=SAS_POLICY,
+            key=SAS_KEY
+        ),
+        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+        retry_total=3,  # Retry up to 3 times to re-do failed operations.
+        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    )
 
-#     async with consumer_client:
-#         print("Calling consumer client get eventhub properties:", await consumer_client.get_eventhub_properties())
+    async with consumer_client:
+        print("Calling consumer client get eventhub properties:", await consumer_client.get_eventhub_properties())
 
 
 asyncio.run(create_producer_client())
-#asyncio.run(create_consumer_client())
+asyncio.run(create_consumer_client())

--- a/sdk/eventhub/azure-eventhub/samples/sync_samples/client_creation.py
+++ b/sdk/eventhub/azure-eventhub/samples/sync_samples/client_creation.py
@@ -17,10 +17,12 @@ from azure.eventhub import (
 )
 
 
-CONNECTION_STRING = 'Endpoint=sb://kashifk1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=LmIpx06/gDr+B6NM3rCmRU7jpcUFvFdY6MzwF+ggnhk='
-#FULLY_QUALIFIED_NAMESPACE = os.envi
-EVENTHUB_NAME = 'test'
-
+CONNECTION_STRING = os.environ['EVENT_HUB_CONN_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['EVENT_HUB_HOSTNAME']
+EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
+SAS_POLICY = os.environ['EVENT_HUB_SAS_POLICY']
+SAS_KEY = os.environ['EVENT_HUB_SAS_KEY']
+CONSUMER_GROUP = "$Default"
 
 
 def create_producer_client():
@@ -29,11 +31,31 @@ def create_producer_client():
     # Create producer client from connection string.
 
     producer_client = EventHubProducerClient.from_connection_string(
-        conn_str=CONNECTION_STRING,
-        eventhub_name= EVENTHUB_NAME
-
+        conn_str=CONNECTION_STRING  # connection string contains EventHub name.
     )
 
+    # Illustration of commonly used parameters.
+    producer_client = EventHubProducerClient.from_connection_string(
+        conn_str=CONNECTION_STRING,
+        eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
+        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+        retry_total=3,  # Retry up to 3 times to re-do failed operations.
+        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    )
+
+    # Create producer client from constructor.
+
+    producer_client = EventHubProducerClient(
+        fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
+        eventhub_name=EVENTHUB_NAME,
+        credential=EventHubSharedKeyCredential(
+            policy=SAS_POLICY,
+            key=SAS_KEY
+        ),
+        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
+        retry_total=3,  # Retry up to 3 times to re-do failed operations.
+        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+    )
 
     print("Calling producer client get eventhub properties:", producer_client.get_eventhub_properties())
 
@@ -77,5 +99,4 @@ def create_consumer_client():
 
 
 create_producer_client()
-#create_consumer_client()
-# 
+create_consumer_client()

--- a/sdk/eventhub/azure-eventhub/samples/sync_samples/client_creation.py
+++ b/sdk/eventhub/azure-eventhub/samples/sync_samples/client_creation.py
@@ -17,12 +17,10 @@ from azure.eventhub import (
 )
 
 
-CONNECTION_STRING = os.environ['EVENT_HUB_CONN_STR']
-FULLY_QUALIFIED_NAMESPACE = os.environ['EVENT_HUB_HOSTNAME']
-EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
-SAS_POLICY = os.environ['EVENT_HUB_SAS_POLICY']
-SAS_KEY = os.environ['EVENT_HUB_SAS_KEY']
-CONSUMER_GROUP = "$Default"
+CONNECTION_STRING = 'Endpoint=sb://kashifk1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=LmIpx06/gDr+B6NM3rCmRU7jpcUFvFdY6MzwF+ggnhk='
+#FULLY_QUALIFIED_NAMESPACE = os.envi
+EVENTHUB_NAME = 'test'
+
 
 
 def create_producer_client():
@@ -31,31 +29,11 @@ def create_producer_client():
     # Create producer client from connection string.
 
     producer_client = EventHubProducerClient.from_connection_string(
-        conn_str=CONNECTION_STRING  # connection string contains EventHub name.
-    )
-
-    # Illustration of commonly used parameters.
-    producer_client = EventHubProducerClient.from_connection_string(
         conn_str=CONNECTION_STRING,
-        eventhub_name=EVENTHUB_NAME,  # EventHub name should be specified if it doesn't show up in connection string.
-        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-        retry_total=3,  # Retry up to 3 times to re-do failed operations.
-        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
+        eventhub_name= EVENTHUB_NAME
+
     )
 
-    # Create producer client from constructor.
-
-    producer_client = EventHubProducerClient(
-        fully_qualified_namespace=FULLY_QUALIFIED_NAMESPACE,
-        eventhub_name=EVENTHUB_NAME,
-        credential=EventHubSharedKeyCredential(
-            policy=SAS_POLICY,
-            key=SAS_KEY
-        ),
-        logging_enable=False,  # To enable network tracing log, set logging_enable to True.
-        retry_total=3,  # Retry up to 3 times to re-do failed operations.
-        transport_type=TransportType.Amqp  # Use Amqp as the underlying transport protocol.
-    )
 
     print("Calling producer client get eventhub properties:", producer_client.get_eventhub_properties())
 
@@ -99,4 +77,5 @@ def create_consumer_client():
 
 
 create_producer_client()
-create_consumer_client()
+#create_consumer_client()
+# 

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_auth_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_auth_async.py
@@ -81,7 +81,7 @@ async def test_client_sas_credential_async(live_eventhub, uamqp_transport):
         await producer_client.send_batch(batch)
 
     # Finally let's do it with SAS token + conn str
-    token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token.decode())
+    token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
     conn_str_producer_client = EventHubProducerClient.from_connection_string(token_conn_str,
                                                                              eventhub_name=live_eventhub['event_hub'], uamqp_transport=uamqp_transport)
 
@@ -105,7 +105,7 @@ async def test_client_azure_sas_credential_async(live_eventhub, uamqp_transport)
 
     credential = EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key'])
     auth_uri = "sb://{}/{}".format(hostname, live_eventhub['event_hub'])
-    token = (await credential.get_token(auth_uri)).token.decode()
+    token = (await credential.get_token(auth_uri)).token
     producer_client = EventHubProducerClient(fully_qualified_namespace=hostname,
                                              eventhub_name=live_eventhub['event_hub'],
                                              auth_timeout=3,

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_auth_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_auth_async.py
@@ -116,6 +116,8 @@ async def test_client_azure_sas_credential_async(live_eventhub, uamqp_transport)
         batch.add(EventData(body='A single message'))
         await producer_client.send_batch(batch)
 
+    assert (await producer_client.get_eventhub_properties()) is not None
+
 
 @pytest.mark.liveTest
 @pytest.mark.asyncio

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_auth.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_auth.py
@@ -81,7 +81,7 @@ def test_client_sas_credential(live_eventhub, uamqp_transport):
         producer_client.send_batch(batch)
 
     # Finally let's do it with SAS token + conn str
-    token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token.decode())
+    token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
     conn_str_producer_client = EventHubProducerClient.from_connection_string(token_conn_str,
                                                                              eventhub_name=live_eventhub['event_hub'],
                                                                              uamqp_transport=uamqp_transport)
@@ -108,7 +108,7 @@ def test_client_azure_sas_credential(live_eventhub, uamqp_transport):
     # This should also work, but now using SAS tokens.
     credential = EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key'])
     auth_uri = "sb://{}/{}".format(hostname, live_eventhub['event_hub'])
-    token = credential.get_token(auth_uri).token.decode()
+    token = credential.get_token(auth_uri).token
     producer_client = EventHubProducerClient(fully_qualified_namespace=hostname,
                                              eventhub_name=live_eventhub['event_hub'],
                                              credential=AzureSasCredential(token),

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_auth.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_auth.py
@@ -120,6 +120,8 @@ def test_client_azure_sas_credential(live_eventhub, uamqp_transport):
         batch.add(EventData(body='A single message'))
         producer_client.send_batch(batch)
 
+    assert producer_client.get_eventhub_properties() is not None
+
 
 @pytest.mark.liveTest
 def test_client_azure_named_key_credential(live_eventhub, uamqp_transport):

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/synctests/test_mgmt_pyamqp.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/synctests/test_mgmt_pyamqp.py
@@ -51,7 +51,7 @@ def test_mgmt_call_sas_credential(live_eventhub):
     hostname = live_eventhub["hostname"]
     credential = EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key'])
     auth_uri = "sb://{}/{}".format(hostname, live_eventhub['event_hub'])
-    token = credential.get_token(auth_uri).token.decode()
+    token = credential.get_token(auth_uri).token
     client = EventHubProducerClient(fully_qualified_namespace=hostname,
                                              eventhub_name=live_eventhub['event_hub'],
                                              credential=AzureSasCredential(token))

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -144,48 +144,6 @@
       ]
     },
     {
-          "type": "Microsoft.DocumentDB/databaseAccounts",
-          "apiVersion": "2020-04-01",
-          "name": "[variables('storageAccount')]",
-          "location": "[parameters('location')]",
-          "tags": {
-              "defaultExperience": "Azure Table",
-              "hidden-cosmos-mmspecial": "",
-              "CosmosAccountType": "Non-Production"
-          },
-          "kind": "GlobalDocumentDB",
-          "properties": {
-              "publicNetworkAccess": "Enabled",
-              "enableAutomaticFailover": false,
-              "enableMultipleWriteLocations": false,
-              "isVirtualNetworkFilterEnabled": false,
-              "virtualNetworkRules": [],
-              "disableKeyBasedMetadataWriteAccess": false,
-              "enableFreeTier": false,
-              "enableAnalyticalStorage": false,
-              "databaseAccountOfferType": "Standard",
-              "consistencyPolicy": {
-                  "defaultConsistencyLevel": "BoundedStaleness",
-                  "maxIntervalInSeconds": 86400,
-                  "maxStalenessPrefix": 1000000
-              },
-              "locations": [
-                  {
-                      "locationName": "[parameters('location')]",
-                      "provisioningState": "Succeeded",
-                      "failoverPriority": 0,
-                      "isZoneRedundant": false
-                  }
-              ],
-              "capabilities": [
-                  {
-                      "name": "EnableTable"
-                  }
-              ],
-              "ipRules": []
-          }
-    },
-    {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
       "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('eventHubsDataOwnerRoleId'), parameters('testApplicationOid'))]",
@@ -255,10 +213,6 @@
     "AZURE_TABLES_CONN_STR": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccount'), ';AccountKey=', listKeys(variables('storageAccountId'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
-    },
-    "AZURE_COSMOS_CONN_STR": {
-      "type": "string",
-      "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccount'), ';AccountKey=', listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('storageAccount')), '2020-04-01').primaryMasterKey, ';TableEndpoint=https://', variables('storageAccount'), '.table.cosmos.azure.com:443/')]"
     }
   }
 }

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -19,3 +19,10 @@ stages:
         AZURE_CLIENT_SECRET: $(python-eh-livetest-event-hub-aad-secret)
         AZURE_SUBSCRIPTION_ID: $(python-eh-livetest-event-hub-subscription-id)
         AZURE_COSMOS_CONN_STR: $(python-eventhub-livetest-cosmos-conn-str)
+      Clouds: 'Public,Canary'
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        Canary:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          Location: 'centraluseuap'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -25,4 +25,4 @@ stages:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Canary:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          Location: 'centraluseuap'
+          Location: 'eastus2euap'


### PR DESCRIPTION
Fixes #28264

We ran in to an issue where we were seeing 401 unauthorized errors on get_partition_ids, get_eventhub_properties etc. on Canary

Canary has turned off anonymous access for those get partition calls. In general, public EH has this now enabled globally except for North America. Canary has enabled this everywhere.

The service is expecting a string token, but our code was sending an encoded token only if `generate_sas_token` was called ie when using connection string based calls. This affected management calls, as the service saw those tokens as empty and therefore treated them as anonymous calls.

Additionally, updated the `AccessToken.token` stored in `EventHubSharedKeyCredential` (returned by internal `_generate_sas_token`) to return a string and not bytes. This was a bug introduced in 5.10.1, when the uamqp switch was added.

Removed Cosmos from `test-resources.json`, which resulted in a deployment error due to limits on cosmos resource in canary regions. This should also fix #27024, fix #25016