### PR TITLE
[tooling] Add exclusions to black for auto generated code

### DIFF
--- a/eng/black-pyproject.toml
+++ b/eng/black-pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 120
+extend-exclude = '''
+# Exclude some directories from formatting (note the slashes at surrounding the pattern)
+/(
+  | _vendor
+  | _generated
+  | _restclient
+)/
+'''

--- a/eng/black-pyproject.toml
+++ b/eng/black-pyproject.toml
@@ -3,6 +3,6 @@ line-length = 120
 extend-exclude = '''
 # Exclude some directories from formatting (note the slashes surrounding the pattern)
 /(
-  _restclient
+  azure/ai/ml/_restclient
 )/
 '''

--- a/eng/black-pyproject.toml
+++ b/eng/black-pyproject.toml
@@ -1,10 +1,8 @@
 [tool.black]
 line-length = 120
 extend-exclude = '''
-# Exclude some directories from formatting (note the slashes at surrounding the pattern)
+# Exclude some directories from formatting (note the slashes surrounding the pattern)
 /(
-  | _vendor
-  | _generated
-  | _restclient
+  _restclient
 )/
 '''

--- a/scripts/devops_tasks/validate_formatting.py
+++ b/scripts/devops_tasks/validate_formatting.py
@@ -28,7 +28,7 @@ def run_black(service_dir):
         package_name = os.path.basename(package)
 
         if is_check_enabled(package, "black", True):
-            out = subprocess.Popen([sys.executable, "-m", "black", "-l", "120", "sdk/{}/{}".format(service_dir, package_name)],
+            out = subprocess.Popen([sys.executable, "-m", "black", "--config", os.path.join(root_dir, "eng", "black-pyproject.toml"), os.path.join("sdk", service_dir, package_name)],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 cwd = root_dir


### PR DESCRIPTION
# Description

This PR:

* Moves the configuration for `black` to a separate file (`eng/black-pyproject.toml`) to address feedback raised in #28784 
* Adds exclusions to the black config, so that it ignores some directories that should be excluded from formatting (e.g. autogenerated code, vendored code, etc...). (See motivation for `azure-ai-ml` here: https://github.com/Azure/azure-sdk-for-python/pull/28817#issuecomment-1431678918)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
