### PR TITLE
Apply black so that core CI will continue to be green

### DIFF
--- a/sdk/core/azure-core/azure/core/_pipeline_client_async.py
+++ b/sdk/core/azure-core/azure/core/_pipeline_client_async.py
@@ -182,14 +182,8 @@ class AsyncPipelineClient(
     async def close(self):
         await self._pipeline.__aexit__()
 
-    def _build_pipeline(    # pylint: disable=no-self-use
-        self,
-        config: Configuration,
-        *,
-        policies=None,
-        per_call_policies=None,
-        per_retry_policies=None,
-        **kwargs
+    def _build_pipeline(  # pylint: disable=no-self-use
+        self, config: Configuration, *, policies=None, per_call_policies=None, per_retry_policies=None, **kwargs
     ) -> AsyncPipeline[HTTPRequestType, AsyncHTTPResponseType]:
         transport = kwargs.get("transport")
         per_call_policies = per_call_policies or []
@@ -259,13 +253,9 @@ class AsyncPipelineClient(
 
             transport = AioHttpTransport(**kwargs)
 
-        return AsyncPipeline[HTTPRequestType, AsyncHTTPResponseType](
-            transport, policies
-        )
+        return AsyncPipeline[HTTPRequestType, AsyncHTTPResponseType](transport, policies)
 
-    async def _make_pipeline_call(
-        self, request: HTTPRequestType, **kwargs
-    ) -> AsyncHTTPResponseType:
+    async def _make_pipeline_call(self, request: HTTPRequestType, **kwargs) -> AsyncHTTPResponseType:
         return_pipeline_response = kwargs.pop("_return_pipeline_response", False)
         pipeline_response = await self._pipeline.run(request, **kwargs)  # pylint: disable=protected-access
         if return_pipeline_response:

--- a/sdk/core/azure-core/azure/core/pipeline/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base.py
@@ -53,15 +53,11 @@ class _SansIOHTTPPolicyRunner(HTTPPolicy[HTTPRequestType, HTTPResponseType]):
     :type policy: ~azure.core.pipeline.policies.SansIOHTTPPolicy
     """
 
-    def __init__(
-        self, policy: SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]
-    ) -> None:
+    def __init__(self, policy: SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]) -> None:
         super(_SansIOHTTPPolicyRunner, self).__init__()
         self._policy = policy
 
-    def send(
-        self, request: PipelineRequest[HTTPRequestType]
-    ) -> PipelineResponse[HTTPRequestType, HTTPResponseType]:
+    def send(self, request: PipelineRequest[HTTPRequestType]) -> PipelineResponse[HTTPRequestType, HTTPResponseType]:
         """Modifies the request and sends to the next policy in the chain.
 
         :param request: The PipelineRequest object.
@@ -88,15 +84,11 @@ class _TransportRunner(HTTPPolicy[HTTPRequestType, HTTPResponseType]):
     :param sender: The Http Transport instance.
     """
 
-    def __init__(
-        self, sender: HttpTransport[HTTPRequestType, HTTPResponseType]
-    ) -> None:
+    def __init__(self, sender: HttpTransport[HTTPRequestType, HTTPResponseType]) -> None:
         super(_TransportRunner, self).__init__()
         self._sender = sender
 
-    def send(
-        self, request: PipelineRequest[HTTPRequestType]
-    ) -> PipelineResponse[HTTPRequestType, HTTPResponseType]:
+    def send(self, request: PipelineRequest[HTTPRequestType]) -> PipelineResponse[HTTPRequestType, HTTPResponseType]:
         """HTTP transport send method.
 
         :param request: The PipelineRequest object.
@@ -195,9 +187,7 @@ class Pipeline(AbstractContextManager, Generic[HTTPRequestType, HTTPResponseType
         self._prepare_multipart_mixed_request(request)
         request.prepare_multipart_body()  # type: ignore
 
-    def run(
-        self, request: HTTPRequestType, **kwargs: Any
-    ) -> PipelineResponse[HTTPRequestType, HTTPResponseType]:
+    def run(self, request: HTTPRequestType, **kwargs: Any) -> PipelineResponse[HTTPRequestType, HTTPResponseType]:
         """Runs the HTTP Request through the chained policies.
 
         :param request: The HTTP request object.
@@ -207,12 +197,6 @@ class Pipeline(AbstractContextManager, Generic[HTTPRequestType, HTTPResponseType
         """
         self._prepare_multipart(request)
         context = PipelineContext(self._transport, **kwargs)
-        pipeline_request: PipelineRequest[HTTPRequestType] = PipelineRequest(
-            request, context
-        )
-        first_node = (
-            self._impl_policies[0]
-            if self._impl_policies
-            else _TransportRunner(self._transport)
-        )
+        pipeline_request: PipelineRequest[HTTPRequestType] = PipelineRequest(request, context)
+        first_node = self._impl_policies[0] if self._impl_policies else _TransportRunner(self._transport)
         return first_node.send(pipeline_request)

--- a/sdk/core/azure-core/azure/core/pipeline/_base_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base_async.py
@@ -50,9 +50,7 @@ class _SansIOAsyncHTTPPolicyRunner(
     :type policy: ~azure.core.pipeline.policies.SansIOHTTPPolicy
     """
 
-    def __init__(
-        self, policy: SansIOHTTPPolicy[HTTPRequestType, AsyncHTTPResponseType]
-    ) -> None:
+    def __init__(self, policy: SansIOHTTPPolicy[HTTPRequestType, AsyncHTTPResponseType]) -> None:
         super(_SansIOAsyncHTTPPolicyRunner, self).__init__()
         self._policy = policy
 
@@ -88,9 +86,7 @@ class _AsyncTransportRunner(
     :param sender: The async Http Transport instance.
     """
 
-    def __init__(
-        self, sender: AsyncHttpTransport[HTTPRequestType, AsyncHTTPResponseType]
-    ) -> None:
+    def __init__(self, sender: AsyncHttpTransport[HTTPRequestType, AsyncHTTPResponseType]) -> None:
         super(_AsyncTransportRunner, self).__init__()
         self._sender = sender
 
@@ -135,9 +131,7 @@ class AsyncPipeline(AbstractAsyncContextManager, Generic[HTTPRequestType, AsyncH
         transport: AsyncHttpTransport[HTTPRequestType, AsyncHTTPResponseType],
         policies: Optional[AsyncPoliciesType] = None,
     ) -> None:
-        self._impl_policies: List[
-            AsyncHTTPPolicy[HTTPRequestType, AsyncHTTPResponseType]
-        ] = []
+        self._impl_policies: List[AsyncHTTPPolicy[HTTPRequestType, AsyncHTTPResponseType]] = []
         self._transport = transport
 
         for policy in policies or []:

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -311,9 +311,7 @@ class AioHttpStreamDownloadGenerator(AsyncIterator):
                 if not self._decompressor:
                     import zlib
 
-                    zlib_mode = (
-                        (16 + zlib.MAX_WBITS) if enc == "gzip" else -zlib.MAX_WBITS
-                    )
+                    zlib_mode = (16 + zlib.MAX_WBITS) if enc == "gzip" else -zlib.MAX_WBITS
                     self._decompressor = zlib.decompressobj(wbits=zlib_mode)
                 chunk = self._decompressor.decompress(chunk)
             return chunk


### PR DESCRIPTION
Hey @xiangyan99 [this pr](https://github.com/Azure/azure-sdk-for-python/pull/28538) was merged with a failing formatting check.

After that PR merged, all `core` ci turned red. This PR just resolves that issue.

