### PR TITLE
[ML][Pipelines] feat: add util to write with int mode

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -889,9 +889,7 @@
         "SEPS",
         "wargs",
         "pycache",
-        "ruamel",
-        "WRONLY",
-        "CREAT"
+        "ruamel"
       ]
     },
     {

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -889,7 +889,9 @@
         "SEPS",
         "wargs",
         "pycache",
-        "ruamel"
+        "ruamel",
+        "WRONLY",
+        "CREAT"
       ]
     },
     {

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_cache_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_cache_utils.py
@@ -16,7 +16,7 @@ from typing import List, Dict, Optional, Union, Callable
 
 from azure.ai.ml._utils._asset_utils import get_object_hash
 from azure.ai.ml._utils.utils import is_on_disk_cache_enabled, is_concurrent_component_registration_enabled, \
-    is_private_preview_enabled, open_file_with_int_mode
+    is_private_preview_enabled, write_with_int_mode
 from azure.ai.ml.constants._common import AzureMLResourceType, AZUREML_COMPONENT_REGISTRATION_MAX_WORKERS
 from azure.ai.ml.entities import Component
 from azure.ai.ml.entities._builders import BaseNode
@@ -245,8 +245,7 @@ class CachedNodeResolver(object):
         on_disk_cache_path = self._get_on_disk_cache_path(on_disk_hash)
         on_disk_cache_path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            with open_file_with_int_mode(on_disk_cache_path, "w") as f:
-                f.write(arm_id)
+            write_with_int_mode(on_disk_cache_path, arm_id)
         except PermissionError:
             logger.warning(
                 "Failed to save on-disk cache for component due to permission error. "

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_cache_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_cache_utils.py
@@ -16,7 +16,7 @@ from typing import List, Dict, Optional, Union, Callable
 
 from azure.ai.ml._utils._asset_utils import get_object_hash
 from azure.ai.ml._utils.utils import is_on_disk_cache_enabled, is_concurrent_component_registration_enabled, \
-    is_private_preview_enabled, write_with_int_mode
+    is_private_preview_enabled, write_to_shared_file
 from azure.ai.ml.constants._common import AzureMLResourceType, AZUREML_COMPONENT_REGISTRATION_MAX_WORKERS
 from azure.ai.ml.entities import Component
 from azure.ai.ml.entities._builders import BaseNode
@@ -245,7 +245,7 @@ class CachedNodeResolver(object):
         on_disk_cache_path = self._get_on_disk_cache_path(on_disk_hash)
         on_disk_cache_path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            write_with_int_mode(on_disk_cache_path, arm_id)
+            write_to_shared_file(on_disk_cache_path, arm_id)
         except PermissionError:
             logger.warning(
                 "Failed to save on-disk cache for component due to permission error. "

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_utils.py
@@ -10,7 +10,7 @@ from azure.ai.ml._utils.utils import (
     get_all_data_binding_expressions,
     is_data_binding_expression,
     map_single_brackets_and_warn,
-    write_with_int_mode,
+    write_to_shared_file,
 )
 from azure.ai.ml.entities import BatchEndpoint
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict
@@ -82,12 +82,11 @@ class TestUtils:
             return oct(int_mode)
         with tempfile.TemporaryDirectory() as temp_dir:
             target_file_path = temp_dir + "/test.txt"
-            write_with_int_mode(target_file_path, "test1", int_mode=0o600)
-            if os.name == "nt":
-                # Windows does not support the mode argument for os.open and will always create file with 0o666
-                assert get_int_mode(target_file_path) == "0o666"
-            else:
-                assert get_int_mode(target_file_path) == "0o600"
-            write_with_int_mode(target_file_path, "test2", int_mode=0o666)
+            with open(target_file_path, "w") as f:
+                # default mode is 0o666 for windows and 0o755 for linux
+                f.write("test")
+            write_to_shared_file(target_file_path, "test2")
+            # check that the file mode is preserved
             assert get_int_mode(target_file_path) == "0o666"
-
+            with open(target_file_path, "r") as f:
+                assert f.read() == "test2"

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_utils.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from collections import OrderedDict
 
 import pytest
@@ -8,6 +10,7 @@ from azure.ai.ml._utils.utils import (
     get_all_data_binding_expressions,
     is_data_binding_expression,
     map_single_brackets_and_warn,
+    write_with_int_mode,
 )
 from azure.ai.ml.entities import BatchEndpoint
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict
@@ -72,3 +75,19 @@ class TestUtils:
         ordered_dict2["c"] = 4
         target_list = [ordered_dict1, ordered_dict2]
         assert convert_ordered_dict_to_dict(target_list) == [{"a": 1, "b": 2}, {"d": 3, "c": 4}]
+
+    def test_open_with_int_mode(self):
+        def get_int_mode(file_path: str) -> str:
+            int_mode = os.stat(file_path).st_mode & 0o777
+            return oct(int_mode)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target_file_path = temp_dir + "/test.txt"
+            write_with_int_mode(target_file_path, "test1", int_mode=0o600)
+            if os.name == "nt":
+                # Windows does not support the mode argument for os.open and will always create file with 0o666
+                assert get_int_mode(target_file_path) == "0o666"
+            else:
+                assert get_int_mode(target_file_path) == "0o600"
+            write_with_int_mode(target_file_path, "test2", int_mode=0o666)
+            assert get_int_mode(target_file_path) == "0o666"
+


### PR DESCRIPTION
# Description

Add util to write to file and try to guarantee that the created file is of a specific mode.

This is to handle the case that a user has created a component local cache file which doesn't allow other users to access.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
