### PR TITLE
azure-communication-identity comment fix

### DIFF
--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
@@ -30,7 +30,7 @@ class CommunicationIdentityClient(object):
     :param Union[TokenCredential, AzureKeyCredential] credential:
         The credential we use to authenticate against the service.
     :keyword api_version: Azure Communication Identity API version.
-        Default value is "2022-06-01". Note that overriding this default value may result in unsupported behavior.
+        Default value is "2022-10-01". Note that overriding this default value may result in unsupported behavior.
     :paramtype api_version: str
 
     .. admonition:: Example:

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
@@ -230,4 +230,3 @@ class CommunicationIdentityClient(object):
             body=request_body,
             cls=lambda pr, u, e: AccessToken(u['token'], u['expiresOn']),
             **kwargs)
-        

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
@@ -230,4 +230,4 @@ class CommunicationIdentityClient(object):
             body=request_body,
             cls=lambda pr, u, e: AccessToken(u['token'], u['expiresOn']),
             **kwargs)
-
+    

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
@@ -230,3 +230,4 @@ class CommunicationIdentityClient(object):
             body=request_body,
             cls=lambda pr, u, e: AccessToken(u['token'], u['expiresOn']),
             **kwargs)
+


### PR DESCRIPTION
just an outdated comment, 

the default api is different, see https://github.com/Azure/azure-sdk-for-python/blob/a991d8200914c4e6cdf81aa05fcc3d88512052b3/sdk/communication/azure-communication-identity/azure/communication/identity/_generated/_configuration.py#L33