### PR TITLE
Fix uppercase handling of deployment name under traffic/mirror_traffic

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
@@ -43,7 +43,7 @@ module_logger = ops_logger.module_logger
 
 
 def _strip_zeroes_from_traffic(traffic: Dict[str, str]) -> Dict[str, str]:
-    return {k: v for k, v in traffic.items() if v and int(v) != 0}
+    return {k.lower(): v for k, v in traffic.items() if v and int(v) != 0}
 
 
 class OnlineEndpointOperations(_ScopeDependentOperations):

--- a/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_online_endpoints.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_online_endpoints.py
@@ -445,6 +445,7 @@ class TestOnlineEndpointsOperations:
         pytest.param({"blue": "100", "green": "0"}, {"blue": "100"}),
         pytest.param({"green": "0"}, {}),
         pytest.param({}, {}),
+        pytest.param({"blue": "10", "GREEN": "90"}, {"blue": "10", "green": "90"}),
     ],
 )
 def test_strip_traffic_from_traffic_map(traffic, expected_traffic) -> None:


### PR DESCRIPTION
# Description

 When creating an online deployment, if the given deployment name has uppercase letters, it is converted to lowercase, and the created deployment has all-lowercased name
 If users try to set traffic using deployment name that has uppercase letters
 we are throwing an error.
 We need to convert the deployment names under traffic/mirror_traffic to be lower case. 

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
Updated unit test to include case for lowercase name