### PR TITLE
[Monitor][Ingestion] Fix incorrect typing

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -32,7 +32,7 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
         stream_name: str,
         logs: Union[List[JSON], IO],
         *,
-        on_error: Optional[Callable[[Exception, List[JSON]], Awaitable[None]]] = None,
+        on_error: Optional[Callable[[UploadLogsError], Awaitable[None]]] = None,
         **kwargs: Any
     ) -> None:
         """Ingestion API used to directly ingest data using Data Collection Rules.


### PR DESCRIPTION
This was missed in a recent commit that was merged to change the type for the on_error callable. (https://github.com/Azure/azure-sdk-for-python/pull/28425)

The recently enabled mypy and pyright checks caught the type mismatch.
