### PR TITLE
[Cosmos] Test changes for failing pipelines

### DIFF
--- a/sdk/cosmos/azure-cosmos/test/test_config.py
+++ b/sdk/cosmos/azure-cosmos/test/test_config.py
@@ -137,7 +137,7 @@ class _test_config(object):
                 collection_id = cls.TEST_COLLECTION_MULTI_PARTITION_ID
                 partition_key = cls.TEST_COLLECTION_MULTI_PARTITION_PARTITION_KEY
 
-        document_collection = database.create_container(
+        document_collection = database.create_container_if_not_exists(
             id=collection_id,
             partition_key=PartitionKey(path='/' + partition_key, kind='Hash'),
             offer_throughput=throughput)


### PR DESCRIPTION
This PR aims at fixing some of the test failures we've been seeing in the pipelines, which seem to mostly revolve around already existing containers. Seems like this bit of code was not updated to reflect the calls to "create_if_not_exists".