### PR TITLE
[Key Vault] Update settings API for review comments

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -3,8 +3,15 @@
 ## 4.3.0b2 (Unreleased)
 
 ### Features Added
+- The `KeyVaultSetting` class has a `getboolean` method that will return the setting's `value` as a `bool`, if possible,
+  and raise a `ValueError` otherwise
 
 ### Breaking Changes
+> These changes do not impact the API of stable versions such as 4.2.0. Only code written against a beta version such as 4.3.0b1 may be affected.
+- `KeyVaultSettingsClient.update_setting` now accepts a single `setting` argument (a `KeyVaultSetting` instance)
+  instead of a `name` and `value`
+- The `KeyVaultSetting` model's `type` parameter and attribute have been renamed to `setting_type`
+- The `SettingType` enum has been renamed to `KeyVaultSettingType`
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azure-keyvault-administration/assets.json
+++ b/sdk/keyvault/azure-keyvault-administration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-administration",
-  "Tag": "python/keyvault/azure-keyvault-administration_6f40de8fcf"
+  "Tag": "python/keyvault/azure-keyvault-administration_1f1c66adf5"
 }

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 from ._access_control_client import KeyVaultAccessControlClient
 from ._backup_client import KeyVaultBackupClient
-from ._enums import KeyVaultRoleScope, KeyVaultDataAction, SettingType
+from ._enums import KeyVaultRoleScope, KeyVaultDataAction, KeyVaultSettingType
 from ._internal.client_base import ApiVersion
 from ._models import (
     KeyVaultBackupResult,
@@ -30,7 +30,7 @@ __all__ = [
     "KeyVaultRoleScope",
     "KeyVaultSetting",
     "KeyVaultSettingsClient",
-    "SettingType",
+    "KeyVaultSettingType",
 ]
 
 from ._version import VERSION

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_enums.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_enums.py
@@ -87,7 +87,7 @@ class KeyVaultDataAction(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     RANDOM_NUMBERS_GENERATE = "Microsoft.KeyVault/managedHsm/rng/action"
 
 
-class SettingType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+class KeyVaultSettingType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """The type specifier of the setting value."""
 
     BOOLEAN = "boolean"

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -173,7 +173,7 @@ class KeyVaultSetting(object):
     """A Key Vault setting.
 
     :ivar str name: The name of the account setting.
-    :ivar value: The value of the setting.
+    :ivar value: The value of the account setting.
     :vartype value: str or bool
     :ivar type: The type specifier of the value.
     :vartype type: str or KeyVaultSettingType or None
@@ -191,6 +191,10 @@ class KeyVaultSetting(object):
         # `value` needs to be a stored as a string
         self.value = value if isinstance(value, str) else str(value)
         self.setting_type = setting_type.lower() if isinstance(setting_type, str) else setting_type
+
+        # If a setting type isn't provided, set it based on `value`'s type (without inferring from the value itself)
+        if self.setting_type is None:
+            self.setting_type = KeyVaultSettingType.BOOLEAN if isinstance(value, bool) else None
 
         # If the setting is a boolean, lower-case the string for serialization
         if self.setting_type == KeyVaultSettingType.BOOLEAN:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -185,7 +185,7 @@ class KeyVaultSetting(object):
         name: str,
         value: Union[str, bool],
         setting_type: Optional[Union[str, KeyVaultSettingType]] = None,
-        **kwargs,  # pylint:disable=unused-argument,redefined-builtin
+        **kwargs,  # pylint:disable=unused-argument
     ) -> None:
         self.name = name
         self.value = value if isinstance(value, str) else str(value)  # `value` is stored as a string

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -188,17 +188,35 @@ class KeyVaultSetting(object):
         **kwargs,  # pylint:disable=unused-argument,redefined-builtin
     ) -> None:
         self.name = name
-        # `value` needs to be a stored as a string
-        self.value = value if isinstance(value, str) else str(value)
+        self.value = value if isinstance(value, str) else str(value)  # `value` is stored as a string
         self.setting_type = setting_type.lower() if isinstance(setting_type, str) else setting_type
 
         # If a setting type isn't provided, set it based on `value`'s type (without inferring from the value itself)
         if self.setting_type is None:
-            self.setting_type = KeyVaultSettingType.BOOLEAN if isinstance(value, bool) else None
+            if isinstance(value, bool):
+                self.setting_type = KeyVaultSettingType.BOOLEAN
 
         # If the setting is a boolean, lower-case the string for serialization
         if self.setting_type == KeyVaultSettingType.BOOLEAN:
             self.value = self.value.lower()
+
+    def getboolean(self) -> bool:
+        """Gets the value of the account setting as a boolean if the `setting_type` is KeyVaultSettingType.BOOLEAN.
+
+        :returns: The account setting value as a boolean.
+        :rtype: bool
+
+        :raises: ValueError if the `setting_type` is not boolean or the value cannot be represented as a boolean.
+        """
+        if self.setting_type == KeyVaultSettingType.BOOLEAN:
+            if self.value == "true":
+                return True
+            if self.value == "false":
+                return False
+        raise ValueError(
+            'The `setting_type` of the setting must be `KeyVaultSettingType.BOOLEAN` and the `value` must be "true" '
+            'or "false" in order to use `getboolean`.'
+        )
 
     @classmethod
     def _from_generated(cls, setting: Setting) -> "KeyVaultSetting":

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -173,15 +173,13 @@ class KeyVaultSetting(object):
     """A Key Vault setting.
 
     :ivar str name: The name of the account setting.
-    :ivar value: The value of the account setting.
-    :vartype value: str or bool
-    :ivar type: The type specifier of the value.
-    :vartype type: str or KeyVaultSettingType or None
+    :ivar str value: The value of the account setting.
+    :ivar setting_type: The type specifier of the value.
+    :vartype setting_type: str or KeyVaultSettingType or None
     """
 
     def __init__(
         self,
-        *,
         name: str,
         value: Union[str, bool],
         setting_type: Optional[Union[str, KeyVaultSettingType]] = None,
@@ -190,7 +188,7 @@ class KeyVaultSetting(object):
         self.name = name
         self.value = value if isinstance(value, str) else str(value)  # `value` is stored as a string
         if setting_type == KeyVaultSettingType.BOOLEAN:
-            self.setting_type = KeyVaultSettingType.BOOLEAN
+            self.setting_type: Optional[Union[str, KeyVaultSettingType]] = KeyVaultSettingType.BOOLEAN
         else:
             self.setting_type = setting_type.lower() if isinstance(setting_type, str) else setting_type
 
@@ -204,12 +202,12 @@ class KeyVaultSetting(object):
             self.value = self.value.lower()
 
     def getboolean(self) -> bool:
-        """Gets the value of the account setting as a boolean if the `setting_type` is KeyVaultSettingType.BOOLEAN.
+        """Gets the account setting value as a boolean if the ``setting_type`` is ``KeyVaultSettingType.BOOLEAN``.
 
         :returns: The account setting value as a boolean.
         :rtype: bool
 
-        :raises: ValueError if the `setting_type` is not boolean or the value cannot be represented as a boolean.
+        :raises: ValueError if the ``setting_type`` is not boolean or the value cannot be represented as a boolean.
         """
         if self.setting_type == KeyVaultSettingType.BOOLEAN:
             if self.value == "true":

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Union
 
 from azure.core.rest import HttpResponse
 
-from ._enums import SettingType
+from ._enums import KeyVaultSettingType
 from ._generated_models import (
     FullBackupOperation,
     Permission,
@@ -176,7 +176,7 @@ class KeyVaultSetting(object):
     :ivar value: The value of the setting.
     :vartype value: str or bool
     :ivar type: The type specifier of the value.
-    :vartype type: str or SettingType or None
+    :vartype type: str or KeyVaultSettingType or None
     """
 
     def __init__(
@@ -184,7 +184,7 @@ class KeyVaultSetting(object):
         *,
         name: str,
         value: Union[str, bool],
-        setting_type: Optional[Union[str, SettingType]] = None,
+        setting_type: Optional[Union[str, KeyVaultSettingType]] = None,
         **kwargs,  # pylint:disable=unused-argument,redefined-builtin
     ) -> None:
         self.name = name
@@ -193,10 +193,10 @@ class KeyVaultSetting(object):
         self.setting_type = setting_type.lower() if isinstance(setting_type, str) else setting_type
 
         # If the setting is a boolean, lower-case the string for serialization
-        if self.setting_type == SettingType.BOOLEAN:
+        if self.setting_type == KeyVaultSettingType.BOOLEAN:
             self.value = self.value.lower()
 
     @classmethod
     def _from_generated(cls, setting: Setting) -> "KeyVaultSetting":
-        setting_type = SettingType.BOOLEAN if setting.type == "boolean" else setting.type
+        setting_type = KeyVaultSettingType.BOOLEAN if setting.type == "boolean" else setting.type
         return cls(name=setting.name, value=setting.value, setting_type=setting_type)

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -189,7 +189,10 @@ class KeyVaultSetting(object):
     ) -> None:
         self.name = name
         self.value = value if isinstance(value, str) else str(value)  # `value` is stored as a string
-        self.setting_type = setting_type.lower() if isinstance(setting_type, str) else setting_type
+        if setting_type == KeyVaultSettingType.BOOLEAN:
+            self.setting_type = KeyVaultSettingType.BOOLEAN
+        else:
+            self.setting_type = setting_type.lower() if isinstance(setting_type, str) else setting_type
 
         # If a setting type isn't provided, set it based on `value`'s type (without inferring from the value itself)
         if self.setting_type is None:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -196,7 +196,7 @@ class KeyVaultSetting(Generic[SettingValueType]):
         self.type = type
 
         # If `value` was given as a string but the type is boolean, convert it to a bool
-        if hasattr(self.value, "lower") and self.type == SettingType.BOOLEAN:
+        if isinstance(self.value, str) and self.type == SettingType.BOOLEAN:
             self.value = cast(SettingValueType, self.value.lower() == "true")
 
     @classmethod

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Dict, Generic, Optional, TypeVar, Union
+from typing import cast, Dict, Generic, Optional, TypeVar, Union
 
 from azure.core.rest import HttpResponse
 
@@ -197,8 +197,8 @@ class KeyVaultSetting(Generic[SettingValueType]):
 
         # If `value` was given as a string but the type is boolean, convert it to a bool
         if hasattr(self.value, "lower") and self.type == SettingType.BOOLEAN:
-            self.value = self.value.lower() == "true"
+            self.value = cast(SettingValueType, self.value.lower() == "true")
 
     @classmethod
     def _from_generated(cls, setting: Setting) -> "KeyVaultSetting":
-        return cls(name=setting.name, value=setting.value, type=SettingType(setting.type))
+        return cls(name=setting.name, value=cast(SettingValueType, setting.value), type=SettingType(setting.type))

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -17,7 +17,7 @@ from ._generated_models import (
     Setting,
 )
 
-T = TypeVar("T", bool, str)
+SettingValueType = TypeVar("SettingValueType", bound=Union[bool, str])
 
 
 class KeyVaultPermission(object):
@@ -171,14 +171,14 @@ class KeyVaultBackupResult(object):
         return cls(folder_url=deserialized_operation.azure_storage_blob_container_uri)
 
 
-class KeyVaultSetting(Generic[T]):
+class KeyVaultSetting(Generic[SettingValueType]):
     """A Key Vault setting.
 
     :ivar str name: The name of the account setting.
     :ivar value: The value of the pool setting. This is a boolean if `type` is SettingType.BOOLEAN, and a string
         otherwise. If `value` is provided as a string when `type` is SettingType.BOOLEAN, the value will be converted
         into a boolean (True if `value` is "True" (case-insensitive); False otherwise).
-    :vartype value: str or bool
+    :vartype value: SettingValueType
     :ivar type: The type specifier of the value.
     :vartype type: SettingType or None
     """
@@ -187,7 +187,7 @@ class KeyVaultSetting(Generic[T]):
         self,
         *,
         name: str,
-        value: Union[str, bool],
+        value: SettingValueType,
         type: Optional[SettingType] = None,
         **kwargs,  # pylint:disable=unused-argument,redefined-builtin
     ) -> None:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -62,7 +62,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
 
     @distributed_trace
     def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
-        """Updates the named account setting.
+        """Updates the named account setting with the provided value.
 
         :param setting: A :class:`~azure.keyvault.administration.KeyVaultSetting` to update. The account setting with
             the provided name will be updated to have the provided value.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Union
-
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 
@@ -63,23 +61,21 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         return ItemPaged(get_next, extract_data)
 
     @distributed_trace
-    def update_setting(self, name: str, value: Union[bool, str], **kwargs) -> KeyVaultSetting:
-        """Updates a given account setting with the provided value.
+    def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
+        """Updates the named account setting.
 
-        :param str name: The name of the account setting to update.
-        :param value: The value to set.
-        :type value: bool or str
+        :param setting: A :class:`~azure.keyvault.administration.KeyVaultSetting` to update. The account setting with
+            the provided name will be updated to have the provided value.
+        :type setting: ~azure.keyvault.administration.KeyVaultSetting
 
         :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        # If `value` is a string, we should send it as-is. Booleans need to be lower-cased
-        final_value = value if isinstance(value, str) else str(value).lower()
-        parameters = UpdateSettingsRequest(value=final_value)
+        parameters = UpdateSettingsRequest(value=setting.value)
         result = self._client.update_settings(
             vault_base_url=self._vault_url,
-            setting_name=name,
+            setting_name=setting.name,
             parameters=parameters,
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import Union
+
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 
@@ -61,17 +63,18 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         return ItemPaged(get_next, extract_data)
 
     @distributed_trace
-    def update_setting(self, name: str, value: str, **kwargs) -> KeyVaultSetting:
+    def update_setting(self, name: str, value: Union[bool, str], **kwargs) -> KeyVaultSetting:
         """Updates a given account setting with the provided value.
 
         :param str name: The name of the account setting to update.
-        :param str value: The value to set.
+        :param value: The value to set.
+        :type value: bool or str
 
         :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        parameters = UpdateSettingsRequest(value=value)
+        parameters = UpdateSettingsRequest(value=str(value).lower())
         result = self._client.update_settings(
             vault_base_url=self._vault_url,
             setting_name=name,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -74,7 +74,9 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        parameters = UpdateSettingsRequest(value=str(value).lower())
+        # If `value` is a string, we should send it as-is. Booleans need to be lower-cased
+        final_value = value if hasattr(value, "lower") else str(value).lower()
+        parameters = UpdateSettingsRequest(value=final_value)
         result = self._client.update_settings(
             vault_base_url=self._vault_url,
             setting_name=name,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -75,7 +75,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         # If `value` is a string, we should send it as-is. Booleans need to be lower-cased
-        final_value = value if hasattr(value, "lower") else str(value).lower()
+        final_value = value if isinstance(value, str) else str(value).lower()
         parameters = UpdateSettingsRequest(value=final_value)
         result = self._client.update_settings(
             vault_base_url=self._vault_url,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Union
-
 from azure.core.async_paging import AsyncItemPaged, AsyncList
 from azure.core.tracing.decorator_async import distributed_trace_async
 
@@ -63,8 +61,8 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         return AsyncItemPaged(get_next, extract_data)
 
     @distributed_trace_async
-    async def update_setting(self, name: str, value: Union[bool, str], **kwargs) -> KeyVaultSetting:
-        """Updates a given account setting with the provided value.
+    async def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
+        """Updates the named account setting.
 
         :param str name: The name of the account setting to update.
         :param value: The value to set.
@@ -75,11 +73,10 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         # If `value` is a string, we should send it as-is. Booleans need to be lower-cased
-        final_value = value if isinstance(value, str) else str(value).lower()
-        parameters = UpdateSettingsRequest(value=final_value)
+        parameters = UpdateSettingsRequest(value=setting.value)
         result = await self._client.update_settings(
             vault_base_url=self._vault_url,
-            setting_name=name,
+            setting_name=setting.name,
             parameters=parameters,
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -62,11 +62,11 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
-        """Updates the named account setting.
+        """Updates the named account setting with the provided value.
 
-        :param str name: The name of the account setting to update.
-        :param value: The value to set.
-        :type value: bool or str
+        :param setting: A :class:`~azure.keyvault.administration.KeyVaultSetting` to update. The account setting with
+            the provided name will be updated to have the provided value.
+        :type setting: ~azure.keyvault.administration.KeyVaultSetting
 
         :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -72,7 +72,6 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        # If `value` is a string, we should send it as-is. Booleans need to be lower-cased
         parameters = UpdateSettingsRequest(value=setting.value)
         result = await self._client.update_settings(
             vault_base_url=self._vault_url,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -74,7 +74,9 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        parameters = UpdateSettingsRequest(value=str(value).lower())
+        # If `value` is a string, we should send it as-is. Booleans need to be lower-cased
+        final_value = value if hasattr(value, "lower") else str(value).lower()
+        parameters = UpdateSettingsRequest(value=final_value)
         result = await self._client.update_settings(
             vault_base_url=self._vault_url,
             setting_name=name,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -75,7 +75,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         # If `value` is a string, we should send it as-is. Booleans need to be lower-cased
-        final_value = value if hasattr(value, "lower") else str(value).lower()
+        final_value = value if isinstance(value, str) else str(value).lower()
         parameters = UpdateSettingsRequest(value=final_value)
         result = await self._client.update_settings(
             vault_base_url=self._vault_url,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import Union
+
 from azure.core.async_paging import AsyncItemPaged, AsyncList
 from azure.core.tracing.decorator_async import distributed_trace_async
 
@@ -61,17 +63,18 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         return AsyncItemPaged(get_next, extract_data)
 
     @distributed_trace_async
-    async def update_setting(self, name: str, value: str, **kwargs) -> KeyVaultSetting:
+    async def update_setting(self, name: str, value: Union[bool, str], **kwargs) -> KeyVaultSetting:
         """Updates a given account setting with the provided value.
 
         :param str name: The name of the account setting to update.
-        :param str value: The value to set.
+        :param value: The value to set.
+        :type value: bool or str
 
         :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        parameters = UpdateSettingsRequest(value=value)
+        parameters = UpdateSettingsRequest(value=str(value).lower())
         result = await self._client.update_settings(
             vault_base_url=self._vault_url,
             setting_name=name,

--- a/sdk/keyvault/azure-keyvault-administration/samples/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/samples/README.md
@@ -35,8 +35,12 @@ pip install azure-keyvault-administration azure-identity
 | [access_control_operations_async.py][access_control_operations_async_sample] | create/update/delete role definitions and role assignments with an async client |
 | [backup_restore_operations.py][backup_operations_sample] | full backup and restore |
 | [backup_restore_operations_async.py][backup_operations_async_sample] | full backup and restore with an async client |
+| [settings_operations.py][settings_operations_sample] | list and update Key Vault settings |
+| [settings_operations_async.py][settings_operations_async_sample] | list and update Key Vault settings with an async client |
 
 [access_control_operations_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations.py
 [access_control_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations_async.py
 [backup_operations_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
 [backup_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations_async.py
+[settings_operations_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
+[settings_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import os
 
-from azure.keyvault.administration import KeyVaultSettingsClient, SettingType
+from azure.keyvault.administration import KeyVaultSettingsClient, KeyVaultSettingType
 from azure.identity import DefaultAzureCredential
 
 # ----------------------------------------------------------------------------------------------------------
@@ -37,12 +37,12 @@ credential = DefaultAzureCredential()
 client = KeyVaultSettingsClient(vault_url=MANAGED_HSM_URL, credential=credential)
 
 # First, let's fetch the settings that apply to our Managed HSM
-# Each setting has a name, value, and type (for example, SettingType.BOOLEAN)
+# Each setting has a name, value, and type (for example, KeyVaultSettingType.BOOLEAN)
 print("\n.. List Key Vault settings")
 settings = client.list_settings()
 boolean_setting = None
 for setting in settings:
-    if setting.type == SettingType.BOOLEAN:
+    if setting.type == KeyVaultSettingType.BOOLEAN:
         boolean_setting = setting
     print(f"{setting.name}: {setting.value} (type: {setting.type})")
 

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import os
 
-from azure.keyvault.administration import KeyVaultSettingsClient, KeyVaultSettingType
+from azure.keyvault.administration import KeyVaultSetting, KeyVaultSettingsClient, KeyVaultSettingType
 from azure.identity import DefaultAzureCredential
 
 # ----------------------------------------------------------------------------------------------------------
@@ -26,9 +26,6 @@ from azure.identity import DefaultAzureCredential
 # 2. Update a setting (update_setting)
 # ----------------------------------------------------------------------------------------------------------
 
-from dotenv import load_dotenv
-load_dotenv()
-
 MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
 
 # Instantiate an access control client that will be used to call the service.
@@ -42,19 +39,18 @@ print("\n.. List Key Vault settings")
 settings = client.list_settings()
 boolean_setting = None
 for setting in settings:
-    if setting.type == KeyVaultSettingType.BOOLEAN:
+    if setting.setting_type == KeyVaultSettingType.BOOLEAN:
         boolean_setting = setting
-    print(f"{setting.name}: {setting.value} (type: {setting.type})")
+    print(f"{setting.name}: {setting.value} (type: {setting.setting_type})")
 
 # Now, let's flip the value of a boolean setting
-# KeyVaultSettingsClient.update_setting accepts booleans and strings, so we can send True or "True", for example
 print(f"\n.. Update value of {boolean_setting.name}")
-opposite_value = not boolean_setting.value
-updated_setting = client.update_setting(boolean_setting.name, opposite_value)
+opposite_value = KeyVaultSetting(name=boolean_setting.name, value=boolean_setting.value == "false")
+updated_setting = client.update_setting(opposite_value)
 print(f"{boolean_setting.name} updated successfully.")
 print(f"Old value: {boolean_setting.value}. New value: {updated_setting.value}")
 
 # Finally, let's restore the setting's old value
 print(f"\n.. Restore original value of {boolean_setting.name}")
-client.update_setting(boolean_setting.name, boolean_setting.value)
+client.update_setting(boolean_setting)
 print(f"{boolean_setting.name} updated successfully.")

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
@@ -44,8 +44,9 @@ for setting in settings:
     print(f"{setting.name}: {setting.value} (type: {setting.setting_type})")
 
 # Now, let's flip the value of a boolean setting
+# The `value` property is a string, but you can get the value of a boolean setting as a bool with `getboolean`
 print(f"\n.. Update value of {boolean_setting.name}")
-opposite_value = KeyVaultSetting(name=boolean_setting.name, value=boolean_setting.value == "false")
+opposite_value = KeyVaultSetting(name=boolean_setting.name, value=not setting.getboolean())
 updated_setting = client.update_setting(opposite_value)
 print(f"{boolean_setting.name} updated successfully.")
 print(f"Old value: {boolean_setting.value}. New value: {updated_setting.value}")

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
@@ -1,0 +1,60 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+
+from azure.keyvault.administration import KeyVaultSettingsClient, SettingType
+from azure.identity import DefaultAzureCredential
+
+# ----------------------------------------------------------------------------------------------------------
+# Prerequisites:
+# 1. A managed HSM (https://docs.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli)
+#
+# 2. azure-keyvault-administration and azure-identity libraries (pip install these)
+#
+# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM
+#    
+# 4. Set up your environment to use azure-identity's DefaultAzureCredential. For more information about how to configure
+#    the DefaultAzureCredential, refer to https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
+#
+# ----------------------------------------------------------------------------------------------------------
+# Sample - demonstrates Key Vault setting management operations for Managed HSM
+#
+# 1. List all settings (list_settings)
+#
+# 2. Update a setting (update_setting)
+# ----------------------------------------------------------------------------------------------------------
+
+from dotenv import load_dotenv
+load_dotenv()
+
+MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
+
+# Instantiate an access control client that will be used to call the service.
+# Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
+credential = DefaultAzureCredential()
+client = KeyVaultSettingsClient(vault_url=MANAGED_HSM_URL, credential=credential)
+
+# First, let's fetch the settings that apply to our Managed HSM
+# Each setting has a name, value, and type (for example, SettingType.BOOLEAN)
+print("\n.. List Key Vault settings")
+settings = client.list_settings()
+boolean_setting = None
+for setting in settings:
+    if setting.type == SettingType.BOOLEAN:
+        boolean_setting = setting
+    print(f"{setting.name}: {setting.value} (type: {setting.type})")
+
+# Now, let's flip the value of a boolean setting
+# KeyVaultSettingsClient.update_setting accepts booleans and strings, so we can send True or "True", for example
+print(f"\n.. Update value of {boolean_setting.name}")
+opposite_value = not boolean_setting.value
+updated_setting = client.update_setting(boolean_setting.name, opposite_value)
+print(f"{boolean_setting.name} updated successfully.")
+print(f"Old value: {boolean_setting.value}. New value: {updated_setting.value}")
+
+# Finally, let's restore the setting's old value
+print(f"\n.. Restore original value of {boolean_setting.name}")
+client.update_setting(boolean_setting.name, boolean_setting.value)
+print(f"{boolean_setting.name} updated successfully.")

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
@@ -5,7 +5,7 @@
 import asyncio
 import os
 
-from azure.keyvault.administration import SettingType
+from azure.keyvault.administration import KeyVaultSettingType
 from azure.keyvault.administration.aio import KeyVaultSettingsClient
 from azure.identity.aio import DefaultAzureCredential
 
@@ -40,12 +40,12 @@ async def run_sample():
     client = KeyVaultSettingsClient(vault_url=MANAGED_HSM_URL, credential=credential)
 
     # First, let's fetch the settings that apply to our Managed HSM
-    # Each setting has a name, value, and type (for example, SettingType.BOOLEAN)
+    # Each setting has a name, value, and type (for example, KeyVaultSettingType.BOOLEAN)
     print("\n.. List Key Vault settings")
     settings = await client.list_settings()
     boolean_setting = None
     async for setting in settings:
-        if setting.type == SettingType.BOOLEAN:
+        if setting.type == KeyVaultSettingType.BOOLEAN:
             boolean_setting = setting
         print(f"{setting.name}: {setting.value} (type: {setting.type})")
 

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
@@ -47,8 +47,9 @@ async def run_sample():
         print(f"{setting.name}: {setting.value} (type: {setting.setting_type})")
 
     # Now, let's flip the value of a boolean setting
+    # The `value` property is a string, but you can get the value of a boolean setting as a bool with `getboolean`
     print(f"\n.. Update value of {boolean_setting.name}")
-    opposite_value = KeyVaultSetting(name=boolean_setting.name, value=boolean_setting.value == "false")
+    opposite_value = KeyVaultSetting(name=boolean_setting.name, value=not setting.getboolean())
     updated_setting = await client.update_setting(opposite_value)
     print(f"{boolean_setting.name} updated successfully.")
     print(f"Old value: {boolean_setting.value}. New value: {updated_setting.value}")

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
@@ -1,0 +1,67 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import asyncio
+import os
+
+from azure.keyvault.administration import SettingType
+from azure.keyvault.administration.aio import KeyVaultSettingsClient
+from azure.identity.aio import DefaultAzureCredential
+
+# ----------------------------------------------------------------------------------------------------------
+# Prerequisites:
+# 1. A managed HSM (https://docs.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli)
+#
+# 2. azure-keyvault-administration and azure-identity libraries (pip install these)
+#
+# 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM
+#    
+# 4. Set up your environment to use azure-identity's DefaultAzureCredential. For more information about how to configure
+#    the DefaultAzureCredential, refer to https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
+#
+# ----------------------------------------------------------------------------------------------------------
+# Sample - demonstrates Key Vault setting management operations for Managed HSM
+#
+# 1. List all settings (list_settings)
+#
+# 2. Update a setting (update_setting)
+# ----------------------------------------------------------------------------------------------------------
+
+from dotenv import load_dotenv
+load_dotenv()
+
+async def run_sample():
+    MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
+
+    # Instantiate an access control client that will be used to call the service.
+    # Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
+    credential = DefaultAzureCredential()
+    client = KeyVaultSettingsClient(vault_url=MANAGED_HSM_URL, credential=credential)
+
+    # First, let's fetch the settings that apply to our Managed HSM
+    # Each setting has a name, value, and type (for example, SettingType.BOOLEAN)
+    print("\n.. List Key Vault settings")
+    settings = await client.list_settings()
+    boolean_setting = None
+    async for setting in settings:
+        if setting.type == SettingType.BOOLEAN:
+            boolean_setting = setting
+        print(f"{setting.name}: {setting.value} (type: {setting.type})")
+
+    # Now, let's flip the value of a boolean setting
+    # KeyVaultSettingsClient.update_setting accepts booleans and strings, so we can send True or "True", for example
+    print(f"\n.. Update value of {boolean_setting.name}")
+    opposite_value = not boolean_setting.value
+    updated_setting = await client.update_setting(boolean_setting.name, opposite_value)
+    print(f"{boolean_setting.name} updated successfully.")
+    print(f"Old value: {boolean_setting.value}. New value: {updated_setting.value}")
+
+    # Finally, let's restore the setting's old value
+    print(f"\n.. Restore original value of {boolean_setting.name}")
+    await client.update_setting(boolean_setting.name, boolean_setting.value)
+    print(f"{boolean_setting.name} updated successfully.")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_sample())

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import pytest
 
-from azure.keyvault.administration import ApiVersion, KeyVaultSetting, KeyVaultSettingsClient, SettingType
+from azure.keyvault.administration import ApiVersion, KeyVaultSetting, KeyVaultSettingsClient, KeyVaultSettingType
 
 from devtools_testutils import recorded_by_proxy
 
@@ -44,11 +44,11 @@ class TestSettings(KeyVaultTestCase):
         assert new_updated.value != updated.value
 
 def test_setting_boolean_type_string_value():
-    """Convert successfully when a KeyVaultSetting is given a SettingType.BOOLEAN `type` and boolean string `value`"""
+    """Convert successfully when a KeyVaultSetting is given a KeyVaultSettingType.BOOLEAN `type` and boolean string `value`"""
     # Mimics what we get from KeyVaultSetting._from_generated when a service setting is True
-    true_setting = KeyVaultSetting(name="test", type=SettingType.BOOLEAN, value="true")
+    true_setting = KeyVaultSetting(name="test", type=KeyVaultSettingType.BOOLEAN, value="true")
     assert isinstance(true_setting.value, bool) and true_setting.value
 
     # If `value` is anything but "True" (case-insensitive), it should be converted to False
-    false_setting = KeyVaultSetting(name="test", type=SettingType.BOOLEAN, value="not true")
+    false_setting = KeyVaultSetting(name="test", type=KeyVaultSettingType.BOOLEAN, value="not true")
     assert isinstance(false_setting.value, bool) and not false_setting.value

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
@@ -33,14 +33,17 @@ class TestSettings(KeyVaultTestCase):
 
         # Set value by using a bool
         opposite_value = KeyVaultSetting(
-            name=setting.name, value=setting.value == "false", setting_type=KeyVaultSettingType.BOOLEAN
+            name=setting.name, value=not setting.getboolean(), setting_type=KeyVaultSettingType.BOOLEAN
         )
         updated = client.update_setting(opposite_value)
         assert updated.name == setting.name
-        assert updated.value == "true" if setting.value == "false" else updated.value == "false"
+        if setting.getboolean():
+            assert not updated.getboolean()
+        else:
+            assert updated.getboolean()
 
         # Set value by using a string
-        new_opposite = KeyVaultSetting(name=updated.name, value="false" if updated.value == "true" else "true")
+        new_opposite = KeyVaultSetting(name=updated.name, value="false" if updated.getboolean() else "true")
         new_updated = client.update_setting(new_opposite)
         assert new_updated.name == updated.name
         assert new_updated.value != updated.value

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
@@ -22,33 +22,25 @@ class TestSettings(KeyVaultTestCase):
         default_settings = [setting for setting in client.list_settings()]
         assert len(default_settings)
         for setting in default_settings:
-            assert setting.name and setting.type and setting.value is not None
+            assert setting.name and setting.setting_type and setting.value is not None
 
     @pytest.mark.parametrize("api_version", only_7_4)
     @KeyVaultSettingsClientPreparer()
     @recorded_by_proxy
     def test_update_settings(self, client: KeyVaultSettingsClient, **kwargs):
         setting = client.get_setting("AllowKeyManagementOperationsThroughARM")
-        assert setting.name and setting.type and setting.value is not None
+        assert setting.name and setting.setting_type and setting.value
 
         # Set value by using a bool
-        opposite_value = not setting.value
-        updated = client.update_setting("AllowKeyManagementOperationsThroughARM", opposite_value)
+        opposite_value = KeyVaultSetting(
+            name=setting.name, value=setting.value == "false", setting_type=KeyVaultSettingType.BOOLEAN
+        )
+        updated = client.update_setting(opposite_value)
         assert updated.name == setting.name
-        assert updated.value != setting.value
+        assert updated.value == "true" if setting.value == "false" else updated.value == "false"
 
         # Set value by using a string
-        new_opposite = "false" if updated.value else "true"
-        new_updated = client.update_setting("AllowKeyManagementOperationsThroughARM", new_opposite)
+        new_opposite = KeyVaultSetting(name=updated.name, value="false" if updated.value == "true" else "true")
+        new_updated = client.update_setting(new_opposite)
         assert new_updated.name == updated.name
         assert new_updated.value != updated.value
-
-def test_setting_boolean_type_string_value():
-    """Convert successfully when a KeyVaultSetting is given a KeyVaultSettingType.BOOLEAN `type` and boolean string `value`"""
-    # Mimics what we get from KeyVaultSetting._from_generated when a service setting is True
-    true_setting = KeyVaultSetting(name="test", type=KeyVaultSettingType.BOOLEAN, value="true")
-    assert isinstance(true_setting.value, bool) and true_setting.value
-
-    # If `value` is anything but "True" (case-insensitive), it should be converted to False
-    false_setting = KeyVaultSetting(name="test", type=KeyVaultSettingType.BOOLEAN, value="not true")
-    assert isinstance(false_setting.value, bool) and not false_setting.value

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
@@ -37,8 +37,8 @@ class TestSettings(KeyVaultTestCase):
         assert updated.name == setting.name
         assert updated.value != setting.value
 
-        # Set value by using a string (providing in uppercase to make sure it's lowercased before being sent)
-        new_opposite = "FALSE" if updated.value else "TRUE"
+        # Set value by using a string
+        new_opposite = "false" if updated.value else "true"
         new_updated = client.update_setting("AllowKeyManagementOperationsThroughARM", new_opposite)
         assert new_updated.name == updated.name
         assert new_updated.value != updated.value

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
@@ -34,14 +34,17 @@ class TestSettings(KeyVaultTestCase):
 
         # Set value by using a bool
         opposite_value = KeyVaultSetting(
-            name=setting.name, value=setting.value == "false", setting_type=KeyVaultSettingType.BOOLEAN
+            name=setting.name, value=not setting.getboolean(), setting_type=KeyVaultSettingType.BOOLEAN
         )
         updated = await client.update_setting(opposite_value)
         assert updated.name == setting.name
-        assert updated.value == "true" if setting.value == "false" else updated.value == "false"
+        if setting.getboolean():
+            assert not updated.getboolean()
+        else:
+            assert updated.getboolean()
 
         # Set value by using a string
-        new_opposite = KeyVaultSetting(name=updated.name, value="false" if updated.value == "true" else "true")
+        new_opposite = KeyVaultSetting(name=updated.name, value="false" if updated.getboolean() else "true")
         new_updated = await client.update_setting(new_opposite)
         assert new_updated.name == updated.name
         assert new_updated.value != updated.value

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import pytest
 from azure.keyvault.administration import ApiVersion
+from azure.keyvault.administration.aio import KeyVaultSettingsClient
 from devtools_testutils.aio import recorded_by_proxy_async
 
 from _async_test_case import KeyVaultSettingsClientPreparer, get_decorator
@@ -17,22 +18,28 @@ class TestSettings(KeyVaultTestCase):
     @pytest.mark.parametrize("api_version", only_7_4)
     @KeyVaultSettingsClientPreparer()
     @recorded_by_proxy_async
-    async def test_list_settings(self, client, **kwargs):
+    async def test_list_settings(self, client: KeyVaultSettingsClient, **kwargs):
         default_settings = [setting async for setting in await client.list_settings()]
         assert len(default_settings)
         for setting in default_settings:
-            assert setting.name and setting.type and setting.value
+            assert setting.name and setting.type and setting.value is not None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("api_version", only_7_4)
     @KeyVaultSettingsClientPreparer()
     @recorded_by_proxy_async
-    async def test_update_settings(self, client, **kwargs):
+    async def test_update_settings(self, client: KeyVaultSettingsClient, **kwargs):
         setting = await client.get_setting("AllowKeyManagementOperationsThroughARM")
-        assert setting.name and setting.type and setting.value
+        assert setting.name and setting.type and setting.value is not None
 
-        # Note: the value provided to `update_setting` *is* case-sensitive, so passing str(True) fails
-        opposite_value = "false" if setting.value.lower() == "true" else "true"
+        # Set value by using a bool
+        opposite_value = not setting.value
         updated = await client.update_setting("AllowKeyManagementOperationsThroughARM", opposite_value)
         assert updated.name == setting.name
         assert updated.value != setting.value
+
+        # Set value by using a string (providing in uppercase to make sure it's lowercased before being sent)
+        new_opposite = "FALSE" if updated.value else "TRUE"
+        new_updated = await client.update_setting("AllowKeyManagementOperationsThroughARM", new_opposite)
+        assert new_updated.name == updated.name
+        assert new_updated.value != updated.value

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
@@ -38,8 +38,8 @@ class TestSettings(KeyVaultTestCase):
         assert updated.name == setting.name
         assert updated.value != setting.value
 
-        # Set value by using a string (providing in uppercase to make sure it's lowercased before being sent)
-        new_opposite = "FALSE" if updated.value else "TRUE"
+        # Set value by using a string
+        new_opposite = "false" if updated.value else "true"
         new_updated = await client.update_setting("AllowKeyManagementOperationsThroughARM", new_opposite)
         assert new_updated.name == updated.name
         assert new_updated.value != updated.value


### PR DESCRIPTION
# Description

This PR updates the settings API in `azure-keyvault-administration` to make it more user-friendly, per the comments in the [Administration package APIView](https://apiview.dev/Assemblies/Review/a4301dfbef584888a796be0f284b35b5?diffRevisionId=c6459c8df6a24d54a273ee3059526796&diffOnly=False&revisionId=3cf9f38239404c35a80d06d14166e322&doc=False).
- The `KeyVaultSetting` object has a string-type `value` attribute to account for future types.
  - A `getboolean` instance method allows users to get the `value` as a `bool`, and will raise a ValueError if we can't represent the value as a boolean (in the same style as [configparser.ConfigParser.getboolean](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.getboolean))
- The `KeyVaultSettingsClient.update_setting` method accepts a `KeyVaultSetting` instance instead of a setting `name` and `value`.
  - This is done to centralize the (de)serialization logic in the `KeyVaultSetting` model itself and make it easier to expand to future types.
- The  `KeyVaultSetting` `type` parameter and attribute has been renamed to `setting_type`.
  - This aligns with other languages and avoids using the `type` keyword.
- The `SettingType` enum has been renamed to `KeyVaultSettingType`.
  - This aligns with other languages and other enums/models in the library.

This PR also adds sync and async samples demonstrating the API and expected uses.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
