### PR TITLE
Update azure monitor otel exporter to OTel 1.15

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -16,7 +16,7 @@
     ([#28322](https://github.com/Azure/azure-sdk-for-python/pull/28322))
 - Add UK to eu statsbeats
     ([#28379](https://github.com/Azure/azure-sdk-for-python/pull/28379))
-- Update to OTel 1.15
+- Update to opentelemetry api/sdk v1.15
     ([#28499](https://github.com/Azure/azure-sdk-for-python/pull/28499))
 
 ## 1.0.0b11 (2022-12-15)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -16,6 +16,8 @@
     ([#28322](https://github.com/Azure/azure-sdk-for-python/pull/28322))
 - Add UK to eu statsbeats
     ([#28379](https://github.com/Azure/azure-sdk-for-python/pull/28379))
+- Update to OTel 1.15
+    ([#28499](https://github.com/Azure/azure-sdk-for-python/pull/28499))
 
 ## 1.0.0b11 (2022-12-15)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -86,11 +86,11 @@ Some of the key concepts for the Azure monitor exporter include:
 
 * [LogRecord][log_record]: Represents a log record emitted from a supported logging library.
 
-* [LogEmitter][log_emitter]: Converts a `LogRecord` into a readable `LogData`, and will be pushed through the SDK to be exported.
+* [Logger][logger]: Converts a `LogRecord` into a readable `LogData`, and will be pushed through the SDK to be exported.
 
-* [LogEmitter Provider][log_emitter_provider]: Provides a `LogEmitter` for the given instrumentation library.
+* [Logger Provider][logger_provider]: Provides a `Logger` for the given instrumentation library.
 
-* [LogProcessor][log_processor]: Interface to hook the log record emitting action.
+* [LogRecordProcessor][log_record_processor]: Interface to hook the log record emitting action.
 
 * [LoggingHandler][logging_handler]: A handler class which writes logging records in OpenTelemetry format from the standard Python `logging` library.
 
@@ -162,22 +162,22 @@ import os
 import logging
 
 from opentelemetry.sdk._logs import (
-    LogEmitterProvider,
+    LoggerProvider,
     LoggingHandler,
-    set_log_emitter_provider,
+    set_logger_provider,
 )
-from opentelemetry.sdk._logs.export import BatchLogProcessor
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 
-log_emitter_provider = LogEmitterProvider()
-set_log_emitter_provider(log_emitter_provider)
+logger_provider = LoggerProvider()
+set_logger_provider(logger_provider)
 
 exporter = AzureMonitorLogExporter(
     connection_string=os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
 )
 
-log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
 handler = LoggingHandler()
 
 # Attach LoggingHandler to root logger
@@ -200,25 +200,25 @@ import logging
 
 from opentelemetry import trace
 from opentelemetry.sdk._logs import (
-    LogEmitterProvider,
+    LoggerProvider,
     LoggingHandler,
-    set_log_emitter_provider,
+    set_logger_provider,
 )
-from opentelemetry.sdk._logs.export import BatchLogProcessor
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.trace import TracerProvider
 
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 
 trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
-log_emitter_provider = LogEmitterProvider()
-set_log_emitter_provider(log_emitter_provider)
+logger_provider = LoggerProvider()
+set_logger_provider(logger_provider)
 
 exporter = AzureMonitorLogExporter(
     connection_string=os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
 )
 
-log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
 handler = LoggingHandler()
 
 # Attach LoggingHandler to root logger
@@ -243,22 +243,22 @@ import os
 import logging
 
 from opentelemetry.sdk._logs import (
-    LogEmitterProvider,
+    LoggerProvider,
     LoggingHandler,
-    set_log_emitter_provider,
+    set_logger_provider,
 )
-from opentelemetry.sdk._logs.export import BatchLogProcessor
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 
-log_emitter_provider = LogEmitterProvider()
-set_log_emitter_provider(log_emitter_provider)
+logger_provider = LoggerProvider()
+set_logger_provider(logger_provider)
 
 exporter = AzureMonitorLogExporter(
     connection_string=os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
 )
 
-log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
 handler = LoggingHandler()
 
 # Attach LoggingHandler to root logger
@@ -281,20 +281,20 @@ import os
 import logging
 
 from opentelemetry.sdk._logs import (
-    LogEmitterProvider,
+    LoggerProvider,
     LoggingHandler,
-    get_log_emitter_provider,
-    set_log_emitter_provider,
+    get_logger_provider,
+    set_logger_provider,
 )
-from opentelemetry.sdk._logs.export import BatchLogProcessor
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 
-set_log_emitter_provider(LogEmitterProvider())
+set_logger_provider(LoggerProvider())
 exporter = AzureMonitorLogExporter(
     connection_string=os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"]
 )
-get_log_emitter_provider().add_log_processor(BatchLogProcessor(exporter))
+get_logger_provider().add_log_record_processor(BatchLogRecordProcessor(exporter))
 
 # Attach LoggingHandler to namespaced logger
 handler = LoggingHandler()
@@ -655,9 +655,9 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [instrumentation_library]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#instrumentation-libraries
 [log_concept]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#log-signal
 [log_record]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogRecord
-[log_emitter]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogEmitter
-[log_emitter_provider]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogEmitterProvider
-[log_processor]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogProcessor
+[logger]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.Logger
+[logger_provider]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LoggerProvider
+[log_record_processor]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LogRecordProcessor
 [logging_handler]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html#opentelemetry.sdk._logs.LoggingHandler
 [log_reference]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
 [ot_logging_sdk]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Sequence, Any
 
-from opentelemetry.sdk._logs.severity import SeverityNumber
+from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.sdk._logs import LogData
 from opentelemetry.sdk._logs.export import LogExporter, LogExportResult

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -84,8 +84,8 @@ setup(
         "azure-core<2.0.0,>=1.23.0",
         "fixedint==0.1.6",
         "msrest>=0.6.10",
-        "opentelemetry-api<1.15.0,>=1.12.0",
-        "opentelemetry-sdk<1.15.0,>=1.12.0",
+        "opentelemetry-api==1.15.0",
+        "opentelemetry-sdk==1.15.0",
     ],
     entry_points={
         "opentelemetry_traces_exporter": [

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
@@ -12,7 +12,7 @@ from opentelemetry.sdk import _logs
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk._logs.export import LogExportResult
-from opentelemetry.sdk._logs.severity import SeverityNumber
+from opentelemetry._logs.severity import SeverityNumber
 
 from azure.monitor.opentelemetry.exporter.export._base import ExportResult
 from azure.monitor.opentelemetry.exporter.export.logs._exporter import (

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -323,9 +323,9 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-monitor-opentelemetry-exporter fixedint==0.1.6
 #override azure-monitor-opentelemetry-exporter msrest>=0.6.10
 #override azure-mgmt-healthbot azure-mgmt-core>=1.3.2,<2.0.0
-#override azure-monitor-opentelemetry-exporter opentelemetry-api<2.0.0,>=1.15.0
+#override azure-monitor-opentelemetry-exporter opentelemetry-api==1.15.0
 #override azure-mgmt-cosmosdb typing-extensions>=4.3.0; python_version<'3.8.0'
-#override azure-monitor-opentelemetry-exporter opentelemetry-sdk<2.0.0,>=1.15.0
+#override azure-monitor-opentelemetry-exporter opentelemetry-sdk==1.15.0
 #override azure-mgmt-support msrest>=0.7.1
 #override azure-core-tracing-opentelemetry opentelemetry-api<2.0.0,>=1.0.0
 #override azure-mgmt-appcontainers typing-extensions>=4.3.0; python_version<'3.8.0'

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -323,9 +323,9 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-monitor-opentelemetry-exporter fixedint==0.1.6
 #override azure-monitor-opentelemetry-exporter msrest>=0.6.10
 #override azure-mgmt-healthbot azure-mgmt-core>=1.3.2,<2.0.0
-#override azure-monitor-opentelemetry-exporter opentelemetry-api<1.15.0,>=1.12.0
+#override azure-monitor-opentelemetry-exporter opentelemetry-api<2.0.0,>=1.15.0
 #override azure-mgmt-cosmosdb typing-extensions>=4.3.0; python_version<'3.8.0'
-#override azure-monitor-opentelemetry-exporter opentelemetry-sdk<1.15.0,>=1.12.0
+#override azure-monitor-opentelemetry-exporter opentelemetry-sdk<2.0.0,>=1.15.0
 #override azure-mgmt-support msrest>=0.7.1
 #override azure-core-tracing-opentelemetry opentelemetry-api<2.0.0,>=1.0.0
 #override azure-mgmt-appcontainers typing-extensions>=4.3.0; python_version<'3.8.0'


### PR DESCRIPTION
* Updated log symbols. https://github.com/open-telemetry/opentelemetry-python/pull/2943
* Severity moved to API. g/set_logger_provider moved from SDK to internal API. https://github.com/open-telemetry/opentelemetry-python/pull/3038

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
