### PR TITLE
[ML][Pipelines] fix: parse default for boolean inputs for internal components

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py
@@ -13,6 +13,7 @@ from azure.ai.ml.constants._common import LABELLED_RESOURCE_NAME, AzureMLResourc
 
 from .._utils import yaml_safe_load_with_base_resolver
 from ..._utils._arm_id_utils import parse_name_label
+from ..._utils.utils import get_valid_dot_keys_with_wildcard
 from .environment import InternalEnvironmentSchema
 from .input_output import (
     InternalEnumParameterSchema,
@@ -118,17 +119,26 @@ class InternalComponentSchema(ComponentSchema):
     def add_param_overrides(self, data, **kwargs):
         source_path = self.context.pop(SOURCE_PATH_CONTEXT_KEY, None)
         if isinstance(data, dict) and source_path and os.path.isfile(source_path):
+            def should_node_overwritten(_root, _parts):
+                parts = _parts.copy()
+                parts.pop()
+                parts.append("type")
+                _input_type = pydash.get(_root, parts, None)
+                return isinstance(_input_type, str) and _input_type.lower() not in ["boolean"]
+
             # do override here
             with open(source_path, "r") as f:
                 origin_data = yaml_safe_load_with_base_resolver(f)
-                dot_keys = ["version"]
-                for input_key in data.get("inputs", {}).keys():
-                    # Keep value in float input as string to avoid precision issue.
-                    for attr_name in ["default", "enum", "min", "max"]:
-                        dot_keys.append(f"inputs.{input_key}.{attr_name}")
-
-                for dot_key in dot_keys:
-                    if pydash.has(data, dot_key) and pydash.has(origin_data, dot_key):
+                for dot_key_wildcard, condition_func in [
+                    ("version", None),
+                    ("inputs.*.default", should_node_overwritten),
+                    ("inputs.*.enum", should_node_overwritten),
+                ]:
+                    for dot_key in get_valid_dot_keys_with_wildcard(
+                        origin_data,
+                        dot_key_wildcard,
+                        validate_func=condition_func
+                    ):
                         pydash.set_(data, dot_key, pydash.get(origin_data, dot_key))
         return super().add_param_overrides(data, **kwargs)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/code.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/code.py
@@ -29,7 +29,7 @@ class InternalComponentIgnoreFile(ComponentIgnoreFile):
 
     def is_file_excluded(self, file_path: Union[str, Path]) -> bool:
         """Override to add custom ignores for internal component."""
-        if self._get_rel_path(file_path) == self._additional_includes_file_name:
+        if self._additional_includes_file_name and self._get_rel_path(file_path) == self._additional_includes_file_name:
             return True
         for ignore_file in self._extra_ignore_list:
             if ignore_file.is_file_excluded(file_path):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -981,7 +981,7 @@ def get_valid_dot_keys_with_wildcard(
     *,
     validate_func: Optional[Callable[[List[str], Dict[str, Any]], bool]] = None,
 ):
-    """Get all valid dot keys with wildcard. Only "*" is supported for now.
+    """Get all valid dot keys with wildcard. Only "x.*.x" and "x.*" is supported for now.
 
     A valid dot key should satisfy the following conditions:
     1) It should be a valid dot key in the root node.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -924,3 +924,77 @@ def write_to_shared_file(file_path: Union[str, PathLike], content: str):
             os.chmod(file_path, share_mode)
         except PermissionError:
             pass
+
+
+def _get_valid_dot_keys_with_wildcard_impl(
+    left_reversed_parts,
+    root,
+    *,
+    validate_func=None,
+    cur_node=None,
+    processed_parts=None
+):
+    if len(left_reversed_parts) == 0:
+        if validate_func is None or validate_func(root, processed_parts):
+            return [".".join(processed_parts)]
+        return []
+
+    if cur_node is None:
+        cur_node = root
+    if not isinstance(cur_node, dict):
+        return []
+    if processed_parts is None:
+        processed_parts = []
+
+    key: str = left_reversed_parts.pop()
+    result = []
+    if key == "*":
+        for next_key in cur_node:
+            if not isinstance(next_key, str):
+                continue
+            processed_parts.append(next_key)
+            result.extend(_get_valid_dot_keys_with_wildcard_impl(
+                left_reversed_parts,
+                root,
+                validate_func=validate_func,
+                cur_node=cur_node[next_key],
+                processed_parts=processed_parts)
+            )
+            processed_parts.pop()
+    elif key in cur_node:
+        processed_parts.append(key)
+        result = _get_valid_dot_keys_with_wildcard_impl(
+            left_reversed_parts,
+            root,
+            validate_func=validate_func,
+            cur_node=cur_node[key],
+            processed_parts=processed_parts
+        )
+        processed_parts.pop()
+
+    left_reversed_parts.append(key)
+    return result
+
+def get_valid_dot_keys_with_wildcard(
+    root: Dict[str, Any],
+    dot_key_wildcard: str,
+    *,
+    validate_func: Optional[Callable[[List[str], Dict[str, Any]], bool]] = None,
+):
+    """Get all valid dot keys with wildcard. Only "*" is supported for now.
+
+    A valid dot key should satisfy the following conditions:
+    1) It should be a valid dot key in the root node.
+    2) It should satisfy the validation function.
+
+    :param root: Root node.
+    :type root: Dict[str, Any]
+    :param dot_key_wildcard: Dot key with wildcard, e.g. "a.*.c".
+    :type dot_key_wildcard: str
+    :param validate_func: Validation function. It takes two parameters: the root node and the dot key parts.
+    If None, no validation will be performed.
+    :type validate_func: Optional[Callable[[List[str], Dict[str, Any]], bool]]
+    :return: List of valid dot keys.
+    """
+    left_reversed_parts = dot_key_wildcard.split(".")[::-1]
+    return _get_valid_dot_keys_with_wildcard_impl(left_reversed_parts, root, validate_func=validate_func)

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -828,6 +828,11 @@ class TestComponent:
                     'optional': False,
                     'type': 'Float'
                 },
+                'input_boolean': {
+                    'default': 'False',
+                    'optional': False,
+                    'type': 'Boolean'
+                },
                 'delimiter': {
                     'default': '\t',
                     'optional': True,

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_utils.py
@@ -11,6 +11,7 @@ from azure.ai.ml._utils.utils import (
     is_data_binding_expression,
     map_single_brackets_and_warn,
     write_to_shared_file,
+    get_valid_dot_keys_with_wildcard,
 )
 from azure.ai.ml.entities import BatchEndpoint
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict
@@ -90,3 +91,31 @@ class TestUtils:
             assert get_int_mode(target_file_path) == "0o666"
             with open(target_file_path, "r") as f:
                 assert f.read() == "test2"
+
+    def test_get_valid_dot_keys_with_wildcard(self):
+        root = {
+            "simple": 1,
+            "deep": {
+                "l1": {
+                    "l2": 1,
+                    "l2_2": 2,
+                },
+                "l1_2": {
+                    "l2": 3,
+                },
+            }
+        }
+        assert get_valid_dot_keys_with_wildcard(root, "simple") == ["simple"]
+        assert get_valid_dot_keys_with_wildcard(root, "deep.l1.l2") == ["deep.l1.l2"]
+        assert get_valid_dot_keys_with_wildcard(root, "deep.*.l2") == ["deep.l1.l2", "deep.l1_2.l2"]
+        assert get_valid_dot_keys_with_wildcard(root, "deep.*.*") == ["deep.l1.l2", "deep.l1.l2_2", "deep.l1_2.l2"]
+        assert get_valid_dot_keys_with_wildcard(root, "deep.*.l2_2") == ["deep.l1.l2_2"]
+        assert get_valid_dot_keys_with_wildcard(root, "deep.*.l2_3") == []
+        assert get_valid_dot_keys_with_wildcard(root, "deep.*.l2.*") == []
+        assert get_valid_dot_keys_with_wildcard(root, "deep.*.l2.*.l3") == []
+
+        assert get_valid_dot_keys_with_wildcard(
+            root,
+            "deep.*.*",
+            validate_func=lambda _root, _parts: _parts[1] == "l1_2",
+        ) == ["deep.l1_2.l2"]

--- a/sdk/ml/azure-ai-ml/tests/test_configs/internal/command-component-serialization-core-case/component_spec.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/internal/command-component-serialization-core-case/component_spec.yaml
@@ -9,6 +9,10 @@ inputs:
     type: Float
     optional: False
     default: 1
+  input_boolean:
+    type: Boolean
+    optional: False
+    default: false
   delimiter:
     type: String
     optional: true


### PR DESCRIPTION
# Description

Bool value in Boolean inputs need to be parsed into standard `True` and `False` or reuse and `generate_package` will break.

```yaml
inputs:
  bool_input:
    type: Boolean
    default: false
```
should be parsed into 
```json
{
  "inputs": {
    "bool_input": {
      "type": "Boolean",
      "default": "False"
    }
  }
}
```

previously it will be parsed into `'false'`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
