### PR TITLE
[Storage] Fix duplicate type annotations

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -86,7 +86,6 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
         credential: Optional[Union[str, Dict[str, str], "AzureNamedKeyCredential", "AzureSasCredential", "TokenCredential"]] = None,  # pylint: disable=line-too-long
         **kwargs: Any
     ) -> None:
-        # type: (...) -> None
         kwargs['retry_policy'] = kwargs.get('retry_policy') or ExponentialRetry(**kwargs)
         super(FileSystemClient, self).__init__(
             account_url,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -182,7 +182,7 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @classmethod
     def from_file_url(
-            cls, file_url: str,  # type: str
+            cls, file_url: str,
             snapshot: Optional[Union[str, Dict[str, Any]]] = None,
             credential: Optional[Union[str, Dict[str, str], "AzureNamedKeyCredential", "AzureSasCredential", "TokenCredential"]] = None,  # pylint: disable=line-too-long
             **kwargs: Any


### PR DESCRIPTION
This fixes duplicate type annotations found in the following packages:

- `azure-storage-file-datalake`
- `azure-storage-file-share`