### PR TITLE
change default mdc path for collections

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -349,12 +349,12 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
 
     def _register_collection_data_assets(self, deployment: OnlineDeployment) -> None:
         for collection in deployment.data_collector.collections:
-            data_name = deployment.endpoint_name + "-" + deployment.name + "-" + collection
+            data_name = f"{deployment.endpoint_name}-{deployment.name}-{collection}"
             data_object = Data(
                 name=data_name,
                 path=deployment.data_collector.destination.path
                 if deployment.data_collector.destination and deployment.data_collector.destination.path
-                else DEFAULT_MDC_PATH,
+                else f"{DEFAULT_MDC_PATH}/{deployment.endpoint_name}/{deployment.name}/{collection}",
                 is_anonymous=True,
             )
             result = self._all_operations._all_operations[AzureMLResourceType.DATA].create_or_update(data_object)


### PR DESCRIPTION
# Description

The default path for mdc collection path has been changed to "azureml://datastores/workspaceblobstore/paths/modelDataCollector/{endpoint}/{deployment}/{collection}"

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
