### PR TITLE
[appconfiguration] fix typing errors for mypy 1.0.0

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed async `update_sync_token` to use async/await keywords
 
 ### Other Changes
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_configuration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_configuration_client_async.py
@@ -554,14 +554,14 @@ class AzureAppConfigurationClient:
         except binascii.Error:
             raise binascii.Error("Connection string secret has incorrect padding")
 
-    def update_sync_token(self, token: str) -> None:
+    async def update_sync_token(self, token: str) -> None:
 
         """Add a sync token to the internal list of tokens.
 
         :param str token: The sync token to be added to the internal list of tokens
         """
 
-        self._sync_token_policy.add_token(token)
+        await self._sync_token_policy.add_token(token)
 
     async def close(self) -> None:
 


### PR DESCRIPTION
Typing errors arising for mypy==1.0.0 can be seen here: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2589635&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=56d4e2e6-c43b-527c-bad7-234ebe7429dd&l=78

Let me know if this is the correct fix. If so, we should probably add to the changelog as a bug fix as well.