### PR TITLE
Azure Load Testing incorrectly named in sdk_packaging.toml

### DIFF
--- a/sdk/loadtesting/azure-developer-loadtesting/sdk_packaging.toml
+++ b/sdk/loadtesting/azure-developer-loadtesting/sdk_packaging.toml
@@ -1,7 +1,7 @@
 [packaging]
 package_name = "azure-developer-loadtesting"
 package_nspkg = "azure-developer-nspkg"
-package_pprint_name = "MyService Management"
+package_pprint_name = "Load Testing"
 package_doc_id = ""
 is_stable = false
 is_arm = true

--- a/sdk/loadtesting/azure-mgmt-loadtesting/sdk_packaging.toml
+++ b/sdk/loadtesting/azure-mgmt-loadtesting/sdk_packaging.toml
@@ -1,7 +1,7 @@
 [packaging]
 package_name = "azure-mgmt-loadtesting"
 package_nspkg = "azure-mgmt-nspkg"
-package_pprint_name = "Loadtesting Management"
+package_pprint_name = "Load Testing Management"
 package_doc_id = ""
 is_stable = false
 is_arm = true


### PR DESCRIPTION
1. "MyService Management" is the boiler plate name, the README shows the same title. 

2. "Loadtesting" is not the name, Azure Load Testing is the correct service name. 