### PR TITLE
[Monitor][Query] Update tests for better coverage

### DIFF
--- a/sdk/monitor/azure-monitor-query/assets.json
+++ b/sdk/monitor/azure-monitor-query/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/monitor/azure-monitor-query",
-  "Tag": "python/monitor/azure-monitor-query_3c8d44893c"
+  "Tag": "python/monitor/azure-monitor-query_86a8ec0380"
 }

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
@@ -10,7 +10,8 @@ from azure.monitor.query import MetricsQueryClient, MetricAggregationType, Metri
 from devtools_testutils import AzureRecordedTestCase
 
 
-METRIC_NAME = "Event"
+METRIC_NAME = "requests/count"
+METRIC_RESOURCE_PROVIDER = "Microsoft.Insights/components"
 
 
 class TestMetricsClient(AzureRecordedTestCase):
@@ -37,6 +38,10 @@ class TestMetricsClient(AzureRecordedTestCase):
             )
         assert response
         assert response.granularity == timedelta(minutes=5)
+        metric = response.metrics[METRIC_NAME]
+        assert metric.timeseries
+        for t in metric.timeseries:
+            assert t.metadata_values is not None
 
     def test_metrics_filter(self, recorded_test, monitor_info):
         client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
@@ -45,7 +50,7 @@ class TestMetricsClient(AzureRecordedTestCase):
             metric_names=[METRIC_NAME],
             timespan=timedelta(days=1),
             granularity=timedelta(minutes=5),
-            filter="Source eq '*'",
+            filter="request/success eq '0'",
             aggregations=[MetricAggregationType.COUNT]
             )
         assert response
@@ -99,7 +104,7 @@ class TestMetricsClient(AzureRecordedTestCase):
     def test_metrics_definitions(self, recorded_test, monitor_info):
         client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
         response = client.list_metric_definitions(
-            monitor_info['metrics_resource_id'], namespace='Microsoft.OperationalInsights/workspaces')
+            monitor_info['metrics_resource_id'], namespace=METRIC_RESOURCE_PROVIDER)
 
         assert response is not None
         for item in response:

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
@@ -14,7 +14,9 @@ from azure.monitor.query.aio import MetricsQueryClient
 from devtools_testutils import AzureRecordedTestCase
 
 
-METRIC_NAME = "Event"
+METRIC_NAME = "requests/count"
+METRIC_RESOURCE_PROVIDER = "Microsoft.Insights/components"
+
 
 class TestMetricsClientAsync(AzureRecordedTestCase):
 
@@ -46,6 +48,10 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
                 )
             assert response
             assert response.granularity == timedelta(minutes=5)
+            metric = response.metrics[METRIC_NAME]
+            assert metric.timeseries
+            for t in metric.timeseries:
+                assert t.metadata_values is not None
 
     @pytest.mark.asyncio
     async def test_metrics_filter(self, recorded_test, monitor_info):
@@ -57,7 +63,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
                 metric_names=[METRIC_NAME],
                 timespan=timedelta(days=1),
                 granularity=timedelta(minutes=5),
-                filter="Source eq '*'",
+                filter="request/success eq '0'",
                 aggregations=[MetricAggregationType.COUNT]
                 )
             assert response
@@ -124,7 +130,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
 
         async with client:
             response = client.list_metric_definitions(
-                monitor_info['metrics_resource_id'], namespace='Microsoft.OperationalInsights/workspaces')
+                monitor_info['metrics_resource_id'], namespace=METRIC_RESOURCE_PROVIDER)
 
             assert response is not None
             async for item in response:

--- a/sdk/monitor/test-resources.bicep
+++ b/sdk/monitor/test-resources.bicep
@@ -231,7 +231,7 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2021-09-01-p
 }
 
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = applicationInsightsComponent.properties.ConnectionString
-output METRICS_RESOURCE_ID string = primaryWorkspace.id
+output METRICS_RESOURCE_ID string = applicationInsightsComponent.id
 output AZURE_MONITOR_WORKSPACE_ID string = primaryWorkspace.properties.customerId
 output AZURE_MONITOR_SECONDARY_WORKSPACE_ID string = secondaryWorkspace.properties.customerId
 output AZURE_MONITOR_DCE string = dataCollectionEndpoint.properties.logsIngestion.endpoint


### PR DESCRIPTION
Ensure that the live/recorded tests actually produce timeseries metrics that can be used for serialization. Previously the live tests were producing empty timeseries data which allowed a regression to slip through.

- Updated the live resource ID being tested to a resource that produces timeseries metrics.
- Updated the the metric name used in the tests.
- Explicitly test for timeseries not being empty.
