### PR TITLE
[Internal Component] Convert environment version to str

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
@@ -17,5 +17,5 @@ class InternalEnvironmentSchema(PathAwareSchema):
         required=False,
     )
     name = fields.Str()
-    version =  VersionField()
+    version = VersionField()
     python = fields.Dict()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-from marshmallow import fields, pre_load
+from marshmallow import fields
 
 from azure.ai.ml._schema import PathAwareSchema
 from azure.ai.ml._schema.core.fields import DumpableEnumField, VersionField

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
@@ -5,7 +5,7 @@
 from marshmallow import fields, pre_load
 
 from azure.ai.ml._schema import PathAwareSchema
-from azure.ai.ml._schema.core.fields import DumpableEnumField
+from azure.ai.ml._schema.core.fields import DumpableEnumField, VersionField
 
 
 class InternalEnvironmentSchema(PathAwareSchema):
@@ -17,11 +17,5 @@ class InternalEnvironmentSchema(PathAwareSchema):
         required=False,
     )
     name = fields.Str()
-    version = fields.Str()
+    version =  VersionField()
     python = fields.Dict()
-
-    @pre_load
-    def convert_version_to_str(self, data, **kwargs):
-        if "version" in data and data["version"] is not None:
-            data["version"] = str(data["version"])
-        return data

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/environment.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-from marshmallow import fields
+from marshmallow import fields, pre_load
 
 from azure.ai.ml._schema import PathAwareSchema
 from azure.ai.ml._schema.core.fields import DumpableEnumField
@@ -19,3 +19,9 @@ class InternalEnvironmentSchema(PathAwareSchema):
     name = fields.Str()
     version = fields.Str()
     python = fields.Dict()
+
+    @pre_load
+    def convert_version_to_str(self, data, **kwargs):
+        if "version" in data and data["version"] is not None:
+            data["version"] = str(data["version"])
+        return data

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -334,6 +334,9 @@ class TestComponent:
         component.environment.resolve(component._base_path)
         rest_obj = component._to_rest_object()
         assert rest_obj.properties.component_spec["environment"] == expected_dict
+        assert component.environment._validate_docker_section(
+            base_path=component.base_path, skip_path_validation=False
+        ).passed
 
     @pytest.mark.parametrize(
         "yaml_path,invalid_field",

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -334,9 +334,6 @@ class TestComponent:
         component.environment.resolve(component._base_path)
         rest_obj = component._to_rest_object()
         assert rest_obj.properties.component_spec["environment"] == expected_dict
-        assert component.environment._validate_docker_section(
-            base_path=component.base_path, skip_path_validation=False
-        ).passed
 
     @pytest.mark.parametrize(
         "yaml_path,invalid_field",
@@ -362,6 +359,17 @@ class TestComponent:
             "will honor in the order conda_dependencies, conda_dependencies_file and pip_requirements_file."
         )
         assert str(validation_result._warnings[0]) == expected_warning_message
+
+    def test_load_environment_with_version(self):
+        yaml_path = (
+            r"tests/test_configs/internal/command-component/command-linux/"
+            r"component_with_bool_and_data_input/component.yaml"
+        )
+        yaml_dict = load_yaml(yaml_path)
+        component = load_component(source=yaml_path)
+        assert component.environment.name == yaml_dict["environment"]["name"]
+        assert component.environment.version == str(yaml_dict["environment"]["version"])
+        assert component.environment.os == yaml_dict["environment"]["os"]
 
     def test_resolve_local_code(self) -> None:
         # internal component code (snapshot) default includes items in base directory when code is None,

--- a/sdk/ml/azure-ai-ml/tests/test_configs/internal/command-component/command-linux/component_with_bool_and_data_input/component.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/internal/command-component/command-linux/component_with_bool_and_data_input/component.yaml
@@ -24,3 +24,5 @@ command: >-
   ls {inputs.input_dir}
 environment:
   name: AzureML-Designer
+  version: 46
+  os: Windows


### PR DESCRIPTION
# Description
When the environment version in the v1.5 component spec is a number, it will be considered as an int type when loading the component. This will cause an error in validation.


# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
