### PR TITLE
[Monitor][Query] Encode commas in metric names

### DIFF
--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
@@ -113,6 +113,8 @@ class MetricsQueryClient(object): # pylint: disable=client-accepts-api-version-k
         if aggregations:
             kwargs.setdefault("aggregation", ",".join(aggregations))
         timespan = construct_iso8601(kwargs.pop("timespan", None))
+        # Metric names with commas need to be encoded.
+        metric_names = [x.replace(",", "%2") for x in metric_names]
         kwargs.setdefault("metricnames", ",".join(metric_names))
         kwargs.setdefault("timespan", timespan)
         kwargs.setdefault("top", kwargs.pop("max_results", None))

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
@@ -95,6 +95,8 @@ class MetricsQueryClient(object): # pylint: disable=client-accepts-api-version-k
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         timespan = construct_iso8601(kwargs.pop("timespan", None))
+        # Metric names with commas need to be encoded.
+        metric_names = [x.replace(",", "%2") for x in metric_names]
         kwargs.setdefault("metricnames", ",".join(metric_names))
         kwargs.setdefault("timespan", timespan)
         kwargs.setdefault("top", kwargs.pop("max_results", None))


### PR DESCRIPTION
The service expects commas in metric names to be encoded as '%2' since multiple metrics are sent up comma-separated, so there needs to be a way to differentiate between a metric with a comma in it and another separate metric.

Ref: `metricnames` of https://learn.microsoft.com/en-us/rest/api/monitor/metrics/list?tabs=HTTP#uri-parameters