### PR TITLE
Restore Eng Sys rules in `CODEOWNERS` + assorted fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,13 +14,6 @@
 # /scripts/
 # /tools/
 
-###########
-# Eng Sys
-###########
-/eng/                                                                @scbedd @weshaggard @benbp
-/**/tests.yml                                                        @scbedd @benbp
-/**/ci.yml                                                           @scbedd @benbp
-
 ################
 # Automation
 ################
@@ -920,6 +913,12 @@
 
 # Management Plane
 /**/*mgmt*/                                                          @Wzb123456789 @msyyc
+
+
+###########
+# Eng Sys
+###########
+/eng/                                                                @scbedd @weshaggard @benbp
 
 # Add owners for notifications for specific pipelines
 /eng/pipelines/templates/jobs/tests-nightly-python.yml               @lmazuel @mccoyp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 ################
 # As of 1/26/2023 these paths have no owners:
 
-# /
+# /**
 # /.devcontainer/
 # /.vscode/
 # /conda-releaselogs/
@@ -19,7 +19,7 @@
 ################
 
 # Git Hub integration and bot rules
-/.github/                                       @jsquire @ronniegeraghty
+/.github/                                                            @jsquire @ronniegeraghty
 
 ###########
 # SDK


### PR DESCRIPTION
This PR fixes some `CODEOWNERS` changes issues introduced by:

- https://github.com/Azure/azure-sdk-for-python/pull/28534

As such, it contributes to:

- https://github.com/Azure/azure-sdk-tools/issues/2770