### PR TITLE
[Test Proxy] Make `recorded_test` compatible with any pytest-asyncio version

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_fixtures.py
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Optional, Tuple
     from pytest import FixtureRequest
 
+# In pytest-asyncio>=0.19.0 async fixtures need to be marked with pytest_asyncio.fixture, not pytest.fixture, by default
+# pytest_asyncio.fixture is only recently available (~0.17.0), so we need to account for an import error
+try:
+    from pytest_asyncio import fixture as async_fixture
+except ImportError:
+    from pytest import fixture as async_fixture
+
 
 _LOGGER = logging.getLogger()
 
@@ -115,7 +122,7 @@ def environment_variables(test_proxy: None) -> EnvironmentVariableSanitizer:
     return EnvironmentVariableSanitizer()
 
 
-@pytest.fixture
+@async_fixture
 async def recorded_test(test_proxy: None, request: "FixtureRequest") -> "Dict[str, Any]":
     """Fixture that redirects network requests to target the azure-sdk-tools test proxy.
 


### PR DESCRIPTION
# Description

`pytest-asyncio` version 0.19.0 defaults to a `strict` asyncio mode, which requires that async fixture methods be marked with `@pytest_asyncio.fixture` instead of `@pytest.fixture`. The `recorded_test` fixture is mishandled today as a result, which causes a
```
TypeError: 'async_generator' object is not subscriptable
```
error when the `variable_recorder` fixture attempts to use it.

`pytest_asyncio.fixture` is only available in recent versions though, and we currently only require `pytest-asyncio>=0.9.0` in [azure-sdk-tools/setup.py](https://github.com/Azure/azure-sdk-for-python/blob/d0f6d33c7e1b954f76f207a43eefc2d6115a45cb/tools/azure-sdk-tools/setup.py#L51) and `pytest-asyncio==0.12.0` in [eng/test_tools.txt](https://github.com/Azure/azure-sdk-for-python/blob/524cea247c871e7909574f42967337b5ce7a03e9/eng/test_tools.txt#L7). Rather than bumping our dependencies for the package, I think it makes more sense to conditionally use the appropriate fixture marker when possible.

This PR was tested with `azure-ai-ml` tests that request the `variable_recorder` fixture, using `pytest-asyncio` versions 0.15.1 (where `pytest_asyncio.fixture` is unavailable) and 0.20.3 (where `pytest_asyncio.fixture` is both available and required).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
