### PR TITLE
[Test Proxy] Temporarily remove `reset` recording management command

### DIFF
--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -396,7 +396,8 @@ the repo.
 
 The `.assets` folder contains one or more directories with random names, which each are a git directory containing
 recordings. If you `cd` into the folder containing your package's recordings, you can use `git status` to view the
-recording updates you've made.
+recording updates you've made. You can also use other `git` commands; for example, `git diff {file name}` to see
+specific file changes, or `git restore {file name}` to undo changes you don't want to keep.
 
 To find the directory containing your package's recordings, open the `.breadcrumb` file in the `.assets` folder. This
 file lists a package name on each line, followed by the recording directory name; for example:
@@ -416,7 +417,6 @@ python scripts/manage_recordings.py push sdk/{service}/{package}/assets.json
 The verbs that can be provided to this script are "push", "restore", and "reset":
 - **push**: pushes recording updates to a new assets repo tag and updates the tag pointer in `assets.json`.
 - **restore**: fetches recordings from the assets repo, based on the tag pointer in `assets.json`.
-- **reset**: discards any pending changes to recordings, based on the tag pointer in `assets.json`.
 
 After pushing your recordings, the `assets.json` file for your package will be updated to point to a new `Tag` that
 contains the updates. Include this `assets.json` update in any pull request to update the recordings pointer in the

--- a/scripts/manage_recordings.py
+++ b/scripts/manage_recordings.py
@@ -40,7 +40,6 @@ import subprocess
 #
 #   * push: pushes recording updates to a new assets repo tag and updates the tag pointer in `assets.json`.
 #   * restore: fetches recordings from the assets repo, based on the tag pointer in `assets.json`.
-#   * reset: discards any pending changes to recordings, based on the tag pointer in `assets.json`.
 #
 # For more information about how recording asset synchronization, please refer to
 # https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/documentation/asset-sync/README.md.
@@ -118,7 +117,7 @@ if not (GIT_TOKEN and GIT_OWNER and GIT_EMAIL):
 
 # Prepare command arguments
 parser = argparse.ArgumentParser(description="Script for managing recording assets with Docker.")
-parser.add_argument("verb", help='The action verb for managing recordings: "restore", "push", or "reset".')
+parser.add_argument("verb", help='The action verb for managing recordings: "push" or "restore".')
 parser.add_argument(
     "path",
     default="assets.json",


### PR DESCRIPTION
# Description

The `reset` command unfortunately doesn't work with Docker, since the prompt to confirm `git` changes can't be responded to in the container. Since the `tests.md` guidance will need to be updated soon to account for standalone test proxy executables anyway, this PR removes the broken `reset` command to avoid confusion.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
