### PR TITLE
[TA] revert max_sentence_count -> sentence_count service naming

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -15,7 +15,6 @@ This version of the client library defaults to the service API version `2022-10-
 - Renamed property `date_time_sub_kind` to `datetime_subkind` on `DateTimeResolution`.
 - Renamed model `AbstractSummaryAction` to `AbstractiveSummaryAction`.
 - Renamed model `AbstractSummaryResult` to `AbstractiveSummaryResult`.
-- Renamed keyword argument `sentence_count` to `max_sentence_count` on `AbstractiveSummaryAction`.
 - Changed automatic language detection, it is now controlled by the boolean keyword argument `auto_detect_language`.
   Pass `True` to enable automatic language detection for text documents analyzed by long-running operation APIs.
 - Removed keyword argument `autodetect_default_language` - use `language` to provide a default/fallback language.

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -3022,7 +3022,7 @@ class AbstractiveSummaryAction(DictMixin):
     .. note:: The abstractive summarization feature is part of a gated preview. Request access here:
         https://aka.ms/applyforgatedsummarizationfeatures
 
-    :keyword Optional[int] max_sentence_count: It controls the approximate number of sentences in the output summaries.
+    :keyword Optional[int] sentence_count: It controls the approximate number of sentences in the output summaries.
     :keyword Optional[str] model_version: The model version to use for the analysis.
     :keyword Optional[str] string_index_type: Specifies the method used to interpret string offsets.
         `UnicodeCodePoint`, the Python encoding, is the default. To override the Python default,
@@ -3041,7 +3041,7 @@ class AbstractiveSummaryAction(DictMixin):
         The *AbstractiveSummaryAction* model.
     """
 
-    max_sentence_count: Optional[int] = None
+    sentence_count: Optional[int] = None
     """It controls the approximate number of sentences in the output summaries."""
     model_version: Optional[str] = None
     """The model version to use for the analysis."""
@@ -3063,13 +3063,13 @@ class AbstractiveSummaryAction(DictMixin):
     def __init__(
         self,
         *,
-        max_sentence_count: Optional[int] = None,
+        sentence_count: Optional[int] = None,
         model_version: Optional[str] = None,
         string_index_type: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         **kwargs: Any
     ) -> None:
-        self.max_sentence_count = max_sentence_count
+        self.sentence_count = sentence_count
         self.model_version = model_version
         self.string_index_type: str = string_index_type if string_index_type is not None else STRING_INDEX_TYPE_DEFAULT
         self.disable_service_logs = disable_service_logs
@@ -3078,7 +3078,7 @@ class AbstractiveSummaryAction(DictMixin):
         return (
             f"AbstractiveSummaryAction(model_version={self.model_version}, "
             f"string_index_type={self.string_index_type}, disable_service_logs={self.disable_service_logs}, "
-            f"max_sentence_count={self.max_sentence_count})"[:1024]
+            f"sentence_count={self.sentence_count})"[:1024]
         )
 
     def _to_generated(self, api_version, task_id):  # pylint: disable=unused-argument
@@ -3088,7 +3088,7 @@ class AbstractiveSummaryAction(DictMixin):
                 model_version=self.model_version,
                 string_index_type=string_index_type_compatibility(self.string_index_type),
                 logging_opt_out=self.disable_service_logs,
-                sentence_count=self.max_sentence_count,
+                sentence_count=self.sentence_count,
             )
         )
 

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -2025,7 +2025,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         show_stats: Optional[bool] = None,
         model_version: Optional[str] = None,
         string_index_type: Optional[str] = None,
-        max_sentence_count: Optional[int] = None,
+        sentence_count: Optional[int] = None,
         **kwargs: Any,
     ) -> TextAnalysisLROPoller[ItemPaged[Union[AbstractiveSummaryResult, DocumentError]]]:
         """Start a long-running abstractive summarization operation.
@@ -2053,7 +2053,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             Optionally use the `language` keyword argument to provide a default/fallback language
             to use for the batch in the event that the service is unable to detect the language.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
-        :keyword Optional[int] max_sentence_count: Maximum number of sentences to return. Defaults to 3.
+        :keyword Optional[int] sentence_count: It controls the approximate number of sentences in the output summaries.
         :keyword Optional[str] model_version: The model version to use for the analysis.
         :keyword Optional[str] string_index_type: Specifies the method used to interpret string offsets.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
@@ -2124,7 +2124,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         AbstractiveSummaryAction(
                             model_version=model_version,
                             string_index_type=string_index_type_arg,
-                            max_sentence_count=max_sentence_count,
+                            sentence_count=sentence_count,
                             disable_service_logs=disable_service_logs,
                         )
                     ],

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -2021,7 +2021,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         show_stats: Optional[bool] = None,
         model_version: Optional[str] = None,
         string_index_type: Optional[str] = None,
-        max_sentence_count: Optional[int] = None,
+        sentence_count: Optional[int] = None,
         **kwargs: Any,
     ) -> AsyncTextAnalysisLROPoller[AsyncItemPaged[Union[AbstractiveSummaryResult, DocumentError]]]:
         """Start a long-running abstractive summarization operation.
@@ -2049,7 +2049,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             Optionally use the `language` keyword argument to provide a default/fallback language
             to use for the batch in the event that the service is unable to detect the language.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
-        :keyword Optional[int] max_sentence_count: Maximum number of sentences to return. Defaults to 3.
+        :keyword Optional[int] sentence_count: It controls the approximate number of sentences in the output summaries.
         :keyword Optional[str] model_version: The model version to use for the analysis.
         :keyword Optional[str] string_index_type: Specifies the method used to interpret string offsets.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
@@ -2120,7 +2120,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         AbstractiveSummaryAction(
                             model_version=model_version,
                             string_index_type=string_index_type_arg,
-                            max_sentence_count=max_sentence_count,
+                            sentence_count=sentence_count,
                             disable_service_logs=disable_service_logs,
                         )
                     ],

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_summarization.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_summarization.py
@@ -176,7 +176,7 @@ class TestSummarization(TextAnalyticsTest):
 
         response = client.begin_abstractive_summary(
             docs,
-            max_sentence_count=5,
+            sentence_count=5,
             show_stats=True,
             polling_interval=self._interval(),
         ).result()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_summarization_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_summarization_async.py
@@ -173,7 +173,7 @@ class TestSummarization(TextAnalyticsTest):
 
         response = await (await client.begin_abstractive_summary(
             docs,
-            max_sentence_count=5,
+            sentence_count=5,
             show_stats=True,
             polling_interval=self._interval(),
         )).result()


### PR DESCRIPTION
We learned that max_sentence_count is appropriate for extractive summarization, but not abstractive summarization where this is more of an approximate count. Reverts back to service naming and what we released previously.