### PR TITLE
Add validation check for MLClient Constructor arguments

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed an issue where ignore files weren't considered during upload directory size calculations.
 - Fixed an issue where symlinks crashed upload directory size calculations.
 - Fixes a bug where enable_node_public_ip returned an improper value when fetching a Compute.
+- Added validation check in MLClient constructor to ensure at least one of `workspace_name` or `registry_name` is supplied
 
 ### Other Changes
 - Update workspace creation to use Log Analytics-Based Application Insights when the user does not specify/bring their own App Insights.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -159,6 +159,14 @@ class MLClient(object):
                 target=ErrorTarget.GENERAL,
                 error_category=ErrorCategory.USER_ERROR,
             )
+        
+        if not registry_name and not workspace_name:
+            raise ValidationException(
+                message="Either one of workspace_name or registry_name is required, for the ml_client.",
+                no_personal_data_message="Neither workspace_name nor registry_name are provided for ml_client.",
+                target=ErrorTarget.GENERAL,
+                error_category=ErrorCategory.USER_ERROR,
+            )
 
         self._credential = credential
 

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_ml_client.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_ml_client.py
@@ -433,3 +433,14 @@ class TestMachineLearningClient:
             message
             == "Both workspace_name and registry_name cannot be used together, for the ml_client."
         )
+    
+    def test_ml_client_with_no_workspace_registry_names_throws(self, e2e_ws_scope: OperationScope, auth: ClientSecretCredential) -> None:
+        with pytest.raises(ValidationException) as exception:
+            MLClient(
+                credential=auth
+            )
+        message = exception.value.args[0]
+        assert (
+            message
+            == "Either one of workspace_name or registry_name is required, for the ml_client."
+        )


### PR DESCRIPTION
# Description

Add more validation check to ensure that at least one of workspace_name or registry_name is supplied to MLClient constructor.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
