### PR TITLE
Ensure that test packages are filtered out of versioning update, but still allow "tests" in name

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/versioning/version_shared.py
+++ b/tools/azure-sdk-tools/ci_tools/versioning/version_shared.py
@@ -39,7 +39,7 @@ from typing import List
 
 
 def path_excluded(path, additional_excludes):
-    return any([excl in path for excl in additional_excludes]) or "tests" in path or is_metapackage(path)
+    return any([excl in path for excl in additional_excludes]) or "tests" in os.path.normpath(path).split(os.sep) or is_metapackage(path)
 
 
 # Metapackages do not have an 'azure' folder within them


### PR DESCRIPTION
`azure-mgmt-loadtestservice` was crashing due to `"tests"` being in the path.