### PR TITLE
pin version of cadl-dpg

### DIFF
--- a/cadl_to_sdk_config.json
+++ b/cadl_to_sdk_config.json
@@ -4,7 +4,7 @@
     "@autorest/python": "6.2.16",
     "@azure-tools/cadl-autorest": "~0.24.0",
     "@azure-tools/cadl-azure-core": "~0.24.0",
-    "@azure-tools/cadl-dpg": "~0.25.0-dev.8",
+    "@azure-tools/cadl-dpg": "0.25.0-dev.8",
     "@cadl-lang/compiler": "~0.38.5",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "@cadl-lang/openapi": "~0.38.0",


### PR DESCRIPTION
original version will use 0.25.0 of cadl-dpg, which imports latest cadl, and leads to dependency conflict.