### PR TITLE
Clear Credscan warnings originating from `azure-servicemanagement-legacy`

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -47,6 +47,15 @@
                 "tools/azure-sdk-tools/devtools_testutils/mgmt_settings_fake.py"
             ],
             "_justification": "File contains private key used by test code."
+        },
+        {
+            "file":[
+                "sdk/core/azure-servicemanagement-legacy/tests/test_legacy_mgmt_servicebus.test_list_namespaces.yml",
+                "sdk/core/azure-servicemanagement-legacy/tests/test_legacy_mgmt_servicebus.test_delete_namespace.yaml",
+                "sdk/core/azure-servicemanagement-legacy/tests/recordings/test_legacy_mgmt_storage.test_get_storage_account_keys.yaml",
+                "sdk/core/azure-servicemanagement-legacy/tests/recordings/test_legacy_mgmt_storage.test_regenerate_storage_account_keys.yaml"
+            ],
+            "_justification": "Management recording containing long expired secrets. Secrets originate from ~7 years ago and do not merit the effort to re-record on a defunct package."
         }
     ]
 }


### PR DESCRIPTION
Confirmed warnings are gone:

![image](https://user-images.githubusercontent.com/45376673/213019270-8c681b5d-055b-43a6-87c8-29623bd0adf5.png)

I noticed these warnings last week on our public builds: 

![image](https://user-images.githubusercontent.com/45376673/213015332-d13502e9-ae5f-4b37-95d0-6474f9a093e3.png)

And this PR should resolve them all.