### PR TITLE
Add path erroneously removed from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,7 +187,6 @@
 /sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/                    @NonStatic2014 @arunsu @stanley-msft @JustinFirsching
 
 # PRLabel: %ML-Jobs
-/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/                         @DouglasXiaoMS @TonyJ1 @wangchao1230
 /sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job*                         @DouglasXiaoMS @TonyJ1 @wangchao1230
 /sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/                       @DouglasXiaoMS @TonyJ1 @wangchao1230
 /sdk/ml/training-experiences.tests.yml                               @DouglasXiaoMS @TonyJ1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -188,6 +188,7 @@
 
 # PRLabel: %ML-Jobs
 /sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/                         @DouglasXiaoMS @TonyJ1 @wangchao1230
+/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job*                         @DouglasXiaoMS @TonyJ1 @wangchao1230
 /sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/                       @DouglasXiaoMS @TonyJ1 @wangchao1230
 /sdk/ml/training-experiences.tests.yml                               @DouglasXiaoMS @TonyJ1
 


### PR DESCRIPTION
This PR fixes a bug introduced by:
- #28504

I.e. by converting path 
`/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job` 
into
`/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/`
I made it stop matching [1] against 
`sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job_resource_configuration.py`

This fixes it.

[1] _Strictly speaking_ the path may have not been matching in the first place, per [.gitignore doc](https://git-scm.com/docs/gitignore#_pattern_format) and [`CODEOWNERS` doc](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax). However, it seems to me what this PR proposes is in fact the intended behavior.