### PR TITLE
Add an option to support creating automatic APIreview from manual pipe…

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -61,7 +61,7 @@ parameters:
   - name: TestProxy
     type: boolean
     default: false
-  - name: SkipScheduledApiReviewGen
+  - name: GenerateApiReviewForManualOnly
     type: boolean
     default: false
 
@@ -135,7 +135,7 @@ jobs:
         Artifacts: ${{ parameters.Artifacts }}
         VerifyAutorest: ${{ parameters.VerifyAutorest }}
         ValidateFormatting: ${{ parameters.ValidateFormatting }}
-        SkipScheduledApiReviewGen: ${{ parameters.SkipScheduledApiReviewGen }}
+        GenerateApiReviewForManualOnly: ${{ parameters.GenerateApiReviewForManualOnly }}
 
   - job: Compliance
     pool:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -61,6 +61,9 @@ parameters:
   - name: TestProxy
     type: boolean
     default: false
+  - name: SkipScheduledApiReviewGen
+    type: boolean
+    default: false
 
 jobs:
   - job: 'Build'
@@ -132,6 +135,7 @@ jobs:
         Artifacts: ${{ parameters.Artifacts }}
         VerifyAutorest: ${{ parameters.VerifyAutorest }}
         ValidateFormatting: ${{ parameters.ValidateFormatting }}
+        SkipScheduledApiReviewGen: ${{ parameters.SkipScheduledApiReviewGen }}
 
   - job: Compliance
     pool:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -72,7 +72,7 @@ parameters:
 - name: TestProxy
   type: boolean
   default: false
-- name: SkipScheduledApiReviewGen
+- name: GenerateApiReviewForManualOnly
   type: boolean
   default: false
 
@@ -109,7 +109,7 @@ stages:
         VerifyAutorest: ${{ parameters.VerifyAutorest }}
         ValidateFormatting: ${{ parameters.ValidateFormatting }}
         TestProxy: ${{ parameters.TestProxy }}
-        SkipScheduledApiReviewGen: ${{ parameters.SkipScheduledApiReviewGen }}
+        GenerateApiReviewForManualOnly: ${{ parameters.GenerateApiReviewForManualOnly }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -72,6 +72,9 @@ parameters:
 - name: TestProxy
   type: boolean
   default: false
+- name: SkipScheduledApiReviewGen
+  type: boolean
+  default: false
 
 variables:
   - template: /eng/pipelines/templates/variables/globals.yml
@@ -106,6 +109,7 @@ stages:
         VerifyAutorest: ${{ parameters.VerifyAutorest }}
         ValidateFormatting: ${{ parameters.ValidateFormatting }}
         TestProxy: ${{ parameters.TestProxy }}
+        SkipScheduledApiReviewGen: ${{ parameters.SkipScheduledApiReviewGen }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -6,6 +6,7 @@ parameters:
   TestPipeline: false
   VerifyAutorest: false
   ValidateFormatting: false
+  SkipScheduledApiReviewGen: false
 
 # The variable TargetingString is set by template `eng/pipelines/templates/steps/targeting-string-resolve.yml`. This template is invoked from yml files:
 #     eng/pipelines/templates/jobs/ci.tests.yml
@@ -140,6 +141,7 @@ steps:
   - template: /eng/pipelines/templates/steps/create-apireview.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
+      SkipScheduledApiReviewGen: ${{ parameters.SkipScheduledApiReviewGen }}
 
   - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
     parameters:

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -6,7 +6,7 @@ parameters:
   TestPipeline: false
   VerifyAutorest: false
   ValidateFormatting: false
-  SkipScheduledApiReviewGen: false
+  GenerateApiReviewForManualOnly: false
 
 # The variable TargetingString is set by template `eng/pipelines/templates/steps/targeting-string-resolve.yml`. This template is invoked from yml files:
 #     eng/pipelines/templates/jobs/ci.tests.yml
@@ -141,7 +141,7 @@ steps:
   - template: /eng/pipelines/templates/steps/create-apireview.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
-      SkipScheduledApiReviewGen: ${{ parameters.SkipScheduledApiReviewGen }}
+      GenerateApiReviewForManualOnly: ${{ parameters.GenerateApiReviewForManualOnly }}
 
   - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
     parameters:

--- a/eng/pipelines/templates/steps/create-apireview.yml
+++ b/eng/pipelines/templates/steps/create-apireview.yml
@@ -4,16 +4,17 @@ parameters:
   ConfigFileDir: $(Build.ArtifactStagingDirectory)/PackageInfo
   Language: 'Python'
   APIViewUri: 'https://apiview.dev/AutoReview/CreateApiReview'
-  SkipScheduledApiReviewGen: false
+  GenerateApiReviewForManualOnly: false
 
 steps:
   # ideally this should be done as initial step of a job in caller template
   # We can remove this step later once it is added in caller
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
  
-  # Run Automatic API review step only for manually running pipeline if a pipeline has paramter to disable API review gen from scheduled run
-  # Otherwise generate API review for all type of pipeline run and this is the default case.
-  - ${{ if or(eq(variables['Build.Reason'], 'Manual'), eq(parameters.SkipScheduledApiReviewGen, false)) }}:
+  # Automatic API review is generated for a package when pipeline runs irrespective of how pipeline gets triggered.
+  # One excpetion to this case is Python Azure ML package. Azure ML does not want API reviews to be created by scheduled and individual CI runs.
+  # Below condition ensures that API review is generated only for manual pipeline runs when flag GenerateApiReviewForManualOnly is set to true. 
+  - ${{ if or(ne(parameters.GenerateApiReviewForManualOnly, true), eq(variables['Build.Reason'], 'Manual')) }}:
     - task: Powershell@2
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/scripts/Create-ApiReview.ps1

--- a/eng/pipelines/templates/steps/create-apireview.yml
+++ b/eng/pipelines/templates/steps/create-apireview.yml
@@ -10,28 +10,29 @@ steps:
   # We can remove this step later once it is added in caller
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
 
-  - task: Powershell@2
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/scripts/Create-ApiReview.ps1
-      arguments: >
-        -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name)
-        -ArtifactPath ${{ parameters.ArtifactPath }}
-        -APIViewUri ${{ parameters.APIViewUri }}
-        -APIKey $(azuresdk-apiview-apikey)
-        -SourceBranch $(Build.SourceBranchName)
-        -DefaultBranch $(DefaultBranch)
-        -ConfigFileDir '${{ parameters.ConfigFileDir }}'
-        -BuildId $(Build.BuildId)
-        -RepoName $(Build.Repository.Name)
-        -Language ${{ parameters.Language }}
-      pwsh: true
-      workingDirectory: $(Pipeline.Workspace)
-    displayName: Create Automatic API Review
-    condition: >-
-      and(
-        succeededOrFailed(),
-        ne(variables['Skip.CreateApiReview'], 'true'),
-        ne(variables['Build.Reason'],'PullRequest'),
-        eq(variables['System.TeamProject'], 'internal'),
-        not(endsWith(variables['Build.Repository.Name'], '-pr'))
-      )
+  - ${{ if or(ne(variables['Skip.ScheduledApiReview'], 'true') ,eq(variables['Build.Reason'], 'Manual')) }}:
+    - task: Powershell@2
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/scripts/Create-ApiReview.ps1
+        arguments: >
+          -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name)
+          -ArtifactPath ${{ parameters.ArtifactPath }}
+          -APIViewUri ${{ parameters.APIViewUri }}
+          -APIKey $(azuresdk-apiview-apikey)
+          -SourceBranch $(Build.SourceBranchName)
+          -DefaultBranch $(DefaultBranch)
+          -ConfigFileDir '${{ parameters.ConfigFileDir }}'
+          -BuildId $(Build.BuildId)
+          -RepoName $(Build.Repository.Name)
+          -Language ${{ parameters.Language }}
+        pwsh: true
+        workingDirectory: $(Pipeline.Workspace)
+      displayName: Create Automatic API Review
+      condition: >-
+        and(
+          succeededOrFailed(),
+          ne(variables['Skip.CreateApiReview'], 'true'),
+          ne(variables['Build.Reason'],'PullRequest'),
+          eq(variables['System.TeamProject'], 'internal'),
+          not(endsWith(variables['Build.Repository.Name'], '-pr'))
+        )

--- a/eng/pipelines/templates/steps/create-apireview.yml
+++ b/eng/pipelines/templates/steps/create-apireview.yml
@@ -4,13 +4,16 @@ parameters:
   ConfigFileDir: $(Build.ArtifactStagingDirectory)/PackageInfo
   Language: 'Python'
   APIViewUri: 'https://apiview.dev/AutoReview/CreateApiReview'
+  SkipScheduledApiReviewGen: false
 
 steps:
   # ideally this should be done as initial step of a job in caller template
   # We can remove this step later once it is added in caller
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-
-  - ${{ if or(ne(variables['Skip.ScheduledApiReview'], 'true') ,eq(variables['Build.Reason'], 'Manual')) }}:
+ 
+  # Run Automatic API review step only for manually running pipeline if a pipeline has paramter to disable API review gen from scheduled run
+  # Otherwise generate API review for all type of pipeline run and this is the default case.
+  - ${{ if or(eq(variables['Build.Reason'], 'Manual'), eq(parameters.SkipScheduledApiReviewGen, false)) }}:
     - task: Powershell@2
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/scripts/Create-ApiReview.ps1

--- a/eng/pipelines/templates/steps/create-apireview.yml
+++ b/eng/pipelines/templates/steps/create-apireview.yml
@@ -12,7 +12,6 @@ steps:
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
  
   # Automatic API review is generated for a package when pipeline runs irrespective of how pipeline gets triggered.
-  # One excpetion to this case is Python Azure ML package. Azure ML does not want API reviews to be created by scheduled and individual CI runs.
   # Below condition ensures that API review is generated only for manual pipeline runs when flag GenerateApiReviewForManualOnly is set to true. 
   - ${{ if or(ne(parameters.GenerateApiReviewForManualOnly, true), eq(variables['Build.Reason'], 'Manual')) }}:
     - task: Powershell@2

--- a/sdk/ml/ci.yml
+++ b/sdk/ml/ci.yml
@@ -32,6 +32,7 @@ extends:
     TestProxy: true
     # This is a short term solution to create API review for python azure-ml package only when running pipeline manually
     # Long term solution should be to have different versions on main branch and release branch for python package so APIView can have different revisions for each version.
+    # Tracking issue: https://github.com/Azure/azure-sdk-for-python/issues/29196
     GenerateApiReviewForManualOnly: true
     Artifacts:
     - name: azure-ai-ml

--- a/sdk/ml/ci.yml
+++ b/sdk/ml/ci.yml
@@ -24,6 +24,9 @@ pr:
     include:
     - sdk/ml/
 
+variables:
+  Skip.ScheduledApiReview: 'true'
+
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:

--- a/sdk/ml/ci.yml
+++ b/sdk/ml/ci.yml
@@ -30,7 +30,9 @@ extends:
     ServiceDirectory: ml
     ValidateFormatting: true
     TestProxy: true
-    SkipScheduledApiReviewGen: true
+    # This is a short term solution to create API review for python azure-ml package only when running pipeline manually
+    # Long term solution should be to have different versions on main branch and release branch for python package so APIView can have different revisions for each version.
+    GenerateApiReviewForManualOnly: true
     Artifacts:
     - name: azure-ai-ml
       safeName: azureaiml

--- a/sdk/ml/ci.yml
+++ b/sdk/ml/ci.yml
@@ -24,15 +24,13 @@ pr:
     include:
     - sdk/ml/
 
-variables:
-  Skip.ScheduledApiReview: 'true'
-
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: ml
     ValidateFormatting: true
     TestProxy: true
+    SkipScheduledApiReviewGen: true
     Artifacts:
     - name: azure-ai-ml
       safeName: azureaiml


### PR DESCRIPTION
…line run only

This PR is to support python azure-ml team to create automatic API review only from release pipeline instead of creating it by scheduled run since scheduled run always create API review from main branch and manual one creates from the branch it's triggered against.