### PR TITLE
[Storage] Document `correlation_id` in blob endpoint delegation SAS

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -457,6 +457,9 @@ def generate_container_sas(
         using this shared access signature.
     :keyword str encryption_scope:
         Specifies the encryption scope for a request made so that all write operations will be service encrypted.
+    :keyword str correlation_id:
+        The correlation id to correlate the storage audit logs with the audit logs used by the principal
+        generating and distributing the SAS. This can only be used when to generate sas with delegation key.
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -581,6 +584,9 @@ def generate_blob_sas(
         using this shared access signature.
     :keyword str encryption_scope:
         Specifies the encryption scope for a request made so that all write operations will be service encrypted.
+    :keyword str correlation_id:
+        The correlation id to correlate the storage audit logs with the audit logs used by the principal
+        generating and distributing the SAS. This can only be used when to generate sas with delegation key.
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """


### PR DESCRIPTION
This PR addresses a gap in documentation discovered while investigating #28995 