### PR TITLE
[ML][Pipelines] fix: pipeline job schema validation fail for data-binding expression

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
@@ -455,6 +455,7 @@ class UnionField(fields.Field):
                 resolve_field_instance(cls_or_instance)
                 for cls_or_instance in union_fields
             ]
+            # TODO: make serialization/de-serialization work in the same way as json schema when is_strict is True
             self.is_strict = is_strict  # S\When True, combine fields with oneOf instead of anyOf at schema generation
         except FieldInstanceResolutionError as error:
             raise ValueError(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_output_fields_provider.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_output_fields_provider.py
@@ -4,6 +4,7 @@
 
 from marshmallow import fields
 
+from azure.ai.ml._schema._utils.data_binding_expression import support_data_binding_expression_for_fields
 from azure.ai.ml._schema.core.fields import NestedField, PrimitiveValueField, UnionField
 from azure.ai.ml._schema.job.input_output_entry import (
     DataInputSchema,
@@ -14,20 +15,30 @@ from azure.ai.ml._schema.job.input_output_entry import (
 )
 
 
-def InputsField(**kwargs):
+def InputsField(*, support_databinding: bool = False, **kwargs):
+    value_fields = [
+        NestedField(DataInputSchema),
+        NestedField(ModelInputSchema),
+        NestedField(MLTableInputSchema),
+        NestedField(InputLiteralValueSchema),
+        PrimitiveValueField(is_strict=False),
+        # This ordering of types for the values keyword is intentional. The ordering of types
+        # determines what order schema values are matched and cast in. Changing the current ordering can
+        # result in values being mis-cast such as 1.0 translating into True.
+    ]
+
+    # As is_strict is set to True, 1 and only 1 value field must be matched.
+    # root level data-binding expression has already been covered by PrimitiveValueField;
+    # If support_databinding is True, we should only add data-binding expression support for nested fields.
+    if support_databinding:
+        for field_obj in value_fields:
+            if isinstance(field_obj, NestedField):
+                support_data_binding_expression_for_fields(field_obj.schema)
+
     return fields.Dict(
         keys=fields.Str(),
         values=UnionField(
-            [
-                NestedField(DataInputSchema),
-                NestedField(ModelInputSchema),
-                NestedField(MLTableInputSchema),
-                NestedField(InputLiteralValueSchema),
-                PrimitiveValueField(is_strict=False),
-                # This ordering of types for the values keyword is intentional. The ordering of types
-                # determines what order schema values are matched and cast in. Changing the current ordering can
-                # result in values being mis-cast such as 1.0 translating into True.
-            ],
+            value_fields,
             metadata={"description": "Inputs to a job."},
             is_strict=True,
             **kwargs

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/component_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/component_job.py
@@ -48,7 +48,7 @@ module_logger = logging.getLogger(__name__)
 class BaseNodeSchema(PathAwareSchema):
     unknown = INCLUDE
 
-    inputs = InputsField()
+    inputs = InputsField(support_databinding=True)
     outputs = fields.Dict(
         keys=fields.Str(),
         values=UnionField([OutputBindingStr, NestedField(OutputSchema)], allow_none=True),
@@ -61,7 +61,7 @@ class BaseNodeSchema(PathAwareSchema):
         # data binding expression is not supported inside component field, while validation error
         # message will be very long when component is an object as error message will include
         # str(component), so just add component to skip list. The same to trial in Sweep.
-        support_data_binding_expression_for_fields(self, ["type", "component", "trial"])
+        support_data_binding_expression_for_fields(self, ["type", "component", "trial", "inputs"])
 
     @post_dump(pass_original=True)
     def add_user_setting_attr_dict(self, data, original_data, **kwargs):  # pylint: disable=unused-argument

--- a/sdk/ml/azure-ai-ml/tests/internal/_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/_utils.py
@@ -280,18 +280,3 @@ def extract_non_primitive(obj):
     if isinstance(obj, (float, int, str)):
         return None
     return obj
-
-
-def unregister_internal_components():
-    from azure.ai.ml._internal._schema.component import NodeType
-    from azure.ai.ml._internal._util import _set_registered
-    from azure.ai.ml.entities._component.component_factory import component_factory
-    from azure.ai.ml.entities._job.pipeline._load_component import pipeline_node_factory
-
-    for _type in NodeType.all_values():
-        pipeline_node_factory._create_instance_funcs.pop(_type, None)  # pylint: disable=protected-access
-        pipeline_node_factory._load_from_rest_object_funcs.pop(_type, None)  # pylint: disable=protected-access
-        component_factory._create_instance_funcs.pop(_type, None)  # pylint: disable=protected-access
-        component_factory._create_schema_funcs.pop(_type, None)  # pylint: disable=protected-access
-
-    _set_registered(False)

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_internal_disabled.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_internal_disabled.py
@@ -1,0 +1,24 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+import pytest
+from azure.ai.ml.constants._common import AZUREML_INTERNAL_COMPONENTS_ENV_VAR
+from azure.ai.ml.dsl._utils import environment_variable_overwrite
+from azure.ai.ml.exceptions import ValidationException
+
+
+@pytest.mark.usefixtures("disable_internal_components")
+@pytest.mark.unittest
+@pytest.mark.pipeline_test
+class TestInternalDisabled:
+    def test_load_pipeline_job_with_internal_nodes_from_rest(self):
+        # this is a simplified test case which avoid constructing a complete pipeline job rest object
+        from azure.ai.ml.entities._job.pipeline._load_component import pipeline_node_factory
+
+        internal_node_type = "CommandComponent"
+        with environment_variable_overwrite(AZUREML_INTERNAL_COMPONENTS_ENV_VAR, "False"):
+            with pytest.raises(ValidationException, match=f"Unsupported component type: {internal_node_type}."):
+                pipeline_node_factory.get_load_from_rest_object_func(internal_node_type)
+
+        with environment_variable_overwrite(AZUREML_INTERNAL_COMPONENTS_ENV_VAR, "True"):
+            pipeline_node_factory.get_load_from_rest_object_func(internal_node_type)

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_pipeline_job.py
@@ -32,12 +32,10 @@ from azure.ai.ml._internal import (
     TargetSelector,
 )
 from azure.ai.ml._internal.entities import InternalBaseNode, InternalComponent, Scope
-from azure.ai.ml.constants._common import AZUREML_INTERNAL_COMPONENTS_ENV_VAR, AssetTypes
+from azure.ai.ml.constants._common import AssetTypes
 from azure.ai.ml.constants._job.job import JobComputePropertyFields
 from azure.ai.ml.dsl import pipeline
-from azure.ai.ml.dsl._utils import environment_variable_overwrite
 from azure.ai.ml.entities import CommandComponent, Data, PipelineJob
-from azure.ai.ml.exceptions import ValidationException
 
 from .._utils import (
     DATA_VERSION,
@@ -46,7 +44,6 @@ from .._utils import (
     extract_non_primitive,
     get_expected_runsettings_items,
     set_run_settings,
-    unregister_internal_components,
 )
 
 
@@ -602,15 +599,3 @@ class TestPipelineJob:
             assert len(node_dict["properties"]) == 1
             assert "AZURE_ML_PathOnCompute_" in list(node_dict["properties"].keys())[0]
             assert node_dict["properties"] == rest_node_dict["properties"]
-
-    def test_load_pipeline_job_with_internal_nodes_from_rest(self):
-        # this is a simplified test case which avoid constructing a complete pipeline job rest object
-        from azure.ai.ml.entities._job.pipeline._load_component import pipeline_node_factory
-
-        unregister_internal_components()
-        internal_node_type = "CommandComponent"
-        with environment_variable_overwrite(AZUREML_INTERNAL_COMPONENTS_ENV_VAR, "False"):
-            with pytest.raises(ValidationException, match=f"Unsupported component type: {internal_node_type}."):
-                pipeline_node_factory.get_load_from_rest_object_func(internal_node_type)
-
-        pipeline_node_factory.get_load_from_rest_object_func(internal_node_type)

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 import pydash
 import pytest
 import yaml
-from jsonschema import validate
 from marshmallow import ValidationError
 from pytest_mock import MockFixture
 
@@ -37,7 +36,6 @@ from azure.ai.ml.entities._job.automl.search_space_utils import _convert_sweep_d
 from azure.ai.ml.entities._job.job_service import JobService
 from azure.ai.ml.entities._job.pipeline._io import PipelineInput, PipelineOutput
 from azure.ai.ml.exceptions import UserErrorException, ValidationException
-from test_utilities.json_schema import PatchedJSONSchema
 
 from .._util import _PIPELINE_JOB_TIMEOUT_SECOND, DATABINDING_EXPRESSION_TEST_CASES
 
@@ -1785,12 +1783,3 @@ class TestPipelineJobSchema:
     ):
         pipeline: PipelineJob = load_job(source=pipeline_job_path)
         pipeline._to_rest_object()
-
-    def test_json_schema_validate(self):
-        base_dir = Path("./tests/test_configs/pipeline_jobs/json_schema_validation")
-        target_schema = PatchedJSONSchema().dump(PipelineJob._create_schema_for_validation(context={"base_path": "./"}))
-
-        with open(base_dir.joinpath("component_spec.yaml"), "r") as f:
-            yaml_data = yaml.safe_load(f.read())
-
-        validate(yaml_data, target_schema)

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 import pydash
 import pytest
 import yaml
+from jsonschema import validate
 from marshmallow import ValidationError
 from pytest_mock import MockFixture
 
@@ -36,6 +37,7 @@ from azure.ai.ml.entities._job.automl.search_space_utils import _convert_sweep_d
 from azure.ai.ml.entities._job.job_service import JobService
 from azure.ai.ml.entities._job.pipeline._io import PipelineInput, PipelineOutput
 from azure.ai.ml.exceptions import UserErrorException, ValidationException
+from test_utilities.json_schema import PatchedJSONSchema
 
 from .._util import _PIPELINE_JOB_TIMEOUT_SECOND, DATABINDING_EXPRESSION_TEST_CASES
 
@@ -1783,3 +1785,12 @@ class TestPipelineJobSchema:
     ):
         pipeline: PipelineJob = load_job(source=pipeline_job_path)
         pipeline._to_rest_object()
+
+    def test_json_schema_validate(self):
+        base_dir = Path("./tests/test_configs/pipeline_jobs/json_schema_validation")
+        target_schema = PatchedJSONSchema().dump(PipelineJob._create_schema_for_validation(context={"base_path": "./"}))
+
+        with open(base_dir.joinpath("component_spec.yaml"), "r") as f:
+            yaml_data = yaml.safe_load(f.read())
+
+        validate(yaml_data, target_schema)

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_private_preview_disabled.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_private_preview_disabled.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import pytest
+import yaml
+from jsonschema.validators import validate
+from azure.ai.ml.entities import PipelineJob
+from test_utilities.json_schema import PatchedJSONSchema
+
+from .._util import _PIPELINE_JOB_TIMEOUT_SECOND
+
+
+# schema of nodes will be reloaded with private preview features disabled in unregister_internal_components
+@pytest.mark.usefixtures("disable_internal_components")
+@pytest.mark.timeout(_PIPELINE_JOB_TIMEOUT_SECOND)
+@pytest.mark.unittest
+@pytest.mark.pipeline_test
+class TestPrivatePreviewDisabled:
+    def test_public_json_schema(self):
+        # public json schema is the json schema to be saved in
+        # https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+        base_dir = Path("./tests/test_configs/pipeline_jobs/json_schema_validation")
+        target_schema = PatchedJSONSchema().dump(PipelineJob._create_schema_for_validation(context={"base_path": "./"}))
+
+        with open(base_dir.joinpath("component_spec.yaml"), "r") as f:
+            yaml_data = yaml.safe_load(f.read())
+
+        validate(yaml_data, target_schema)

--- a/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/json_schema_validation/component_spec.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/json_schema_validation/component_spec.yaml
@@ -1,0 +1,17 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+
+settings:
+  default_compute: azureml:cpu-cluster
+
+
+jobs:
+  process_data:
+    type: command
+    component: ./1process_data_component.yaml
+    inputs:
+      raw_data: ${{parent.inputs.raw_data}}
+    outputs:
+      train:
+      validation:
+    compute: azureml:cpu-cluster

--- a/sdk/ml/azure-ai-ml/tests/test_utilities/json_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/test_utilities/json_schema.py
@@ -1,0 +1,131 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+# This file is part of scripts\generate_json_schema.py in sdk-cli-v2, which is used to generate json schema
+
+from inspect import isclass
+
+from marshmallow import Schema, fields, missing
+from marshmallow.class_registry import get_class
+from marshmallow_jsonschema import JSONSchema
+
+from azure.ai.ml._schema import (
+    ExperimentalField,
+    UnionField,
+    YamlFileSchema,
+)
+
+
+class PatchedJSONSchema(JSONSchema):
+    required = fields.Method("get_required")
+    properties = fields.Method("get_properties")
+
+    def __init__(self, *args, **kwargs):
+        """Setup internal cache of nested fields, to prevent recursion.
+        :param bool props_ordered: if `True` order of properties will be save as declare in class,
+                                   else will using sorting, default is `False`.
+                                   Note: For the marshmallow scheme, also need to enable
+                                   ordering of fields too (via `class Meta`, attribute `ordered`).
+        """
+        self._nested_schema_classes = {}
+        self.nested = kwargs.pop("nested", False)
+        self.props_ordered = kwargs.pop("props_ordered", False)
+        setattr(self.opts, "ordered", self.props_ordered)
+        super().__init__(*args, **kwargs)
+
+    def _from_python_type(self, obj, field, pytype):
+        metadata = field.metadata.get("metadata", {})
+        metadata.update(field.metadata)
+        # This is in the upcoming release of marshmallow-jsonschema, but not available yet
+        if isinstance(field, fields.Dict):
+            values = metadata.get("values", None) or field.value_field
+            json_schema = {"title": field.attribute or field.data_key or field.name}
+            json_schema["type"] = "object"
+            if values:
+                values.parent = field
+            json_schema["additionalProperties"] = self._get_schema_for_field(obj, values) if values else {}
+            return json_schema
+
+        return super()._from_python_type(obj, field, pytype)
+
+    def _get_schema_for_field(self, obj, field):
+        """Get schema and validators for field."""
+        if hasattr(field, "_jsonschema_type_mapping"):
+            schema = field._jsonschema_type_mapping()  # pylint: disable=protected-access
+        elif "_jsonschema_type_mapping" in field.metadata:
+            schema = field.metadata["_jsonschema_type_mapping"]
+        else:
+            if isinstance(field, UnionField):
+                schema = self._get_schema_for_union_field(obj, field)
+            elif isinstance(field, ExperimentalField):
+                schema = self._get_schema_for_field(obj, field._experimental_field)  # pylint: disable=protected-access
+            elif isinstance(field, fields.Constant):
+                schema = {"const": field.constant}
+            else:
+                schema = super()._get_schema_for_field(obj, field)
+        if field.data_key:
+            schema["title"] = field.data_key
+        return schema
+
+    def _get_schema_for_union_field(self, obj, field):
+        has_yaml_option = False
+        schemas = []
+        for field_item in field._union_fields:  # pylint: disable=protected-access
+            if isinstance(field_item, fields.Nested) and isinstance(field_item.schema, YamlFileSchema):
+                has_yaml_option = True
+            schemas.append(self._get_schema_for_field(obj, field_item))
+        if has_yaml_option:
+            schemas.append({"type": "string", "pattern": "^file:.*"})
+        if field.allow_none:
+            schemas.append({"type": "null"})
+        if field.is_strict:
+            schema = {"oneOf": schemas}
+        else:
+            schema = {"anyOf": schemas}
+        # This happens in the super() call to get_schema, doing here to allow for adding
+        # descriptions and other schema attributes from marshmallow metadata
+        metadata = field.metadata.get("metadata", {})
+        for md_key, md_val in metadata.items():
+            if md_key in ("metadata", "name"):
+                continue
+            schema[md_key] = md_val
+        return schema
+
+    def _from_nested_schema(self, obj, field):
+        """patch in context for nested field"""
+        if isinstance(field.nested, (str, bytes)):
+            nested = get_class(field.nested)
+        else:
+            nested = field.nested
+
+        if isclass(nested) and issubclass(nested, Schema):
+            only = field.only
+            exclude = field.exclude
+            context = getattr(field.parent, "context", {})
+            field.nested = nested(only=only, exclude=exclude, context=context)
+        return super()._from_nested_schema(obj, field)
+
+    def get_properties(self, obj):
+        """Fill out properties field."""
+        properties = self.dict_class()
+
+        if self.props_ordered:
+            fields_items_sequence = obj.fields.items()
+        else:
+            fields_items_sequence = sorted(obj.fields.items())
+
+        for _, field in fields_items_sequence:
+            schema = self._get_schema_for_field(obj, field)
+            properties[field.metadata.get("name") or field.data_key or field.name] = schema
+        return properties
+
+    def get_required(self, obj):
+        """Fill out required field."""
+        required = []
+
+        for _, field in sorted(obj.fields.items()):
+            if field.required:
+                required.append(field.metadata.get("name") or field.data_key or field.name)
+
+        return required or missing


### PR DESCRIPTION
# Description

For a valid yaml like below:
```
$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
type: pipeline

settings:
  default_compute: azureml:cpu-cluster


jobs:
  process_data:
    type: command
    component: ./1process_data_component.yaml
    inputs:
      raw_data: ${{parent.inputs.raw_data}}
```

Its json schema validation will fail before this PR.

The root cause is that current implementation of schema support for data-binding expression will insert data-binding expression schema to root level of `inputs`; On the other hand, `inputs` is a strict union field and primitive value schema has already matched the expression.

Will update https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json after this PR is merged.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
