### PR TITLE
[tables] refactor to fix typing errors for mypy 1.0.0

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_authentication.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_authentication.py
@@ -7,11 +7,12 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse  # type: ignore
+from typing import Optional, Union, overload, cast
 
-from azure.core.credentials import TokenCredential
+from azure.core.credentials import TokenCredential, AzureSasCredential, AzureNamedKeyCredential
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline import PipelineResponse, PipelineRequest
-from azure.core.pipeline.policies import BearerTokenCredentialPolicy, SansIOHTTPPolicy
+from azure.core.pipeline.policies import BearerTokenCredentialPolicy, SansIOHTTPPolicy, AzureSasCredentialPolicy
 
 try:
     from azure.core.pipeline.transport import AsyncHttpTransport
@@ -25,6 +26,7 @@ except ImportError:
 
 from ._common_conversion import _sign_string
 from ._error import _wrap_exception
+from ._constants import STORAGE_OAUTH_SCOPE
 
 
 class AzureSigningError(ClientAuthenticationError):
@@ -216,3 +218,55 @@ class BearerTokenChallengePolicy(BearerTokenCredentialPolicy):
         else:
             self.authorize_request(request, scope)
         return True
+
+
+@overload
+def _configure_credential(credential: AzureNamedKeyCredential) -> SharedKeyCredentialPolicy:
+    ...
+
+@overload
+def _configure_credential(credential: SharedKeyCredentialPolicy) -> SharedKeyCredentialPolicy:
+    ...
+
+@overload
+def _configure_credential(credential: AzureSasCredential) -> AzureSasCredentialPolicy:
+    ...
+
+@overload
+def _configure_credential(credential: TokenCredential) -> BearerTokenChallengePolicy:
+    ...
+
+@overload
+def _configure_credential(credential: None) -> None:
+    ...
+
+def _configure_credential(
+    credential: Optional[
+        Union[
+            AzureNamedKeyCredential,
+            AzureSasCredential,
+            TokenCredential,
+            SharedKeyCredentialPolicy
+        ]
+    ]
+) -> Optional[
+    Union[
+        BearerTokenChallengePolicy,
+        AzureSasCredentialPolicy,
+        SharedKeyCredentialPolicy
+    ]
+]:
+    if hasattr(credential, "get_token"):
+        credential = cast(TokenCredential, credential)
+        return BearerTokenChallengePolicy(
+            credential, STORAGE_OAUTH_SCOPE
+        )
+    if isinstance(credential, SharedKeyCredentialPolicy):
+        return credential
+    if isinstance(credential, AzureSasCredential):
+        return AzureSasCredentialPolicy(credential)
+    if isinstance(credential, AzureNamedKeyCredential):
+        return SharedKeyCredentialPolicy(credential)
+    if credential is not None:
+        raise TypeError("Unsupported credential: {}".format(credential))
+    return None


### PR DESCRIPTION
Fixing new typing errors that arise from mypy==1.0.0. Errors can be seen here: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2589662&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=56d4e2e6-c43b-527c-bad7-234ebe7429dd&l=102

@YalinLi0312 I realize this is a fairly big refactor so feel free to reject this PR and suggest something else. Things got a little tricky since the sync and async clients share the same base class and I didn't want to `type: ignore` the error.