### PR TITLE
[ML][Pipelines] support ignore files in additional includes

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/_additional_includes.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/_additional_includes.py
@@ -11,7 +11,7 @@ from typing import Optional, Union
 
 import yaml
 
-from azure.ai.ml._utils._asset_utils import IgnoreFile, get_local_paths
+from azure.ai.ml._utils._asset_utils import IgnoreFile, get_local_paths, get_ignore_file
 from azure.ai.ml.entities._util import _general_copy
 from azure.ai.ml.entities._validation import MutableValidationResult, _ValidationResultBuilder
 
@@ -192,7 +192,11 @@ class _AdditionalIncludes:
                 self._resolve_folder_to_compress(additional_include, Path(tmp_folder_path))
             else:
                 dst_path = (tmp_folder_path / src_path.name).resolve()
-                self._copy(src_path, dst_path, ignore_file=IgnoreFile() if self._is_artifact_includes else None)
+                self._copy(
+                    src_path,
+                    dst_path,
+                    ignore_file=IgnoreFile() if self._is_artifact_includes else get_ignore_file(src_path)
+                )
         self._tmp_code_path = tmp_folder_path  # point code path to tmp folder
         return
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/code.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/code.py
@@ -11,25 +11,29 @@ from ...entities._component.code import ComponentIgnoreFile
 
 
 class InternalComponentIgnoreFile(ComponentIgnoreFile):
-    _INTERNAL_COMPONENT_CODE_IGNORES = ["*.additional_includes"]
-
-    def __init__(self, directory_path: Union[str, Path]):
+    def __init__(self, directory_path: Union[str, Path], additional_include_file_name: Optional[str]):
         super(InternalComponentIgnoreFile, self).__init__(directory_path=directory_path)
+        # only the additional include file in root directory is ignored
+        # additional include files in subdirectories are not processed so keep them
+        self._additional_include_file_name = additional_include_file_name
         self._other_ignores = []
 
     def _get_ignore_list(self) -> List[str]:
         """Override to add custom ignores for internal component."""
-        return super(InternalComponentIgnoreFile, self)._get_ignore_list() + self._INTERNAL_COMPONENT_CODE_IGNORES
+        if self._additional_include_file_name is None:
+            return super(InternalComponentIgnoreFile, self)._get_ignore_list()
+        return super(InternalComponentIgnoreFile, self)._get_ignore_list() + [self._additional_include_file_name]
 
     def merge(self, other: IgnoreFile):
         """Merge other ignore file with this one and create a new IgnoreFile for it.
         """
-        ignore_file = InternalComponentIgnoreFile(self._base_path)
+        ignore_file = InternalComponentIgnoreFile(self._base_path, self._additional_include_file_name)
         ignore_file._other_ignores.append(other)  # pylint: disable=protected-access
         return ignore_file
 
     def is_file_excluded(self, file_path: Union[str, Path]) -> bool:
         """Override to check if file is excluded in other ignore files."""
+        # TODO: current design of ignore file can't distinguish between files and directories of the same name
         if super(InternalComponentIgnoreFile, self).is_file_excluded(file_path):
             return True
         for other in self._other_ignores:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/component.py
@@ -20,10 +20,11 @@ from azure.ai.ml.entities._validation import MutableValidationResult
 
 from ... import Input, Output
 from ..._utils._arm_id_utils import parse_name_label
+from ..._utils._asset_utils import IgnoreFile
 from ...entities._assets import Code
 from ...entities._job.distribution import DistributionConfiguration
 from .._schema.component import InternalComponentSchema
-from ._additional_includes import _AdditionalIncludes
+from ._additional_includes import _AdditionalIncludes, ADDITIONAL_INCLUDES_SUFFIX
 from ._input_outputs import InternalInput, InternalOutput
 from ._merkle_tree import create_merkletree
 from .code import InternalCode, InternalComponentIgnoreFile
@@ -124,6 +125,7 @@ class InternalComponent(Component):
         self.environment = InternalEnvironment(**environment) if isinstance(environment, dict) else environment
         self.environment_variables = environment_variables
         self.__additional_includes = None
+        self.__ignore_file = None
         # TODO: remove these to keep it a general component class
         self.command = command
         self.scope = scope
@@ -152,9 +154,6 @@ class InternalComponent(Component):
             self.__additional_includes = _AdditionalIncludes(
                 code_path=self.code,
                 yaml_path=self._source_path,
-                ignore_file=InternalComponentIgnoreFile(
-                    self.code if self.code is not None else Path(self._source_path).parent,
-                ),  # use YAML's parent as code when self.code is None
             )
         return self.__additional_includes
 
@@ -208,7 +207,7 @@ class InternalComponent(Component):
     def _get_snapshot_id(
         cls,
         code_path: Union[str, PathLike],
-        ignore_file: Optional[InternalComponentIgnoreFile],
+        ignore_file: IgnoreFile,
     ) -> str:
         """Get the snapshot id of a component with specific working directory in ml-components.
         Use this as the name of code asset to reuse steps in a pipeline job from ml-components runs.
@@ -216,7 +215,7 @@ class InternalComponent(Component):
         :param code_path: The path of the working directory.
         :type code_path: str
         :param ignore_file: The ignore file of the snapshot.
-        :type ignore_file: InternalComponentIgnoreFile
+        :type ignore_file: IgnoreFile
         :return: The snapshot id of a component in ml-components with code_path as its working directory.
         """
         curr_root = create_merkletree(code_path, ignore_file.is_file_excluded)
@@ -242,7 +241,26 @@ class InternalComponent(Component):
             yield code
             return
 
-        self._additional_includes.resolve()
+        def get_additional_include_file_name():
+            if self._source_path is not None:
+                return Path(self._source_path).with_suffix(ADDITIONAL_INCLUDES_SUFFIX).name
+            return None
+
+        def get_ignore_file() -> InternalComponentIgnoreFile:
+            if self.code is None and self._source_path is None:
+                # no code and no yaml, ignore file is not needed; return ignore file on cwd to avoid error
+                return InternalComponentIgnoreFile(
+                    self.base_path,
+                    additional_include_file_name=get_additional_include_file_name(),
+                )
+
+            return InternalComponentIgnoreFile(
+                self.code if self.code is not None else Path(self._source_path).parent,
+                additional_include_file_name=get_additional_include_file_name(),
+            )
+        ignore_file = get_ignore_file()
+
+        self._additional_includes.resolve(ignore_file=ignore_file)
 
         # file dependency in code will be read during internal environment resolution
         # for example, docker file of the environment may be in additional includes
@@ -252,18 +270,26 @@ class InternalComponent(Component):
             self.environment.resolve(self._additional_includes.code)
         # use absolute path in case temp folder & work dir are in different drive
         tmp_code_dir = self._additional_includes.code.absolute()
-        ignore_file = InternalComponentIgnoreFile(tmp_code_dir)
+        rebased_ignore_file = InternalComponentIgnoreFile(
+            tmp_code_dir,
+            additional_include_file_name=get_additional_include_file_name(),
+        )
         # Use the snapshot id in ml-components as code name to enable anonymous
         # component reuse from ml-component runs.
         # calculate snapshot id here instead of inside InternalCode to ensure that
         # snapshot id is calculated based on the resolved code path
         yield InternalCode(
-            name=self._get_snapshot_id(tmp_code_dir, ignore_file),
+            name=self._get_snapshot_id(
+                # use absolute path in case temp folder & work dir are in different drive
+                self._additional_includes.code.absolute(),
+                # this ignore-file should be rebased to the resolved code path
+                rebased_ignore_file,
+            ),
             version="1",
             base_path=self._base_path,
             path=tmp_code_dir,
             is_anonymous=True,
-            ignore_file=ignore_file,
+            ignore_file=rebased_ignore_file,
         )
 
         self._additional_includes.cleanup()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/code.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/code.py
@@ -13,10 +13,10 @@ class ComponentIgnoreFile(IgnoreFile):
     _COMPONENT_CODE_IGNORES = ["__pycache__"]
 
     def __init__(self, directory_path: Union[str, Path]):
+        self._base_path = Path(directory_path)
         # note: the parameter changes to directory path in this class, rather than file path
         file_path = get_ignore_file(directory_path).path
         super(ComponentIgnoreFile, self).__init__(file_path=file_path)
-        self._base_path = Path(directory_path)
 
     def exists(self) -> bool:
         """Override to always return True as we do have default ignores."""

--- a/sdk/ml/azure-ai-ml/tests/internal/_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/_utils.py
@@ -219,11 +219,13 @@ def get_expected_runsettings_items(runsettings_dict, client=None):
 ANONYMOUS_COMPONENT_TEST_PARAMS = [
     (
         "simple-command/powershell_copy.yaml",
+        # Please DO NOT change the expected snapshot id unless you are sure you have changed the component spec
         "75c43313-4777-b2e9-fe3a-3b98cabfaa77"
     ),
     (
         "additional-includes/component_spec.yaml",
-        "1928c330-6272-fc7d-818c-f411a3e6eb09"
+        # Please DO NOT change the expected snapshot id unless you are sure you have changed the component spec
+        "a0083afd-fee4-9c0d-65c2-ec75d0d5f048"
     ),
     # TODO(2076035): skip tests related to zip additional includes for now
     # (

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -366,7 +366,7 @@ class TestComponent:
 
         assert not code_path.is_dir()
 
-    def test_additional_includes_pycache_ignore(self) -> None:
+    def test_additional_includes_default_ignore(self) -> None:
         with build_temp_folder(
             source_base_dir="./tests/test_configs/internal/",
             relative_dirs_to_copy=[
@@ -374,6 +374,7 @@ class TestComponent:
                 "additional_includes"
             ],
             extra_files_to_create={
+                "component_with_additional_includes/x.additional_includes": None,
                 "component_with_additional_includes/__pycache__/a.pyc": None,
                 "additional_includes/__pycache__/a.pyc": None,
                 "additional_includes/library1/x.additional_includes": None,
@@ -387,8 +388,10 @@ class TestComponent:
             with component._resolve_local_code() as code:
                 code_path = code.path
                 assert not (code_path / "__pycache__").exists()
-                assert not (code_path / "library1" / "x.additional_includes").exists()
                 assert not (code_path / "library1" / "__pycache__").exists()
+                assert not (code_path / "helloworld_additional_includes.additional_includes").exists()
+                assert (code_path / "library1" / "x.additional_includes").is_file()
+                assert (code_path / "x.additional_includes").is_file()
 
     def test_additional_includes_file_ignore(self) -> None:
         with build_temp_folder(
@@ -398,7 +401,8 @@ class TestComponent:
                 "additional_includes"
             ],
             extra_files_to_create={
-                "component_with_additional_includes/.amlignore": "code_only",
+                "component_with_additional_includes/test_code/hello.py": None,
+                "component_with_additional_includes/.amlignore": "code_only\nlibrary1/world.py",
                 "additional_includes/library1/.amlignore": "hello.py",
             }
         ) as test_configs_dir:
@@ -413,6 +417,8 @@ class TestComponent:
                 code_path = code.path
                 assert not (code_path / "code_only").exists()
                 assert not (code_path / "library1" / "hello.py").exists()
+                assert not (code_path / "library1" / "world.py").exists()
+                assert (code_path / "test_code" / "hello.py").is_file()
 
     def test_additional_includes_merge_folder(self) -> None:
         yaml_path = (

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -358,11 +358,11 @@ class TestComponent:
         with component._resolve_local_code() as code:
             code_path = code.path
             assert code_path.is_dir()
-            assert (code_path / "LICENSE").exists()
-            assert (code_path / "library.zip").exists()
+            assert (code_path / "LICENSE").is_file()
+            assert (code_path / "library.zip").is_file()
             assert ZipFile(code_path / "library.zip").namelist() == ["library/", "library/hello.py", "library/world.py"]
-            assert (code_path / "library1" / "hello.py").exists()
-            assert (code_path / "library1" / "world.py").exists()
+            assert (code_path / "library1" / "hello.py").is_file()
+            assert (code_path / "library1" / "world.py").is_file()
 
         assert not code_path.is_dir()
 
@@ -407,8 +407,8 @@ class TestComponent:
             component: InternalComponent = load_component(source=yaml_path)
 
             # resolve and check snapshot directory
-            assert (Path(test_configs_dir) / "component_with_additional_includes" / "code_only").exists()
-            assert (Path(test_configs_dir) / "additional_includes" / "library1" / "hello.py").exists()
+            assert (Path(test_configs_dir) / "component_with_additional_includes" / "code_only").is_dir()
+            assert (Path(test_configs_dir) / "additional_includes" / "library1" / "hello.py").is_file()
             with component._resolve_local_code() as code:
                 code_path = code.path
                 assert not (code_path / "code_only").exists()
@@ -423,12 +423,12 @@ class TestComponent:
         with component._resolve_local_code() as code:
             code_path = code.path
             # first folder
-            assert (code_path / "library1" / "__init__.py").exists()
-            assert (code_path / "library1" / "hello.py").exists()
+            assert (code_path / "library1" / "__init__.py").is_file()
+            assert (code_path / "library1" / "hello.py").is_file()
             # second folder content
             assert (code_path / "library1" / "utils").is_dir()
-            assert (code_path / "library1" / "utils" / "__init__.py").exists()
-            assert (code_path / "library1" / "utils" / "salute.py").exists()
+            assert (code_path / "library1" / "utils" / "__init__.py").is_file()
+            assert (code_path / "library1" / "utils" / "salute.py").is_file()
 
     @pytest.mark.parametrize(
         "yaml_path,has_additional_includes",
@@ -459,8 +459,8 @@ class TestComponent:
                     "helloworld_invalid_additional_includes_zip_file_not_found.yml",
                     "no_code_and_additional_includes",
                 ]:
-                    assert (code_path / path).exists()
-                assert (code_path / "LICENSE").exists()
+                    assert (code_path / path).is_file() if ".yml" in path else (code_path / path).is_dir()
+                assert (code_path / "LICENSE").is_file()
             else:
                 # additional includes not specified, code should be specified path (default yaml folder)
                 yaml_dict = load_yaml(yaml_path)

--- a/sdk/ml/azure-ai-ml/tests/test_utilities/utils.py
+++ b/sdk/ml/azure-ai-ml/tests/test_utilities/utils.py
@@ -355,6 +355,21 @@ def build_temp_folder(
         relative_files_to_copy: List[str] = None,
         extra_files_to_create: Dict[str, Optional[str]] = None,
 ) -> str:
+    """Build a temporary folder with files and subfolders copied from source_base_dir.
+
+    :param source_base_dir: The base directory to copy files from.
+    :type source_base_dir: Union[str, os.PathLike]
+    :param relative_dirs_to_copy: The relative paths of subfolders to copy from source_base_dir.
+    :type relative_dirs_to_copy: List[str]
+    :param relative_files_to_copy: The relative paths of files to copy from source_base_dir.
+    :type relative_files_to_copy: List[str]
+    :param extra_files_to_create: The relative paths of files to create in the temporary folder.
+    The value of each key-value pair is the content of the file.
+    If the value is None, the file will be empty.
+    :type extra_files_to_create: Dict[str, Optional[str]]
+    :return: The path of the temporary folder.
+    :rtype: str
+    """
     source_base_dir = Path(source_base_dir)
     with tempfile.TemporaryDirectory() as temp_dir:
         if relative_dirs_to_copy:


### PR DESCRIPTION
# Description

source:
```
additional_includes
  .amlignore
  hello.py
  world.py
```
hello.py is in `.amlignore`
result before this PR:
```
additional_includes
  hello.py/hello.py
  world.py/world.py # this is a bug brought in by [this commit](https://github.com/Azure/azure-sdk-for-python/pull/27960)
```
result after this PR:
```
additional_includes
  world.py
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
