### PR TITLE
run pyright with 3.7

### DIFF
--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -11,9 +11,9 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.10'
+    displayName: 'Use Python 3.7'
     inputs:
-     versionSpec: '3.10'
+     versionSpec: '3.7'
     condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'))
 
   - script: |

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,5 +3,5 @@
   "reportUnnecessaryTypeIgnoreComment": "warning",
   "reportTypeCommentUsage": true,
   "reportMissingImports": false,
-  "pythonVersion": "3.10"
+  "pythonVersion": "3.7"
 }


### PR DESCRIPTION
We should run our static type checks with the minimum supported version of python.