### PR TITLE
[ML][Pipelines] fix: keep False values in pipeline_job.settings

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bugs Fixed
 - Fixed an issue where the ordering of `.amlignore` and `.gitignore` files are not respected
+- Fixed an issue that attributes with a value of `False` in `PipelineJobSettings` are not respected
 
 ### Other Changes
 - Update workspace creation to use Log Analytics-Based Application Insights when the user does not specify/bring their own App Insights.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/pipeline.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/pipeline.py
@@ -9,6 +9,7 @@ class PipelineConstants:
     DEFAULT_DATASTORE = "default_datastore"
     DEFAULT_COMPUTE = "default_compute"
     CONTINUE_ON_STEP_FAILURE = "continue_on_step_failure"
+    CONTINUE_RUN_ON_FAILED_OPTIONAL_INPUT = "continue_run_on_failed_optional_input"
     DATASTORE_REST = "Datastore"
     ENVIRONMENT = "environment"
     CODE = "code"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
@@ -65,7 +65,8 @@ class _AttrDict(Generic[K, V], dict, ABC):
         def remove_empty_values(data):
             if not isinstance(data, dict):
                 return data
-            return {k: remove_empty_values(v) for k, v in data.items() if v}
+            # skip empty dicts as default value of _AttrDict is empty dict
+            return {k: remove_empty_values(v) for k, v in data.items() if v or not isinstance(v, dict)}
 
         return remove_empty_values(self)
 

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_attr_dict.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_attr_dict.py
@@ -81,3 +81,8 @@ class TestAttrDict:
         assert not obj
         obj.continue_on_step_failure = False
         assert obj
+
+    def test_attr_dict_false_value(self):
+        obj = _AttrDict()
+        obj.false_value = False
+        assert obj._get_attrs() == {"false_value": False}

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pydash
 import pytest
+
+from azure.ai.ml.constants._job import PipelineConstants
 from test_configs.dsl_pipeline import data_binding_expression
 from test_utilities.utils import omit_with_wildcard, prepare_dsl_curated
 
@@ -2596,3 +2598,25 @@ class TestDSLPipeline:
             'description': 'new description', 'job_output_type': 'uri_folder', 'mode': 'Upload'
         }}
         assert pipeline_job._to_rest_object().as_dict()["properties"]["outputs"] == expected_outputs
+
+    def test_dsl_pipeline_run_settings(self) -> None:
+        hello_world_component_yaml = "./tests/test_configs/components/helloworld_component.yml"
+        hello_world_component_func = load_component(source=hello_world_component_yaml)
+
+        @dsl.pipeline()
+        def my_pipeline() -> Output(type="uri_folder", description="new description", mode="upload"):
+            node = hello_world_component_func(component_in_path=Input(path="path/on/ds"), component_in_number=10)
+            return {"output": node.outputs.component_out_path}
+
+        pipeline_job: PipelineJob = my_pipeline()
+        pipeline_job.settings.default_compute = "cpu-cluster"
+        pipeline_job.settings.continue_on_step_failure = True
+        pipeline_job.settings.continue_run_on_failed_optional_input = False
+
+        assert pipeline_job._to_rest_object().properties.settings == {
+            PipelineConstants.DEFAULT_COMPUTE: "cpu-cluster",
+            PipelineConstants.CONTINUE_ON_STEP_FAILURE: True,
+            PipelineConstants.CONTINUE_RUN_ON_FAILED_OPTIONAL_INPUT: False,
+            "_source": "DSL"
+        }
+


### PR DESCRIPTION
# Description

Previously, if we set a pipeline job run setting to `False` like below:
```python
pipeline_job.settings.xxx = False
```
The value will be dropped in the rest object of the pipeline job.

We change the logic to keep this value in this PR.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
