### PR TITLE
[DT] fix flaky cancel test for translation

### DIFF
--- a/sdk/translation/azure-ai-translation-document/assets.json
+++ b/sdk/translation/azure-ai-translation-document/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/translation/azure-ai-translation-document",
-  "Tag": "python/translation/azure-ai-translation-document_d8387d1500"
+  "Tag": "python/translation/azure-ai-translation-document_a26c6e3759"
 }

--- a/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation.py
@@ -36,13 +36,9 @@ class TestCancelTranslation(DocumentTranslationTest):
 
         # cancel translation
         client.cancel_translation(poller.id)
-
+        poller.result()
         # check translation status
         translation_details = client.get_translation_status(poller.id)
         assert translation_details.status in ["Canceled", "Canceling"]
         self._validate_translations(translation_details)
-        try:
-            poller.wait()
-        except HttpResponseError:
-            pass  # expected if the operation was already in a terminal state.
         return variables

--- a/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation_async.py
+++ b/sdk/translation/azure-ai-translation-document/tests/test_cancel_translation_async.py
@@ -36,13 +36,9 @@ class TestCancelTranslation(AsyncDocumentTranslationTest):
 
         # cancel translation
         await client.cancel_translation(poller.id)
-
+        await poller.result()
         # check translation status
         translation_details = await client.get_translation_status(poller.id)
         assert translation_details.status in ["Canceled", "Canceling"]
         self._validate_translations(translation_details)
-        try:
-            await poller.wait()
-        except HttpResponseError:
-            pass  # expected if the operation was already in a terminal state.
         return variables


### PR DESCRIPTION
We cancel the job and then try to assert on a canceled status, but sometimes the operation is "NotStarted" and creates a flaky test. To fix this, we will wait until the operation is complete and then check that the job was successfully canceled.