### PR TITLE
[core] fix typing errors for mypy 1.0.0

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -429,6 +429,7 @@ class HttpResponse(_HttpResponseBase):  # pylint: disable=abstract-method
 
         :rtype: iterator[bytes]
         """
+        raise NotImplementedError("stream_download is not implemented.")
 
     def parts(self) -> Iterator["HttpResponse"]:
         """Assuming the content-type is multipart/mixed, will return the parts as an iterator.

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base_async.py
@@ -72,6 +72,7 @@ class AsyncHttpResponse(_HttpResponseBase):  # pylint: disable=abstract-method
         :keyword bool decompress: If True which is default, will attempt to decode the body based
             on the *content-encoding* header.
         """
+        raise NotImplementedError("stream_download is not implemented.")
 
     def parts(self) -> AsyncIterator:
         """Assuming the content-type is multipart/mixed, will return the parts as an async iterator.

--- a/sdk/core/azure-core/azure/core/tracing/decorator.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator.py
@@ -27,7 +27,7 @@
 
 import functools
 
-from typing import Callable, Any, TypeVar, overload
+from typing import Callable, Any, TypeVar, overload, Optional
 from typing_extensions import ParamSpec
 from .common import change_context, get_function_and_class_name
 from . import SpanKind as _SpanKind
@@ -50,7 +50,7 @@ def distributed_trace(  # pylint:disable=function-redefined
     pass
 
 
-def distributed_trace(__func: Callable[P, T] = None, **kwargs: Any):  # pylint:disable=function-redefined
+def distributed_trace(__func: Optional[Callable[P, T]] = None, **kwargs: Any):  # pylint:disable=function-redefined
     """Decorator to apply to function to get traced automatically.
 
     Span will use the func name or "name_of_span".

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -27,7 +27,7 @@
 
 import functools
 
-from typing import Awaitable, Callable, Any, TypeVar, overload
+from typing import Awaitable, Callable, Any, TypeVar, overload, Optional
 from typing_extensions import ParamSpec
 from .common import change_context, get_function_and_class_name
 from . import SpanKind as _SpanKind
@@ -50,7 +50,7 @@ def distributed_trace_async(  # pylint:disable=function-redefined
 
 
 def distributed_trace_async(  # pylint:disable=function-redefined
-    __func: Callable[P, Awaitable[T]] = None, **kwargs: Any
+    __func: Optional[Callable[P, Awaitable[T]]] = None, **kwargs: Any
 ):
     """Decorator to apply to function to get traced automatically.
 


### PR DESCRIPTION
Fixing new typing errors that show up for mypy==1.0.0. Errors can be seen here: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2589639&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=56d4e2e6-c43b-527c-bad7-234ebe7429dd&l=158