### PR TITLE
[Monitor][Ingestion] Encapsulate error callback args

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
   - Added new `on_error` parameter to the `upload` method to allow users to handle errors in their own way.
+    - An `UploadLogsError` class was added to encapsulate information about the error. An instance of this class is passed to the `on_error` callback.
   - Added IO support for upload. Now IO streams can be passed in using the `logs` parameter. ([#28373](https://github.com/Azure/azure-sdk-for-python/pull/28373))
 
 ### Breaking Changes

--- a/sdk/monitor/azure-monitor-ingestion/README.md
+++ b/sdk/monitor/azure-monitor-ingestion/README.md
@@ -133,14 +133,14 @@ except HttpResponseError as e:
 
 ### Upload with custom error handling
 
-To upload logs with custom error handling, you can pass a callback function to the `on_error` parameter of the `upload` method. The callback function will be called for each error that occurs during the upload and should expect two arguments which correspond to the error encountered and the list of logs that failed to upload.
+To upload logs with custom error handling, you can pass a callback function to the `on_error` parameter of the `upload` method. The callback function will be called for each error that occurs during the upload and should expect one argument that corresponds to an `UploadLogsError` object. This object contains the error encountered and the list of logs that failed to upload.
 
 ```python
 failed_logs = []
-def on_error(error, logs):
-    print("Log chunk failed to upload with error: ", error)
+def on_error(error):
+    print("Log chunk failed to upload with error: ", error.error)
     # Collect all logs that failed to upload.
-    failed_logs.extend(logs)
+    failed_logs.extend(error.failed_logs)
 
 client.upload(rule_id=rule_id, stream_name=os.environ['LOGS_DCR_STREAM_NAME'], logs=body, on_error=on_error)
 ```

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_models.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_models.py
@@ -1,0 +1,32 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import sys
+from typing import Any, List
+
+if sys.version_info >= (3, 9):
+    from collections.abc import MutableMapping
+else:
+    from typing import MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
+
+JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
+
+
+class UploadLogsError:
+    """Error information for a failed upload to Azure Monitor.
+
+    :param error: The error that occured during the upload.
+    :type error: Exception
+    :param failed_logs: The list of logs that failed to upload.
+    :type failed_logs: list[JSON]
+    """
+
+    error: Exception
+    """The error that occurred during the upload."""
+    failed_logs: List[JSON]
+    """The list of logs that failed to upload."""
+
+    def __init__(self, error: Exception, failed_logs: List[JSON]) -> None:
+        self.error = error
+        self.failed_logs = failed_logs

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_patch.py
@@ -9,6 +9,7 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 from typing import TYPE_CHECKING, Any
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy
 from ._client import LogsIngestionClient as GeneratedClient
+from ._models import UploadLogsError
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
@@ -37,7 +38,10 @@ class LogsIngestionClient(GeneratedClient):
         )
 
 
-__all__ = ["LogsIngestionClient"]
+__all__ = [
+    "LogsIngestionClient",
+    "UploadLogsError"
+]
 
 
 def patch_sdk():

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -13,6 +13,7 @@ from typing import Callable, List, Any, Awaitable, Optional, Union, IO
 
 from ._operations import LogsIngestionClientOperationsMixin as GeneratedOps
 from ..._helpers import _create_gzip_requests, GZIP_MAGIC_NUMBER
+from ..._models import UploadLogsError
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping
@@ -45,11 +46,10 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         :type stream: str
         :param logs: An array of objects matching the schema defined by the provided stream.
         :type logs: list[JSON] or IO
-        :keyword on_error: The asynchronous callback function that is called when a chunk of logs fails to upload.
-            This function should expect two arguments that correspond to the error encountered and
-            the list of logs that failed to upload. If no function is provided, then the first exception
-            encountered will be raised.
-        :paramtype on_error: Optional[Callable[[Exception, List[JSON]], None]]
+        :keyword on_error: The callback function that is called when a chunk of logs fails to upload.
+            This function should expect one argument that corresponds to an "UploadLogsError" object.
+            If no function is provided, then the first exception encountered will be raised.
+        :paramtype on_error: Optional[Callable[[~azure.monitor.ingestion.UploadLogsError], None]]
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -72,7 +72,7 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
                 await super().upload(rule_id, stream=stream_name, body=gzip_data, content_encoding="gzip", **kwargs)
             except Exception as err:  # pylint: disable=broad-except
                 if on_error:
-                    await on_error(err, log_chunk)
+                    await on_error(UploadLogsError(error=err, failed_logs=log_chunk))
                 else:
                     _LOGGER.error("Failed to upload chunk containing %d log entries", len(log_chunk))
                     raise err

--- a/sdk/monitor/azure-monitor-ingestion/samples/async_samples/sample_custom_error_callback_async.py
+++ b/sdk/monitor/azure-monitor-ingestion/samples/async_samples/sample_custom_error_callback_async.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 
 from azure.identity.aio import DefaultAzureCredential
+from azure.monitor.ingestion import UploadLogsError
 from azure.monitor.ingestion.aio import LogsIngestionClient
 
 
@@ -28,12 +29,12 @@ async def send_logs():
     failed_logs = []
 
     # Sample callback that stores the logs that failed to upload.
-    async def on_error(error, logs):
-        print("Log chunk failed to upload with error: ", error)
-        failed_logs.extend(logs)
+    async def on_error(error: UploadLogsError) -> None:
+        print("Log chunk failed to upload with error: ", error.error)
+        failed_logs.extend(error.failed_logs)
 
     # Sample callback that just ignores the error.
-    async def on_error_pass(*_):
+    async def on_error_pass(*_) -> None:
         pass
 
     client = LogsIngestionClient(endpoint=endpoint, credential=credential, logging_enable=True)

--- a/sdk/monitor/azure-monitor-ingestion/samples/sample_custom_error_callback.py
+++ b/sdk/monitor/azure-monitor-ingestion/samples/sample_custom_error_callback.py
@@ -4,7 +4,7 @@ Usage: python sample_custom_error_callback.py
 import os
 
 from azure.identity import DefaultAzureCredential
-from azure.monitor.ingestion import LogsIngestionClient
+from azure.monitor.ingestion import LogsIngestionClient, UploadLogsError
 
 
 endpoint = os.environ['DATA_COLLECTION_ENDPOINT']
@@ -29,12 +29,12 @@ body = [
 failed_logs = []
 
 # Sample callback that stores the logs that failed to upload.
-def on_error(error, logs):
-    print("Log chunk failed to upload with error: ", error)
-    failed_logs.extend(logs)
+def on_error(error: UploadLogsError) -> None:
+    print("Log chunk failed to upload with error: ", error.error)
+    failed_logs.extend(error.failed_logs)
 
 # Sample callback that just ignores the error.
-def on_error_pass(*_):
+def on_error_pass(*_) -> None:
     pass
 
 client.upload(rule_id=rule_id, stream_name=os.environ['LOGS_DCR_STREAM_NAME'], logs=body, on_error=on_error)

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
@@ -56,10 +56,10 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
             LogsIngestionClient, self.get_credential(LogsIngestionClient), endpoint=monitor_info['dce'])
         body = [{"foo": "bar"}]
 
-        def on_error(error, logs):
+        def on_error(e):
             on_error.called = True
-            assert isinstance(error, HttpResponseError)
-            assert logs == body
+            assert isinstance(e.error, HttpResponseError)
+            assert e.failed_logs == body
 
         on_error.called = False
 

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
@@ -65,10 +65,10 @@ class TestLogsIngestionClientAsync(AzureRecordedTestCase):
             LogsIngestionClient, credential, endpoint=monitor_info['dce'])
         body = [{"foo": "bar"}]
 
-        async def on_error(error, logs):
+        async def on_error(e):
             on_error.called = True
-            assert isinstance(error, HttpResponseError)
-            assert logs == body
+            assert isinstance(e.error, HttpResponseError)
+            assert e.failed_logs == body
 
         on_error.called = False
 


### PR DESCRIPTION
This creates a new public class called `UploadLogsError` that will be used to contain the exception encountered and the list of failed logs. This follows the same pattern as error callbacks in other language ingestion SDKs, and will allow for some flexibility, allowing us to add more attributes without breaking user callbacks.

