### PR TITLE
[Storage] Change method for reading from async streams

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added support for new blob tier, `Cold`.
 - Added support for `AsyncIterable` as data type for async blob upload.
 
+### Bugs Fixed
+- Changed how async streams are detected on async `upload_blob` to increase compatiblity with different types.
+
 ### Other Changes
 - Removed `msrest` dependency.
 - Added `typing-extensions>=4.0.1` as a dependency.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -6,6 +6,7 @@
 # pylint: disable=no-self-use
 
 import asyncio
+import inspect
 import threading
 from asyncio import Lock
 from io import UnsupportedOperation
@@ -186,10 +187,9 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             while True:
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
-                if asyncio.iscoroutinefunction(self.stream.read):
-                    temp = await self.stream.read(read_size)
-                else:
-                    temp = self.stream.read(read_size)
+                temp = self.stream.read(read_size)
+                if inspect.isawaitable(temp):
+                    temp = await temp
                 if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 # pylint: disable=no-self-use
 
-import asyncio
+import inspect
 from io import SEEK_SET, UnsupportedOperation
 from typing import TypeVar, TYPE_CHECKING
 
@@ -70,10 +70,9 @@ async def upload_block_blob(  # pylint: disable=too-many-locals, too-many-statem
         # Do single put if the size is smaller than config.max_single_put_size
         if adjusted_count is not None and (adjusted_count <= blob_settings.max_single_put_size):
             try:
-                if asyncio.iscoroutinefunction(data.read):
-                    data = await data.read(length)
-                else:
-                    data = data.read(length)
+                data = data.read(length)
+                if inspect.isawaitable(data):
+                    data = await data
                 if not isinstance(data, bytes):
                     raise TypeError('Blob data should be of type bytes.')
             except AttributeError:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -6,6 +6,7 @@
 # pylint: disable=no-self-use
 
 import asyncio
+import inspect
 import threading
 from asyncio import Lock
 from io import UnsupportedOperation
@@ -186,10 +187,9 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             while True:
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
-                if asyncio.iscoroutinefunction(self.stream.read):
-                    temp = await self.stream.read(read_size)
-                else:
-                    temp = self.stream.read(read_size)
+                temp = self.stream.read(read_size)
+                if inspect.isawaitable(temp):
+                    temp = await temp
                 if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -6,6 +6,7 @@
 # pylint: disable=no-self-use
 
 import asyncio
+import inspect
 import threading
 from asyncio import Lock
 from io import UnsupportedOperation
@@ -186,10 +187,9 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             while True:
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
-                if asyncio.iscoroutinefunction(self.stream.read):
-                    temp = await self.stream.read(read_size)
-                else:
-                    temp = self.stream.read(read_size)
+                temp = self.stream.read(read_size)
+                if inspect.isawaitable(temp):
+                    temp = await temp
                 if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -6,6 +6,7 @@
 # pylint: disable=no-self-use
 
 import asyncio
+import inspect
 import threading
 from asyncio import Lock
 from io import UnsupportedOperation
@@ -186,10 +187,9 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             while True:
                 if self.total_size:
                     read_size = min(self.chunk_size - len(data), self.total_size - (index + len(data)))
-                if asyncio.iscoroutinefunction(self.stream.read):
-                    temp = await self.stream.read(read_size)
-                else:
-                    temp = self.stream.read(read_size)
+                temp = self.stream.read(read_size)
+                if inspect.isawaitable(temp):
+                    temp = await temp
                 if not isinstance(temp, bytes):
                     raise TypeError('Blob data should be of type bytes.')
                 data += temp or b""


### PR DESCRIPTION
Resolves #28307

This change aims to improve compatibility with different types of async streams by switching from using `asyncio.iscoroutinefunction` to `inspect.isawaitable`. Specifically, this should work better with `aiofiles`.