### PR TITLE
[EventHubs] patch pyamqp websocket not installed error

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.11.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.11.1 (2023-01-25)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed a bug where, when `websocket-client` was not installed, the error was not caught/raised properly (issue #28453).
 
 ## 5.11.0 (2023-01-19)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -585,6 +585,9 @@ class ConsumerProducerMixin(object):
                 return operation()
             except Exception as exception:  # pylint:disable=broad-except
                 last_exception = self._handle_exception(exception)
+                # If optional dependency is not installed, do not retry.
+                if isinstance(exception.__cause__, ModuleNotFoundError):
+                    raise last_exception
                 self._client._backoff(
                     retried_times=retried_times,
                     last_exception=last_exception,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -586,7 +586,7 @@ class ConsumerProducerMixin(object):
             except Exception as exception:  # pylint:disable=broad-except
                 last_exception = self._handle_exception(exception)
                 # If optional dependency is not installed, do not retry.
-                if isinstance(exception.__cause__, ModuleNotFoundError):
+                if isinstance(exception.__cause__, ImportError):
                     raise last_exception
                 self._client._backoff(
                     retried_times=retried_times,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -235,6 +235,9 @@ class EventHubConsumer(
                     if self._last_received_event:
                         self._offset = self._last_received_event.offset
                     last_exception = self._handle_exception(exception, is_consumer=True)
+                    # If optional dependency is not installed, do not retry.
+                    if isinstance(exception.__cause__, ModuleNotFoundError):
+                        raise last_exception
                     retried_times += 1
                     if retried_times > max_retries:
                         _LOGGER.info(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -236,7 +236,7 @@ class EventHubConsumer(
                         self._offset = self._last_received_event.offset
                     last_exception = self._handle_exception(exception, is_consumer=True)
                     # If optional dependency is not installed, do not retry.
-                    if isinstance(exception.__cause__, ModuleNotFoundError):
+                    if isinstance(exception.__cause__, ImportError):
                         raise last_exception
                     retried_times += 1
                     if retried_times > max_retries:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -716,10 +716,10 @@ class WebSocketTransport(_AbstractTransport):
                 WebSocketTimeoutException,
                 WebSocketConnectionClosedException
             )
-        except ImportError as exc:
-            raise ValueError(
-                "Please install websocket-client library to use websocket transport."
-            ) from exc
+        except ImportError:
+            raise ImportError(
+                "Please install websocket-client library to use sync websocket transport."
+            )
         try:
             self.ws = create_connection(
                 url="wss://{}".format(self._custom_endpoint or self._host),

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -679,8 +679,6 @@ def Transport(host, transport_type, connect_timeout=None, ssl_opts=True, **kwarg
         transport = WebSocketTransport
     else:
         transport = SSLTransport
-    print('heeerrre')
-    print(transport)
     return transport(host, connect_timeout=connect_timeout, ssl_opts=ssl_opts, **kwargs)
 
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -501,10 +501,10 @@ class WebSocketTransportAsync(
         try:
             from aiohttp import ClientSession, ClientConnectorError
             from urllib.parse import urlsplit
-        except ImportError as exc:
+        except ImportError:
             raise ImportError(
                 "Please install aiohttp library to use async websocket transport."
-            ) from exc
+            )
 
         if username or password:
             from aiohttp import BasicAuth

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -544,7 +544,7 @@ class WebSocketTransportAsync(
                     )
                 raise ConnectionError("Failed to establish websocket connection: " + str(exc))
             self.connected = True
-        except ImportError as exc:
+        except ModuleNotFoundError as exc:
             raise ValueError(
                 "Please install aiohttp library to use websocket transport."
             ) from exc

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -501,53 +501,53 @@ class WebSocketTransportAsync(
         try:
             from aiohttp import ClientSession, ClientConnectorError
             from urllib.parse import urlsplit
-
-            if username or password:
-                from aiohttp import BasicAuth
-
-                http_proxy_auth = BasicAuth(login=username, password=password)
-
-            self.session = ClientSession()
-            if self._custom_endpoint:
-                url = f"wss://{self._custom_endpoint}"
-            else:
-                url = f"wss://{self.host}"
-                parsed_url = urlsplit(url)
-                url = f"{parsed_url.scheme}://{parsed_url.netloc}:{self.port}{parsed_url.path}"
-
-            try:
-                # Enabling heartbeat that sends a ping message every n seconds and waits for pong response.
-                # if pong response is not received then close connection. This raises an error when trying
-                # to communicate with the websocket which is no longer active.
-                # We are waiting a bug fix in aiohttp for these 2 bugs where aiohttp ws might hang on network disconnect
-                # and the heartbeat mechanism helps mitigate these two.
-                # https://github.com/aio-libs/aiohttp/pull/5860
-                # https://github.com/aio-libs/aiohttp/issues/2309
-
-                self.ws = await self.session.ws_connect(
-                    url=url,
-                    timeout=self._connect_timeout,
-                    protocols=[AMQP_WS_SUBPROTOCOL],
-                    autoclose=False,
-                    proxy=http_proxy_host,
-                    proxy_auth=http_proxy_auth,
-                    ssl=self.sslopts,
-                    heartbeat=DEFAULT_WEBSOCKET_HEARTBEAT_SECONDS,
-                )
-            except ClientConnectorError as exc:
-                _LOGGER.info("Websocket connect failed: %r", exc, extra=self.network_trace_params)
-                if self._custom_endpoint:
-                    raise AuthenticationException(
-                        ErrorCondition.ClientError,
-                        description="Failed to authenticate the connection due to exception: " + str(exc),
-                        error=exc,
-                    )
-                raise ConnectionError("Failed to establish websocket connection: " + str(exc))
-            self.connected = True
-        except ModuleNotFoundError as exc:
+        except ImportError as exc:
             raise ValueError(
                 "Please install aiohttp library to use websocket transport."
             ) from exc
+
+        if username or password:
+            from aiohttp import BasicAuth
+
+            http_proxy_auth = BasicAuth(login=username, password=password)
+
+        self.session = ClientSession()
+        if self._custom_endpoint:
+            url = f"wss://{self._custom_endpoint}"
+        else:
+            url = f"wss://{self.host}"
+            parsed_url = urlsplit(url)
+            url = f"{parsed_url.scheme}://{parsed_url.netloc}:{self.port}{parsed_url.path}"
+
+        try:
+            # Enabling heartbeat that sends a ping message every n seconds and waits for pong response.
+            # if pong response is not received then close connection. This raises an error when trying
+            # to communicate with the websocket which is no longer active.
+            # We are waiting a bug fix in aiohttp for these 2 bugs where aiohttp ws might hang on network disconnect
+            # and the heartbeat mechanism helps mitigate these two.
+            # https://github.com/aio-libs/aiohttp/pull/5860
+            # https://github.com/aio-libs/aiohttp/issues/2309
+
+            self.ws = await self.session.ws_connect(
+                url=url,
+                timeout=self._connect_timeout,
+                protocols=[AMQP_WS_SUBPROTOCOL],
+                autoclose=False,
+                proxy=http_proxy_host,
+                proxy_auth=http_proxy_auth,
+                ssl=self.sslopts,
+                heartbeat=DEFAULT_WEBSOCKET_HEARTBEAT_SECONDS,
+            )
+        except ClientConnectorError as exc:
+            _LOGGER.info("Websocket connect failed: %r", exc, extra=self.network_trace_params)
+            if self._custom_endpoint:
+                raise AuthenticationException(
+                    ErrorCondition.ClientError,
+                    description="Failed to authenticate the connection due to exception: " + str(exc),
+                    error=exc,
+                )
+            raise ConnectionError("Failed to establish websocket connection: " + str(exc))
+        self.connected = True
 
     async def _read(self, toread, buffer=None, **kwargs):  # pylint: disable=unused-argument
         """Read exactly n bytes from the peer."""

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -502,8 +502,8 @@ class WebSocketTransportAsync(
             from aiohttp import ClientSession, ClientConnectorError
             from urllib.parse import urlsplit
         except ImportError as exc:
-            raise ValueError(
-                "Please install aiohttp library to use websocket transport."
+            raise ImportError(
+                "Please install aiohttp library to use async websocket transport."
             ) from exc
 
         if username or password:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -544,10 +544,10 @@ class WebSocketTransportAsync(
                     )
                 raise ConnectionError("Failed to establish websocket connection: " + str(exc))
             self.connected = True
-        except ImportError:
+        except ImportError as exc:
             raise ValueError(
                 "Please install aiohttp library to use websocket transport."
-            )
+            ) from exc
 
     async def _read(self, toread, buffer=None, **kwargs):  # pylint: disable=unused-argument
         """Read exactly n bytes from the peer."""

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
@@ -352,6 +352,9 @@ class ClientBaseAsync(ClientBase):
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
             except Exception as exception:  # pylint:disable=broad-except
+                # If optional dependency is not installed, do not retry.
+                if isinstance(exception, ImportError):
+                    raise exception
                 # is_consumer=True passed in here, ALTHOUGH this method is shared by the producer and consumer.
                 # is_consumer will only be checked if FileNotFoundError is raised by self.mgmt_client.open() due to
                 # invalid/non-existent connection_verify filepath. The producer will encounter the FileNotFoundError
@@ -514,10 +517,10 @@ class ConsumerProducerMixin(_MIXIN_BASE):
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
             except Exception as exception:  # pylint:disable=broad-except
-                last_exception = await self._handle_exception(exception)
                 # If optional dependency is not installed, do not retry.
-                if isinstance(exception.__cause__, ImportError):
-                    raise last_exception
+                if isinstance(exception, ImportError):
+                    raise exception
+                last_exception = await self._handle_exception(exception)
                 await self._client._backoff_async(
                     retried_times=retried_times,
                     last_exception=last_exception,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
@@ -516,7 +516,7 @@ class ConsumerProducerMixin(_MIXIN_BASE):
             except Exception as exception:  # pylint:disable=broad-except
                 last_exception = await self._handle_exception(exception)
                 # If optional dependency is not installed, do not retry.
-                if isinstance(exception.__cause__, ModuleNotFoundError):
+                if isinstance(exception.__cause__, ImportError):
                     raise last_exception
                 await self._client._backoff_async(
                     retried_times=retried_times,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
@@ -515,6 +515,9 @@ class ConsumerProducerMixin(_MIXIN_BASE):
                 raise
             except Exception as exception:  # pylint:disable=broad-except
                 last_exception = await self._handle_exception(exception)
+                # If optional dependency is not installed, do not retry.
+                if isinstance(exception.__cause__, ModuleNotFoundError):
+                    raise last_exception
                 await self._client._backoff_async(
                     retried_times=retried_times,
                     last_exception=last_exception,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -195,6 +195,9 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
                     if consumer._last_received_event:
                         consumer._offset = consumer._last_received_event.offset
                     last_exception = await consumer._handle_exception(exception)
+                    # If optional dependency is not installed, do not retry.
+                    if isinstance(exception.__cause__, ModuleNotFoundError):
+                        raise last_exception
                     retried_times += 1
                     if retried_times > max_retries:
                         _LOGGER.info(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -196,7 +196,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
                         consumer._offset = consumer._last_received_event.offset
                     last_exception = await consumer._handle_exception(exception)
                     # If optional dependency is not installed, do not retry.
-                    if isinstance(exception.__cause__, ModuleNotFoundError):
+                    if isinstance(exception.__cause__, ImportError):
                         raise last_exception
                     retried_times += 1
                     if retried_times > max_retries:


### PR DESCRIPTION
fixes: #28453

Two updates:
* when websocket-client was not installed, sync Websocket was not catching the ModuleNotFoundError/ImportError correctly.
* For both sync and async, updated producer + consumer to not retry when the underlying error is ModuleNotFoundError (ie. don't retry when websocket-client/aiohttp aren't installed).