### PR TITLE
[Storage] Fix Datalake rename operations when new name contains `?`

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -736,7 +736,8 @@
         "cpksubdirectory",
         "thead",
         "tbody",
-        "racwdlmeop"
+        "racwdlmeop",
+        "newfs"
       ]
     },
     {

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added ability to perform leasing actions on file append and flush. See new keyword `lease_action` for details.
 - Added support for `AsyncIterable` as data type for async file upload.
 
+### Bugs Fixed
+- Fixed an issue where `rename_file` and `rename_directory` would not work correctly if the new file/directory name
+contained a `?` character.
+
 ### Other Changes
 - Removed `msrest` dependency.
 - Added `typing-extensions>=4.0.1` as a dependency.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -375,17 +375,7 @@ class DataLakeDirectoryClient(PathClient):
                 :dedent: 4
                 :caption: Rename the source directory.
         """
-        new_name = new_name.strip('/')
-        new_file_system = new_name.split('/')[0]
-        new_path_and_token = new_name[len(new_file_system):].strip('/').split('?')
-        new_path = new_path_and_token[0]
-        try:
-            new_dir_sas = new_path_and_token[1] or self._query_str.strip('?')
-        except IndexError:
-            if not self._raw_credential and new_file_system != self.file_system_name:
-                raise ValueError("please provide the sas token for the new file")
-            if not self._raw_credential and new_file_system == self.file_system_name:
-                new_dir_sas = self._query_str.strip('?')
+        new_file_system, new_path, new_dir_sas = self._parse_rename_path(new_name)
 
         new_directory_client = DataLakeDirectoryClient(
             "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, directory_name=new_path,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -831,17 +831,7 @@ class DataLakeFileClient(PathClient):
                 :dedent: 4
                 :caption: Rename the source file.
         """
-        new_name = new_name.strip('/')
-        new_file_system = new_name.split('/')[0]
-        new_path_and_token = new_name[len(new_file_system):].strip('/').split('?')
-        new_path = new_path_and_token[0]
-        try:
-            new_file_sas = new_path_and_token[1] or self._query_str.strip('?')
-        except IndexError:
-            if not self._raw_credential and new_file_system != self.file_system_name:
-                raise ValueError("please provide the sas token for the new file")
-            if not self._raw_credential and new_file_system == self.file_system_name:
-                new_file_sas = self._query_str.strip('?')
+        new_file_system, new_path, new_file_sas = self._parse_rename_path(new_name)
 
         new_file_client = DataLakeFileClient(
             "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, file_path=new_path,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -4,9 +4,10 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import re
 from datetime import datetime
 from typing import ( # pylint: disable=unused-import
-    Any, Dict, Optional, Union,
+    Any, Dict, Optional, Tuple, Union,
     TYPE_CHECKING
 )
 from urllib.parse import urlparse, quote
@@ -736,6 +737,30 @@ class PathClient(StorageAccountHostsMixin):
         except AzureError as error:
             error.continuation_token = last_continuation_token
             raise error
+
+    def _parse_rename_path(self, new_name: str) -> Tuple[str, str, Optional[str]]:
+        new_name = new_name.strip('/')
+        new_file_system = new_name.split('/')[0]
+        new_path = new_name[len(new_file_system):].strip('/')
+
+        new_sas = None
+        sas_split = new_path.split('?')
+        # If there is a ?, there could be a SAS token
+        if len(sas_split) > 0:
+            # Check last element for SAS by looking for sv= and sig=
+            potential_sas = sas_split[-1]
+            if re.search(r'sv=\d{4}-\d{2}-\d{2}', potential_sas) and 'sig=' in potential_sas:
+                new_sas = potential_sas
+                # Remove SAS from new path
+                new_path = new_path[:-(len(new_sas) + 1)]
+
+        if not new_sas:
+            if not self._raw_credential and new_file_system != self.file_system_name:
+                raise ValueError("please provide the sas token for the new file")
+            if not self._raw_credential and new_file_system == self.file_system_name:
+                new_sas = self._query_str.strip('?')
+
+        return new_file_system, new_path, new_sas
 
     def _rename_path_options(self,  # pylint: disable=no-self-use
                              rename_source,  # type: str

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
@@ -343,17 +343,7 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
                 :dedent: 4
                 :caption: Rename the source directory.
         """
-        new_name = new_name.strip('/')
-        new_file_system = new_name.split('/')[0]
-        new_path_and_token = new_name[len(new_file_system):].strip('/').split('?')
-        new_path = new_path_and_token[0]
-        try:
-            new_dir_sas = new_path_and_token[1] or self._query_str.strip('?')
-        except IndexError:
-            if not self._raw_credential and new_file_system != self.file_system_name:
-                raise ValueError("please provide the sas token for the new directory")
-            if not self._raw_credential and new_file_system == self.file_system_name:
-                new_dir_sas = self._query_str.strip('?')
+        new_file_system, new_path, new_dir_sas = self._parse_rename_path(new_name)
 
         new_directory_client = DataLakeDirectoryClient(
             "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, directory_name=new_path,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -675,17 +675,7 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
                 :dedent: 4
                 :caption: Rename the source file.
         """
-        new_name = new_name.strip('/')
-        new_file_system = new_name.split('/')[0]
-        new_path_and_token = new_name[len(new_file_system):].strip('/').split('?')
-        new_path = new_path_and_token[0]
-        try:
-            new_file_sas = new_path_and_token[1] or self._query_str.strip('?')
-        except IndexError:
-            if not self._raw_credential and new_file_system != self.file_system_name:
-                raise ValueError("please provide the sas token for the new file")
-            if not self._raw_credential and new_file_system == self.file_system_name:
-                new_file_sas = self._query_str.strip('?')
+        new_file_system, new_path, new_file_sas = self._parse_rename_path(new_name)
 
         new_file_client = DataLakeFileClient(
             "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, file_path=new_path,

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_directory.pyTestDirectorytest_rename_directory_special_chars.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_directory.pyTestDirectorytest_rename_directory_special_chars.json
@@ -1,0 +1,129 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystem6e3c2f71?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:57:44 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:57:44 GMT",
+        "ETag": "\u00220x8DB03E6F27FAE14\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:57:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem6e3c2f71/olddir?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "ETag": "\u00220x8DB03E6F2DE38DD\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem6e3c2f71/%3F%21%40%23%24%25%5E%26%2A.%3Ftest?mode=legacy",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "x-ms-rename-source": "/filesystem6e3c2f71/olddir",
+        "x-ms-source-lease-id": "",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "ETag": "\u00220x8DB03E6F2DE38DD\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystem6e3c2f71/%3F%21%40%23%24%25%5E%26%2A.%3Ftest",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "ETag": "\u00220x8DB03E6F2DE38DD\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Tue, 31 Jan 2023 23:57:45 GMT",
+        "x-ms-group": "$superuser",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-hdi_isfolder": "true",
+        "x-ms-owner": "$superuser",
+        "x-ms-permissions": "rwxr-x---",
+        "x-ms-resource-type": "directory",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_directory_async.pyTestDirectoryAsynctest_rename_directory_special_chars.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_directory_async.pyTestDirectoryAsynctest_rename_directory_special_chars.json
@@ -1,0 +1,125 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystema0d033ec?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 01 Feb 2023 00:00:44 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 01 Feb 2023 00:00:44 GMT",
+        "ETag": "\u00220x8DB03E75DE541D8\u0022",
+        "Last-Modified": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystema0d033ec/olddir?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "ETag": "\u00220x8DB03E75E5BC906\u0022",
+        "Last-Modified": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystema0d033ec/%3F!@%23$%25%5E\u0026*.%3Ftest?mode=legacy",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "x-ms-rename-source": "/filesystema0d033ec/olddir",
+        "x-ms-source-lease-id": "",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "ETag": "\u00220x8DB03E75E5BC906\u0022",
+        "Last-Modified": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystema0d033ec/%3F!@%23$%25%5E\u0026*.%3Ftest",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 01 Feb 2023 00:00:46 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "ETag": "\u00220x8DB03E75E5BC906\u0022",
+        "Last-Modified": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Wed, 01 Feb 2023 00:00:45 GMT",
+        "x-ms-group": "$superuser",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-hdi_isfolder": "true",
+        "x-ms-owner": "$superuser",
+        "x-ms-permissions": "rwxr-x---",
+        "x-ms-resource-type": "directory",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.pyTestFiletest_rename_file_different_filesystem_with_sas.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.pyTestFiletest_rename_file_different_filesystem_with_sas.json
@@ -1,0 +1,184 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystem85d42f9d?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:42:12 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:42:12 GMT",
+        "ETag": "\u00220x8DB03D4035074CF\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:42:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem85d42f9d/oldfile?resource=file\u0026se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:42:12 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "ETag": "\u00220x8DB03D403B7BC79\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem85d42f9d/oldfile?action=append\u0026position=0\u0026flush=true\u0026se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "abc",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "ETag": "\u00220x8DB03D403CCD616\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/newfs?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "ETag": "\u00220x8DB03D403DA2A0C\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/newfs/new%3Ffile?mode=legacy\u0026se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "x-ms-rename-source": "/filesystem85d42f9d/oldfile?se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+        "x-ms-source-lease-id": "",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "ETag": "\u00220x8DB03D403CCD616\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/newfs/new%3Ffile?se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:42:14 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "Date": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "ETag": "\u00220x8DB03D403CCD616\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Tue, 31 Jan 2023 21:42:13 GMT",
+        "x-ms-group": "$superuser",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-owner": "$superuser",
+        "x-ms-permissions": "rw-r-----",
+        "x-ms-resource-type": "file",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.pyTestFiletest_rename_file_special_chars.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file.pyTestFiletest_rename_file_special_chars.json
@@ -1,0 +1,157 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystemafc128d2?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:44:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:44:49 GMT",
+        "ETag": "\u00220x8DB03D460F2E8E7\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:44:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemafc128d2/oldfile?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:44:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:44:49 GMT",
+        "ETag": "\u00220x8DB03D461446F33\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemafc128d2/oldfile?action=append\u0026position=0\u0026flush=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "abc",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:44:49 GMT",
+        "ETag": "\u00220x8DB03D4615738FA\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemafc128d2/%3F%21%40%23%24%25%5E%26%2A.%3Ftest?mode=legacy",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "x-ms-rename-source": "/filesystemafc128d2/oldfile",
+        "x-ms-source-lease-id": "",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 21:44:49 GMT",
+        "ETag": "\u00220x8DB03D4615738FA\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystemafc128d2/%3F%21%40%23%24%25%5E%26%2A.%3Ftest",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "Date": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "ETag": "\u00220x8DB03D4615738FA\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Tue, 31 Jan 2023 21:44:50 GMT",
+        "x-ms-group": "$superuser",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-owner": "$superuser",
+        "x-ms-permissions": "rw-r-----",
+        "x-ms-resource-type": "file",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.pyTestFileAsynctest_rename_file_different_filesystem_with_sas.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.pyTestFileAsynctest_rename_file_different_filesystem_with_sas.json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystemb9f03418?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:32:36 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:32:36 GMT",
+        "ETag": "\u00220x8DB03E36FDE7A0C\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemb9f03418/oldfile?resource=file\u0026se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:32:36 GMT",
+        "ETag": "\u00220x8DB03E37032F5D5\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystemb9f03418/oldfile?action=append\u0026position=0\u0026flush=true\u0026se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "abc",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "ETag": "\u00220x8DB03E3706B1510\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:32:38 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/newfs?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:32:38 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "ETag": "\u00220x8DB03E370785A0B\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:32:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/newfs/new%3Ffile?mode=legacy\u0026se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:32:38 GMT",
+        "x-ms-rename-source": "/filesystemb9f03418/oldfile?se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+        "x-ms-source-lease-id": "",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "ETag": "\u00220x8DB03E3706B1510\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:32:38 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/newfs/new%3Ffile?se=end\u0026sp=rwd\u0026sv=2021-12-02\u0026sr=c\u0026sig=fake_token_value",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:32:38 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "Date": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "ETag": "\u00220x8DB03E3706B1510\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:32:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Tue, 31 Jan 2023 23:32:37 GMT",
+        "x-ms-group": "$superuser",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-owner": "$superuser",
+        "x-ms-permissions": "rw-r-----",
+        "x-ms-resource-type": "file",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.pyTestFileAsynctest_rename_file_special_chars.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_async.pyTestFileAsynctest_rename_file_special_chars.json
@@ -1,0 +1,152 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystem9c2d2d4d?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:33:58 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:33:58 GMT",
+        "ETag": "\u00220x8DB03E3A05DFEA7\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:33:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem9c2d2d4d/oldfile?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:33:58 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:33:58 GMT",
+        "ETag": "\u00220x8DB03E3A0B78353\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem9c2d2d4d/oldfile?action=append\u0026position=0\u0026flush=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "abc",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:33:58 GMT",
+        "ETag": "\u00220x8DB03E3A0D64952\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.dfs.core.windows.net/filesystem9c2d2d4d/%3F!@%23$%25%5E\u0026*.%3Ftest?mode=legacy",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "x-ms-rename-source": "/filesystem9c2d2d4d/oldfile",
+        "x-ms-source-lease-id": "",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "ETag": "\u00220x8DB03E3A0D64952\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/filesystem9c2d2d4d/%3F!@%23$%25%5E\u0026*.%3Ftest",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-dfs/12.10.0b1 Python/3.10.6 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Tue, 31 Jan 2023 23:34:00 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "3",
+        "Content-Type": "application/json",
+        "Date": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "ETag": "\u00220x8DB03E3A0D64952\u0022",
+        "Last-Modified": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Tue, 31 Jan 2023 23:33:59 GMT",
+        "x-ms-group": "$superuser",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-owner": "$superuser",
+        "x-ms-permissions": "rw-r-----",
+        "x-ms-resource-type": "file",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory.py
@@ -1349,6 +1349,20 @@ class TestDirectory(StorageRecordedTestCase):
 
     @DataLakePreparer()
     @recorded_by_proxy
+    def test_rename_directory_special_chars(self, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+
+        dir_client = self._create_directory_and_get_directory_client('olddir')
+        new_client = dir_client.rename_directory(dir_client.file_system_name + '/' + '?!@#$%^&*.?test')
+        new_props = new_client.get_directory_properties()
+
+        assert new_props.name == '?!@#$%^&*.?test'
+
+    @DataLakePreparer()
+    @recorded_by_proxy
     def test_get_properties(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
         datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")

--- a/sdk/storage/azure-storage-file-datalake/tests/test_directory_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_directory_async.py
@@ -1324,6 +1324,20 @@ class TestDirectoryAsync(AsyncStorageRecordedTestCase):
 
     @DataLakePreparer()
     @recorded_by_proxy_async
+    async def test_rename_directory_special_chars(self, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        await self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+
+        dir_client = await self._create_directory_and_get_directory_client('olddir')
+        new_client = await dir_client.rename_directory(dir_client.file_system_name + '/' + '?!@#$%^&*.?test')
+        new_props = await new_client.get_directory_properties()
+
+        assert new_props.name == '?!@#$%^&*.?test'
+
+    @DataLakePreparer()
+    @recorded_by_proxy_async
     async def test_get_properties(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
         datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file.py
@@ -1372,6 +1372,65 @@ class TestFile(StorageRecordedTestCase):
 
     @DataLakePreparer()
     @recorded_by_proxy
+    def test_rename_file_different_filesystem_with_sas(self, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+
+        # Use filesystem SAS without access to new filesystem
+        existing_sas = self.generate_sas(
+            generate_file_system_sas,
+            self.dsc.account_name,
+            self.file_system_name,
+            self.dsc.credential.account_key,
+            FileSystemSasPermissions(write=True, read=True, delete=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        file_client = DataLakeFileClient(self.dsc.url, self.file_system_name, "oldfile", credential=existing_sas)
+        file_client.create_file()
+        file_client.append_data(b"abc", 0, 3, flush=True)
+
+        # Create another filesystem to rename to
+        new_file_system = self.dsc.get_file_system_client('newfs')
+        new_file_system.create_file_system()
+
+        # Get different SAS to new file system
+        new_sas = self.generate_sas(
+            generate_file_system_sas,
+            self.dsc.account_name,
+            new_file_system.file_system_name,
+            self.dsc.credential.account_key,
+            FileSystemSasPermissions(write=True, read=True, delete=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        # ? in new name to test parsing
+        new_name = new_file_system.file_system_name + '/' + 'new?file' + '?' + new_sas
+        new_client = file_client.rename_file(new_name)
+        new_props = new_client.get_file_properties()
+
+        assert new_props.name == 'new?file'
+
+    @DataLakePreparer()
+    @recorded_by_proxy
+    def test_rename_file_special_chars(self, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+
+        file_client = self._create_file_and_return_client(file="oldfile")
+        file_client.append_data(b"abc", 0, 3, flush=True)
+
+        new_client = file_client.rename_file(file_client.file_system_name + '/' + '?!@#$%^&*.?test')
+        new_props = new_client.get_file_properties()
+
+        assert new_props.name == '?!@#$%^&*.?test'
+
+    @DataLakePreparer()
+    @recorded_by_proxy
     def test_read_file_read(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
         datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_async.py
@@ -24,8 +24,10 @@ from azure.storage.filedatalake import (
     ContentSettings,
     EncryptionScopeOptions,
     FileSasPermissions,
+    FileSystemSasPermissions,
     generate_account_sas,
     generate_file_sas,
+    generate_file_system_sas,
     ResourceTypes
 )
 from azure.storage.filedatalake.aio import DataLakeDirectoryClient, DataLakeFileClient, DataLakeServiceClient, FileSystemClient
@@ -1261,6 +1263,65 @@ class TestFileAsync(AsyncStorageRecordedTestCase):
 
         with pytest.raises(HttpResponseError):
             await (await f3.download_file()).readall()
+
+    @DataLakePreparer()
+    @recorded_by_proxy_async
+    async def test_rename_file_different_filesystem_with_sas(self, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        await self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+
+        # Use filesystem SAS without access to new filesystem
+        existing_sas = self.generate_sas(
+            generate_file_system_sas,
+            self.dsc.account_name,
+            self.file_system_name,
+            self.dsc.credential.account_key,
+            FileSystemSasPermissions(write=True, read=True, delete=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        file_client = DataLakeFileClient(self.dsc.url, self.file_system_name, "oldfile", credential=existing_sas)
+        await file_client.create_file()
+        await file_client.append_data(b"abc", 0, 3, flush=True)
+
+        # Create another filesystem to rename to
+        new_file_system = self.dsc.get_file_system_client('newfs')
+        await new_file_system.create_file_system()
+
+        # Get different SAS to new file system
+        new_sas = self.generate_sas(
+            generate_file_system_sas,
+            self.dsc.account_name,
+            new_file_system.file_system_name,
+            self.dsc.credential.account_key,
+            FileSystemSasPermissions(write=True, read=True, delete=True),
+            datetime.utcnow() + timedelta(hours=1),
+        )
+
+        # ? in new name to test parsing
+        new_name = new_file_system.file_system_name + '/' + 'new?file' + '?' + new_sas
+        new_client = await file_client.rename_file(new_name)
+        new_props = await new_client.get_file_properties()
+
+        assert new_props.name == 'new?file'
+
+    @DataLakePreparer()
+    @recorded_by_proxy_async
+    async def test_rename_file_special_chars(self, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        await self._setUp(datalake_storage_account_name, datalake_storage_account_key)
+
+        file_client = await self._create_file_and_return_client(file="oldfile")
+        await file_client.append_data(b"abc", 0, 3, flush=True)
+
+        new_client = await file_client.rename_file(file_client.file_system_name + '/' + '?!@#$%^&*.?test')
+        new_props = await new_client.get_file_properties()
+
+        assert new_props.name == '?!@#$%^&*.?test'
 
     @DataLakePreparer()
     @recorded_by_proxy_async


### PR DESCRIPTION
Resolves #28482.

This change resolves an issue where `rename_file` and `rename_directory` in the Datalake SDK would not rename to the correct name if the new path contained a `?`. This was due to how we parsed the new path to account for the presence of a SAS token. The solution was to check for the presence of `sv=XXXX-XX-XX` and `sig=` in the path segment which could contain a SAS before removing it from the new path and using it as a SAS token. This is not a perfect solution but should realistically prevent any issues with renaming in the future without needing to change the public interface for how we accept a SAS token.

Also took this opportunity to move path parsing logic to common base class function.