### PR TITLE
[Communication] Fix Method Name in Readme

### DIFF
--- a/sdk/communication/azure-communication-email/README.md
+++ b/sdk/communication/azure-communication-email/README.md
@@ -162,7 +162,7 @@ The result from the `send` call contains a `messageId` which can be used to quer
 
 ```python
 response = client.send(message)
-status = client.get_sent_status(response['messageId'])
+status = client.get_send_status(response['messageId'])
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
# Description

A method name used in the `azure-communication-email` package's readme is incorrect as called out in [this issue](https://github.com/Azure/azure-sdk-for-python/issues/28408).

resolves #28408

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
