### PR TITLE
Resolve https <-> docker interaction

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -37,7 +37,14 @@ discovered_roots = []
 from urllib3 import PoolManager, Retry
 from urllib3.exceptions import HTTPError
 
-http_client = PoolManager(retries=Retry(total=1, raise_on_status=False))
+if os.getenv("REQUESTS_CA_BUNDLE"):
+    http_client = PoolManager(
+        retries=Retry(total=3, raise_on_status=False),
+        cert_reqs="CERT_REQUIRED",
+        ca_certs=os.getenv("REQUESTS_CA_BUNDLE"),
+    )
+else:
+    http_client = PoolManager(retries=Retry(total=1, raise_on_status=False))
 
 
 def get_image_tag(repo_root: str) -> str:


### PR DESCRIPTION
This bugfix originates from [this pr](https://github.com/Azure/azure-sdk-for-python/pull/27101). Not certain how local verification on my and Paul's part both missed this. At the time the runs absolutely discovered these https issues, and resulted in the http_client creation change on [proxy_testcase.py L35.](https://github.com/Azure/azure-sdk-for-python/blob/621aa1c838ed903a01de0ae6838525ec195a11cb/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py#L35)

All this PR does is re-use that same logic.

Resolves #28510