### PR TITLE
[Monitor][Ingestion] Allow IO type in upload

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
   - Added new `on_error` parameter to the `upload` method to allow users to handle errors in their own way.
+  - Added IO support for upload. Now IO streams can be passed in using the `logs` parameter. ([#28373](https://github.com/Azure/azure-sdk-for-python/pull/28373))
 
 ### Breaking Changes
   - Removed support for max_concurrency

--- a/sdk/monitor/azure-monitor-ingestion/assets.json
+++ b/sdk/monitor/azure-monitor-ingestion/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/monitor/azure-monitor-ingestion",
-  "Tag": "python/monitor/azure-monitor-ingestion_7c256dddd2"
+  "Tag": "python/monitor/azure-monitor-ingestion_8aeeee2d98"
 }

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_helpers.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_helpers.py
@@ -19,6 +19,7 @@ JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
 
 MAX_CHUNK_SIZE_BYTES = 1024 * 1024 # 1 MiB
 CHAR_SIZE_BYTES = 4
+GZIP_MAGIC_NUMBER = b"\x1f\x8b"
 
 
 def _split_chunks(logs: List[JSON]) -> Generator[List[JSON], None, None]:

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
@@ -55,11 +55,14 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         if isinstance(logs, IOBase):
-            # Check if the stream is gzip-compressed..
+            if not logs.readable():
+                raise ValueError("The 'logs' stream must be readable.")
             content_encoding = None
-            if logs.read(2) == GZIP_MAGIC_NUMBER:
-                content_encoding = "gzip"
-            logs.seek(0)
+            # Check if the stream is gzip-compressed if stream is seekable.
+            if logs.seekable():
+                if logs.read(2) == GZIP_MAGIC_NUMBER:
+                    content_encoding = "gzip"
+                logs.seek(0)
 
             super().upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
             return

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
@@ -6,12 +6,13 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+from io import IOBase
 import logging
 import sys
-from typing import Callable, List, Any, Optional
+from typing import Callable, List, Any, Optional, Union, IO
 
 from ._operations import LogsIngestionClientOperationsMixin as GeneratedOps
-from .._helpers import _create_gzip_requests
+from .._helpers import _create_gzip_requests, GZIP_MAGIC_NUMBER
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping
@@ -28,21 +29,22 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         self,
         rule_id: str,
         stream_name: str,
-        logs: List[JSON],
+        logs: Union[List[JSON], IO],
         *,
         on_error: Optional[Callable[[Exception, List[JSON]], None]] = None,
         **kwargs: Any
     ) -> None:
         """Ingestion API used to directly ingest data using Data Collection Rules.
 
-        Logs are divided into chunks of 1MB or less, then each chunk is gzip-compressed and uploaded.
+        A list of logs is divided into chunks of 1MB or less, then each chunk is gzip-compressed and uploaded.
+        If an I/O stream is passed in, the stream is uploaded as-is.
 
         :param rule_id: The immutable ID of the Data Collection Rule resource.
         :type rule_id: str
         :param stream_name: The streamDeclaration name as defined in the Data Collection Rule.
         :type stream_name: str
         :param logs: An array of objects matching the schema defined by the provided stream.
-        :type logs: list[JSON]
+        :type logs: list[JSON] or IO
         :keyword on_error: The callback function that is called when a chunk of logs fails to upload.
             This function should expect two arguments that correspond to the error encountered and
             the list of logs that failed to upload. If no function is provided, then the first exception
@@ -52,6 +54,16 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
+        if isinstance(logs, IOBase):
+            # Check if the stream is gzip-compressed..
+            content_encoding = None
+            if logs.read(2) == GZIP_MAGIC_NUMBER:
+                content_encoding = "gzip"
+            logs.seek(0)
+
+            super().upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
+            return
+
         for gzip_data, log_chunk in _create_gzip_requests(logs):
             try:
                 super().upload(rule_id, stream=stream_name, body=gzip_data, content_encoding="gzip", **kwargs)

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -55,11 +55,14 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         if isinstance(logs, IOBase):
-            # Check if the stream is gzip-compressed.
+            if not logs.readable():
+                raise ValueError("The 'logs' stream must be readable.")
             content_encoding = None
-            if logs.read(2) == GZIP_MAGIC_NUMBER:
-                content_encoding = "gzip"
-            logs.seek(0)
+            # Check if the stream is gzip-compressed if stream is seekable.
+            if logs.seekable():
+                if logs.read(2) == GZIP_MAGIC_NUMBER:
+                    content_encoding = "gzip"
+                logs.seek(0)
 
             await super().upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
             return

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -6,12 +6,13 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+from io import IOBase
 import logging
 import sys
-from typing import Callable, List, Any, Awaitable, Optional
+from typing import Callable, List, Any, Awaitable, Optional, Union, IO
 
 from ._operations import LogsIngestionClientOperationsMixin as GeneratedOps
-from ..._helpers import _create_gzip_requests
+from ..._helpers import _create_gzip_requests, GZIP_MAGIC_NUMBER
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping
@@ -28,21 +29,22 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         self,
         rule_id: str,
         stream_name: str,
-        logs: List[JSON],
+        logs: Union[List[JSON], IO],
         *,
         on_error: Optional[Callable[[Exception, List[JSON]], Awaitable[None]]] = None,
         **kwargs: Any
     ) -> None:
         """Ingestion API used to directly ingest data using Data Collection Rules.
 
-        Logs are divided into chunks of 1MB or less, then each chunk is gzip-compressed and uploaded.
+        A list of logs is divided into chunks of 1MB or less, then each chunk is gzip-compressed and uploaded.
+        If an I/O stream is passed in, the stream is uploaded as-is.
 
         :param rule_id: The immutable ID of the Data Collection Rule resource.
         :type rule_id: str
         :param stream: The streamDeclaration name as defined in the Data Collection Rule.
         :type stream: str
         :param logs: An array of objects matching the schema defined by the provided stream.
-        :type logs: list[JSON]
+        :type logs: list[JSON] or IO
         :keyword on_error: The asynchronous callback function that is called when a chunk of logs fails to upload.
             This function should expect two arguments that correspond to the error encountered and
             the list of logs that failed to upload. If no function is provided, then the first exception
@@ -52,6 +54,16 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
+        if isinstance(logs, IOBase):
+            # Check if the stream is gzip-compressed.
+            content_encoding = None
+            if logs.read(2) == GZIP_MAGIC_NUMBER:
+                content_encoding = "gzip"
+            logs.seek(0)
+
+            await super().upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
+            return
+
         for gzip_data, log_chunk in _create_gzip_requests(logs):
             try:
                 await super().upload(rule_id, stream=stream_name, body=gzip_data, content_encoding="gzip", **kwargs)

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
@@ -3,11 +3,36 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import gzip
+import json
+import os
+import uuid
+
 import pytest
 
 from azure.core.exceptions import HttpResponseError
 from azure.monitor.ingestion import LogsIngestionClient
 from devtools_testutils import AzureRecordedTestCase
+
+
+LOGS_BODY = [
+    {
+        "Time": "2021-12-08T23:51:14.1104269Z",
+        "Computer": "Computer1",
+        "AdditionalContext": {
+            "testContextKey": 3,
+            "CounterName": "AppMetric1"
+        }
+    },
+    {
+        "Time": "2021-12-08T23:51:14.1104269Z",
+        "Computer": "Computer2",
+        "AdditionalContext": {
+            "testContextKey": 2,
+            "CounterName": "AppMetric1"
+        }
+    }
+]
 
 
 class TestLogsIngestionClient(AzureRecordedTestCase):
@@ -16,26 +41,7 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
         client = self.create_client_from_credential(
             LogsIngestionClient, self.get_credential(LogsIngestionClient), endpoint=monitor_info['dce'])
         with client:
-            body = [
-                {
-                    "Time": "2021-12-08T23:51:14.1104269Z",
-                    "Computer": "Computer1",
-                    "AdditionalContext": {
-                        "testContextKey": 3,
-                        "CounterName": "AppMetric1"
-                    }
-                },
-                {
-                    "Time": "2021-12-08T23:51:14.1104269Z",
-                    "Computer": "Computer2",
-                    "AdditionalContext": {
-                        "testContextKey": 2,
-                        "CounterName": "AppMetric1"
-                    }
-                }
-            ]
-
-            client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=body)
+            client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=LOGS_BODY)
 
     def test_send_logs_error(self, recorded_test, monitor_info):
         client = self.create_client_from_credential(
@@ -60,3 +66,29 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
         client.upload(
             rule_id='bad-rule', stream_name=monitor_info['stream_name'], logs=body, on_error=on_error)
         assert on_error.called
+
+    def test_send_logs_json_file(self, recorded_test, monitor_info):
+        client = self.create_client_from_credential(
+            LogsIngestionClient, self.get_credential(LogsIngestionClient), endpoint=monitor_info['dce'])
+
+        temp_file = str(uuid.uuid4()) + '.json'
+        with open(temp_file, 'w') as f:
+            json.dump(LOGS_BODY, f)
+
+        with client:
+            with open(temp_file, 'r') as f:
+                client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=f)
+        os.remove(temp_file)
+
+    @pytest.mark.live_test_only("Issues recording binary streams with test-proxy")
+    def test_send_logs_gzip_file(self, monitor_info):
+        client = self.create_client_from_credential(
+            LogsIngestionClient, self.get_credential(LogsIngestionClient), endpoint=monitor_info['dce'])
+
+        temp_file = str(uuid.uuid4()) + '.json.gz'
+        with gzip.open(temp_file, 'wb') as f:
+            f.write(json.dumps(LOGS_BODY).encode('utf-8'))
+
+        with open(temp_file, 'rb') as f:
+            client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=f)
+        os.remove(temp_file)

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
@@ -3,6 +3,11 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import gzip
+import os
+import json
+import uuid
+
 import pytest
 
 from azure.core.exceptions import HttpResponseError
@@ -10,47 +15,54 @@ from azure.monitor.ingestion.aio import LogsIngestionClient
 from devtools_testutils import AzureRecordedTestCase
 
 
+LOGS_BODY = [
+    {
+        "Time": "2021-12-08T23:51:14.1104269Z",
+        "Computer": "Computer1",
+        "AdditionalContext": {
+            "testContextKey": 3,
+            "CounterName": "AppMetric1"
+        }
+    },
+    {
+        "Time": "2021-12-08T23:51:14.1104269Z",
+        "Computer": "Computer2",
+        "AdditionalContext": {
+            "testContextKey": 2,
+            "CounterName": "AppMetric1"
+        }
+    }
+]
+
+
 class TestLogsIngestionClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_send_logs_async(self, recorded_test, monitor_info):
+        credential = self.get_credential(LogsIngestionClient, is_async=True)
         client = self.create_client_from_credential(
-            LogsIngestionClient, self.get_credential(LogsIngestionClient, is_async=True), endpoint=monitor_info['dce'])
+            LogsIngestionClient, credential, endpoint=monitor_info['dce'])
         async with client:
-            body = [
-                {
-                    "Time": "2021-12-08T23:51:14.1104269Z",
-                    "Computer": "Computer1",
-                    "AdditionalContext": {
-                        "testContextKey": 3,
-                        "CounterName": "AppMetric1"
-                    }
-                },
-                {
-                    "Time": "2021-12-08T23:51:14.1104269Z",
-                    "Computer": "Computer2",
-                    "AdditionalContext": {
-                        "testContextKey": 2,
-                        "CounterName": "AppMetric1"
-                    }
-                }
-            ]
-            await client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=body)
+            await client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=LOGS_BODY)
+        credential.close()
 
     @pytest.mark.asyncio
     async def test_send_logs_error(self, recorded_test, monitor_info):
+        credential = self.get_credential(LogsIngestionClient, is_async=True)
         client = self.create_client_from_credential(
-            LogsIngestionClient, self.get_credential(LogsIngestionClient, is_async=True), endpoint=monitor_info['dce'])
+            LogsIngestionClient, credential, endpoint=monitor_info['dce'])
         body = [{"foo": "bar"}]
 
         with pytest.raises(HttpResponseError) as ex:
             async with client:
                 await client.upload(rule_id='bad-rule', stream_name=monitor_info['stream_name'], logs=body)
+        credential.close()
 
     @pytest.mark.asyncio
     async def test_send_logs_error_custom(self, recorded_test, monitor_info):
+        credential = self.get_credential(LogsIngestionClient, is_async=True)
         client = self.create_client_from_credential(
-            LogsIngestionClient, self.get_credential(LogsIngestionClient, is_async=True), endpoint=monitor_info['dce'])
+            LogsIngestionClient, credential, endpoint=monitor_info['dce'])
         body = [{"foo": "bar"}]
 
         async def on_error(error, logs):
@@ -64,3 +76,37 @@ class TestLogsIngestionClientAsync(AzureRecordedTestCase):
             await client.upload(
                 rule_id='bad-rule', stream_name=monitor_info['stream_name'], logs=body, on_error=on_error)
         assert on_error.called
+        credential.close()
+
+    @pytest.mark.asyncio
+    async def test_send_logs_json_file(self, recorded_test, monitor_info):
+        credential = self.get_credential(LogsIngestionClient, is_async=True)
+        client = self.create_client_from_credential(
+            LogsIngestionClient, credential, endpoint=monitor_info['dce'])
+
+        temp_file = str(uuid.uuid4()) + '.json'
+        with open(temp_file, 'w') as f:
+            json.dump(LOGS_BODY, f)
+
+        async with client:
+            with open(temp_file, 'r') as f:
+                await client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=f)
+        os.remove(temp_file)
+        credential.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.live_test_only("Issues recording binary streams with test-proxy")
+    async def test_send_logs_gzip_file(self, monitor_info):
+        credential = self.get_credential(LogsIngestionClient, is_async=True)
+        client = self.create_client_from_credential(
+            LogsIngestionClient, credential, endpoint=monitor_info['dce'])
+
+        temp_file = str(uuid.uuid4()) + '.json.gz'
+        with gzip.open(temp_file, 'wb') as f:
+            f.write(json.dumps(LOGS_BODY).encode('utf-8'))
+
+        async with client:
+            with open(temp_file, 'rb') as f:
+                await client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=f)
+        os.remove(temp_file)
+        credential.close()


### PR DESCRIPTION
Typing for logs argument is changed to indicate an IO type can be passed in, thus matching the [typing of the generated upload method](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_operations.py#L168). An IO type is checked for and passed in as-is without chunking. If the stream is gzip-encoded, we set the content-encoding accordingly.

Closes: #25245
Closes: #26137
