### PR TITLE
[Storage] Fix `is_current_version` behavior to correctly reflect boolean values

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_deserialize.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_deserialize.py
@@ -166,7 +166,7 @@ def get_blob_properties_from_generated_code(generated):
     blob.archive_status = generated.properties.archive_status
     blob.blob_tier_change_time = generated.properties.access_tier_change_time
     blob.version_id = generated.version_id
-    blob.is_current_version = generated.is_current_version
+    blob.is_current_version = False if (blob.version_id and not generated.is_current_version) else generated.is_current_version  # pylint: disable=line-too-long
     blob.tag_count = generated.properties.tag_count
     blob.tags = parse_tags(generated.blob_tags)  # pylint: disable=protected-access
     blob.object_replication_source_properties = deserialize_ors_policies(generated.object_replication_metadata)

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_blob_version_properties_versioning_disabled.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_blob_version_properties_versioning_disabled.json
@@ -1,0 +1,183 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer46563554?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:28 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:f79c3a96-901e-00cf-4928-437873000000\n",
+        "Time:2023-02-17T23:36:24.9849129Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainersource46563554?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:29 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:f79c3ab7-901e-00cf-6228-437873000000\n",
+        "Time:2023-02-17T23:36:25.0838795Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer46563554/utcontainer46563554",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "3",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:29 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "kAFQmDzST7DWlj99KOF/cg==",
+        "Date": "Fri, 17 Feb 2023 23:36:25 GMT",
+        "ETag": "\u00220x8DB113FC8C008AD\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "6/rBP7vK5QU=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer46563554?restype=container\u0026comp=list\u0026include=versions",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:29 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer46563554\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eutcontainer46563554\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:33:10 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:25 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FC8C008AD\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer46563554/utcontainer46563554",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "6",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:29 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJjYWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "RArIWJLKQ60m1Ex62dR9Pg==",
+        "Date": "Fri, 17 Feb 2023 23:36:25 GMT",
+        "ETag": "\u00220x8DB113FC8DBF2CD\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "j5pW8UIQPR0=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer46563554?restype=container\u0026comp=list\u0026include=versions",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:29 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer46563554\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eutcontainer46563554\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:33:10 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:25 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FC8DBF2CD\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_blob_version_properties_versioning_enabled.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_blob_version_properties_versioning_enabled.json
@@ -1,0 +1,158 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainerff234e7?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:40 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:28254164-401e-001e-5228-43cfa1000000\n",
+        "Time:2023-02-17T23:36:36.5679523Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainersourceff234e7?restype=container\u0026timeout=5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:40 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:282541d9-401e-001e-3328-43cfa1000000\n",
+        "Time:2023-02-17T23:36:36.6459094Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainerff234e7/utcontainerff234e7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "3",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:40 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "kAFQmDzST7DWlj99KOF/cg==",
+        "Date": "Fri, 17 Feb 2023 23:36:36 GMT",
+        "ETag": "\u00220x8DB113FCF9DE230\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "6/rBP7vK5QU=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02",
+        "x-ms-version-id": "2023-02-17T23:36:36.6909754Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainerff234e7/utcontainerff234e7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "6",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:40 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJjYWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "RArIWJLKQ60m1Ex62dR9Pg==",
+        "Date": "Fri, 17 Feb 2023 23:36:36 GMT",
+        "ETag": "\u00220x8DB113FCFA422CD\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "j5pW8UIQPR0=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02",
+        "x-ms-version-id": "2023-02-17T23:36:36.7319517Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainerff234e7?restype=container\u0026comp=list\u0026include=versions",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:40 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagenamestorname.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainerff234e7\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:00:30.3802557Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:00:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:00:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113AC46540BD\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:00:30.4242293Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:00:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:00:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113AC46BCF65\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:02:35.0294265Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:02:35 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:02:35 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113B0EB10DE9\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:02:35.0734019Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:02:35 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:02:35 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113B0EB7C3B3\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:19:05.2501321Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:19:05 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:19:05 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113D5CE8972D\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:19:05.2941071Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:19:05 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:19:05 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113D5CEF73FF\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:35:12.5161745Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:35:12 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:35:12 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113F9D71D401\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:35:12.6001254Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:35:12 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:35:12 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113F9D7EA356\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:36:36.6909754Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:36:36 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:36 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FCF9DE230\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e7\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:36:36.7319517Z\u003C/VersionId\u003E\u003CIsCurrentVersion\u003Etrue\u003C/IsCurrentVersion\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:36:36 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:36 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FCFA422CD\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e71\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:03:50.0953092Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:03:50 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:03:50 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113B3B6F5A04\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e71\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:04:25.9942472Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:04:25 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:04:25 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113B50D4F138\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e71\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:18:50.7445823Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:18:50 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:18:50 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113D54435F2F\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerff234e71\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:18:50.7895560Z\u003C/VersionId\u003E\u003CIsCurrentVersion\u003Etrue\u003C/IsCurrentVersion\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:18:50 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:18:50 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113D544A14EF\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.pyTestStorageCommonBlobAsynctest_blob_version_properties_versioning_disabled.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.pyTestStorageCommonBlobAsynctest_blob_version_properties_versioning_disabled.json
@@ -1,0 +1,177 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainerb88839cf?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:72ef6340-d01e-0005-2628-4324fa000000\n",
+        "Time:2023-02-17T23:36:45.4881989Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainersourceb88839cf?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:72ef634f-d01e-0005-3028-4324fa000000\n",
+        "Time:2023-02-17T23:36:45.6181561Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainerb88839cf/utcontainerb88839cf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "3",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "kAFQmDzST7DWlj99KOF/cg==",
+        "Date": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "ETag": "\u00220x8DB113FD500FE8C\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "6/rBP7vK5QU=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainerb88839cf?restype=container\u0026comp=list\u0026include=versions",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainerb88839cf\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerb88839cf\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:24:17 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:45 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FD500FE8C\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainerb88839cf/utcontainerb88839cf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "6",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJjYWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "RArIWJLKQ60m1Ex62dR9Pg==",
+        "Date": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "ETag": "\u00220x8DB113FD51DD2F7\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "j5pW8UIQPR0=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainerb88839cf?restype=container\u0026comp=list\u0026include=versions",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:36:49 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainerb88839cf\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eutcontainerb88839cf\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:24:17 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:45 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FD51DD2F7\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.pyTestStorageCommonBlobAsynctest_blob_version_properties_versioning_enabled.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob_async.pyTestStorageCommonBlobAsynctest_blob_version_properties_versioning_enabled.json
@@ -1,0 +1,153 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainer7da93962?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:37:02 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:fdbe284c-701e-0048-1a28-433e4e000000\n",
+        "Time:2023-02-17T23:36:58.3990469Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainersource7da93962?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:37:02 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:fdbe2872-701e-0048-3b28-433e4e000000\n",
+        "Time:2023-02-17T23:36:58.4790008Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainer7da93962/utcontainer7da93962",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "3",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:37:02 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "kAFQmDzST7DWlj99KOF/cg==",
+        "Date": "Fri, 17 Feb 2023 23:36:58 GMT",
+        "ETag": "\u00220x8DB113FDCA21F61\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "6/rBP7vK5QU=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02",
+        "x-ms-version-id": "2023-02-17T23:36:58.5291377Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainer7da93962/utcontainer7da93962",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "6",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Fri, 17 Feb 2023 23:37:02 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": "YWJjYWJj",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "RArIWJLKQ60m1Ex62dR9Pg==",
+        "Date": "Fri, 17 Feb 2023 23:36:58 GMT",
+        "ETag": "\u00220x8DB113FDCA9E665\u0022",
+        "Last-Modified": "Fri, 17 Feb 2023 23:36:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "j5pW8UIQPR0=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-12-02",
+        "x-ms-version-id": "2023-02-17T23:36:58.5801077Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagenamestorname.blob.core.windows.net/utcontainer7da93962?restype=container\u0026comp=list\u0026include=versions",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-blob/12.15.0 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 17 Feb 2023 23:37:02 GMT",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 17 Feb 2023 23:36:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagenamestorname.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer7da93962\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eutcontainer7da93962\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:25:38.5178265Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:25:38 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:25:38 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113E4750C899\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainer7da93962\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:25:38.5697973Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:25:38 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:25:38 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113E47588FA5\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainer7da93962\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:36:58.5291377Z\u003C/VersionId\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:36:58 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:58 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FDCA21F61\u003C/Etag\u003E\u003CContent-Length\u003E3\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EkAFQmDzST7DWlj99KOF/cg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eutcontainer7da93962\u003C/Name\u003E\u003CVersionId\u003E2023-02-17T23:36:58.5801077Z\u003C/VersionId\u003E\u003CIsCurrentVersion\u003Etrue\u003C/IsCurrentVersion\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 17 Feb 2023 23:36:58 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 17 Feb 2023 23:36:58 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB113FDCA9E665\u003C/Etag\u003E\u003CContent-Length\u003E6\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ERArIWJLKQ60m1Ex62dR9Pg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -3283,4 +3283,63 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         assert props['content_settings'] is not None
         assert props['size'] == len(blob_data)
 
+    @BlobPreparer()
+    @recorded_by_proxy
+    def test_blob_version_properties_versioning_disabled(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+
+        blob_name = self.get_resource_name("utcontainer")
+        blob_data = 'abc'
+        blob_data2 = 'abcabc'
+
+        # Act
+        blob_client = self.bsc.get_blob_client(self.container_name, blob_name)
+        blob_client.upload_blob(blob_data, overwrite=True)
+
+        container_client = self.bsc.get_container_client(self.container_name)
+
+        # Assert
+        blobs = container_client.list_blobs(include=['versions'])
+        for blob in blobs:
+            if blob['size'] == len(blob_data):
+                assert blob['version_id'] is None
+                assert blob['is_current_version'] is None
+        blob_client.upload_blob(blob_data2, overwrite=True)
+        blobs = container_client.list_blobs(include=['versions'])
+        for blob in blobs:
+            if blob['size'] == len(blob_data2):
+                assert blob['version_id'] is None
+                assert blob['is_current_version'] is None
+
+    @BlobPreparer()
+    @recorded_by_proxy
+    def test_blob_version_properties_versioning_enabled(self, **kwargs):
+        versioned_storage_account_name = kwargs.pop("versioned_storage_account_name")
+        versioned_storage_account_key = kwargs.pop("versioned_storage_account_key")
+
+        self._setup(versioned_storage_account_name, versioned_storage_account_key)
+
+        blob_name = self.get_resource_name("utcontainer")
+        blob_data = 'abc'
+        blob_data2 = 'abcabc'
+
+        # Act
+        blob_client = self.bsc.get_blob_client(self.container_name, blob_name)
+        v1_props = blob_client.upload_blob(blob_data, overwrite=True)
+        v2_props = blob_client.upload_blob(blob_data2, overwrite=True)
+        container_client = self.bsc.get_container_client(self.container_name)
+
+        # Assert
+        blobs = container_client.list_blobs(include=['versions'])
+        for blob in blobs:
+            if blob['version_id'] == v1_props['version_id']:
+                assert blob['version_id'] is not None
+                assert blob['is_current_version'] is False
+            if blob['version_id'] == v2_props['version_id']:
+                assert blob['version_id'] is not None
+                assert blob['is_current_version'] is True
+
     # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR aims to improve `is_current_version` behavior to correctly show `False` if versioning is enabled and it is not the current version, `True` if versioning is enable and it **is** the current version, and `None` if versioning is disabled.