### PR TITLE
[TA] renamed sample

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -142,8 +142,8 @@ IGNORED_SAMPLES = {
     "azure-ai-textanalytics": [
         "sample_analyze_healthcare_entities_with_cancellation.py",
         "sample_analyze_healthcare_entities_with_cancellation_async.py",
-        "sample_abstract_summary.py",
-        "sample_abstract_summary_async.py",
+        "sample_abstractive_summary.py",
+        "sample_abstractive_summary_async.py",
     ],
     "azure-ai-language-conversations": [
         "sample_assign_deployment_resources.py",


### PR DESCRIPTION
renamed the sample and now it's failing in CI. abstractive summarization isn't supported in the region where our custom resource is located. The custom resource is needed to run the rest of the samples.
