### PR TITLE
Attach sdkVersion prefix to AzureMonitorOpenTelemetryExporter

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Add sdkVersion prefix during App Service attach
+    ([#28637](https://github.com/Azure/azure-sdk-for-python/pull/28637))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 import locale
+from os import environ, getenv
 import platform
 import threading
 import time
@@ -20,13 +22,29 @@ opentelemetry_version = pkg_resources.get_distribution(
     "opentelemetry-sdk"
 ).version
 
+
+def _get_sdk_version_prefix():
+    is_on_app_service = "WEBSITE_SITE_NAME" in environ
+    is_attach_enabled = getenv("ApplicationInsightsAgent_EXTENSION_VERSION") == "~3"
+    sdk_version_prefix = ''
+    if is_on_app_service and is_attach_enabled:
+        os = None
+        system = platform.system()
+        if system == "Linux":
+            os = 'l'
+        elif system == "Windows":
+            os = 'w'
+        sdk_version_prefix = "a{}d_".format(os)
+    return sdk_version_prefix
+
+
 azure_monitor_context = {
     "ai.device.id": platform.node(),
     "ai.device.locale": locale.getdefaultlocale()[0],
     "ai.device.osVersion": platform.version(),
     "ai.device.type": "Other",
-    "ai.internal.sdkVersion": "py{}:otel{}:ext{}".format(
-        platform.python_version(), opentelemetry_version, ext_version
+    "ai.internal.sdkVersion": "{}py{}:otel{}:ext{}".format(
+        _get_sdk_version_prefix(), platform.python_version(), opentelemetry_version, ext_version
     ),
 }
 


### PR DESCRIPTION
# Description

Appending the sdkVersion prefix when the app is on App Service and attach is enabled.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
