### PR TITLE
appending endpoint,deployment and collection name to destination path

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -350,14 +350,17 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
     def _register_collection_data_assets(self, deployment: OnlineDeployment) -> None:
         for collection in deployment.data_collector.collections:
             data_name = f"{deployment.endpoint_name}-{deployment.name}-{collection}"
+            short_form_path = (
+                f"{deployment.data_collector.destination.path}/{deployment.endpoint_name}/{deployment.name}/{collection}"  # pylint: disable=line-too-long
+                if deployment.data_collector.destination and deployment.data_collector.destination.path
+                else f"{DEFAULT_MDC_PATH}/{deployment.endpoint_name}/{deployment.name}/{collection}"
+            )
             data_object = Data(
                 name=data_name,
-                path=deployment.data_collector.destination.path
-                if deployment.data_collector.destination and deployment.data_collector.destination.path
-                else f"{DEFAULT_MDC_PATH}/{deployment.endpoint_name}/{deployment.name}/{collection}",
+                path=short_form_path,
                 is_anonymous=True,
             )
             result = self._all_operations._all_operations[AzureMLResourceType.DATA].create_or_update(data_object)
             deployment.data_collector.collections[collection].data = DataAsset(
-                data_id=result.id, path=result.path, name=result.name, version=result.version
+                path=short_form_path, name=result.name, version=result.version
             )


### PR DESCRIPTION
# Description

Online Deployment MDC feature will pass in the short form path to each collection in order to avoid hitting the tag value length constraint. Data_id attribute was also removed from the data_asset object. UI will use the data name and version to locate the data asset. 

[Bug 2256212](https://msdata.visualstudio.com/DefaultCollection/Vienna/_workitems/edit/2256212): [SDK] Fixing mdc character limit constraint

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ x There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
