### PR TITLE
[Storage] Document deprecated methods on StorageStreamDownloader

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -662,9 +662,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         return data
 
     def content_as_bytes(self, max_concurrency=1):
-        """Download the contents of this file.
+        """DEPRECATED: Download the contents of this file.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :keyword int max_concurrency:
             The number of parallel connections with which to download.
@@ -678,9 +680,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         return self.readall()
 
     def content_as_text(self, max_concurrency=1, encoding="UTF-8"):
-        """Download the contents of this blob, and decode as text.
+        """DEPRECATED: Download the contents of this blob, and decode as text.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :keyword int max_concurrency:
             The number of parallel connections with which to download.
@@ -773,7 +777,9 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         return remaining_size
 
     def download_to_stream(self, stream, max_concurrency=1):
-        """Download the contents of this blob to a stream.
+        """DEPRECATED: Download the contents of this blob to a stream.
+
+        This method is deprecated, use func:`readinto` instead.
 
         :param stream:
             The stream to download to. This can be an open file-handle,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -568,9 +568,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         return data
 
     async def content_as_bytes(self, max_concurrency=1):
-        """Download the contents of this file.
+        """DEPRECATED: Download the contents of this file.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :keyword int max_concurrency:
             The number of parallel connections with which to download.
@@ -584,9 +586,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         return await self.readall()
 
     async def content_as_text(self, max_concurrency=1, encoding="UTF-8"):
-        """Download the contents of this blob, and decode as text.
+        """DEPRECATED: Download the contents of this blob, and decode as text.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :param int max_concurrency:
             The number of parallel connections with which to download.
@@ -698,7 +702,9 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         return remaining_size
 
     async def download_to_stream(self, stream, max_concurrency=1):
-        """Download the contents of this blob to a stream.
+        """DEPRECATED: Download the contents of this blob to a stream.
+
+        This method is deprecated, use func:`readinto` instead.
 
         :param stream:
             The stream to download to. This can be an open file-handle,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
@@ -398,9 +398,11 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         return data
 
     def content_as_bytes(self, max_concurrency=1):
-        """Download the contents of this file.
+        """DEPRECATED: Download the contents of this file.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :keyword int max_concurrency:
             The number of parallel connections with which to download.
@@ -414,9 +416,11 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         return self.readall()
 
     def content_as_text(self, max_concurrency=1, encoding="UTF-8"):
-        """Download the contents of this file, and decode as text.
+        """DEPRECATED: Download the contents of this file, and decode as text.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :keyword int max_concurrency:
             The number of parallel connections with which to download.
@@ -495,7 +499,9 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         return self.size
 
     def download_to_stream(self, stream, max_concurrency=1):
-        """Download the contents of this file to a stream.
+        """DEPRECATED: Download the contents of this file to a stream.
+
+        This method is deprecated, use func:`readinto` instead.
 
         :param stream:
             The stream to download to. This can be an open file-handle,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -350,9 +350,11 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         return data
 
     async def content_as_bytes(self, max_concurrency=1):
-        """Download the contents of this file.
+        """DEPRECATED: Download the contents of this file.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :keyword int max_concurrency:
             The number of parallel connections with which to download.
@@ -366,9 +368,11 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         return await self.readall()
 
     async def content_as_text(self, max_concurrency=1, encoding="UTF-8"):
-        """Download the contents of this file, and decode as text.
+        """DEPRECATED: Download the contents of this file, and decode as text.
 
         This operation is blocking until all data is downloaded.
+
+        This method is deprecated, use func:`readall` instead.
 
         :keyword int max_concurrency:
             The number of parallel connections with which to download.
@@ -457,6 +461,8 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
 
     async def download_to_stream(self, stream, max_concurrency=1):
         """Download the contents of this file to a stream.
+
+        This method is deprecated, use func:`readinto` instead.
 
         :param stream:
             The stream to download to. This can be an open file-handle,


### PR DESCRIPTION
Resolves #28674

There are some methods on `StorageStreamDownloader` that have long since been deprecated with warnings being generated but the docs did not reflect this state. This change updates the docstrings for these methods to include the deprecation information.