### PR TITLE
[Cosmos] Adds cross regional retries for Service Unavailable/Request Timeouts 

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.3.1b2 (Unreleased)
 #### Features Added
  - Added `correlated_activity_id` for query operations
+ - Added cross regional retries for Service Unavailable/Request Timeouts for read/Query Plan operations
 #### Breaking Changes
 
 #### Bugs Fixed

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -71,7 +71,7 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
 
     partition_key_range_gone_retry_policy = _gone_retry_policy.PartitionKeyRangeGoneRetryPolicy(client, *args)
 
-    timeout_failover_retry_policy = _timeout_failover_retry_policy(
+    timeout_failover_retry_policy = _timeout_failover_retry_policy._TimeoutRetryPolicy(
         client.connection_policy.EnableEndpointDiscovery, global_endpoint_manager, *args
     )
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -71,7 +71,7 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
 
     partition_key_range_gone_retry_policy = _gone_retry_policy.PartitionKeyRangeGoneRetryPolicy(client, *args)
 
-    timeout_failover_retry_policy = _timeout_failover_retry_policy._TimeoutRetryPolicy(
+    timeout_failover_retry_policy = _timeout_failover_retry_policy._TimeoutFailoverRetryPolicy(
         client.connection_policy.EnableEndpointDiscovery, global_endpoint_manager, *args
     )
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -109,7 +109,7 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
                 retry_policy = sessionRetry_policy
             elif exceptions._partition_range_is_gone(e):
                 retry_policy = partition_key_range_gone_retry_policy
-            elif (e.status_code == StatusCodes.REQUEST_TIMEOUT):
+            elif e.status_code == StatusCodes.REQUEST_TIMEOUT:
                 retry_policy = timeout_failover_retry_policy
             else:
                 retry_policy = defaultRetry_policy

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -109,7 +109,7 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
                 retry_policy = sessionRetry_policy
             elif exceptions._partition_range_is_gone(e):
                 retry_policy = partition_key_range_gone_retry_policy
-            elif e.status_code == StatusCodes.REQUEST_TIMEOUT:
+            elif e.status_code == StatusCodes.REQUEST_TIMEOUT or e.status_code == StatusCodes.SERVICE_UNAVAILABLE:
                 retry_policy = timeout_failover_retry_policy
             else:
                 retry_policy = defaultRetry_policy

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -80,10 +80,8 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
             client_timeout = kwargs.get('timeout')
             start_time = time.time()
             if args:
-                print("EXE FUN 1")
                 result = ExecuteFunction(function, global_endpoint_manager, *args, **kwargs)
             else:
-                print("EXE FUN 2")
                 result = ExecuteFunction(function, *args, **kwargs)
             if not client.last_response_headers:
                 client.last_response_headers = {}
@@ -98,7 +96,6 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
 
             return result
         except exceptions.CosmosHttpResponseError as e:
-            print(" GOT TO ERROR")
             retry_policy = None
             if e.status_code == StatusCodes.FORBIDDEN and e.sub_status == SubStatusCodes.WRITE_FORBIDDEN:
                 retry_policy = endpointDiscovery_retry_policy
@@ -113,7 +110,6 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
             elif exceptions._partition_range_is_gone(e):
                 retry_policy = partition_key_range_gone_retry_policy
             elif (e.status_code == StatusCodes.REQUEST_TIMEOUT):
-                print("TIMEOUT RETRY POLICY SET")
                 retry_policy = timeout_failover_retry_policy
             else:
                 retry_policy = defaultRetry_policy

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
@@ -49,7 +49,6 @@ class TimeoutFailoverRetryPolicy(object):
     def needsRetry(self):
         if self.args:
             if (self.args[3].method == "GET") or (http_constants.HttpHeaders.IsQueryPlanRequest in self.args[3].headers):
-                print("NEEDS RETRY")
                 return True
         return False
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
@@ -28,6 +28,9 @@ from ..cosmos.documents import _OperationType
 
 class _TimeoutFailoverRetryPolicy(object):
 
+    Max_retry_attempt_count = 1
+    Retry_after_in_milliseconds = 0
+
     def __init__(self, connection_policy, global_endpoint_manager, *args):
         self._max_retry_attempt_count = 120
         self.current_retry_attempt_count = 0
@@ -49,12 +52,13 @@ class _TimeoutFailoverRetryPolicy(object):
 
     def needsRetry(self):
         if self.args:
-            if (self.args[3].method == "GET") or (http_constants.HttpHeaders.IsQueryPlanRequest in self.args[3].headers):
+            if (self.args[3].method == "GET") \
+                    or (http_constants.HttpHeaders.IsQueryPlanRequest in self.args[3].headers):
                 return True
         return False
 
 
-    def ShouldRetry(self, exception):
+    def ShouldRetry(self, _exception):
         """Returns true if should retry based on the passed-in exception.
 
         :param (exceptions.CosmosHttpResponseError instance) exception:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
@@ -25,7 +25,8 @@ Cosmos database service.
 from . import http_constants
 from ..cosmos.documents import _OperationType
 
-class TimeoutFailoverRetryPolicy(object):
+
+class _TimeoutFailoverRetryPolicy(object):
 
     def __init__(self, connection_policy, global_endpoint_manager, *args):
         self._max_retry_attempt_count = 120

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
@@ -39,6 +39,14 @@ class _TimeoutFailoverRetryPolicy(object):
         self.connection_policy = connection_policy
         self.request = args[0] if args else None
 
+        if self.request:
+            self.request.clear_route_to_location()
+
+            # Resolve the endpoint for the request and pin the resolution to the resolved endpoint
+            # This enables marking the endpoint unavailability on endpoint failover/unreachability
+            self.location_endpoint = self.global_endpoint_manager.resolve_service_endpoint(self.request)
+            self.request.route_to_location(self.location_endpoint)
+
     def needsRetry(self):
         if self.args:
             if (self.args[3].method == "GET") \

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_timeout_failover_retry_policy.py
@@ -1,0 +1,98 @@
+# The MIT License (MIT)
+# Copyright (c) 2017 Microsoft Corporation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Internal class for timeout failover retry policy implementation in the Azure
+Cosmos database service.
+"""
+from . import http_constants
+from ..cosmos.documents import _OperationType
+
+class TimeoutFailoverRetryPolicy(object):
+
+    def __init__(self, connection_policy, global_endpoint_manager, *args):
+        self._max_retry_attempt_count = 120
+        self.current_retry_attempt_count = 0
+        self.retry_after_in_milliseconds = 1000
+        self.args = args
+
+        self.global_endpoint_manager = global_endpoint_manager
+        self.failover_retry_count = 0
+        self.connection_policy = connection_policy
+        self.request = args[0] if args else None
+        # clear previous location-based routing directive
+        if self.request:
+            self.request.clear_route_to_location()
+
+            # Resolve the endpoint for the request and pin the resolution to the resolved endpoint
+            # This enables marking the endpoint unavailability on endpoint failover/unreachability
+            self.location_endpoint = self.global_endpoint_manager.resolve_service_endpoint(self.request)
+            self.request.route_to_location(self.location_endpoint)
+
+    def needsRetry(self):
+        if self.args:
+            if (self.args[3].method == "GET") or (http_constants.HttpHeaders.IsQueryPlanRequest in self.args[3].headers):
+                print("NEEDS RETRY")
+                return True
+        return False
+
+
+    def ShouldRetry(self, exception):
+        """Returns true if should retry based on the passed-in exception.
+
+        :param (exceptions.CosmosHttpResponseError instance) exception:
+        :rtype: boolean
+
+        """
+        if not self.needsRetry():
+            return False
+
+        if not self.connection_policy.EnableEndpointDiscovery:
+            return False
+
+        if self.failover_retry_count >= self.Max_retry_attempt_count:
+            return False
+
+        self.failover_retry_count += 1
+
+        if self.location_endpoint:
+            if _OperationType.IsReadOnlyOperation(self.request.operation_type):
+                # Mark current read endpoint as unavailable
+                self.global_endpoint_manager.mark_endpoint_unavailable_for_read(self.location_endpoint)
+            else:
+                self.global_endpoint_manager.mark_endpoint_unavailable_for_write(self.location_endpoint)
+
+        # set the refresh_needed flag to ensure that endpoint list is
+        # refreshed with new writable and readable locations
+        self.global_endpoint_manager.refresh_needed = True
+
+        # clear previous location-based routing directive
+        self.request.clear_route_to_location()
+
+        # set location-based routing directive based on retry count
+        # simulating single master writes by ensuring usePreferredLocations
+        # is set to false
+        self.request.route_to_location_with_preferred_location_flag(self.failover_retry_count, False)
+
+        # Resolve the endpoint for the request and pin the resolution to the resolved endpoint
+        # This enables marking the endpoint unavailability on endpoint failover/unreachability
+        self.location_endpoint = self.global_endpoint_manager.resolve_service_endpoint(self.request)
+        self.request.route_to_location(self.location_endpoint)
+        return True

--- a/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
@@ -19,6 +19,9 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #SOFTWARE.
 
+import sys
+sys.path.insert(0, r"C:\Users\ntripician\source\repos\azure-sdk-for-python\sdk\cosmos\azure-cosmos")
+print("\n\n\n\nSYS\n\n\n\n")
 import unittest
 import azure.cosmos.cosmos_client as cosmos_client
 import pytest
@@ -74,185 +77,204 @@ class Test_retry_policy_tests(unittest.TestCase):
             test_config._test_config.TEST_COLLECTION_SINGLE_PARTITION_ID, PartitionKey(path="/id"))
         cls.retry_after_in_milliseconds = 1000
 
-    def test_resource_throttle_retry_policy_default_retry_after(self):
-        connection_policy = Test_retry_policy_tests.connectionPolicy
-        connection_policy.RetryOptions = retry_options.RetryOptions(5)
+    # def test_resource_throttle_retry_policy_default_retry_after(self):
+    #     connection_policy = Test_retry_policy_tests.connectionPolicy
+    #     connection_policy.RetryOptions = retry_options.RetryOptions(5)
+    #
+    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+    #     try:
+    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
+    #
+    #         document_definition = { 'id': 'doc',
+    #                                 'name': 'sample document',
+    #                                 'key': 'value'}
+    #
+    #         try:
+    #             self.created_collection.create_item(body=document_definition)
+    #         except exceptions.CosmosHttpResponseError as e:
+    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+    #             self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
+    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+    #                                     connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
+    #     finally:
+    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+    #
+    # def test_resource_throttle_retry_policy_fixed_retry_after(self):
+    #     connection_policy = Test_retry_policy_tests.connectionPolicy
+    #     connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000)
+    #
+    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+    #     try:
+    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
+    #
+    #         document_definition = { 'id': 'doc',
+    #                                 'name': 'sample document',
+    #                                 'key': 'value'}
+    #
+    #         try:
+    #             self.created_collection.create_item(body=document_definition)
+    #         except exceptions.CosmosHttpResponseError as e:
+    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+    #             self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
+    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+    #                                     connection_policy.RetryOptions.MaxRetryAttemptCount * connection_policy.RetryOptions.FixedRetryIntervalInMilliseconds)
+    #
+    #     finally:
+    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+    #
+    # def test_resource_throttle_retry_policy_max_wait_time(self):
+    #     connection_policy = Test_retry_policy_tests.connectionPolicy
+    #     connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000, 3)
+    #
+    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+    #     try:
+    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
+    #
+    #         document_definition = { 'id': 'doc',
+    #                                 'name': 'sample document',
+    #                                 'key': 'value'}
+    #
+    #         try:
+    #             self.created_collection.create_item(body=document_definition)
+    #         except exceptions.CosmosHttpResponseError as e:
+    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+    #                                     connection_policy.RetryOptions.MaxWaitTimeInSeconds * 1000)
+    #     finally:
+    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+    #
+    # def test_resource_throttle_retry_policy_query(self):
+    #     connection_policy = Test_retry_policy_tests.connectionPolicy
+    #     connection_policy.RetryOptions = retry_options.RetryOptions(5)
+    #
+    #     document_definition = { 'id': 'doc',
+    #                             'name': 'sample document',
+    #                             'key': 'value'}
+    #
+    #     self.created_collection.create_item(body=document_definition)
+    #
+    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+    #     try:
+    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
+    #
+    #         try:
+    #             list(self.created_collection.query_items(
+    #             {
+    #                 'query': 'SELECT * FROM root r WHERE r.id=@id',
+    #                 'parameters': [
+    #                     {'name': '@id', 'value': document_definition['id']}
+    #                 ]
+    #             }))
+    #         except exceptions.CosmosHttpResponseError as e:
+    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+    #             self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount,
+    #                             self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
+    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+    #                                     connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
+    #     finally:
+    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+    #
+    # @pytest.mark.xfail
+    # def test_default_retry_policy_for_query(self):
+    #     document_definition_1 = { 'id': 'doc1',
+    #                               'name': 'sample document',
+    #                               'key': 'value'}
+    #     document_definition_2 = { 'id': 'doc2',
+    #                               'name': 'sample document',
+    #                               'key': 'value'}
+    #
+    #     self.created_collection.create_item(body=document_definition_1)
+    #     self.created_collection.create_item(body=document_definition_2)
+    #
+    #     try:
+    #         original_execute_function = _retry_utility.ExecuteFunction
+    #         mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
+    #         _retry_utility.ExecuteFunction = mf
+    #
+    #         docs = self.created_collection.query_items(query="Select * from c", max_item_count=1, enable_cross_partition_query=True)
+    #
+    #         result_docs = list(docs)
+    #         self.assertEqual(result_docs[0]['id'], 'doc1')
+    #         self.assertEqual(result_docs[1]['id'], 'doc2')
+    #
+    #         # TODO: Differing result between live and emulator
+    #         if 'localhost' in self.host or '127.0.0.1' in self.host:
+    #             self.assertEqual(mf.counter, 12)
+    #         else:
+    #             self.assertEqual(mf.counter, 18)
+    #     finally:
+    #         _retry_utility.ExecuteFunction = original_execute_function
+    #
+    #     self.created_collection.delete_item(item=result_docs[0], partition_key=result_docs[0]['id'])
+    #     self.created_collection.delete_item(item=result_docs[1], partition_key=result_docs[1]['id'])
 
-        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-        try:
-            _retry_utility.ExecuteFunction = self._MockExecuteFunction
-
-            document_definition = { 'id': 'doc',
-                                    'name': 'sample document',
-                                    'key': 'value'}
-
-            try:
-                self.created_collection.create_item(body=document_definition)
-            except exceptions.CosmosHttpResponseError as e:
-                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
-                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
-        finally:
-            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-
-    def test_resource_throttle_retry_policy_fixed_retry_after(self):
-        connection_policy = Test_retry_policy_tests.connectionPolicy
-        connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000)
-
-        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-        try:
-            _retry_utility.ExecuteFunction = self._MockExecuteFunction
-
-            document_definition = { 'id': 'doc',
-                                    'name': 'sample document',
-                                    'key': 'value'}
-
-            try:
-                self.created_collection.create_item(body=document_definition)
-            except exceptions.CosmosHttpResponseError as e:
-                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
-                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxRetryAttemptCount * connection_policy.RetryOptions.FixedRetryIntervalInMilliseconds)
-
-        finally:
-            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-
-    def test_resource_throttle_retry_policy_max_wait_time(self):
-        connection_policy = Test_retry_policy_tests.connectionPolicy
-        connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000, 3)
-
-        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-        try:
-            _retry_utility.ExecuteFunction = self._MockExecuteFunction
-
-            document_definition = { 'id': 'doc',
-                                    'name': 'sample document',
-                                    'key': 'value'}
-
-            try:
-                self.created_collection.create_item(body=document_definition)
-            except exceptions.CosmosHttpResponseError as e:
-                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxWaitTimeInSeconds * 1000)
-        finally:
-            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-
-    def test_resource_throttle_retry_policy_query(self):
-        connection_policy = Test_retry_policy_tests.connectionPolicy
-        connection_policy.RetryOptions = retry_options.RetryOptions(5)
-
-        document_definition = { 'id': 'doc',
-                                'name': 'sample document',
-                                'key': 'value'}
-
-        self.created_collection.create_item(body=document_definition)
-
-        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-        try:
-            _retry_utility.ExecuteFunction = self._MockExecuteFunction
-
-            try:
-                list(self.created_collection.query_items(
-                {
-                    'query': 'SELECT * FROM root r WHERE r.id=@id',
-                    'parameters': [
-                        {'name': '@id', 'value': document_definition['id']}
-                    ]
-                }))
-            except exceptions.CosmosHttpResponseError as e:
-                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount,
-                                self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
-                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-                                        connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
-        finally:
-            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-
-    @pytest.mark.xfail
-    def test_default_retry_policy_for_query(self):
-        document_definition_1 = { 'id': 'doc1',
-                                  'name': 'sample document',
-                                  'key': 'value'}
-        document_definition_2 = { 'id': 'doc2',
-                                  'name': 'sample document',
-                                  'key': 'value'}
-
-        self.created_collection.create_item(body=document_definition_1)
-        self.created_collection.create_item(body=document_definition_2)
-
-        try:
-            original_execute_function = _retry_utility.ExecuteFunction
-            mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
-            _retry_utility.ExecuteFunction = mf
-
-            docs = self.created_collection.query_items(query="Select * from c", max_item_count=1, enable_cross_partition_query=True)
-
-            result_docs = list(docs)
-            self.assertEqual(result_docs[0]['id'], 'doc1')
-            self.assertEqual(result_docs[1]['id'], 'doc2')
-
-            # TODO: Differing result between live and emulator
-            if 'localhost' in self.host or '127.0.0.1' in self.host:
-                self.assertEqual(mf.counter, 12)
-            else:
-                self.assertEqual(mf.counter, 18)
-        finally:
-            _retry_utility.ExecuteFunction = original_execute_function
-
-        self.created_collection.delete_item(item=result_docs[0], partition_key=result_docs[0]['id'])
-        self.created_collection.delete_item(item=result_docs[1], partition_key=result_docs[1]['id'])
-
-    def test_default_retry_policy_for_read(self):
-        document_definition = { 'id': 'doc',
-                                'name': 'sample document',
-                                'key': 'value'}
+    # def test_default_retry_policy_for_read(self):
+    #     document_definition = { 'id': 'doc',
+    #                             'name': 'sample document',
+    #                             'key': 'value'}
+    #
+    #     created_document = self.created_collection.create_item(body=document_definition)
+    #
+    #     try:
+    #         original_execute_function = _retry_utility.ExecuteFunction
+    #         mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
+    #         _retry_utility.ExecuteFunction = mf
+    #
+    #         doc = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
+    #         self.assertEqual(doc['id'], 'doc')
+    #         self.assertEqual(mf.counter, 3)
+    #
+    #     finally:
+    #         _retry_utility.ExecuteFunction = original_execute_function
+    #
+    #     self.created_collection.delete_item(item=created_document, partition_key=created_document['id'])
+    #
+    # def test_default_retry_policy_for_create(self):
+    #     document_definition = { 'id': 'doc',
+    #                             'name': 'sample document',
+    #                             'key': 'value'}
+    #
+    #     try:
+    #         original_execute_function = _retry_utility.ExecuteFunction
+    #         mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
+    #         _retry_utility.ExecuteFunction = mf
+    #
+    #         created_document = {}
+    #         try:
+    #             created_document = self.created_collection.create_item(body=document_definition)
+    #         except exceptions.CosmosHttpResponseError as err:
+    #             self.assertEqual(err.status_code, 10054)
+    #
+    #         self.assertDictEqual(created_document, {})
+    #
+    #         # 3 retries for readCollection. No retry for createDocument.
+    #         # Counter ends up in three additional calls while doing create_item,
+    #         # which are reads to the database and container before creating the item.
+    #         # As such, even though the retry_utility does not retry for the create, the counter is affected by these.
+    #         # TODO: Figure out a way to make the counter only take in the POST call it is looking for.
+    #         mf.counter = mf.counter - 3
+    #         self.assertEqual(mf.counter, 1)
+    #     finally:
+    #         _retry_utility.ExecuteFunction = original_execute_function
+    def test_timeout_failover_retry_policy_for_read(self):
+        document_definition = {'id': 'doc',
+                               'name': 'sample document',
+                               'key': 'value'}
 
         created_document = self.created_collection.create_item(body=document_definition)
 
         try:
             original_execute_function = _retry_utility.ExecuteFunction
-            mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
+            mf = self.MockExecuteFunctionTimeout(original_execute_function)
+
             _retry_utility.ExecuteFunction = mf
-
-            doc = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
-            self.assertEqual(doc['id'], 'doc')
-            self.assertEqual(mf.counter, 3)
-
+            print("\nStart Read")
+            hi = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
         finally:
             _retry_utility.ExecuteFunction = original_execute_function
+            print("Finally")
 
         self.created_collection.delete_item(item=created_document, partition_key=created_document['id'])
-
-    def test_default_retry_policy_for_create(self):
-        document_definition = { 'id': 'doc',
-                                'name': 'sample document',
-                                'key': 'value'}
-
-        try:
-            original_execute_function = _retry_utility.ExecuteFunction
-            mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
-            _retry_utility.ExecuteFunction = mf
-
-            created_document = {}
-            try:
-                created_document = self.created_collection.create_item(body=document_definition)
-            except exceptions.CosmosHttpResponseError as err:
-                self.assertEqual(err.status_code, 10054)
-
-            self.assertDictEqual(created_document, {})
-
-            # 3 retries for readCollection. No retry for createDocument.
-            # Counter ends up in three additional calls while doing create_item,
-            # which are reads to the database and container before creating the item.
-            # As such, even though the retry_utility does not retry for the create, the counter is affected by these.
-            # TODO: Figure out a way to make the counter only take in the POST call it is looking for.
-            mf.counter = mf.counter - 3
-            self.assertEqual(mf.counter, 1)
-        finally:
-            _retry_utility.ExecuteFunction = original_execute_function
 
     def _MockExecuteFunction(self, function, *args, **kwargs):
         response = test_config.FakeResponse({HttpHeaders.RetryAfterInMilliseconds: self.retry_after_in_milliseconds})
@@ -261,6 +283,23 @@ class Test_retry_policy_tests(unittest.TestCase):
             message="Request rate is too large",
             response=response)
 
+    class MockExecuteFunctionTimeout(object):
+        def __init__(self, org_func):
+            self.org_func = org_func
+            self.counter = 0
+
+        def __call__(self, func, *args, **kwargs):
+            self.counter += 1
+            print(self.counter)
+
+            if self.counter > 1:
+                print("DOING ORG FUN")
+                return self.org_func(func, *args, **kwargs)
+            else:
+                raise exceptions.CosmosHttpResponseError(
+                    status_code=408,
+                    message="Timeout",
+                    response=test_config.FakeResponse({}))
 
     class MockExecuteFunctionConnectionReset(object):
 

--- a/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
@@ -20,8 +20,6 @@
 #SOFTWARE.
 
 import sys
-sys.path.insert(0, r"C:\Users\ntripician\source\repos\azure-sdk-for-python\sdk\cosmos\azure-cosmos")
-print("\n\n\n\nSYS\n\n\n\n")
 import unittest
 import azure.cosmos.cosmos_client as cosmos_client
 import pytest
@@ -77,185 +75,185 @@ class Test_retry_policy_tests(unittest.TestCase):
             test_config._test_config.TEST_COLLECTION_SINGLE_PARTITION_ID, PartitionKey(path="/id"))
         cls.retry_after_in_milliseconds = 1000
 
-    # def test_resource_throttle_retry_policy_default_retry_after(self):
-    #     connection_policy = Test_retry_policy_tests.connectionPolicy
-    #     connection_policy.RetryOptions = retry_options.RetryOptions(5)
-    #
-    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-    #     try:
-    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
-    #
-    #         document_definition = { 'id': 'doc',
-    #                                 'name': 'sample document',
-    #                                 'key': 'value'}
-    #
-    #         try:
-    #             self.created_collection.create_item(body=document_definition)
-    #         except exceptions.CosmosHttpResponseError as e:
-    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-    #             self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
-    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-    #                                     connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
-    #     finally:
-    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-    #
-    # def test_resource_throttle_retry_policy_fixed_retry_after(self):
-    #     connection_policy = Test_retry_policy_tests.connectionPolicy
-    #     connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000)
-    #
-    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-    #     try:
-    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
-    #
-    #         document_definition = { 'id': 'doc',
-    #                                 'name': 'sample document',
-    #                                 'key': 'value'}
-    #
-    #         try:
-    #             self.created_collection.create_item(body=document_definition)
-    #         except exceptions.CosmosHttpResponseError as e:
-    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-    #             self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
-    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-    #                                     connection_policy.RetryOptions.MaxRetryAttemptCount * connection_policy.RetryOptions.FixedRetryIntervalInMilliseconds)
-    #
-    #     finally:
-    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-    #
-    # def test_resource_throttle_retry_policy_max_wait_time(self):
-    #     connection_policy = Test_retry_policy_tests.connectionPolicy
-    #     connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000, 3)
-    #
-    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-    #     try:
-    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
-    #
-    #         document_definition = { 'id': 'doc',
-    #                                 'name': 'sample document',
-    #                                 'key': 'value'}
-    #
-    #         try:
-    #             self.created_collection.create_item(body=document_definition)
-    #         except exceptions.CosmosHttpResponseError as e:
-    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-    #                                     connection_policy.RetryOptions.MaxWaitTimeInSeconds * 1000)
-    #     finally:
-    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-    #
-    # def test_resource_throttle_retry_policy_query(self):
-    #     connection_policy = Test_retry_policy_tests.connectionPolicy
-    #     connection_policy.RetryOptions = retry_options.RetryOptions(5)
-    #
-    #     document_definition = { 'id': 'doc',
-    #                             'name': 'sample document',
-    #                             'key': 'value'}
-    #
-    #     self.created_collection.create_item(body=document_definition)
-    #
-    #     self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
-    #     try:
-    #         _retry_utility.ExecuteFunction = self._MockExecuteFunction
-    #
-    #         try:
-    #             list(self.created_collection.query_items(
-    #             {
-    #                 'query': 'SELECT * FROM root r WHERE r.id=@id',
-    #                 'parameters': [
-    #                     {'name': '@id', 'value': document_definition['id']}
-    #                 ]
-    #             }))
-    #         except exceptions.CosmosHttpResponseError as e:
-    #             self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
-    #             self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount,
-    #                             self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
-    #             self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
-    #                                     connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
-    #     finally:
-    #         _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
-    #
-    # @pytest.mark.xfail
-    # def test_default_retry_policy_for_query(self):
-    #     document_definition_1 = { 'id': 'doc1',
-    #                               'name': 'sample document',
-    #                               'key': 'value'}
-    #     document_definition_2 = { 'id': 'doc2',
-    #                               'name': 'sample document',
-    #                               'key': 'value'}
-    #
-    #     self.created_collection.create_item(body=document_definition_1)
-    #     self.created_collection.create_item(body=document_definition_2)
-    #
-    #     try:
-    #         original_execute_function = _retry_utility.ExecuteFunction
-    #         mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
-    #         _retry_utility.ExecuteFunction = mf
-    #
-    #         docs = self.created_collection.query_items(query="Select * from c", max_item_count=1, enable_cross_partition_query=True)
-    #
-    #         result_docs = list(docs)
-    #         self.assertEqual(result_docs[0]['id'], 'doc1')
-    #         self.assertEqual(result_docs[1]['id'], 'doc2')
-    #
-    #         # TODO: Differing result between live and emulator
-    #         if 'localhost' in self.host or '127.0.0.1' in self.host:
-    #             self.assertEqual(mf.counter, 12)
-    #         else:
-    #             self.assertEqual(mf.counter, 18)
-    #     finally:
-    #         _retry_utility.ExecuteFunction = original_execute_function
-    #
-    #     self.created_collection.delete_item(item=result_docs[0], partition_key=result_docs[0]['id'])
-    #     self.created_collection.delete_item(item=result_docs[1], partition_key=result_docs[1]['id'])
+    def test_resource_throttle_retry_policy_default_retry_after(self):
+        connection_policy = Test_retry_policy_tests.connectionPolicy
+        connection_policy.RetryOptions = retry_options.RetryOptions(5)
 
-    # def test_default_retry_policy_for_read(self):
-    #     document_definition = { 'id': 'doc',
-    #                             'name': 'sample document',
-    #                             'key': 'value'}
-    #
-    #     created_document = self.created_collection.create_item(body=document_definition)
-    #
-    #     try:
-    #         original_execute_function = _retry_utility.ExecuteFunction
-    #         mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
-    #         _retry_utility.ExecuteFunction = mf
-    #
-    #         doc = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
-    #         self.assertEqual(doc['id'], 'doc')
-    #         self.assertEqual(mf.counter, 3)
-    #
-    #     finally:
-    #         _retry_utility.ExecuteFunction = original_execute_function
-    #
-    #     self.created_collection.delete_item(item=created_document, partition_key=created_document['id'])
-    #
-    # def test_default_retry_policy_for_create(self):
-    #     document_definition = { 'id': 'doc',
-    #                             'name': 'sample document',
-    #                             'key': 'value'}
-    #
-    #     try:
-    #         original_execute_function = _retry_utility.ExecuteFunction
-    #         mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
-    #         _retry_utility.ExecuteFunction = mf
-    #
-    #         created_document = {}
-    #         try:
-    #             created_document = self.created_collection.create_item(body=document_definition)
-    #         except exceptions.CosmosHttpResponseError as err:
-    #             self.assertEqual(err.status_code, 10054)
-    #
-    #         self.assertDictEqual(created_document, {})
-    #
-    #         # 3 retries for readCollection. No retry for createDocument.
-    #         # Counter ends up in three additional calls while doing create_item,
-    #         # which are reads to the database and container before creating the item.
-    #         # As such, even though the retry_utility does not retry for the create, the counter is affected by these.
-    #         # TODO: Figure out a way to make the counter only take in the POST call it is looking for.
-    #         mf.counter = mf.counter - 3
-    #         self.assertEqual(mf.counter, 1)
-    #     finally:
-    #         _retry_utility.ExecuteFunction = original_execute_function
+        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+        try:
+            _retry_utility.ExecuteFunction = self._MockExecuteFunction
+
+            document_definition = { 'id': 'doc',
+                                    'name': 'sample document',
+                                    'key': 'value'}
+
+            try:
+                self.created_collection.create_item(body=document_definition)
+            except exceptions.CosmosHttpResponseError as e:
+                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
+                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+                                        connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
+        finally:
+            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+
+    def test_resource_throttle_retry_policy_fixed_retry_after(self):
+        connection_policy = Test_retry_policy_tests.connectionPolicy
+        connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000)
+
+        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+        try:
+            _retry_utility.ExecuteFunction = self._MockExecuteFunction
+
+            document_definition = { 'id': 'doc',
+                                    'name': 'sample document',
+                                    'key': 'value'}
+
+            try:
+                self.created_collection.create_item(body=document_definition)
+            except exceptions.CosmosHttpResponseError as e:
+                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount, self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
+                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+                                        connection_policy.RetryOptions.MaxRetryAttemptCount * connection_policy.RetryOptions.FixedRetryIntervalInMilliseconds)
+
+        finally:
+            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+
+    def test_resource_throttle_retry_policy_max_wait_time(self):
+        connection_policy = Test_retry_policy_tests.connectionPolicy
+        connection_policy.RetryOptions = retry_options.RetryOptions(5, 2000, 3)
+
+        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+        try:
+            _retry_utility.ExecuteFunction = self._MockExecuteFunction
+
+            document_definition = { 'id': 'doc',
+                                    'name': 'sample document',
+                                    'key': 'value'}
+
+            try:
+                self.created_collection.create_item(body=document_definition)
+            except exceptions.CosmosHttpResponseError as e:
+                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+                                        connection_policy.RetryOptions.MaxWaitTimeInSeconds * 1000)
+        finally:
+            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+
+    def test_resource_throttle_retry_policy_query(self):
+        connection_policy = Test_retry_policy_tests.connectionPolicy
+        connection_policy.RetryOptions = retry_options.RetryOptions(5)
+
+        document_definition = { 'id': 'doc',
+                                'name': 'sample document',
+                                'key': 'value'}
+
+        self.created_collection.create_item(body=document_definition)
+
+        self.OriginalExecuteFunction = _retry_utility.ExecuteFunction
+        try:
+            _retry_utility.ExecuteFunction = self._MockExecuteFunction
+
+            try:
+                list(self.created_collection.query_items(
+                {
+                    'query': 'SELECT * FROM root r WHERE r.id=@id',
+                    'parameters': [
+                        {'name': '@id', 'value': document_definition['id']}
+                    ]
+                }))
+            except exceptions.CosmosHttpResponseError as e:
+                self.assertEqual(e.status_code, StatusCodes.TOO_MANY_REQUESTS)
+                self.assertEqual(connection_policy.RetryOptions.MaxRetryAttemptCount,
+                                self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryCount])
+                self.assertGreaterEqual(self.created_collection.client_connection.last_response_headers[HttpHeaders.ThrottleRetryWaitTimeInMs],
+                                        connection_policy.RetryOptions.MaxRetryAttemptCount * self.retry_after_in_milliseconds)
+        finally:
+            _retry_utility.ExecuteFunction = self.OriginalExecuteFunction
+
+    @pytest.mark.xfail
+    def test_default_retry_policy_for_query(self):
+        document_definition_1 = { 'id': 'doc1',
+                                  'name': 'sample document',
+                                  'key': 'value'}
+        document_definition_2 = { 'id': 'doc2',
+                                  'name': 'sample document',
+                                  'key': 'value'}
+
+        self.created_collection.create_item(body=document_definition_1)
+        self.created_collection.create_item(body=document_definition_2)
+
+        try:
+            original_execute_function = _retry_utility.ExecuteFunction
+            mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
+            _retry_utility.ExecuteFunction = mf
+
+            docs = self.created_collection.query_items(query="Select * from c", max_item_count=1, enable_cross_partition_query=True)
+
+            result_docs = list(docs)
+            self.assertEqual(result_docs[0]['id'], 'doc1')
+            self.assertEqual(result_docs[1]['id'], 'doc2')
+
+            # TODO: Differing result between live and emulator
+            if 'localhost' in self.host or '127.0.0.1' in self.host:
+                self.assertEqual(mf.counter, 12)
+            else:
+                self.assertEqual(mf.counter, 18)
+        finally:
+            _retry_utility.ExecuteFunction = original_execute_function
+
+        self.created_collection.delete_item(item=result_docs[0], partition_key=result_docs[0]['id'])
+        self.created_collection.delete_item(item=result_docs[1], partition_key=result_docs[1]['id'])
+
+    def test_default_retry_policy_for_read(self):
+        document_definition = { 'id': 'doc',
+                                'name': 'sample document',
+                                'key': 'value'}
+
+        created_document = self.created_collection.create_item(body=document_definition)
+
+        try:
+            original_execute_function = _retry_utility.ExecuteFunction
+            mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
+            _retry_utility.ExecuteFunction = mf
+
+            doc = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
+            self.assertEqual(doc['id'], 'doc')
+            self.assertEqual(mf.counter, 3)
+
+        finally:
+            _retry_utility.ExecuteFunction = original_execute_function
+
+        self.created_collection.delete_item(item=created_document, partition_key=created_document['id'])
+
+    def test_default_retry_policy_for_create(self):
+        document_definition = { 'id': 'doc',
+                                'name': 'sample document',
+                                'key': 'value'}
+
+        try:
+            original_execute_function = _retry_utility.ExecuteFunction
+            mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
+            _retry_utility.ExecuteFunction = mf
+
+            created_document = {}
+            try:
+                created_document = self.created_collection.create_item(body=document_definition)
+            except exceptions.CosmosHttpResponseError as err:
+                self.assertEqual(err.status_code, 10054)
+
+            self.assertDictEqual(created_document, {})
+
+            # 3 retries for readCollection. No retry for createDocument.
+            # Counter ends up in three additional calls while doing create_item,
+            # which are reads to the database and container before creating the item.
+            # As such, even though the retry_utility does not retry for the create, the counter is affected by these.
+            # TODO: Figure out a way to make the counter only take in the POST call it is looking for.
+            mf.counter = mf.counter - 3
+            self.assertEqual(mf.counter, 1)
+        finally:
+            _retry_utility.ExecuteFunction = original_execute_function
     def test_timeout_failover_retry_policy_for_read(self):
         document_definition = {'id': 'doc',
                                'name': 'sample document',
@@ -268,11 +266,9 @@ class Test_retry_policy_tests(unittest.TestCase):
             mf = self.MockExecuteFunctionTimeout(original_execute_function)
 
             _retry_utility.ExecuteFunction = mf
-            print("\nStart Read")
             hi = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
         finally:
             _retry_utility.ExecuteFunction = original_execute_function
-            print("Finally")
 
         self.created_collection.delete_item(item=created_document, partition_key=created_document['id'])
 
@@ -290,10 +286,8 @@ class Test_retry_policy_tests(unittest.TestCase):
 
         def __call__(self, func, *args, **kwargs):
             self.counter += 1
-            print(self.counter)
 
             if self.counter > 1:
-                print("DOING ORG FUN")
                 return self.org_func(func, *args, **kwargs)
             else:
                 raise exceptions.CosmosHttpResponseError(

--- a/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
@@ -213,7 +213,6 @@ class Test_retry_policy_tests(unittest.TestCase):
         created_document = self.created_collection.create_item(body=document_definition)
 
         try:
-            print("\n\n\n\n\nIN TEST\n\n\n\n\n")
             original_execute_function = _retry_utility.ExecuteFunction
             mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
             _retry_utility.ExecuteFunction = mf
@@ -256,7 +255,7 @@ class Test_retry_policy_tests(unittest.TestCase):
             _retry_utility.ExecuteFunction = original_execute_function
 
     def test_timeout_failover_retry_policy_for_read(self):
-        document_definition = {'id': 'doc',
+        document_definition = {'id': 'failoverDoc',
                                'name': 'sample document',
                                'key': 'value'}
 

--- a/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/test/test_retry_policy.py
@@ -19,7 +19,6 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #SOFTWARE.
 
-import sys
 import unittest
 import azure.cosmos.cosmos_client as cosmos_client
 import pytest
@@ -214,6 +213,7 @@ class Test_retry_policy_tests(unittest.TestCase):
         created_document = self.created_collection.create_item(body=document_definition)
 
         try:
+            print("\n\n\n\n\nIN TEST\n\n\n\n\n")
             original_execute_function = _retry_utility.ExecuteFunction
             mf = self.MockExecuteFunctionConnectionReset(original_execute_function)
             _retry_utility.ExecuteFunction = mf
@@ -254,19 +254,20 @@ class Test_retry_policy_tests(unittest.TestCase):
             self.assertEqual(mf.counter, 1)
         finally:
             _retry_utility.ExecuteFunction = original_execute_function
+
     def test_timeout_failover_retry_policy_for_read(self):
         document_definition = {'id': 'doc',
                                'name': 'sample document',
                                'key': 'value'}
 
         created_document = self.created_collection.create_item(body=document_definition)
-
         try:
             original_execute_function = _retry_utility.ExecuteFunction
             mf = self.MockExecuteFunctionTimeout(original_execute_function)
 
             _retry_utility.ExecuteFunction = mf
-            hi = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
+            doc = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
+            self.assertEqual(doc['id'], 'doc')
         finally:
             _retry_utility.ExecuteFunction = original_execute_function
 


### PR DESCRIPTION
# Description

Fix for [#26750](https://github.com/Azure/azure-sdk-for-python/issues/26750).  Currently request timeouts (Status code 408) or service unavailable (Status code 503) do not failover and retry on other regions for multi-master accounts. 

The Python SDK needs to add retries for the following scenarios: 

| Type | Read/Write | 
|----------|------------|
| Data plane |  Read |
| Metadata |  Read | |
|  Query Plan | Read (it is always read) | 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
