### PR TITLE
[ML] Bug fix for enable_no_public_ip for Compute 

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -6,8 +6,9 @@
 -Add dedicated classes for each type of job service. The classes added are `JupyterLabJobService, SshJobService, TensorBoardJobService, VsCodeJobService` with a few properties specific to the type.
 
 ### Bugs Fixed
-- Fixed an issue where the ordering of `.amlignore` and `.gitignore` files are not respected
-- Fixed an issue that attributes with a value of `False` in `PipelineJobSettings` are not respected
+- Fixed an issue where the ordering of `.amlignore` and `.gitignore` files are not respected.
+- Fixed an issue that attributes with a value of `False` in `PipelineJobSettings` are not respected.
+- Fixes a bug where enable_node_public_ip returned an improper value when fetching a Compute.
 
 ### Other Changes
 - Update workspace creation to use Log Analytics-Based Application Insights when the user does not specify/bring their own App Insights.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
@@ -182,7 +182,7 @@ class AmlCompute(Compute):
             identity=IdentityConfiguration._from_compute_rest_object(rest_obj.identity) if rest_obj.identity else None,
             created_on=prop.additional_properties.get("createdOn", None),
             enable_node_public_ip=prop.properties.enable_node_public_ip
-            if prop.properties.enable_node_public_ip
+            if prop.properties.enable_node_public_ip is not None
             else True,
         )
         return response

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute_instance.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute_instance.py
@@ -401,7 +401,7 @@ class ComputeInstance(Compute):
             idle_time_before_shutdown_minutes=idle_time_before_shutdown_minutes,
             os_image_metadata=os_image_metadata,
             enable_node_public_ip=prop.properties.enable_node_public_ip
-            if (prop.properties and prop.properties.enable_node_public_ip)
+            if (prop.properties and prop.properties.enable_node_public_ip is not None)
             else True,
         )
         return response

--- a/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_entity.py
@@ -351,7 +351,7 @@ class TestComputeEntity:
             compute_resource = compute._to_rest_object()
             assert compute_resource.properties.properties.enable_node_public_ip == False
             compute_from_rest = Compute._from_rest_object(compute_resource)
-            assert compute.enable_node_public_ip == False
+            assert compute_from_rest.enable_node_public_ip == False
 
         validate_no_public_ip(compute=compute_instance)
         validate_no_public_ip(compute=aml_compute)


### PR DESCRIPTION
# Description

Fixes a bug where `enable_node_public_ip` did not return a proper value from the Rest API.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
