### PR TITLE
[Pipeline] optimize multiapi generation

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -33,15 +33,24 @@ def del_outdated_samples(readme: str):
     with open(python_readme, "r") as file_in:
         content = file_in.readlines()
     pattern = ["$(python-sdks-folder)", "azure-mgmt-"]
+    is_multiapi = "multiapi: true" in ("".join(content))
     for line in content:
         if all(p in line for p in pattern):
             sdk_folder = re.findall("[a-z]+/[a-z]+-[a-z]+-[a-z]+", line)[0]
+            # remove generated_samples
             sample_folder = Path(f"sdk/{sdk_folder}/generated_samples") 
             if sample_folder.exists():
                 shutil.rmtree(sample_folder)
                 _LOGGER.info(f"remove sample folder: {sample_folder}")
             else:
                 _LOGGER.info(f"sample folder does not exist: {sample_folder}")
+            # remove old generated SDK code
+            code_folder = Path("sdk") / sdk_folder
+            if is_multiapi and code_folder.exists():
+                shutil.rmtree(code_folder)
+                _LOGGER.info(f"remove code folder: {code_folder}")
+            else:
+                _LOGGER.info(f"code folder does not exist or it is not multiapi: {code_folder}")
             return
 
     _LOGGER.info(f"do not find {pattern} in {python_readme}")

--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -24,7 +24,7 @@ from .generate_utils import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def del_outdated_samples(readme: str):
+def del_outdated_folder(readme: str):
     python_readme = Path(readme).parent / "readme.python.md"
     if not python_readme.exists():
         _LOGGER.info(f"do not find python configuration: {python_readme}")
@@ -95,7 +95,7 @@ def main(generate_input, generate_output):
         is_cadl = False
         if "resource-manager" in input_readme:
             relative_path_readme = str(Path(spec_folder, input_readme))
-            del_outdated_samples(relative_path_readme)
+            del_outdated_folder(relative_path_readme)
             config = generate(
                 CONFIG_FILE,
                 sdk_folder,

--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -34,10 +34,11 @@ def del_outdated_samples(readme: str):
         content = file_in.readlines()
     pattern = ["$(python-sdks-folder)", "azure-mgmt-"]
     is_multiapi = "multiapi: true" in ("".join(content))
+    special_service = ["azure-mgmt-resource/"]
     for line in content:
         if all(p in line for p in pattern):
-            sdk_folder = re.findall("[a-z]+/[a-z]+-[a-z]+-[a-z]+", line)[0]
             # remove generated_samples
+            sdk_folder = re.findall("[a-z]+/[a-z]+-[a-z]+-[a-z]+", line)[0]
             sample_folder = Path(f"sdk/{sdk_folder}/generated_samples") 
             if sample_folder.exists():
                 shutil.rmtree(sample_folder)
@@ -45,9 +46,15 @@ def del_outdated_samples(readme: str):
             else:
                 _LOGGER.info(f"sample folder does not exist: {sample_folder}")
             # remove old generated SDK code
-            code_folder = Path("sdk") / sdk_folder
+            sdk_folder = re.findall("[a-z]+/[a-z]+-[a-z]+-[a-z]+/[a-z]+/[a-z]+/[a-z]+", line)[0]
+            code_folder = Path(f"sdk/{sdk_folder}") 
             if is_multiapi and code_folder.exists():
-                shutil.rmtree(code_folder)
+                if any(item in str(sdk_folder) for item in special_service):
+                    for folder in code_folder.iterdir():
+                        if folder.is_dir():
+                            shutil.rmtree(folder)
+                else:
+                    shutil.rmtree(code_folder)
                 _LOGGER.info(f"remove code folder: {code_folder}")
             else:
                 _LOGGER.info(f"code folder does not exist or it is not multiapi: {code_folder}")


### PR DESCRIPTION
when generating multiapi package, autorest.python can't remove old folder which result in genreation failure in pipeline: https://github.com/Azure/azure-rest-api-specs/pull/22639. So we have to delete old folder in pipeline before generation.