### PR TITLE
[Internal Component] Skip verifying existing docker files after environment is resolved

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
@@ -77,7 +77,7 @@ class InternalEnvironment:
         dockerfile_file = self.docker[self.BUILD][self.DOCKERFILE]
         dockerfile_file = self._parse_file_path(dockerfile_file)
         if (
-            not self._docker_file_resolve
+            not self._docker_file_resolved
             and not skip_path_validation
             and not (Path(base_path) / dockerfile_file).is_file()
         ):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
@@ -76,7 +76,11 @@ class InternalEnvironment:
             return validation_result
         dockerfile_file = self.docker[self.BUILD][self.DOCKERFILE]
         dockerfile_file = self._parse_file_path(dockerfile_file)
-        if not self._docker_file_resolved and not skip_path_validation and not (Path(base_path) / dockerfile_file).is_file():
+        if (
+            not self._docker_file_resolve
+            and not skip_path_validation
+            and not (Path(base_path) / dockerfile_file).is_file()
+        ):
             validation_result.append_error(
                 yaml_path=f"docker.{self.BUILD}.{self.DOCKERFILE}",
                 message=f"Dockerfile not exists: {dockerfile_file}",

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
@@ -30,11 +30,13 @@ class InternalEnvironment:
         python: Optional[Dict] = None,
     ):
         self.docker = docker
+        print("Init: ", self.docker)
         self.conda = conda
         self.os = os if os else "Linux"
         self.name = name
         self.version = version
         self.python = python
+        self._docker_file_resolved = False
 
     @staticmethod
     def _parse_file_path(value: str) -> str:
@@ -75,7 +77,7 @@ class InternalEnvironment:
             return validation_result
         dockerfile_file = self.docker[self.BUILD][self.DOCKERFILE]
         dockerfile_file = self._parse_file_path(dockerfile_file)
-        if not skip_path_validation and not (Path(base_path) / dockerfile_file).is_file():
+        if not self._docker_file_resolved and not skip_path_validation and not (Path(base_path) / dockerfile_file).is_file():
             validation_result.append_error(
                 yaml_path=f"docker.{self.BUILD}.{self.DOCKERFILE}",
                 message=f"Dockerfile not exists: {dockerfile_file}",
@@ -128,6 +130,7 @@ class InternalEnvironment:
         dockerfile_file = self._parse_file_path(dockerfile_file)
         with open(Path(base_path) / dockerfile_file, "r") as f:
             self.docker[self.BUILD][self.DOCKERFILE] = f.read()
+            self._docker_file_resolved = True
         return
 
     def resolve(self, base_path: Union[Path, str]) -> None:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
@@ -30,7 +30,6 @@ class InternalEnvironment:
         python: Optional[Dict] = None,
     ):
         self.docker = docker
-        print("Init: ", self.docker)
         self.conda = conda
         self.os = os if os else "Linux"
         self.name = name

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -334,6 +334,7 @@ class TestComponent:
         component.environment.resolve(component._base_path)
         rest_obj = component._to_rest_object()
         assert rest_obj.properties.component_spec["environment"] == expected_dict
+        assert component.environment._validate_docker_section(base_path=component.base_path, skip_path_validation=False).passed
 
     @pytest.mark.parametrize(
         "yaml_path,invalid_field",

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -335,7 +335,8 @@ class TestComponent:
         rest_obj = component._to_rest_object()
         assert rest_obj.properties.component_spec["environment"] == expected_dict
         assert component.environment._validate_docker_section(
-            base_path=component.base_path, skip_path_validation=False).passed
+            base_path=component.base_path, skip_path_validation=False
+        ).passed
 
     @pytest.mark.parametrize(
         "yaml_path,invalid_field",

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -334,7 +334,8 @@ class TestComponent:
         component.environment.resolve(component._base_path)
         rest_obj = component._to_rest_object()
         assert rest_obj.properties.component_spec["environment"] == expected_dict
-        assert component.environment._validate_docker_section(base_path=component.base_path, skip_path_validation=False).passed
+        assert component.environment._validate_docker_section(
+            base_path=component.base_path, skip_path_validation=False).passed
 
     @pytest.mark.parametrize(
         "yaml_path,invalid_field",


### PR DESCRIPTION
# Description

Fix the proble,, when reigster the component with the docker file, it will raise "Dockerfile not exists".
Root cause is that the docker file is resolved to the docker file content, need to skip the validation after environment is resolved.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
