### PR TITLE
[Monitor][Query] Fix inconsistent kwarg usage

### DIFF
--- a/sdk/monitor/azure-monitor-query/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-query/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an inconsistent keyword argument name in the `LogsTable` constructor, changing `column_types` to `columns_types`. Note that this is a class that is typically only instantiated internally, and not by users. ([#29076](https://github.com/Azure/azure-sdk-for-python/pull/29076))
+
 ### Other Changes
 
 ## 1.1.1 (2023-02-13)

--- a/sdk/monitor/azure-monitor-query/README.md
+++ b/sdk/monitor/azure-monitor-query/README.md
@@ -162,7 +162,7 @@ LogsQueryResult
     |---name
     |---rows
     |---columns
-    |---column_types
+    |---columns_types
 
 LogsQueryPartialResult
 |---statistics
@@ -176,7 +176,7 @@ LogsQueryPartialResult
     |---name
     |---rows
     |---columns
-    |---column_types
+    |---columns_types
 ```
 
 The `LogsQueryResult` directly iterates over the table as a convenience. For example, to handle a logs query response with tables and display it using pandas:

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_models.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_models.py
@@ -82,7 +82,7 @@ class LogsTable:
     def __init__(self, **kwargs: Any) -> None:
         self.name = kwargs.pop("name", "")
         self.columns = kwargs.pop("columns", [])
-        self.columns_types = kwargs.pop("column_types", [])
+        self.columns_types = kwargs.pop("columns_types", [])
         _rows = kwargs.pop("rows", [])
         self.rows: List[LogsTableRow] = [
             LogsTableRow(
@@ -99,7 +99,7 @@ class LogsTable:
         return cls(
             name=generated.get("name"),
             columns=[col["name"] for col in generated.get("columns", [])],
-            column_types=[col["type"] for col in generated.get("columns", [])],
+            columns_types=[col["type"] for col in generated.get("columns", [])],
             rows=generated.get("rows"),
         )
 


### PR DESCRIPTION
The name of the class attribute is columns_types but the kwargs we use in the constructor is column_type. This PR makes the naming consistent.

Closes: #28688
