### PR TITLE
`archetype-sdk-tests` analysis stage needs renaming

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -143,7 +143,7 @@ stages:
               Cloud: ${{ cloud.key }}
 
 - ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly')  }}:
-  - stage: ${{ cloud.key }}_${{ parameters.JobName }}_Analysis
+  - stage: ${{ parameters.JobName }}_Analysis
     dependsOn: []
     jobs:
       - job: 'Analyze'

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -143,7 +143,7 @@ stages:
               Cloud: ${{ cloud.key }}
 
 - ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly')  }}:
-  - stage: Analysis
+  - stage: ${{ cloud.key }}_${{ parameters.JobName }}_Analysis
     dependsOn: []
     jobs:
       - job: 'Analyze'

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -143,12 +143,12 @@ stages:
               Cloud: ${{ cloud.key }}
 
 - ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly')  }}:
-  - stage: ${{ parameters.JobName }}_Analysis
+  - stage:
+    displayName: 'Analyze_${{ parameters.JobName }}'
     dependsOn: []
     jobs:
       - job: 'Analyze'
         timeoutInMinutes: 90
-
 
         variables:
           PythonVersion: '3.9'


### PR DESCRIPTION
Due to the fact that when we call it multiple times, duplicate stage names break yml generation.

@mccoyp @LibbaLawrence 