### PR TITLE
Use test proxy in quickstart templates

### DIFF
--- a/scripts/quickstart_tooling_dpg/template_ci/ci.yml
+++ b/scripts/quickstart_tooling_dpg/template_ci/ci.yml
@@ -28,6 +28,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: {{ service_name }}
+    TestProxy: true
     Artifacts:
     - name: {{ package_name }}
       safeName: {{ safe_name }}

--- a/scripts/quickstart_tooling_dpg/template_tests/conftest.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/conftest.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import os
+import pytest
+
+from dotenv import load_dotenv
+
+from devtools_testutils import test_proxy, add_general_regex_sanitizer
+
+load_dotenv()
+
+@pytest.fixture(scope="session", autouse=True)
+def add_sanitizers(test_proxy):
+    subscription_id = os.environ.get("{{ test_prefix | upper }}_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")
+    tenant_id = os.environ.get("{{ test_prefix | upper }}_TENANT_ID", "00000000-0000-0000-0000-000000000000")
+    client_id = os.environ.get("{{ test_prefix | upper }}_CLIENT_ID", "00000000-0000-0000-0000-000000000000")
+    client_secret = os.environ.get("{{ test_prefix | upper }}_CLIENT_SECRET", "00000000-0000-0000-0000-000000000000")
+    add_general_regex_sanitizer(regex=subscription_id, value="00000000-0000-0000-0000-000000000000")
+    add_general_regex_sanitizer(regex=tenant_id, value="00000000-0000-0000-0000-000000000000")
+    add_general_regex_sanitizer(regex=client_id, value="00000000-0000-0000-0000-000000000000")
+    add_general_regex_sanitizer(regex=client_secret, value="00000000-0000-0000-0000-000000000000")

--- a/scripts/quickstart_tooling_dpg/template_tests/conftest.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/conftest.py
@@ -13,6 +13,7 @@ from devtools_testutils import test_proxy, add_general_regex_sanitizer
 
 load_dotenv()
 
+# For more info about add_sanitizers, please refer to https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/test_proxy_migration_guide.md#register-sanitizers
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):
     subscription_id = os.environ.get("{{ test_prefix | upper }}_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")

--- a/scripts/quickstart_tooling_dpg/template_tests/conftest.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/conftest.py
@@ -7,11 +7,7 @@
 import os
 import pytest
 
-from dotenv import load_dotenv
-
-from devtools_testutils import test_proxy, add_general_regex_sanitizer
-
-load_dotenv()
+from devtools_testutils import test_proxy, add_general_string_sanitizer
 
 # For more info about add_sanitizers, please refer to https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/test_proxy_migration_guide.md#register-sanitizers
 @pytest.fixture(scope="session", autouse=True)
@@ -20,7 +16,7 @@ def add_sanitizers(test_proxy):
     tenant_id = os.environ.get("{{ test_prefix | upper }}_TENANT_ID", "00000000-0000-0000-0000-000000000000")
     client_id = os.environ.get("{{ test_prefix | upper }}_CLIENT_ID", "00000000-0000-0000-0000-000000000000")
     client_secret = os.environ.get("{{ test_prefix | upper }}_CLIENT_SECRET", "00000000-0000-0000-0000-000000000000")
-    add_general_regex_sanitizer(regex=subscription_id, value="00000000-0000-0000-0000-000000000000")
-    add_general_regex_sanitizer(regex=tenant_id, value="00000000-0000-0000-0000-000000000000")
-    add_general_regex_sanitizer(regex=client_id, value="00000000-0000-0000-0000-000000000000")
-    add_general_regex_sanitizer(regex=client_secret, value="00000000-0000-0000-0000-000000000000")
+    add_general_string_sanitizer(target=subscription_id, value="00000000-0000-0000-0000-000000000000")
+    add_general_string_sanitizer(target=tenant_id, value="00000000-0000-0000-0000-000000000000")
+    add_general_string_sanitizer(target=client_id, value="00000000-0000-0000-0000-000000000000")
+    add_general_string_sanitizer(target=client_secret, value="00000000-0000-0000-0000-000000000000")

--- a/scripts/quickstart_tooling_dpg/template_tests/test_smoke.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/test_smoke.py
@@ -4,12 +4,14 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-from testcase import {{ test_prefix.capitalize() }}Test, {{ test_prefix.capitalize() }}PowerShellPreparer
+from devtools_testutils import recorded_by_proxy
+from testcase import {{ test_prefix.capitalize() }}Test, {{ test_prefix.capitalize() }}Preparer
 
 class {{ test_prefix.capitalize() }}SmokeTest({{ test_prefix.capitalize() }}Test):
 
 
-    @{{ test_prefix.capitalize() }}PowerShellPreparer()
+    @{{ test_prefix.capitalize() }}Preparer()
+    @recorded_by_proxy
     def test_smoke(self, {{ test_prefix }}_endpoint):
         client = self.create_client(endpoint={{ test_prefix }}_endpoint)
         # test your code here, for example:

--- a/scripts/quickstart_tooling_dpg/template_tests/test_smoke.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/test_smoke.py
@@ -7,6 +7,8 @@
 from devtools_testutils import recorded_by_proxy
 from testcase import {{ test_prefix.capitalize() }}Test, {{ test_prefix.capitalize() }}Preparer
 
+
+# For more info about how to write and run test, please refer to https://github.com/Azure/azure-sdk-for-python/wiki/Dataplane-Codegen-Quick-Start-for-Test
 class {{ test_prefix.capitalize() }}SmokeTest({{ test_prefix.capitalize() }}Test):
 
 

--- a/scripts/quickstart_tooling_dpg/template_tests/test_smoke_async.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/test_smoke_async.py
@@ -4,13 +4,15 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-from testcase import {{ test_prefix.capitalize() }}PowerShellPreparer
+from devtools_testutils.aio import recorded_by_proxy_async
+from testcase import {{ test_prefix.capitalize() }}Preparer
 from testcase_async import {{ test_prefix.capitalize() }}AsyncTest
 
 
 class {{ test_prefix.capitalize() }}SmokeAsyncTest({{ test_prefix.capitalize() }}AsyncTest):
 
-    @{{ test_prefix.capitalize() }}PowerShellPreparer()
+    @{{ test_prefix.capitalize() }}Preparer()
+    @recorded_by_proxy_async
     async def test_smoke_async(self, {{ test_prefix }}_endpoint):
         client = self.create_client(endpoint={{ test_prefix }}_endpoint)
         # test your code here, for example:

--- a/scripts/quickstart_tooling_dpg/template_tests/test_smoke_async.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/test_smoke_async.py
@@ -9,6 +9,7 @@ from testcase import {{ test_prefix.capitalize() }}Preparer
 from testcase_async import {{ test_prefix.capitalize() }}AsyncTest
 
 
+# For more info about how to write and run test, please refer to https://github.com/Azure/azure-sdk-for-python/wiki/Dataplane-Codegen-Quick-Start-for-Test
 class {{ test_prefix.capitalize() }}SmokeAsyncTest({{ test_prefix.capitalize() }}AsyncTest):
 
     @{{ test_prefix.capitalize() }}Preparer()

--- a/scripts/quickstart_tooling_dpg/template_tests/testcase.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/testcase.py
@@ -5,14 +5,11 @@
 # license information.
 # --------------------------------------------------------------------------
 import functools
-from devtools_testutils import AzureTestCase, PowerShellPreparer
+from devtools_testutils import AzureRecordedTestCase, EnvironmentVariableLoader
 from {{ namespace }} import {{ client_name }}
 
 
-class {{ test_prefix.capitalize() }}Test(AzureTestCase):
-    def __init__(self, method_name, **kwargs):
-        super({{ test_prefix.capitalize() }}Test, self).__init__(method_name, **kwargs)
-
+class {{ test_prefix.capitalize() }}Test(AzureRecordedTestCase):
     def create_client(self, endpoint):
         credential = self.get_credential({{ client_name }})
         return self.create_client_from_credential(
@@ -22,8 +19,8 @@ class {{ test_prefix.capitalize() }}Test(AzureTestCase):
         )
 
 
-{{ test_prefix.capitalize() }}PowerShellPreparer = functools.partial(
-    PowerShellPreparer,
+{{ test_prefix.capitalize() }}Preparer = functools.partial(
+    EnvironmentVariableLoader,
     "{{ test_prefix }}",
     {{ test_prefix }}_endpoint="https://myservice.azure.com"
 )

--- a/scripts/quickstart_tooling_dpg/template_tests/testcase.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/testcase.py
@@ -5,7 +5,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import functools
-from devtools_testutils import AzureRecordedTestCase, EnvironmentVariableLoader
+from devtools_testutils import AzureRecordedTestCase, PowerShellPreparer
 from {{ namespace }} import {{ client_name }}
 
 
@@ -20,7 +20,7 @@ class {{ test_prefix.capitalize() }}Test(AzureRecordedTestCase):
 
 
 {{ test_prefix.capitalize() }}Preparer = functools.partial(
-    EnvironmentVariableLoader,
+    PowerShellPreparer,
     "{{ test_prefix }}",
     {{ test_prefix }}_endpoint="https://myservice.azure.com"
 )

--- a/scripts/quickstart_tooling_dpg/template_tests/testcase_async.py
+++ b/scripts/quickstart_tooling_dpg/template_tests/testcase_async.py
@@ -4,14 +4,11 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from devtools_testutils import AzureTestCase
+from devtools_testutils import AzureRecordedTestCase
 from {{ namespace }}.aio import {{ client_name}}
 
 
-class {{ test_prefix.capitalize() }}AsyncTest(AzureTestCase):
-    def __init__(self, method_name, **kwargs):
-        super({{ test_prefix.capitalize() }}AsyncTest, self).__init__(method_name, **kwargs)
-
+class {{ test_prefix.capitalize() }}AsyncTest(AzureRecordedTestCase):
     def create_client(self, endpoint):
         credential = self.get_credential({{ client_name}}, is_async=True)
         return self.create_client_from_credential(


### PR DESCRIPTION
# Description

Someone recently onboarded a package to the SDK and wrote tests that use `vcrpy` instead of the test proxy. Our main testing document, [`tests.md`](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md), states that the test proxy should be used, but they assumed they should follow the same test structure that was generated with `quickstart_tooling_dpg`.

This PR updates the quickstart templates for tests and CI to point at test proxy tooling.

One question might be if we should include a README of sorts for `quickstart_tooling_dpg` so that users are conveniently directed to `tests.md` -- otherwise, the tests generated by these templates won't be locally usable without test proxy setup and could cause confusion.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
