### PR TITLE
[Tables] Fix a bug when entity's key in empty string

### DIFF
--- a/sdk/tables/azure-data-tables/CHANGELOG.md
+++ b/sdk/tables/azure-data-tables/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed a bug when deleting an entity with partition key or row key in empty string.([#24480](https://github.com/Azure/azure-sdk-for-python/issues/24480))
 
 ### Other Changes
 * Added support for Python 3.11.

--- a/sdk/tables/azure-data-tables/assets.json
+++ b/sdk/tables/azure-data-tables/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/tables/azure-data-tables",
-  "Tag": "python/tables/azure-data-tables_473ccdc741"
+  "Tag": "python/tables/azure-data-tables_9a03fa14fd"
 }

--- a/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
@@ -343,10 +343,10 @@ class TableClient(TablesBaseClient):
             row_key = entity['RowKey']
         except (TypeError, IndexError):
             partition_key = kwargs.pop('partition_key', None)
-            if not partition_key:
+            if partition_key is None:
                 partition_key = args[0]
             row_key = kwargs.pop("row_key", None)
-            if not row_key:
+            if row_key is None:
                 row_key = args[1]
 
         match_condition = kwargs.pop("match_condition", None)

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_table_client_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_table_client_async.py
@@ -331,10 +331,10 @@ class TableClient(AsyncTablesBaseClient):
             row_key = entity['RowKey']
         except (TypeError, IndexError):
             partition_key = kwargs.pop('partition_key', None)
-            if not partition_key:
+            if partition_key is None:
                 partition_key = args[0]
             row_key = kwargs.pop("row_key", None)
-            if not row_key:
+            if row_key is None:
                 row_key = args[1]
 
         match_condition = kwargs.pop("match_condition", None)

--- a/sdk/tables/azure-data-tables/tests/test_table_entity.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity.py
@@ -1223,6 +1223,20 @@ class TestTableEntity(AzureRecordedTestCase, TableTestCase):
 
     @tables_decorator
     @recorded_by_proxy
+    def test_delete_entity_with_empty_keys(self, tables_storage_account_name, tables_primary_storage_account_key):
+        self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
+        try:
+            entity, _ = self._insert_random_entity(rk="")
+            self.table.delete_entity(entity)
+            entity, _ = self._insert_random_entity(pk="", rk="")
+            self.table.delete_entity(partition_key="", row_key="")
+            res = self.table.list_entities()
+            assert len(list(res)) == 0
+        finally:
+            self._tear_down()
+
+    @tables_decorator
+    @recorded_by_proxy
     def test_unicode_property_value(self, tables_storage_account_name, tables_primary_storage_account_key):
         # Arrange
         self._set_up(tables_storage_account_name, tables_primary_storage_account_key)

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
@@ -493,6 +493,22 @@ class TestTableEntityAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @tables_decorator_async
     @recorded_by_proxy_async
+    async def test_delete_entity_with_empty_keys(self, tables_storage_account_name, tables_primary_storage_account_key):
+        await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)
+        try:
+            entity, _ = await self._insert_random_entity(rk="")
+            await self.table.delete_entity(entity)
+            entity, _ = await self._insert_random_entity(pk="", rk="")
+            await self.table.delete_entity(partition_key="", row_key="")
+            count = 0
+            async for entity in self.table.list_entities():
+                count += 1
+            assert count == 0
+        finally:
+            await self._tear_down()
+
+    @tables_decorator_async
+    @recorded_by_proxy_async
     async def test_get_entity_full_metadata(self, tables_storage_account_name, tables_primary_storage_account_key):
         # Arrange
         await self._set_up(tables_storage_account_name, tables_primary_storage_account_key)

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos.py
@@ -1150,6 +1150,22 @@ class TestTableEntityCosmos(AzureRecordedTestCase, TableTestCase):
 
     @cosmos_decorator
     @recorded_by_proxy
+    def test_delete_entity_with_empty_keys(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+        self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
+        try:
+            with pytest.raises(HttpResponseError) as exc:
+                entity, _ = self._insert_random_entity(pk="")
+            assert "PartitionKey/RowKey cannot be empty" in str(exc.value)
+            # self.table.delete_entity(entity)
+            with pytest.raises(HttpResponseError) as exc:
+                entity, _ = self._insert_random_entity(rk="")
+            assert "PartitionKey/RowKey cannot be empty" in str(exc.value)
+            # self.table.delete_entity(partition_key=entity['PartitionKey'], row_key="")
+        finally:
+            self._tear_down()
+
+    @cosmos_decorator
+    @recorded_by_proxy
     def test_unicode_property_value(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
         # Arrange
         self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_cosmos_async.py
@@ -452,6 +452,22 @@ class TestTableEntityCosmosAsync(AzureRecordedTestCase, AsyncTableTestCase):
 
     @cosmos_decorator_async
     @recorded_by_proxy_async
+    async def test_delete_entity_with_empty_keys(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
+        await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")
+        try:
+            with pytest.raises(HttpResponseError) as exc:
+                entity, _ = await self._insert_random_entity(pk="")
+            assert "PartitionKey/RowKey cannot be empty" in str(exc.value)
+            # self.table.delete_entity(entity)
+            with pytest.raises(HttpResponseError) as exc:
+                entity, _ = await self._insert_random_entity(rk="")
+            assert "PartitionKey/RowKey cannot be empty" in str(exc.value)
+            # self.table.delete_entity(partition_key=entity['PartitionKey'], row_key="")
+        finally:
+            await self._tear_down()
+
+    @cosmos_decorator_async
+    @recorded_by_proxy_async
     async def test_get_entity_full_metadata(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
         # Arrange
         await self._set_up(tables_cosmos_account_name, tables_primary_cosmos_account_key, url="cosmos")


### PR DESCRIPTION
For issue: https://github.com/Azure/azure-sdk-for-python/issues/24480