### PR TITLE
[Monitor][Ingestion] Regen using stable API spec

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/assets.json
+++ b/sdk/monitor/azure-monitor-ingestion/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/monitor/azure-monitor-ingestion",
-  "Tag": "python/monitor/azure-monitor-ingestion_8aeeee2d98"
+  "Tag": "python/monitor/azure-monitor-ingestion_70c5ade383"
 }

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_client.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_client.py
@@ -29,8 +29,8 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure. Required.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword api_version: Api Version. Default value is "2021-11-01-preview". Note that overriding
-     this default value may result in unsupported behavior.
+    :keyword api_version: Api Version. Default value is "2023-01-01". Note that overriding this
+     default value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
@@ -76,5 +76,5 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
         self._client.__enter__()
         return self
 
-    def __exit__(self, *exc_details) -> None:
+    def __exit__(self, *exc_details: Any) -> None:
         self._client.__exit__(*exc_details)

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_configuration.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_configuration.py
@@ -35,14 +35,14 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure. Required.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword api_version: Api Version. Default value is "2021-11-01-preview". Note that overriding
-     this default value may result in unsupported behavior.
+    :keyword api_version: Api Version. Default value is "2023-01-01". Note that overriding this
+     default value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, endpoint: str, credential: "TokenCredential", **kwargs: Any) -> None:
         super(LogsIngestionClientConfiguration, self).__init__(**kwargs)
-        api_version: Literal["2021-11-01-preview"] = kwargs.pop("api_version", "2021-11-01-preview")
+        api_version: Literal["2023-01-01"] = kwargs.pop("api_version", "2023-01-01")
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_models.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_models.py
@@ -6,11 +6,11 @@ import sys
 from typing import Any, List
 
 if sys.version_info >= (3, 9):
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping
 else:
-    from typing import MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
+    from typing import Mapping  # type: ignore  # pylint: disable=ungrouped-imports
 
-JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
+JSON = Mapping[str, Any]  # pylint: disable=unsubscriptable-object
 
 
 class UploadLogsError:

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_operations.py
@@ -54,9 +54,7 @@ def build_logs_ingestion_upload_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: Literal["2021-11-01-preview"] = kwargs.pop(
-        "api_version", _params.pop("api-version", "2021-11-01-preview")
-    )
+    api_version: Literal["2023-01-01"] = kwargs.pop("api_version", _params.pop("api-version", "2023-01-01"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -180,7 +178,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         :param stream: The streamDeclaration name as defined in the Data Collection Rule. Required.
         :type stream: str
         :param body: An array of objects matching the schema defined by the provided stream. Is either
-         a list type or a IO type. Required.
+         a [JSON] type or a IO type. Required.
         :type body: list[JSON] or IO
         :keyword content_encoding: gzip. Default value is None.
         :paramtype content_encoding: str

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
@@ -16,9 +16,9 @@ from .._helpers import _create_gzip_requests, GZIP_MAGIC_NUMBER
 from .._models import UploadLogsError
 
 if sys.version_info >= (3, 9):
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
 else:
-    from typing import MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
+    from typing import Mapping, MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
 
 
 class LogsIngestionClientOperationsMixin(GeneratedOps):
-    def upload(  # type:ignore[override] # pylint: disable=arguments-renamed, arguments-differ
+    def upload(  # type: ignore[override] # pylint: disable=arguments-renamed, arguments-differ
         self,
         rule_id: str,
         stream_name: str,
@@ -70,15 +70,11 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         for gzip_data, log_chunk in _create_gzip_requests(cast(List[JSON], logs)):
             try:
                 super().upload(
-                    rule_id,
-                    stream=stream_name,
-                    body=gzip_data,  # type: ignore
-                    content_encoding="gzip",
-                    **kwargs
+                    rule_id, stream=stream_name, body=gzip_data, content_encoding="gzip", **kwargs  # type: ignore
                 )
             except Exception as err:  # pylint: disable=broad-except
                 if on_error:
-                    on_error(UploadLogsError(error=err, failed_logs=log_chunk))
+                    on_error(UploadLogsError(error=err, failed_logs=cast(List[Mapping[str, Any]], log_chunk)))
                 else:
                     _LOGGER.error("Failed to upload chunk containing %d log entries", len(log_chunk))
                     raise err

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_client.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_client.py
@@ -29,8 +29,8 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword api_version: Api Version. Default value is "2021-11-01-preview". Note that overriding
-     this default value may result in unsupported behavior.
+    :keyword api_version: Api Version. Default value is "2023-01-01". Note that overriding this
+     default value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
@@ -76,5 +76,5 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
         await self._client.__aenter__()
         return self
 
-    async def __aexit__(self, *exc_details) -> None:
+    async def __aexit__(self, *exc_details: Any) -> None:
         await self._client.__aexit__(*exc_details)

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_configuration.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_configuration.py
@@ -35,14 +35,14 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure. Required.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword api_version: Api Version. Default value is "2021-11-01-preview". Note that overriding
-     this default value may result in unsupported behavior.
+    :keyword api_version: Api Version. Default value is "2023-01-01". Note that overriding this
+     default value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, endpoint: str, credential: "AsyncTokenCredential", **kwargs: Any) -> None:
         super(LogsIngestionClientConfiguration, self).__init__(**kwargs)
-        api_version: Literal["2021-11-01-preview"] = kwargs.pop("api_version", "2021-11-01-preview")
+        api_version: Literal["2023-01-01"] = kwargs.pop("api_version", "2023-01-01")
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_operations.py
@@ -132,7 +132,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         :param stream: The streamDeclaration name as defined in the Data Collection Rule. Required.
         :type stream: str
         :param body: An array of objects matching the schema defined by the provided stream. Is either
-         a list type or a IO type. Required.
+         a [JSON] type or a IO type. Required.
         :type body: list[JSON] or IO
         :keyword content_encoding: gzip. Default value is None.
         :paramtype content_encoding: str

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -16,9 +16,9 @@ from ..._helpers import _create_gzip_requests, GZIP_MAGIC_NUMBER
 from ..._models import UploadLogsError
 
 if sys.version_info >= (3, 9):
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
 else:
-    from typing import MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
+    from typing import Mapping, MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
 
 
 class LogsIngestionClientOperationsMixin(GeneratedOps):
-    async def upload(  # type:ignore[override] # pylint: disable=arguments-renamed, arguments-differ
+    async def upload(  # type: ignore[override] # pylint: disable=arguments-renamed, arguments-differ
         self,
         rule_id: str,
         stream_name: str,
@@ -70,15 +70,11 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         for gzip_data, log_chunk in _create_gzip_requests(cast(List[JSON], logs)):
             try:
                 await super().upload(
-                    rule_id,
-                    stream=stream_name,
-                    body=gzip_data,  # type: ignore
-                    content_encoding="gzip",
-                    **kwargs
+                    rule_id, stream=stream_name, body=gzip_data, content_encoding="gzip", **kwargs  # type: ignore
                 )
             except Exception as err:  # pylint: disable=broad-except
                 if on_error:
-                    await on_error(UploadLogsError(error=err, failed_logs=log_chunk))
+                    await on_error(UploadLogsError(error=err, failed_logs=cast(List[Mapping[str, Any]], log_chunk)))
                 else:
                     _LOGGER.error("Failed to upload chunk containing %d log entries", len(log_chunk))
                     raise err

--- a/sdk/monitor/azure-monitor-ingestion/swagger/README.PYTHON.md
+++ b/sdk/monitor/azure-monitor-ingestion/swagger/README.PYTHON.md
@@ -13,8 +13,8 @@ license-header: MICROSOFT_MIT_NO_VERSION
 no-namespace-folders: true
 output-folder: ../azure/monitor/ingestion
 source-code-folder-path: ./azure/monitor/ingestion
-input-file: 
-    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/monitor/data-plane/ingestion/preview/2021-11-01-preview/DataCollectionRules.json
+input-file:
+    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/monitor/data-plane/ingestion/stable/2023-01-01/DataCollectionRules.json
 python: true
 version-tolerant: true
 python3-only: true


### PR DESCRIPTION
The package was regenerated using the newly created [stable API spec](https://github.com/Azure/azure-rest-api-specs/pull/22287) for the ingestion API and a small update in autorest.

One minor additional change was to change UploadLogsError `failed_logs` typing to be a list of `Mapping` instead of `MutableMapping` since we don't expect changes to be made to the objects.