### PR TITLE
[ML][Pipelines] fix: avoid raising OSError for invalid paths in LocalPathField deserialization

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
@@ -144,9 +144,7 @@ class LocalPathField(fields.Str):
                 return result
         except OSError:
             raise self.make_error("invalid_path")
-        raise self.make_error(
-            "path_not_exist", path=result.as_posix(), allow_type=self.allowed_path_type
-        )
+        raise self.make_error("path_not_exist", path=result.as_posix(), allow_type=self.allowed_path_type)
 
     @property
     def allowed_path_type(self) -> str:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
@@ -131,14 +131,22 @@ class LocalPathField(fields.Str):
         """Resolve path to absolute path based on base_path in context.
         Will resolve the path if it's already an absolute path.
         """
-        result = Path(value)
-        base_path = Path(self.context[BASE_PATH_CONTEXT_KEY])
-        if not result.is_absolute():
-            result = base_path / result
         try:
-            return result.resolve()
+            result = Path(value)
+            base_path = Path(self.context[BASE_PATH_CONTEXT_KEY])
+            if not result.is_absolute():
+                result = base_path / result
+
+            # for non-path string like "azureml:/xxx", OSError can be raised in either
+            # resolve() or is_dir() or is_file()
+            result = result.resolve()
+            if (self._allow_dir and result.is_dir()) or (self._allow_file and result.is_file()):
+                return result
         except OSError:
             raise self.make_error("invalid_path")
+        raise self.make_error(
+            "path_not_exist", path=result.as_posix(), allow_type=self.allowed_path_type
+        )
 
     @property
     def allowed_path_type(self) -> str:
@@ -154,16 +162,12 @@ class LocalPathField(fields.Str):
 
         if value is None:
             return
-        path = self._resolve_path(value)
-        if (self._allow_dir and path.is_dir()) or (self._allow_file and path.is_file()):
-            return
-        raise self.make_error("path_not_exist", path=path.as_posix(), allow_type=self.allowed_path_type)
+        self._resolve_path(value)
 
     def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
         # do not block serializing None even if required or not allow_none.
         if value is None:
             return None
-        self._validate(value)
         # always dump path as absolute path in string as base_path will be dropped after serialization
         return super(LocalPathField, self)._serialize(self._resolve_path(value).as_posix(), attr, obj, **kwargs)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -162,7 +162,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
                 operation_config=self._operation_config,
             )
             if deployment.data_collector:
-                self._register_collection_data_assets(deployment= deployment)
+                self._register_collection_data_assets(deployment=deployment)
 
             upload_dependencies(deployment, orchestrators)
             try:
@@ -351,16 +351,13 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         for collection in deployment.data_collector.collections:
             data_name = deployment.endpoint_name + "-" + deployment.name + "-" + collection
             data_object = Data(
-                name = data_name,
-                path = deployment.data_collector.destination.path
+                name=data_name,
+                path=deployment.data_collector.destination.path
                 if deployment.data_collector.destination and deployment.data_collector.destination.path
                 else DEFAULT_MDC_PATH,
-                is_anonymous= True
-        )
+                is_anonymous=True,
+            )
             result = self._all_operations._all_operations[AzureMLResourceType.DATA].create_or_update(data_object)
             deployment.data_collector.collections[collection].data = DataAsset(
-                data_id = result.id,
-                path = result.path,
-                name = result.name,
-                version = result.version
-                )
+                data_id=result.id, path=result.path, name=result.name, version=result.version
+            )

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_schema.py
@@ -329,12 +329,15 @@ class TestCommandComponent:
         component_entity._to_dict()
 
     def test_arm_code_from_rest_object(self):
-        arm_code = "azureml:/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.MachineLearningServices/" \
-                       "workspaces/zzz/codes/90b33c11-365d-4ee4-aaa1-224a042deb41/versions/1"
+        arm_code = (
+            "azureml:/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.MachineLearningServices/"
+            "workspaces/zzz/codes/90b33c11-365d-4ee4-aaa1-224a042deb41/versions/1"
+        )
         yaml_path = "./tests/test_configs/components/helloworld_component.yml"
         yaml_component = load_component(yaml_path)
 
         from azure.ai.ml.entities import Component
+
         rest_object = yaml_component._to_rest_object()
         rest_object.properties.component_spec["code"] = arm_code
         component = Component._from_rest_object(rest_object)

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_schema.py
@@ -328,6 +328,18 @@ class TestCommandComponent:
         component_entity._base_path = "/non/existent/path"
         component_entity._to_dict()
 
+    def test_arm_code_from_rest_object(self):
+        arm_code = "azureml:/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.MachineLearningServices/" \
+                       "workspaces/zzz/codes/90b33c11-365d-4ee4-aaa1-224a042deb41/versions/1"
+        yaml_path = "./tests/test_configs/components/helloworld_component.yml"
+        yaml_component = load_component(yaml_path)
+
+        from azure.ai.ml.entities import Component
+        rest_object = yaml_component._to_rest_object()
+        rest_object.properties.component_spec["code"] = arm_code
+        component = Component._from_rest_object(rest_object)
+        assert component.code == arm_code[8:]
+
 
 @pytest.mark.timeout(_COMPONENT_TIMEOUT_SECOND)
 @pytest.mark.unittest


### PR DESCRIPTION
# Description

For invalid path value like "azureml:/subscription/xxxxx", raise ValidationError instead of OSError, as OSError will directly break UnionField deserialization.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
