### PR TITLE
[containerregistry] fix typing errors for mypy 1.0.0

### DIFF
--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
@@ -886,7 +886,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
 
     @distributed_trace
     def download_blob(self, repository, digest, **kwargs):
-        # type: (str, str, **Any) -> DownloadBlobResult | None
+        # type: (str, str, **Any) -> Union[DownloadBlobResult, None]
         """Download a blob that is part of an artifact.
 
         :param str repository: Name of the repository


### PR DESCRIPTION
Fix new errors that arise from mypy==1.0.0. Typing errors can be seen here: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2589672&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=56d4e2e6-c43b-527c-bad7-234ebe7429dd&l=79