### PR TITLE
[Key Vault] Correct type hints for `cer` attributes

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- The type hints for `KeyVaultCertificate.cer` and `DeletedCertificate.cer` are now
+  `Optional[bytearray]` instead of `Optional[bytes]`
+  ([#28959](https://github.com/Azure/azure-sdk-for-python/issues/28959))
 
 ### Other Changes
 - Updated minimum `azure-core` version to 1.24.0

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -278,14 +278,14 @@ class KeyVaultCertificate(object):
     :param properties: The certificate's properties.
     :type properties: ~azure.keyvault.certificates.CertificateProperties or None
     :param cer: CER contents of the X509 certificate.
-    :type cer: bytes or None
+    :type cer: bytearray or None
     """
 
     def __init__(
         self,
         policy: "Optional[CertificatePolicy]" = None,
         properties: "Optional[CertificateProperties]" = None,
-        cer: "Optional[bytes]" = None,
+        cer: "Optional[bytearray]" = None,
         **kwargs,
     ) -> None:
         self._properties = properties
@@ -312,7 +312,7 @@ class KeyVaultCertificate(object):
             key_id=certificate_bundle.kid,
             secret_id=certificate_bundle.sid,
             policy=policy,
-            cer=certificate_bundle.cer,
+            cer=certificate_bundle.cer,  # type: ignore
         )
 
     @property
@@ -364,10 +364,10 @@ class KeyVaultCertificate(object):
         return self._policy
 
     @property
-    def cer(self) -> "Optional[bytes]":
+    def cer(self) -> "Optional[bytearray]":
         """The CER contents of the certificate.
 
-        :rtype: bytes or None
+        :rtype: bytearray or None
         """
         return self._cer
 
@@ -1280,7 +1280,7 @@ class DeletedCertificate(KeyVaultCertificate):
     :param policy: The management policy of the deleted certificate.
     :type policy: ~azure.keyvault.certificates.CertificatePolicy or None
     :param cer: CER contents of the X509 certificate.
-    :type cer: bytes or None
+    :type cer: bytearray or None
     :param deleted_on: The time when the certificate was deleted, in UTC.
     :type deleted_on: ~datetime.datetime or None
     :param recovery_id: The url of the recovery object, used to identify and recover the deleted certificate.
@@ -1293,7 +1293,7 @@ class DeletedCertificate(KeyVaultCertificate):
         self,
         properties: "Optional[CertificateProperties]" = None,
         policy: "Optional[CertificatePolicy]" = None,
-        cer: "Optional[bytes]" = None,
+        cer: "Optional[bytearray]" = None,
         **kwargs,
     ) -> None:
         super(DeletedCertificate, self).__init__(properties=properties, policy=policy, cer=cer, **kwargs)
@@ -1333,7 +1333,7 @@ class DeletedCertificate(KeyVaultCertificate):
             key_id=deleted_certificate_bundle.kid,
             secret_id=deleted_certificate_bundle.sid,
             policy=CertificatePolicy._from_certificate_policy_bundle(deleted_certificate_bundle.policy),
-            cer=deleted_certificate_bundle.cer,
+            cer=deleted_certificate_bundle.cer,  # type: ignore
             deleted_on=deleted_certificate_bundle.deleted_date,
             recovery_id=deleted_certificate_bundle.recovery_id,
             scheduled_purge_date=deleted_certificate_bundle.scheduled_purge_date,


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/28959. `cer` attributes on KeyVaultCertificates (and subclasses) have been typed as `bytes`, but are actually `bytearray`s. Looking at our generated code, the type hint was probably incorrect because the generated CertificateBundle model actually has the incorrect `bytes` type itself: https://github.com/Azure/azure-sdk-for-python/blob/cfcfb0fa04b79f4d0edbe130c664292ce98091ae/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_generated_models.py#L243-L244

Funnily enough, though, the implementation does show the correct `bytearray` type within the same class: https://github.com/Azure/azure-sdk-for-python/blob/cfcfb0fa04b79f4d0edbe130c664292ce98091ae/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_generated_models.py#L267

It might be worth looking into why that discrepancy came up at all, but for now this PR just fixes the error in our handwritten types.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
