### PR TITLE
[Monitor][Query] Fix CI failures

### DIFF
--- a/sdk/monitor/azure-monitor-query/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-query/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0 (2023-02-07)
+## 1.1.0 (Unreleased)
 
 ### Bugs Fixed
 

--- a/sdk/monitor/azure-monitor-query/assets.json
+++ b/sdk/monitor/azure-monitor-query/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/monitor/azure-monitor-query",
-  "Tag": "python/monitor/azure-monitor-query_a38512761f"
+  "Tag": "python/monitor/azure-monitor-query_3c8d44893c"
 }

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
@@ -47,15 +47,17 @@ class TestLogsClientAsync(AzureRecordedTestCase):
     async def test_logs_server_timeout(self, recorded_test, monitor_info):
         client = self.create_client_from_credential(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
-        async with client:
-            with pytest.raises(HttpResponseError) as e:
-                response = await client.query_workspace(
+
+        with pytest.raises(HttpResponseError) as e:
+            async with client:
+                await client.query_workspace(
                     monitor_info['workspace_id'],
-                    "range x from 1 to 10000000000 step 1 | count",
+                    "range x from 1 to 1000000000000000 step 1 | count",
                     timespan=None,
                     server_timeout=1,
                 )
-                assert e.message.contains('Gateway timeout')
+
+        assert 'Gateway timeout' in e.value.message
 
     @pytest.mark.asyncio
     async def test_logs_query_batch_raises_on_no_timespan(self, monitor_info):


### PR DESCRIPTION
Fixes a live test CI failure that has been occurring recently.

Also sets the query changelog to Unreleased for now to stop failing the apireview analyze step until the apireview gets approved. Will change it back next week.
