### PR TITLE
fix verifytypes

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -151,6 +151,11 @@ deps =
   {[base]deps}
   pyright==1.1.287
 commands =
+    {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py \
+      -d {distdir} \
+      -p {toxinidir} \
+      -w {envtmpdir} \
+      --package-type sdist
     {envbindir}/python {toxinidir}/../../../eng/tox/run_verifytypes.py -t {toxinidir}
 
 


### PR DESCRIPTION
In the verifytypes check, we compare the type completeness score of the latest release vs. the code in main for a library and fail if the code in PR decreases the score (lacks type hints). @lmazuel recently made core typing improvements which have boosted the type completeness score of our client libraries that depend on azure-core. verifytypes was only seeing those improvements in the latest release due to the way we were installing the package for main. This PR fixes the check and lets the standard tox scripts install the package.