### PR TITLE
[EventHub] Use Streams API For Async Socket Connections

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -271,7 +271,6 @@ class AsyncTransport(
                 family=socket.AF_UNSPEC,
                 proto=SOL_TCP,
                 server_hostname=self.host if self.sslopts else None,
-                happy_eyeballs_delay=0.25,
             )
             # we've sent the banner; signal connect
             # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
@@ -361,7 +360,6 @@ class AsyncTransport(
                 # Sometimes SSL raises APPLICATION_DATA_AFTER_CLOSE_NOTIFY here on close.
                 _LOGGER.debug("Error shutting down socket: %r", e, extra=self.network_trace_params)
             self.writer, self.reader = None, None
-        self.sock = None
         self.connected = False
 
     async def negotiate(self):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -53,10 +53,8 @@ from .._transport import (
     AMQP_FRAME,
     get_errno,
     to_host_port,
-    DEFAULT_SOCKET_SETTINGS,
     SIGNED_INT_MAX,
     _UNAVAIL,
-    set_cloexec,
     AMQP_PORT,
     TIMEOUT_INTERVAL,
 )
@@ -256,12 +254,25 @@ class AsyncTransport(
             # are we already connected?
             if self.connected:
                 return
-            await self._connect(self.host, self.port, self.connect_timeout)
-            self._init_socket(self.socket_settings)
+            try:
+            # Building ssl opts here instead of constructor, so that invalid cert error is raised
+            # when client is connecting, rather then during creation. For uamqp exception parity.
+                self.sslopts = self._build_ssl_opts(self.sslopts)
+            except FileNotFoundError as exc:
+            # FileNotFoundError does not have missing filename info, so adding it below.
+            # Assuming that this must be ca_certs, since this is the only file path that
+            # users can pass in (`connection_verify` in the EH/SB clients) through sslopts above.
+            # For uamqp exception parity. Remove later when resolving issue #27128.
+                exc.filename = self.sslopts
+                raise exc
             self.reader, self.writer = await asyncio.open_connection(
-                sock=self.sock,
+                host=self.host,
+                port=self.port,
                 ssl=self.sslopts,
+                family=socket.AF_UNSPEC,
+                proto=SOL_TCP,
                 server_hostname=self.host if self.sslopts else None,
+                happy_eyeballs_delay=0.25,
             )
             # we've sent the banner; signal connect
             # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
@@ -274,101 +285,6 @@ class AsyncTransport(
                 self.sock.close()
                 self.sock = None
             raise
-
-    async def _connect(self, host, port, timeout):
-        # Below we are trying to avoid additional DNS requests for AAAA if A
-        # succeeds. This helps a lot in case when a hostname has an IPv4 entry
-        # in /etc/hosts but not IPv6. Without the (arguably somewhat twisted)
-        # logic below, getaddrinfo would attempt to resolve the hostname for
-        # both IP versions, which would make the resolver talk to configured
-        # DNS servers. If those servers are for some reason not available
-        # during resolution attempt (either because of system misconfiguration,
-        # or network connectivity problem), resolution process locks the
-        # _connect call for extended time.
-        e = None
-        addr_types = (socket.AF_INET, socket.AF_INET6)
-        addr_types_num = len(addr_types)
-        for n, family in enumerate(addr_types):
-            # first, resolve the address for a single address family
-            try:
-                entries = await asyncio.get_event_loop().getaddrinfo(
-                    host, port, family=family, type=socket.SOCK_STREAM, proto=SOL_TCP
-                )
-                entries_num = len(entries)
-            except socket.gaierror:
-                # we may have depleted all our options
-                if n + 1 >= addr_types_num:
-                    # if getaddrinfo succeeded before for another address
-                    # family, reraise the previous socket.error since it's more
-                    # relevant to users
-                    raise e if e is not None else socket.error("failed to resolve broker hostname")
-                continue    # pragma: no cover
-            # now that we have address(es) for the hostname, connect to broker
-            for i, res in enumerate(entries):
-                af, socktype, proto, _, sa = res
-                try:
-                    self.sock = socket.socket(af, socktype, proto)
-                    try:
-                        set_cloexec(self.sock, True)
-                    except NotImplementedError:
-                        pass
-                    self.sock.settimeout(timeout)
-                    await asyncio.get_event_loop().sock_connect(self.sock, sa)
-                except socket.error as ex:
-                    e = ex
-                    if self.sock is not None:
-                        self.sock.close()
-                        self.sock = None
-                    # we may have depleted all our options
-                    if i + 1 >= entries_num and n + 1 >= addr_types_num:
-                        raise
-                else:
-                    # hurray, we established connection
-                    return
-
-    def _init_socket(self, socket_settings):
-        self.sock.settimeout(None)  # set socket back to blocking mode
-        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-        self._set_socket_options(socket_settings)
-        try:
-            # Building ssl opts here instead of constructor, so that invalid cert error is raised
-            # when client is connecting, rather then during creation. For uamqp exception parity.
-            self.sslopts = self._build_ssl_opts(self.sslopts)
-        except FileNotFoundError as exc:
-            # FileNotFoundError does not have missing filename info, so adding it below.
-            # Assuming that this must be ca_certs, since this is the only file path that
-            # users can pass in (`connection_verify` in the EH/SB clients) through sslopts above.
-            # For uamqp exception parity. Remove later when resolving issue #27128.
-            exc.filename = self.sslopts
-            raise exc
-        self.sock.settimeout(1)  # set socket back to non-blocking mode
-
-    def _get_tcp_socket_defaults(self, sock):  # pylint: disable=no-self-use
-        tcp_opts = {}
-        for opt in KNOWN_TCP_OPTS:
-            enum = None
-            if opt == "TCP_USER_TIMEOUT":
-                try:
-                    from socket import TCP_USER_TIMEOUT as enum
-                except ImportError:
-                    # should be in Python 3.6+ on Linux.
-                    enum = 18
-            elif hasattr(socket, opt):
-                enum = getattr(socket, opt)
-
-            if enum:
-                if opt in DEFAULT_SOCKET_SETTINGS:
-                    tcp_opts[enum] = DEFAULT_SOCKET_SETTINGS[opt]
-                elif hasattr(socket, opt):
-                    tcp_opts[enum] = sock.getsockopt(SOL_TCP, getattr(socket, opt))
-        return tcp_opts
-
-    def _set_socket_options(self, socket_settings):
-        tcp_opts = self._get_tcp_socket_defaults(self.sock)
-        if socket_settings:
-            tcp_opts.update(socket_settings)
-        for opt, val in tcp_opts.items():
-            self.sock.setsockopt(SOL_TCP, opt, val)
 
     async def _read(
         self,


### PR DESCRIPTION
The library was raising the following error when asyncio debug mode was set up. 

`EventProcessor instance 'eafb1af4-b6e3-4877-8f2c-0a57f7e353fa' of eventhub 'ehtest' consumer group '$Default'. An error occurred while load-balancing and claiming ownership. The exception is EventHubError('the socket must be non-blocking\nthe socket must be non-blocking'). Retrying after 10.27072635958343 seconds`

This was happening because `_transport_async.py` was using a blocking socket and passing it into [`asyncio.get_event_loop.open_connection`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.sock_connect) which expects a non-blocking socket. For a socket to be non-blocking the timeout has to be `0.0` and the code was using `None`. 

This socket was also then passed into the high-level streams API, which should be avoided. The recommended approach to create nonblocking sockets is to use the [high level streams API](https://docs.python.org/3/library/asyncio-stream.html)

While most of the changes were 1:1 there are some deltas that need to be discussed:
* `_connect` was using a happy eyeballs algo to determine which endpoint to connect to (IPv4 or IPv6). Replaced it by using the `happy_eyeballs_delay` with a value of .25 as specified in [`loop.create_connection`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_connection)
  * Update  -- had to remove this as the param is only for py3.8+ 
* Passing in a family param of `socket.AF_UNSPEC` to handle both IPv4 and IPv6.
* Some of the other settings as keep_alive, tcp options etc. were removed since there is no access to the socket object created. I could go back to creating a socket object manually, keeping it non blocking , set all those options and then pass it in to `asyncio.open_connection`. The socket would have to be connected however.