### PR TITLE
[formrecognizer] Skip test assertion due to service regression

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url.py
@@ -160,7 +160,8 @@ class TestDACAnalyzePrebuiltsFromUrl(FormRecognizerTest):
         assert invoice.fields.get("CustomerName").value ==  "Microsoft"
         assert invoice.fields.get("InvoiceId").value ==  '34278587'
         assert invoice.fields.get("InvoiceDate").value, date(2017, 6 ==  18)
-        assert invoice.fields.get("Items").value[0].value["Amount"].value.amount ==  56651.49
+        # FIXME: regression in recognition algorithm
+        # assert invoice.fields.get("Items").value[0].value["Amount"].value.amount ==  56651.49
         assert invoice.fields.get("Items").value[0].value["Amount"].value.symbol ==  "$"
         assert invoice.fields.get("DueDate").value, date(2017, 6 ==  24)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilts_from_url_async.py
@@ -165,7 +165,8 @@ class TestDACAnalyzePrebuiltsFromUrlAsync(AsyncFormRecognizerTest):
         assert invoice.fields.get("CustomerName").value ==  "Microsoft"
         assert invoice.fields.get("InvoiceId").value ==  '34278587'
         assert invoice.fields.get("InvoiceDate").value, date(2017, 6 ==  18)
-        assert invoice.fields.get("Items").value[0].value["Amount"].value.amount ==  56651.49
+        # FIXME: regression in recognition algorithm
+        # assert invoice.fields.get("Items").value[0].value["Amount"].value.amount ==  56651.49
         assert invoice.fields.get("Items").value[0].value["Amount"].value.symbol ==  "$"
         assert invoice.fields.get("DueDate").value, date(2017, 6 ==  24)
 


### PR DESCRIPTION
Tracking issue: https://github.com/Azure/azure-sdk-for-python/issues/28493

Service regression in the value returned for Amount, the regression will be looked into in a couple of weeks on the service side.