### PR TITLE
Correct logic in `install_python_version.py`

### DIFF
--- a/scripts/devops_tasks/install_python_version.py
+++ b/scripts/devops_tasks/install_python_version.py
@@ -142,7 +142,7 @@ def necessary_to_install(version_requested) -> bool:
         if version_from_spec > Version(f"{precached_version.major}.{precached_version.minor}"):
             precached = False
     else:
-        precached = version_from_spec > precached_version
+        precached = version_from_spec <= precached_version
 
     return not precached
 


### PR DESCRIPTION
@mccoyp you absolutely called this out on the original PR that fixed the precache warning.

Not especially urgent to get this fixed until python 3.12, but given that I noticed it I'm going to resolve this now.