### PR TITLE
[Event Hubs] Update load balance interval

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
@@ -274,7 +274,7 @@ class EventHubConsumerClient(
         :keyword float partition_ownership_expiration_interval: A partition ownership will expire after this number
          of seconds. Every load-balancing evaluation will automatically extend the ownership expiration time.
          Default is 6 * load_balancing_interval, i.e. 60 seconds when using the default load_balancing_interval
-         of 10 seconds.
+         of 30 seconds.
         :keyword load_balancing_strategy: When load-balancing kicks in,
          it will use this strategy to claim and balance the partition ownership.
          Use "greedy" or `LoadBalancingStrategy.GREEDY` for the greedy strategy, which, for every

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
@@ -103,11 +103,11 @@ class EventHubConsumerClient(
      in memory, and the `EventHubConsumerClient` instance will receive events without load-balancing.
     :paramtype checkpoint_store: Optional[~azure.eventhub.CheckpointStore]
     :keyword float load_balancing_interval: When load-balancing kicks in. This is the interval, in seconds,
-     between two load-balancing evaluations. Default is 10 seconds.
+     between two load-balancing evaluations. Default is 30 seconds.
     :keyword float partition_ownership_expiration_interval: A partition ownership will expire after this number
      of seconds. Every load-balancing evaluation will automatically extend the ownership expiration time.
-     Default is 6 * load_balancing_interval, i.e. 60 seconds when using the default load_balancing_interval
-     of 10 seconds.
+     Default is 6 * load_balancing_interval, i.e. 180 seconds when using the default load_balancing_interval
+     of 30 seconds.
     :keyword load_balancing_strategy: When load-balancing kicks in,
      it will use this strategy to claim and balance the partition ownership.
      Use "greedy" or `LoadBalancingStrategy.GREEDY` for the greedy strategy, which, for every
@@ -156,7 +156,7 @@ class EventHubConsumerClient(
         self._checkpoint_store = kwargs.pop("checkpoint_store", None)
         self._load_balancing_interval = kwargs.pop("load_balancing_interval", None)
         if self._load_balancing_interval is None:
-            self._load_balancing_interval = 10
+            self._load_balancing_interval = 30
         self._partition_ownership_expiration_interval = kwargs.pop(
             "partition_ownership_expiration_interval", None
         )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
@@ -88,7 +88,7 @@ class EventProcessor(
         )  # type: Union[bool, Dict[str, bool]]
 
         self._load_balancing_interval = kwargs.get(
-            "load_balancing_interval", 10.0
+            "load_balancing_interval", 30.0
         )  # type: float
         self._load_balancing_strategy = (
             kwargs.get("load_balancing_strategy") or LoadBalancingStrategy.GREEDY

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
@@ -112,7 +112,7 @@ class EventHubConsumerClient(
     :keyword float partition_ownership_expiration_interval: A partition ownership will expire after this number
      of seconds. Every load-balancing evaluation will automatically extend the ownership expiration time.
      Default is 6 * load_balancing_interval, i.e. 180 seconds when using the default load_balancing_interval
-     of 10 seconds.
+     of 30 seconds.
     :keyword load_balancing_strategy: When load-balancing kicks in,
      it will use this strategy to claim and balance the partition ownership.
      Use "greedy" or `LoadBalancingStrategy.GREEDY` for the greedy strategy, which, for every
@@ -293,7 +293,7 @@ class EventHubConsumerClient(
         :keyword float partition_ownership_expiration_interval: A partition ownership will expire after this number
          of seconds. Every load-balancing evaluation will automatically extend the ownership expiration time.
          Default is 6 * load_balancing_interval, i.e. 180 seconds when using the default load_balancing_interval
-         of 10 seconds.
+         of 30 seconds.
         :keyword load_balancing_strategy: When load-balancing kicks in,
          it will use this strategy to claim and balance the partition ownership.
          Use "greedy" or `LoadBalancingStrategy.GREEDY` for the greedy strategy, which, for every

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
@@ -108,10 +108,10 @@ class EventHubConsumerClient(
      in memory, and the `EventHubConsumerClient` instance will receive events without load-balancing.
     :paramtype checkpoint_store: Optional[~azure.eventhub.aio.CheckpointStore]
     :keyword float load_balancing_interval: When load-balancing kicks in. This is the interval, in seconds,
-     between two load-balancing evaluations. Default is 10 seconds.
+     between two load-balancing evaluations. Default is 30 seconds.
     :keyword float partition_ownership_expiration_interval: A partition ownership will expire after this number
      of seconds. Every load-balancing evaluation will automatically extend the ownership expiration time.
-     Default is 6 * load_balancing_interval, i.e. 60 seconds when using the default load_balancing_interval
+     Default is 6 * load_balancing_interval, i.e. 180 seconds when using the default load_balancing_interval
      of 10 seconds.
     :keyword load_balancing_strategy: When load-balancing kicks in,
      it will use this strategy to claim and balance the partition ownership.
@@ -159,7 +159,7 @@ class EventHubConsumerClient(
         self._checkpoint_store = kwargs.pop("checkpoint_store", None)
         self._load_balancing_interval = kwargs.pop("load_balancing_interval", None)
         if self._load_balancing_interval is None:
-            self._load_balancing_interval = 10
+            self._load_balancing_interval = 30
         self._partition_ownership_expiration_interval = kwargs.pop(
             "partition_ownership_expiration_interval", None
         )
@@ -240,7 +240,7 @@ class EventHubConsumerClient(
         retry_total: int = 3,
         transport_type: TransportType = TransportType.Amqp,
         checkpoint_store: Optional["CheckpointStore"] = None,
-        load_balancing_interval: float = 10,
+        load_balancing_interval: float = 30,
         **kwargs: Any
     ) -> "EventHubConsumerClient":
         """Create an EventHubConsumerClient from a connection string.
@@ -289,10 +289,10 @@ class EventHubConsumerClient(
          in memory, and the `EventHubConsumerClient` instance will receive events without load-balancing.
         :paramtype checkpoint_store: Optional[~azure.eventhub.aio.CheckpointStore]
         :keyword float load_balancing_interval: When load-balancing kicks in. This is the interval, in seconds,
-         between two load-balancing evaluations. Default is 10 seconds.
+         between two load-balancing evaluations. Default is 30 seconds.
         :keyword float partition_ownership_expiration_interval: A partition ownership will expire after this number
          of seconds. Every load-balancing evaluation will automatically extend the ownership expiration time.
-         Default is 6 * load_balancing_interval, i.e. 60 seconds when using the default load_balancing_interval
+         Default is 6 * load_balancing_interval, i.e. 180 seconds when using the default load_balancing_interval
          of 10 seconds.
         :keyword load_balancing_strategy: When load-balancing kicks in,
          it will use this strategy to claim and balance the partition ownership.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
@@ -64,7 +64,7 @@ class EventProcessor(
         checkpoint_store: Optional[CheckpointStore] = None,
         initial_event_position: Union[str, int, "datetime", Dict[str, Any]] = "@latest",
         initial_event_position_inclusive: Union[bool, Dict[str, bool]] = False,
-        load_balancing_interval: float = 10.0,
+        load_balancing_interval: float = 30.0,
         partition_ownership_expiration_interval: Optional[float] = None,
         load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.GREEDY,
         owner_level: Optional[int] = None,


### PR DESCRIPTION
Increasing the `load_balance_interval` to 30 seconds and `partition_ownership_expiration_interval` to 3 mins, to bring the library up to par with the other SDKs.